### PR TITLE
Implemented worker name validation #110

### DIFF
--- a/frontend/src/components/WorkerInputGeneric.vue
+++ b/frontend/src/components/WorkerInputGeneric.vue
@@ -96,7 +96,7 @@ limitations under the License.
   import VolumeType from '@/components/VolumeType'
   import { required, maxLength, minValue } from 'vuelidate/lib/validators'
   import { getValidationErrors } from '@/utils'
-  import { uniqueWorkerName, minVolumeSize, resourceName, noStartEndHyphen, noConsecutiveHyphen } from '@/utils/validators'
+  import { uniqueWorkerName, minVolumeSize, resourceName, noStartEndHyphen } from '@/utils/validators'
 
   const validationErrors = {
     worker: {
@@ -105,7 +105,6 @@ limitations under the License.
         maxLength: 'Name ist too long',
         resourceName: 'Name must only be lowercase letters, numbers and hyphens',
         uniqueWorkerName: 'Name is taken. Try another.',
-        noConsecutiveHyphen: 'Name must not contain consecutive hyphens',
         noStartEndHyphen: 'Name must not start or end with a hyphen'
       },
       volumeSize: {
@@ -125,7 +124,6 @@ limitations under the License.
       name: {
         required,
         maxLength: maxLength(15),
-        noConsecutiveHyphen,
         noStartEndHyphen,
         resourceName,
         uniqueWorkerName

--- a/frontend/src/components/WorkerInputGeneric.vue
+++ b/frontend/src/components/WorkerInputGeneric.vue
@@ -24,6 +24,7 @@ limitations under the License.
         @input="$v.worker.name.$touch()"
         @blur="$v.worker.name.$touch()"
         v-model="worker.name"
+        counter="15"
         label="Group Name">
       </v-text-field>
     </v-flex>
@@ -93,15 +94,19 @@ limitations under the License.
   import SizeInput from '@/components/VolumeSizeInput'
   import MachineType from '@/components/MachineType'
   import VolumeType from '@/components/VolumeType'
-  import { required, minValue } from 'vuelidate/lib/validators'
+  import { required, maxLength, minValue } from 'vuelidate/lib/validators'
   import { getValidationErrors } from '@/utils'
-  import { uniqueWorkerName, minVolumeSize } from '@/utils/validators'
+  import { uniqueWorkerName, minVolumeSize, resourceName, noStartEndHyphen, noConsecutiveHyphen } from '@/utils/validators'
 
   const validationErrors = {
     worker: {
       name: {
-        required: 'You can\'t leave this empty.',
-        uniqueWorkerName: 'Name is taken. Try another.'
+        required: 'Name is required',
+        maxLength: 'Name ist too long',
+        resourceName: 'Name must only be lowercase letters, numbers and hyphens',
+        uniqueWorkerName: 'Name is taken. Try another.',
+        noConsecutiveHyphen: 'Name must not contain consecutive hyphens',
+        noStartEndHyphen: 'Name must not start or end with a hyphen'
       },
       volumeSize: {
         minVolumeSize: 'Invalid volume size'
@@ -119,6 +124,10 @@ limitations under the License.
     worker: {
       name: {
         required,
+        maxLength: maxLength(15),
+        noConsecutiveHyphen,
+        noStartEndHyphen,
+        resourceName,
         uniqueWorkerName
       },
       volumeSize: {

--- a/frontend/src/components/WorkerInputGeneric.vue
+++ b/frontend/src/components/WorkerInputGeneric.vue
@@ -124,7 +124,7 @@ limitations under the License.
       name: {
         required,
         maxLength: maxLength(15),
-        noStartEndHyphen,
+        noStartEndHyphen, // Order is important for UI hints
         resourceName,
         uniqueWorkerName
       },

--- a/frontend/src/dialogs/CreateCluster.vue
+++ b/frontend/src/dialogs/CreateCluster.vue
@@ -588,7 +588,7 @@ limitations under the License.
             required,
             maxLength: maxLength(10),
             noConsecutiveHyphen,
-            noStartEndHyphen,
+            noStartEndHyphen, // Order is important for UI hints
             resourceName,
             unique (value) {
               return this.shootByNamespaceAndName({namespace: this.namespace, name: value}) === undefined

--- a/frontend/src/dialogs/ProjectDialog.vue
+++ b/frontend/src/dialogs/ProjectDialog.vue
@@ -187,7 +187,7 @@ limitations under the License.
             required,
             maxLength: maxLength(10),
             noConsecutiveHyphen,
-            noStartEndHyphen,
+            noStartEndHyphen, // Order is important for UI hints
             resourceName,
             unique: unique('projectNames')
           }


### PR DESCRIPTION
Add worker name validation

max length: 15
has to be a valid subdomain name

Related issue: #110 

```release-note
Worker names are now validated in the dashboard: Worker names have to be valid subdomain names and each name has a maximum length of 15 characters.
```