### PR TITLE
filter deprecated machine types

### DIFF
--- a/frontend/src/components/MachineType.vue
+++ b/frontend/src/components/MachineType.vue
@@ -4,8 +4,11 @@
     :items="machineTypes"
     item-text="name"
     item-value="name"
+    :error-messages="getErrorMessages('worker.machineType')"
+    @input="$v.worker.machineType.$touch()"
+    @blur="$v.worker.machineType.$touch()"
     v-model="worker.machineType"
-    label="Machine Types"
+    label="Machine Type"
   >
     <template slot="item" slot-scope="data">
       <v-list-tile-content>
@@ -17,6 +20,25 @@
 </template>
 
 <script>
+  import { required } from 'vuelidate/lib/validators'
+  import { getValidationErrors } from '@/utils'
+
+  const validationErrors = {
+    worker: {
+      machineType: {
+        required: 'Machine Type is required'
+      }
+    }
+  }
+
+  const validations = {
+    worker: {
+      machineType: {
+        required
+      }
+    }
+  }
+
   export default {
     props: {
       worker: {
@@ -27,6 +49,20 @@
         type: Array,
         default: () => []
       }
+    },
+    data () {
+      return {
+        validationErrors
+      }
+    },
+    validations,
+    methods: {
+      getErrorMessages (field) {
+        return getValidationErrors(this, field)
+      }
+    },
+    mounted () {
+      this.$v.$touch()
     }
   }
 </script>

--- a/frontend/src/components/WorkerInputGeneric.vue
+++ b/frontend/src/components/WorkerInputGeneric.vue
@@ -136,6 +136,9 @@ limitations under the License.
       },
       autoScalerMax: {
         minValue: minValue(1)
+      },
+      machineType: {
+        required
       }
     }
   }

--- a/frontend/src/dialogs/CreateClusterDialog.vue
+++ b/frontend/src/dialogs/CreateClusterDialog.vue
@@ -100,7 +100,7 @@ limitations under the License.
                   <v-flex xs3>
                     <v-select
                       color="cyan darken-2"
-                      label="Secrets"
+                      label="Secret"
                       :items="infrastructureSecretsByProfileName"
                       v-model="secret"
                       :error-messages="getErrorMessages('shootDefinition.spec.cloud.secretBindingRef.name')"

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -93,7 +93,8 @@ const getters = {
   machineTypesByCloudProfileName (state, getters) {
     return (cloudProfileName) => {
       const cloudProfile = getters.cloudProfileByName(cloudProfileName)
-      return get(cloudProfile, 'data.machineTypes')
+      const machineTypes = get(cloudProfile, 'data.machineTypes')
+      return filter(machineTypes, machineType => get(machineType, 'deprecated', false) === false)
     }
   },
   volumeTypesByCloudProfileName (state, getters) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Machine types with deprecated flag should not be displayed for selection on the create cluster dialog
```yaml
    machineTypes:
    - deprecated: true 
      name: m4.large
      cpu: "2"
      gpu: "0"
      memory: 8Gi
    - name: m5.large
      cpu: "2"
      gpu: "0"
      memory: 8Gi
```

**Which issue(s) this PR fixes**:
Fixes #175

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
Machine types that are marked as deprecated (in the cloudprofile) will not be displayed for selection on the create cluster dialog
```
