### PR TITLE
do not show kubernetes dashboard link when addon disabled

### DIFF
--- a/frontend/src/components/ClusterAccess.vue
+++ b/frontend/src/components/ClusterAccess.vue
@@ -25,25 +25,29 @@ limitations under the License.
         <v-list-tile-title><a :href="dashboardUrl" target="_blank" class="cyan--text text--darken-2">{{dashboardUrlText}}</a></v-list-tile-title>
       </v-list-tile-content>
     </v-list-tile>
+    <v-divider v-show="!!dashboardUrl && !!username && !!password" class="my-2" inset></v-divider>
     <username-password :username="username" :password="password"></username-password>
   </v-list>
 </template>
 
 <script>
   import UsernamePassword from '@/components/UsernamePasswordListTile'
+  import get from 'lodash/get'
 
   export default {
     components: {
       UsernamePassword
     },
     props: {
-      info: {
-        type: Object,
-        required: true
+      item: {
+        type: Object
       }
     },
     computed: {
       dashboardUrl () {
+        if (!this.hasDashboardEnabled) {
+          return ''
+        }
         return this.info.dashboardUrl || ''
       },
       dashboardUrlText () {
@@ -54,6 +58,12 @@ limitations under the License.
       },
       password () {
         return this.info.cluster_password || ''
+      },
+      info () {
+        return get(this.item, 'info', {})
+      },
+      hasDashboardEnabled () {
+        return get(this.item, 'spec.addons.kubernetes-dashboard.enabled', false) === true
       }
     }
   }

--- a/frontend/src/components/ClusterMetrics.vue
+++ b/frontend/src/components/ClusterMetrics.vue
@@ -41,6 +41,7 @@ limitations under the License.
         <v-list-tile-title><a :href="alertmanagerUrl" target="_blank" class="cyan--text text--darken-2">{{alertmanagerUrl}}</a></v-list-tile-title>
       </v-list-tile-content>
     </v-list-tile>
+    <v-divider class="my-2" inset></v-divider>
     <username-password :username="username" :password="password"></username-password>
   </v-list>
 </template>

--- a/frontend/src/components/UsernamePasswordListTile.vue
+++ b/frontend/src/components/UsernamePasswordListTile.vue
@@ -16,7 +16,6 @@ limitations under the License.
 
 <template>
   <div v-show="!!username && !!password">
-    <v-divider class="my-2" inset></v-divider>
     <v-list-tile>
       <v-list-tile-action>
         <v-icon class="cyan--text text--darken-2">perm_identity</v-icon>

--- a/frontend/src/pages/ShootItem.vue
+++ b/frontend/src/pages/ShootItem.vue
@@ -233,7 +233,7 @@ limitations under the License.
               <v-card-title class="subheading white--text cyan darken-2 mt-3">
                 Access
               </v-card-title>
-              <cluster-access :info="info"></cluster-access>
+              <cluster-access :item="item"></cluster-access>
               <template v-if="!!info.kubeconfig">
                 <v-divider class="my-2" inset></v-divider>
                 <v-expansion-panel>

--- a/frontend/src/pages/ShootList.vue
+++ b/frontend/src/pages/ShootList.vue
@@ -122,7 +122,7 @@ limitations under the License.
               <v-icon>close</v-icon>
             </v-btn>
           </v-card-title>
-          <cluster-access ref="clusterAccess" :info="currentInfo"></cluster-access>
+          <cluster-access ref="clusterAccess" :item="selectedItem"></cluster-access>
         </v-card>
       </v-dialog>
 

--- a/frontend/src/store/modules/shoots.js
+++ b/frontend/src/store/modules/shoots.js
@@ -162,10 +162,9 @@ const actions = {
         if (info.serverUrl) {
           const [, scheme, host] = uriPattern.exec(info.serverUrl)
           const authority = `//${replace(host, /^\/\//, '')}`
-          const pathnameAlias = '/ui'
-          const pathname = get(rootState.cfg, 'dashboardUrl.pathname', pathnameAlias)
+          const pathname = get(rootState.cfg, 'dashboardUrl.pathname')
           info.dashboardUrl = [scheme, authority, pathname].join('')
-          info.dashboardUrlText = [scheme, host, pathnameAlias].join('')
+          info.dashboardUrlText = [scheme, host].join('')
         }
 
         if (info.seedShootIngressDomain) {


### PR DESCRIPTION
**What this PR does / why we need it**:
- The dashboard link is hidden when kubernetes dashboard addon is disabled. 
- Also the deprecated dashboard `/ui` path alias has been removed. If none has been specified in the config the default is taken https://github.com/gardener/dashboard/blob/519852f661b760ec9794fe7937a4447de9507df7/backend/lib/config/gardener.js#L87-L88

**Which issue(s) this PR fixes**:
Fixes #160

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement user
The link to the kubernetes dashboard is hidden when creating a cluster without the `Dashboard` addon
```