### PR TITLE
use american english for pipeline definition

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -30,7 +30,7 @@ dashboard:
     release:
       traits:
         version:
-          preprocess: 'finalise'
+          preprocess: 'finalize'
           inject_effective_version: true
         release:
           nextversion: 'bump_minor'


### PR DESCRIPTION
Users expect to write american english in pipeline definitions.
Therefore rename "finalise" to "finalize"