### PR TITLE
Replace MAINTAINERS.md by CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# dashboard maintainers
+*   @grolu @holgerkoser @petersutter

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,5 +1,0 @@
-Maintainers of this repository:
-
-* Peter Sutter <peter.sutter@sap.com> @petersutter
-* Lukas Gross <lukas.gross@sap.com> @grolu
-* Holger Koser <holger.koser@sap.com> @holgerkoser


### PR DESCRIPTION
This enables use of the Github codeowners feature
https://help.github.com/articles/about-codeowners/