### PR TITLE
use node:8.11-alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM node:8.9-alpine
+FROM node:8.11-alpine
 
 # Create app directory
 RUN mkdir -p /usr/src/app/public


### PR DESCRIPTION
**What this PR does / why we need it**:
node 8.11.3 fixes CVE-2018-7167 https://github.com/nodejs/node/releases/tag/v8.11.3

**Which issue(s) this PR fixes**:
Fixes 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
Bumped node version to 8.11.3 that fixes CVE-2018-7167
```
