### PR TITLE
Enable draft release for head update variant

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -23,7 +23,9 @@ dashboard:
       test:
         image: *node_image
   variants:
-    head-update: ~
+    head-update:
+      traits:
+        draft_release: ~
     pull-request:
       traits:
         pull-request: ~


### PR DESCRIPTION
**What this PR does / why we need it**:
We want to have draft releases generated on every head update

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@AndreasBurger we can already merge this pull request even if this trait does not exist (yet), correct? If not, we have to wait for it until we can merge..