### PR TITLE
Fix too many project issue

### DIFF
--- a/backend/lib/services/shoots.js
+++ b/backend/lib/services/shoots.js
@@ -35,7 +35,12 @@ exports.list = async function ({user, namespace, shootsWithIssuesOnly = false}) 
   if (shootsWithIssuesOnly) {
     qs = {labelSelector: 'shoot.garden.sapcloud.io/unhealthy=true'}
   }
-  return Garden(user).namespaces(namespace).shoots.get({qs})
+  if (namespace) {
+    return Garden(user).namespaces(namespace).shoots.get({qs})
+  } else {
+    // only works if user is member of garden-administrators (admin)
+    return Garden(user).shoots.get({qs})
+  }
 }
 
 exports.create = async function ({user, namespace, body}) {

--- a/frontend/src/utils/Emitter.js
+++ b/frontend/src/utils/Emitter.js
@@ -206,7 +206,8 @@ class ShootsSubscription extends AbstractSubscription {
       store.dispatch('clearShoots'),
       store.dispatch('setShootsLoading')
     ])
-    if (namespace === '_all') {
+    if (namespace === '_all' && !store.getters.isAdmin) {
+      // Non admim users cannot fetch all shoots but must make requests for each ns they have access to
       const allNamespaces = await store.getters.namespaces
       const namespaces = map(allNamespaces, (namespace) => { return {namespace, filter} })
       this.socket.emit('subscribeShoots', {namespaces})

--- a/frontend/src/utils/Emitter.js
+++ b/frontend/src/utils/Emitter.js
@@ -16,7 +16,6 @@
 
 import io from 'socket.io-client'
 import forEach from 'lodash/forEach'
-import map from 'lodash/map'
 import isEqual from 'lodash/isEqual'
 import concat from 'lodash/concat'
 import Emitter from 'component-emitter'
@@ -206,11 +205,8 @@ class ShootsSubscription extends AbstractSubscription {
       store.dispatch('clearShoots'),
       store.dispatch('setShootsLoading')
     ])
-    if (namespace === '_all' && !store.getters.isAdmin) {
-      // Non admim users cannot fetch all shoots but must make requests for each ns they have access to
-      const allNamespaces = await store.getters.namespaces
-      const namespaces = map(allNamespaces, (namespace) => { return {namespace, filter} })
-      this.socket.emit('subscribeShoots', {namespaces})
+    if (namespace === '_all') {
+      this.socket.emit('subscribeAllShoots', {filter})
     } else if (namespace) {
       this.socket.emit('subscribeShoots', {namespaces: [{namespace, filter}]})
     } else {


### PR DESCRIPTION
**What this PR does / why we need it**:
We face issues when a user (operator) has access to many projects and tries to fetch the all shoots list. This PR adds a special handling for users that have the operator role. These users can fetch all shoots at once (without namespace selector). This way, we do not need to make a requests for each namespace to the Kubernetes API.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

```noteworthy operator
Fixes an issue that leads to errors when a user (most likely with the operator role) has access to many projects and tries to fetch the all clusters list
```
