### PR TITLE
Dialog Improvements and Lazy Loading

### DIFF
--- a/frontend/src/dialogs/ConfirmDialog.vue
+++ b/frontend/src/dialogs/ConfirmDialog.vue
@@ -15,7 +15,7 @@ limitations under the License.
  -->
 
 <template>
-  <v-dialog v-model="value" persistent max-width="500">
+  <v-dialog v-model="value" persistent max-width="500" lazy>
   <v-card>
     <v-card-title :class="titleColorClass">
       <div class="headline">

--- a/frontend/src/dialogs/ConfirmDialog.vue
+++ b/frontend/src/dialogs/ConfirmDialog.vue
@@ -47,7 +47,7 @@ limitations under the License.
     <v-card-actions>
       <v-spacer></v-spacer>
       <v-btn flat @click.native.stop="cancelClicked()">Cancel</v-btn>
-      <v-btn @click.native.stop="okClicked()" :disabled="confirmDisabled || hasError" :class="textColorClass" flat>Confirm</v-btn>
+      <v-btn @click.native.stop="okClicked()" :disabled="!valid" :class="textColorClass" flat>Confirm</v-btn>
     </v-card-actions>
   </v-card>
   </v-dialog>
@@ -141,6 +141,9 @@ limitations under the License.
       },
       textColorClass () {
         return this.confirm ? this.textColorClassForString(this.confirmColor) : this.textColorClassForString(this.defaultColor)
+      },
+      valid () {
+        return !this.confirmDisabled && !this.hasError
       }
     },
     methods: {
@@ -170,7 +173,7 @@ limitations under the License.
         }
       },
       okClicked () {
-        if (this.ok && !this.confirmDisabled && !this.hasError) {
+        if (this.ok && this.valid) {
           this.ok()
         }
       },

--- a/frontend/src/dialogs/ConfirmDialog.vue
+++ b/frontend/src/dialogs/ConfirmDialog.vue
@@ -30,6 +30,7 @@ limitations under the License.
         This is a generic dialog template.
       </slot>
       <v-text-field
+        @keyup.enter="okClicked()"
         v-if="confirm && !confirmDisabled"
         ref="deleteDialogInput"
         :hint="hint"
@@ -169,7 +170,7 @@ limitations under the License.
         }
       },
       okClicked () {
-        if (this.ok) {
+        if (this.ok && !this.confirmDisabled && !this.hasError) {
           this.ok()
         }
       },

--- a/frontend/src/dialogs/MemberAddDialog.vue
+++ b/frontend/src/dialogs/MemberAddDialog.vue
@@ -33,6 +33,7 @@ limitations under the License.
             :error-messages="emailErrors"
             @input="$v.email.$touch()"
             @blur="$v.email.$touch()"
+            @keyup.enter="submit()"
             required
             tabindex="1"
           ></v-text-field>
@@ -45,6 +46,7 @@ limitations under the License.
             :error-messages="serviceAccountNameErrors"
             @input="$v.serviceAccountName.$touch()"
             @blur="$v.serviceAccountName.$touch()"
+            @keyup.enter="submit()"
             required
             tabindex="1"
           ></v-text-field>

--- a/frontend/src/dialogs/MemberAddDialog.vue
+++ b/frontend/src/dialogs/MemberAddDialog.vue
@@ -19,7 +19,7 @@ limitations under the License.
     <v-card class="add_member" :class="cardClass">
       <v-card-title>
         <v-icon x-large class="white--text">mdi-account-plus</v-icon>
-        <span v-if="isUserDialog">Assign user to Project</span>
+        <span v-if="isUserDialog">Add user to Project</span>
         <span v-if="isServiceDialog">Add Service Account to Project</span>
       </v-card-title>
 

--- a/frontend/src/dialogs/SecretDialog.vue
+++ b/frontend/src/dialogs/SecretDialog.vue
@@ -78,7 +78,7 @@ limitations under the License.
       <v-card-actions>
         <v-spacer></v-spacer>
         <v-btn flat @click.native="cancel">Cancel</v-btn>
-        <v-btn flat @click.native="submit" :class="`${color}--text`" :disabled="!valid">{{submitButtonText}}</v-btn>
+        <v-btn flat @click.native="submit" :class="`${textColor}`" :disabled="!valid">{{submitButtonText}}</v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>
@@ -89,7 +89,7 @@ limitations under the License.
   import { mapActions, mapState, mapGetters } from 'vuex'
   import { required, maxLength } from 'vuelidate/lib/validators'
   import { unique, resourceName } from '@/utils/validators'
-  import { getValidationErrors, setDelayedInputFocus, setInputFocus } from '@/utils'
+  import { getValidationErrors, setDelayedInputFocus, setInputFocus, textColor } from '@/utils'
   import CloudProfile from '@/components/CloudProfile'
   import cloneDeep from 'lodash/cloneDeep'
   import get from 'lodash/get'
@@ -234,6 +234,9 @@ limitations under the License.
       },
       title () {
         return this.isCreateMode ? this.createTitle : this.replaceTitle
+      },
+      textColor () {
+        return textColor(this.color)
       }
     },
     methods: {

--- a/frontend/src/dialogs/SecretDialogAzure.vue
+++ b/frontend/src/dialogs/SecretDialogAzure.vue
@@ -36,6 +36,9 @@ limitations under the License.
             ref="clientId"
             v-model="clientId"
             :label="clientIdLabel"
+            :error-messages="getErrorMessages('clientId')"
+            @input="$v.clientId.$touch()"
+            @blur="$v.clientId.$touch()"
           ></v-text-field>
         </v-flex>
       </v-layout>
@@ -49,6 +52,9 @@ limitations under the License.
             :append-icon-cb="() => (hideSecret = !hideSecret)"
             :type="hideSecret ? 'password' : 'text'"
             :label="clientSecretLabel"
+            :error-messages="getErrorMessages('clientSecret')"
+            @input="$v.clientSecret.$touch()"
+            @blur="$v.clientSecret.$touch()"
           ></v-text-field>
         </v-flex>
       </v-layout>
@@ -59,6 +65,9 @@ limitations under the License.
             color="blue"
             v-model="tenantId"
             :label="tenantIdLabel"
+            :error-messages="getErrorMessages('tenantId')"
+            @input="$v.tenantId.$touch()"
+            @blur="$v.tenantId.$touch()"
           ></v-text-field>
         </v-flex>
       </v-layout>
@@ -69,6 +78,9 @@ limitations under the License.
             color="blue"
             v-model="subscriptionId"
             :label="subscriptionIdLabel"
+            :error-messages="getErrorMessages('subscriptionId')"
+            @input="$v.subscriptionId.$touch()"
+            @blur="$v.subscriptionId.$touch()"
           ></v-text-field>
         </v-flex>
       </v-layout>
@@ -82,8 +94,22 @@ limitations under the License.
 <script>
   import SecretDialog from '@/dialogs/SecretDialog'
   import { getValidationErrors, setDelayedInputFocus } from '@/utils'
+  import { required } from 'vuelidate/lib/validators'
 
-  const validationErrors = {}
+  const validationErrors = {
+    clientId: {
+      required: 'You can\'t leave this empty.'
+    },
+    clientSecret: {
+      required: 'You can\'t leave this empty.'
+    },
+    tenantId: {
+      required: 'You can\'t leave this empty.'
+    },
+    subscriptionId: {
+      required: 'You can\'t leave this empty.'
+    }
+  }
 
   export default {
     components: {
@@ -125,7 +151,20 @@ limitations under the License.
         }
       },
       validators () {
-        const validators = {}
+        const validators = {
+          clientId: {
+            required
+          },
+          clientSecret: {
+            required
+          },
+          tenantId: {
+            required
+          },
+          subscriptionId: {
+            required
+          }
+        }
         return validators
       },
       isCreateMode () {

--- a/frontend/src/dialogs/SecretDialogDelete.vue
+++ b/frontend/src/dialogs/SecretDialogDelete.vue
@@ -24,7 +24,7 @@ limitations under the License.
       >
         <v-container>
           <v-layout>
-            <v-flex xs2>
+            <v-flex xs1>
               <v-icon x-large class="white--text icon">mdi-alert-outline</v-icon>
             </v-flex>
             <v-flex>
@@ -140,7 +140,6 @@ limitations under the License.
 
   .credential_title {
     font-size:30px
-    padding-top:40px
     font-weight:400
   }
 </style>

--- a/frontend/src/pages/ShootList.vue
+++ b/frontend/src/pages/ShootList.vue
@@ -98,7 +98,7 @@ limitations under the License.
         </template>
       </v-data-table>
 
-      <v-dialog v-model="kubeconfigDialog" persistent max-width="67%">
+      <v-dialog v-model="kubeconfigDialog" persistent max-width="67%" lazy>
         <v-card>
           <v-card-title class="teal darken-1 grey--text text--lighten-4">
             <div class="headline">Kubeconfig <code class="cluster_name">{{currentName}}</code></div>
@@ -113,7 +113,7 @@ limitations under the License.
         </v-card>
       </v-dialog>
 
-      <v-dialog v-model="dashboardDialog" max-width="600">
+      <v-dialog v-model="dashboardDialog" max-width="600" lazy>
         <v-card>
           <v-card-title class="teal darken-1 grey--text text--lighten-4">
             <div class="headline">Kube-Cluster Access <code class="cluster_name">{{currentName}}</code></div>
@@ -128,7 +128,9 @@ limitations under the License.
 
       <delete-cluster-dialog v-model="deleteDialog" @close="hideDialog" :clusterName="currentName" :clusterNamespace="currentNamespace" :clusterCreatedBy="currentCreatedBy"></delete-cluster-dialog>
 
-      <create-cluster-dialog v-if="projectScope" v-model="createDialog" @close="hideDialog"></create-cluster-dialog>
+      <template v-if="renderCreateDialog">
+        <create-cluster-dialog v-if="projectScope" v-model="createDialog" @close="hideDialog"></create-cluster-dialog>
+      </template>
     </v-card>
     <v-fab-transition>
       <v-btn v-if="projectScope" class="cyan darken-2" dark fab fixed bottom right v-show="floatingButton" @click.native.stop="showDialog({action: 'create'})">
@@ -151,6 +153,12 @@ limitations under the License.
   import DeleteClusterDialog from '@/dialogs/DeleteClusterDialog'
   import ClusterAccess from '@/components/ClusterAccess'
   import { getCreatedBy } from '@/utils'
+  import VueLazyload from 'vue-lazyload'
+  import Vue from 'vue'
+
+  Vue.use(VueLazyload, {
+    lazyComponent: true
+  })
 
   export default {
     name: 'shoot-list',
@@ -184,7 +192,8 @@ limitations under the License.
         tableMenu: false,
         pagination: this.$localStorage.getObject('dataTable_sortBy') || { rowsPerPage: Number.MAX_SAFE_INTEGER },
         cachedItems: null,
-        clearSelectedShootTimerID: undefined
+        clearSelectedShootTimerID: undefined,
+        renderCreateDialog: false
       }
     },
     watch: {
@@ -219,6 +228,7 @@ limitations under the License.
               })
             break
           case 'create':
+            this.renderCreateDialog = true
             this.dialog = args.action
         }
       },

--- a/frontend/src/pages/ShootList.vue
+++ b/frontend/src/pages/ShootList.vue
@@ -153,12 +153,6 @@ limitations under the License.
   import DeleteClusterDialog from '@/dialogs/DeleteClusterDialog'
   import ClusterAccess from '@/components/ClusterAccess'
   import { getCreatedBy } from '@/utils'
-  import VueLazyload from 'vue-lazyload'
-  import Vue from 'vue'
-
-  Vue.use(VueLazyload, {
-    lazyComponent: true
-  })
 
   export default {
     name: 'shoot-list',

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -301,3 +301,15 @@ export function isShootMarkedForDeletion (metadata) {
 
   return !!deletionTimestamp && !!confirmation
 }
+
+// expect colors to be in format <color> <optional:modifier>
+export function textColor (color) {
+  const colorArr = split(color, ' ')
+  const colorStr = colorArr[0]
+  const colorMod = colorArr[1]
+  let textColor = `${colorStr}--text`
+  if (colorMod) {
+    textColor = `${textColor} text--${colorMod}`
+  }
+  return textColor
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds lazy loading to confirm dialogs as well as the create cluster dialog. Moreover, it fixes various minor issues.

**Which issue(s) this PR fixes**:
Fixes #164 #165 #168 #169 #170

**Release note**:

```noteworthy user
Lazy load dialogs for better performance, especially when rendering large cluster lists gardener/dashboard#164
```
```noteworthy user
Confirm dialogs and add user / service account dialogs can be confirmed with enter-key wile input field has focus gardener/dashboard#165
```
```noteworthy user
All fields on add azure secret dialog are now _required_ gardener/dashboard#169
```
```improvement user
Fixed misaligned icon and missing color on secret dialogs gardener/dashboard#168
```
```improvement user
Changed 'Assign' to 'Add' on add member dialog gardener/dashboard#170
```
