### PR TITLE
Shoot update

### DIFF
--- a/frontend/src/components/ShootVersion.vue
+++ b/frontend/src/components/ShootVersion.vue
@@ -47,6 +47,7 @@ limitations under the License.
           :selectedVersion.sync="selectedVersion"
           :selectedVersionInvalid.sync="selectedVersionInvalid"
           :confirmRequired.sync="confirmRequired"
+          :currentk8sVersion="k8sVersion"
         ></shoot-version-update>
         <template v-if="!selectedVersionInvalid && confirmRequired">
           You should always back up all your data before attempting an upgrade. Don’t forget to include the workload inside your cluster!<br />

--- a/frontend/src/components/ShootVersionUpdate.vue
+++ b/frontend/src/components/ShootVersionUpdate.vue
@@ -57,6 +57,9 @@ limitations under the License.
       },
       confirmRequired: {
         type: Boolean
+      },
+      currentk8sVersion: {
+        type: String
       }
     },
     data () {
@@ -123,14 +126,15 @@ limitations under the License.
         return isPatch
       },
       selectedMinorVersionIsNotNextMinor () {
-        const invalid = get(this.selectedItem, 'type') === 'minor' &&
-          find(this.items, item => {
-            return item.type === 'minor' &&
-            item.version !== undefined &&
-            (semver.lt(item.version, this.selectedItem.version))
-          })
-        this.$emit('update:selectedVersionInvalid', !!invalid)
-        return !!invalid
+        const selectedVersion = get(this, 'selectedItem.version')
+        let invalid = false
+        if (selectedVersion && this.selectedItem.type === 'minor') {
+          const currentMinorVersion = semver.minor(this.currentk8sVersion)
+          const selectedItemMinorVersion = semver.minor(selectedVersion)
+          invalid = selectedItemMinorVersion - currentMinorVersion !== 1
+        }
+        this.$emit('update:selectedVersionInvalid', invalid)
+        return invalid
       },
       label () {
         if (this.selectedVersionIsPatch) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes some issues with the upgrade Kubernetes version validation checks. Moreover usability is improved by showing invalid versions as disabled

**Release note**:
```improvement user
Fixes some issues with the upgrade Kubernetes version frontend validation checks
```
```improvement user
Show invalid versions as disabled in update Kubernetes version selection
```
