### PR TITLE
Tag dashboard image as 'latest'

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -35,6 +35,10 @@ dashboard:
         release:
           nextversion: 'bump_minor'
         component_descriptor: ~
+        publish:
+          dockerimages:
+            dashboard:
+              tag_as_latest: true
       steps:
         prepare_release:
           image: *node_image

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 
 image:
   repository: eu.gcr.io/gardener-project/gardener/dashboard
-  tag: 1.18.0
+  tag: latest
   pullPolicy: Always
 
 logLevel: debug


### PR DESCRIPTION
**What this PR does / why we need it**:
tag dashboard image as latest, so that we can reference it directly [here](https://github.com/gardener/dashboard/blob/master/charts/gardener-dashboard/values.yaml#L8) so that we do not have to update this file after every build

**Which issue(s) this PR fixes**:
Fixes #141

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
NONE
```
