### PR TITLE
fix wrong last operation

### DIFF
--- a/frontend/src/components/ShootListRow.vue
+++ b/frontend/src/components/ShootListRow.vue
@@ -58,7 +58,7 @@ limitations under the License.
          :popperKey="`${row.namespace}/${row.name}`"
          :isHibernated="row.isHibernated"
          :reconciliationDeactivated="reconciliationDeactivated"
-         :shootDeleted="isShootMarkedForDeletion">
+         :shootDeleted="isTypeDelete">
         </shoot-status>
         <retry-operation :shootItem="shootItem"></retry-operation>
       </div>
@@ -160,7 +160,8 @@ limitations under the License.
     getCreatedBy,
     isHibernated,
     isReconciliationDeactivated,
-    isShootMarkedForDeletion } from '@/utils'
+    isShootMarkedForDeletion,
+    isTypeDelete } from '@/utils'
 
   export default {
     components: {
@@ -258,6 +259,9 @@ limitations under the License.
       isShootMarkedForDeletion () {
         const metadata = { deletionTimestamp: this.row.deletionTimestamp, annotations: this.row.annotations }
         return isShootMarkedForDeletion(metadata)
+      },
+      isTypeDelete () {
+        return isTypeDelete(this.row.lastOperation)
       },
       isDashboardDialogDisabled () {
         const itemInfo = this.row.info || {}

--- a/frontend/src/components/StatusCard.vue
+++ b/frontend/src/components/StatusCard.vue
@@ -31,7 +31,7 @@ limitations under the License.
             :popperKey="`${namespace}/${name}_lastOp`"
             :isHibernated="isHibernated"
             :reconciliationDeactivated="reconciliationDeactivated"
-            :shootDeleted="isShootMarkedForDeletion"
+            :shootDeleted="isTypeDelete"
             popperPlacement="bottom"
             @titleChange="onShootStatusTitleChange">
           </shoot-status>
@@ -66,7 +66,7 @@ limitations under the License.
   import get from 'lodash/get'
   import { isHibernated,
            isReconciliationDeactivated,
-           isShootMarkedForDeletion } from '@/utils'
+           isTypeDelete } from '@/utils'
   import { mapGetters } from 'vuex'
 
   export default {
@@ -124,8 +124,8 @@ limitations under the License.
         const metadata = { annotations: this.annotations }
         return isReconciliationDeactivated(metadata)
       },
-      isShootMarkedForDeletion () {
-        return isShootMarkedForDeletion(this.metadata)
+      isTypeDelete () {
+        return isTypeDelete(this.lastOperation)
       },
       info () {
         return get(this.shootItem, 'info', {})

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -306,6 +306,10 @@ export function isShootMarkedForDeletion (metadata) {
   return !!deletionTimestamp && !!confirmation
 }
 
+export function isTypeDelete (lastOperation) {
+  return get(lastOperation, 'type') === 'Delete'
+}
+
 // expect colors to be in format <color> <optional:modifier>
 export function textColor (color) {
   const colorArr = split(color, ' ')


### PR DESCRIPTION
**What this PR does / why we need it**:
The dashboard shows a wrong status icon e.g. if the shoot is marked for deletion, but the create operation is still in process. For the icon, instead of checking if the shoot was marked for deletion, we should check that the last operation type is `Delete`

**Which issue(s) this PR fixes**:
Fixes #183

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement user
Fixed wrong status icon when cluster is marked for deletion but is still being created.
```
