### PR TITLE
Read monitoring credentials from monitoring-ingress-credentials secret

### DIFF
--- a/backend/test/acceptance/gardener.api.shoots.spec.js
+++ b/backend/test/acceptance/gardener.api.shoots.spec.js
@@ -147,13 +147,15 @@ describe('gardener', function () {
       it('should return shoot info', function () {
         const shootUser = 'shootFoo'
         const shootPassword = 'shootFooPwd'
+        const monitoringUser = 'monitoringFoo'
+        const monitoringPassword = 'monitoringFooPwd'
         const seedClusterName = `${region}.${kind}.example.org`
         const shootServerUrl = 'https://seed.foo.bar:443'
         const seedShootIngressDomain = `${name}.${project}.ingress.${seedClusterName}`
 
         common.stub.getCloudProfiles(sandbox)
         oidc.stub.getKeys()
-        k8s.stub.getShootInfo({bearer, namespace, name, project, kind, region, seedClusterName, shootServerUrl, shootUser, shootPassword, seedSecretName, seedName})
+        k8s.stub.getShootInfo({bearer, namespace, name, project, kind, region, seedClusterName, shootServerUrl, shootUser, shootPassword, monitoringUser, monitoringPassword, seedSecretName, seedName})
         return chai.request(app)
           .get(`/api/namespaces/${namespace}/shoots/${name}/info`)
           .set('authorization', `Bearer ${bearer}`)
@@ -162,8 +164,10 @@ describe('gardener', function () {
             expect(res).to.have.status(200)
             expect(res).to.be.json
             expect(res.body).to.have.own.property('kubeconfig')
-            expect(res.body.username).to.eql(shootUser)
-            expect(res.body.password).to.eql(shootPassword)
+            expect(res.body.cluster_username).to.eql(shootUser)
+            expect(res.body.cluster_password).to.eql(shootPassword)
+            expect(res.body.monitoring_username).to.eql(monitoringUser)
+            expect(res.body.monitoring_password).to.eql(monitoringPassword)
             expect(res.body.serverUrl).to.eql(shootServerUrl)
             expect(res.body.seedShootIngressDomain).to.eql(seedShootIngressDomain)
           })

--- a/frontend/src/components/ClusterAccess.vue
+++ b/frontend/src/components/ClusterAccess.vue
@@ -55,6 +55,11 @@ limitations under the License.
       password () {
         return this.info.cluster_password || ''
       }
+    },
+    methods: {
+      reset () {
+        this.$refs.usernamePassword.reset()
+      }
     }
   }
 </script>

--- a/frontend/src/components/ClusterMetrics.vue
+++ b/frontend/src/components/ClusterMetrics.vue
@@ -77,6 +77,11 @@ limitations under the License.
       password () {
         return this.info.monitoring_password || ''
       }
+    },
+    methods: {
+      reset () {
+        this.$refs.usernamePassword.reset()
+      }
     }
   }
 </script>

--- a/frontend/src/components/ClusterMetrics.vue
+++ b/frontend/src/components/ClusterMetrics.vue
@@ -16,13 +16,29 @@ limitations under the License.
 
 <template>
   <v-list>
-    <v-list-tile v-show="!!dashboardUrl">
+    <v-list-tile>
       <v-list-tile-action>
         <v-icon class="cyan--text text--darken-2">developer_board</v-icon>
       </v-list-tile-action>
       <v-list-tile-content>
-        <v-list-tile-sub-title>Dashboard</v-list-tile-sub-title>
-        <v-list-tile-title><a :href="dashboardUrl" target="_blank" class="cyan--text text--darken-2">{{dashboardUrlText}}</a></v-list-tile-title>
+        <v-list-tile-sub-title>Grafana</v-list-tile-sub-title>
+        <v-list-tile-title><a :href="grafanaUrl" target="_blank" class="cyan--text text--darken-2">{{grafanaUrlText}}</a></v-list-tile-title>
+      </v-list-tile-content>
+    </v-list-tile>
+    <v-list-tile>
+      <v-list-tile-action>
+      </v-list-tile-action>
+      <v-list-tile-content>
+        <v-list-tile-sub-title>Prometheus</v-list-tile-sub-title>
+        <v-list-tile-title><a :href="prometheusUrl" target="_blank" class="cyan--text text--darken-2">{{prometheusUrl}}</a></v-list-tile-title>
+      </v-list-tile-content>
+    </v-list-tile>
+    <v-list-tile>
+      <v-list-tile-action>
+      </v-list-tile-action>
+      <v-list-tile-content>
+        <v-list-tile-sub-title>Alertmanager</v-list-tile-sub-title>
+        <v-list-tile-title><a :href="alertmanagerUrl" target="_blank" class="cyan--text text--darken-2">{{alertmanagerUrl}}</a></v-list-tile-title>
       </v-list-tile-content>
     </v-list-tile>
     <username-password :username="username" :password="password"></username-password>
@@ -43,17 +59,23 @@ limitations under the License.
       }
     },
     computed: {
-      dashboardUrl () {
-        return this.info.dashboardUrl || ''
+      grafanaUrl () {
+        return this.info.grafanaUrl || ''
       },
-      dashboardUrlText () {
-        return this.info.dashboardUrlText || ''
+      grafanaUrlText () {
+        return this.info.grafanaUrlText || ''
+      },
+      prometheusUrl () {
+        return this.info.prometheusUrl || ''
+      },
+      alertmanagerUrl () {
+        return this.info.alertmanagerUrl || ''
       },
       username () {
-        return this.info.cluster_username || ''
+        return this.info.monitoring_username || ''
       },
       password () {
-        return this.info.cluster_password || ''
+        return this.info.monitoring_password || ''
       }
     }
   }

--- a/frontend/src/components/StatusCard.vue
+++ b/frontend/src/components/StatusCard.vue
@@ -48,6 +48,10 @@ limitations under the License.
           <status-tags v-else :conditions="conditions" popperPlacement="bottom"></status-tags>
         </div>
       </v-card-title>
+      <template v-if="isAdmin && seedShootIngressDomain">
+        <v-divider class="my-2" inset></v-divider>
+        <cluster-metrics :info="info"></cluster-metrics>
+      </template>
     </div>
   </v-card>
 </template>
@@ -58,16 +62,19 @@ limitations under the License.
   import ShootStatus from '@/components/ShootStatus'
   import StatusTags from '@/components/StatusTags'
   import RetryOperation from '@/components/RetryOperation'
+  import ClusterMetrics from '@/components/ClusterMetrics'
   import get from 'lodash/get'
   import { isHibernated,
            isReconciliationDeactivated,
            isShootMarkedForDeletion } from '@/utils'
+  import { mapGetters } from 'vuex'
 
   export default {
     components: {
       ShootStatus,
       StatusTags,
-      RetryOperation
+      RetryOperation,
+      ClusterMetrics
     },
     props: {
       shootItem: {
@@ -80,6 +87,9 @@ limitations under the License.
       }
     },
     computed: {
+      ...mapGetters([
+        'isAdmin'
+      ]),
       lastOperation () {
         return get(this.shootItem, 'status.lastOperation', {})
       },
@@ -116,6 +126,12 @@ limitations under the License.
       },
       isShootMarkedForDeletion () {
         return isShootMarkedForDeletion(this.metadata)
+      },
+      info () {
+        return get(this.shootItem, 'info', {})
+      },
+      seedShootIngressDomain () {
+        return this.info.seedShootIngressDomain || ''
       }
     },
     methods: {

--- a/frontend/src/components/UsernamePasswordListTile.vue
+++ b/frontend/src/components/UsernamePasswordListTile.vue
@@ -1,0 +1,118 @@
+<!--
+Copyright (c) 2018 by SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<template>
+  <div v-show="!!username && !!password">
+    <v-divider class="my-2" inset></v-divider>
+    <v-list-tile>
+      <v-list-tile-action>
+        <v-icon class="cyan--text text--darken-2">perm_identity</v-icon>
+      </v-list-tile-action>
+      <v-list-tile-content>
+        <v-list-tile-sub-title>User</v-list-tile-sub-title>
+        <v-list-tile-title>{{username}}</v-list-tile-title>
+      </v-list-tile-content>
+    </v-list-tile>
+    <v-list-tile>
+      <v-list-tile-action>
+      </v-list-tile-action>
+      <v-list-tile-content>
+        <v-list-tile-sub-title>Password</v-list-tile-sub-title>
+        <v-list-tile-title>{{passwordText}}</v-list-tile-title>
+        <v-snackbar :bottom="true" v-model="snackbar" :success="true" :absolute="true" :timeout.number="2000">
+          Copied to clipboard!
+        </v-snackbar>
+      </v-list-tile-content>
+      <v-tooltip top>
+        <v-btn slot="activator" icon ref="copy">
+          <v-icon>content_copy</v-icon>
+        </v-btn>
+        <span>Copy to clipboard</span>
+      </v-tooltip>
+      <v-tooltip top>
+        <v-btn slot="activator" icon @click.native.stop="showPassword = !showPassword">
+          <v-icon>{{visibilityIcon}}</v-icon>
+        </v-btn>
+        <span>{{passwordVisibilityTitle}}</span>
+      </v-tooltip>
+    </v-list-tile>
+  </div>
+</template>
+
+<script>
+  import Clipboard from 'clipboard'
+
+  export default {
+    components: {
+      Clipboard
+    },
+    props: {
+      username: {
+        type: String
+      },
+      password: {
+        type: String
+      }
+    },
+    data () {
+      return {
+        snackbar: false,
+        showPassword: false,
+        clipboard: undefined
+      }
+    },
+    methods: {
+      enableCopy () {
+        this.clipboard = new Clipboard(this.$refs.copy.$el, {
+          text: () => this.password
+        })
+        this.clipboard.on('success', (event) => {
+          this.snackbar = true
+        })
+      },
+      reset () {
+        this.snackbar = false
+        this.showPassword = false
+      }
+    },
+    computed: {
+      passwordText () {
+        if (this.showPassword) {
+          return this.password
+        } else {
+          return '****************'
+        }
+      },
+      passwordVisibilityTitle () {
+        if (this.showPassword) {
+          return 'Hide password'
+        } else {
+          return 'Show password'
+        }
+      },
+      visibilityIcon () {
+        if (this.showPassword) {
+          return 'visibility_off'
+        } else {
+          return 'visibility'
+        }
+      }
+    },
+    mounted () {
+      this.enableCopy()
+    }
+  }
+</script>

--- a/frontend/src/pages/ShootItem.vue
+++ b/frontend/src/pages/ShootItem.vue
@@ -231,7 +231,7 @@ limitations under the License.
 
             <v-card>
               <v-card-title class="subheading white--text cyan darken-2 mt-3">
-                Kube-Cluster Access
+                Access
               </v-card-title>
               <cluster-access ref="clusterAccess" :info="info"></cluster-access>
               <template v-if="!!info.kubeconfig">
@@ -405,22 +405,8 @@ limitations under the License.
           }
         }
       },
-      userinfo () {
-        if (this.info.username && this.info.password) {
-          const username = encodeURIComponent(this.info.username)
-          const password = encodeURIComponent(this.info.password)
-          return `${username}:${password}`
-        }
-        return ''
-      },
       monocularUrl () {
-        let url = 'https://'
-        const userinfo = this.userinfo
-        if (userinfo) {
-          url += `${userinfo}@`
-        }
-        url += `monocular.ingress.${this.domain}`
-        return url
+        return `https://monocular.ingress.${this.domain}`
       },
       rawItem () {
         const item = omit(this.item, ['info'])

--- a/frontend/src/pages/ShootItem.vue
+++ b/frontend/src/pages/ShootItem.vue
@@ -552,6 +552,7 @@ limitations under the License.
     },
     beforeRouteUpdate (to, from, next) {
       this.$refs.clusterAccess.reset()
+      this.$refs.clusterMetrics.reset()
       next()
     }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The dashboard needs to read monitoring credentials from a new secret called monitoring-ingress-credentials, which is placed in the Shoot namespace of the corresponding Seed cluster. (Requirement from gardener/gardener#271)

**Which issue(s) this PR fixes**:
Fixes #135

**Release note**:
```noteworthy operator
Read monitoring credentials from monitoring-ingress-credentials secret in shoot namespace of seed cluster #135
```

```noteworthy operator
Moved monitoring URLs from 'Access' to 'Monitoring' card on cluster details page, this means they also won't show up in dashboard card on cluster list anymore
```

```noteworthy operator
Removed username and password from monocular URLs (security requirement)
```
