### PR TITLE
do not show ingress url if nginx-ingress addon is disabled

### DIFF
--- a/frontend/src/pages/ShootItemCards.vue
+++ b/frontend/src/pages/ShootItemCards.vue
@@ -155,7 +155,7 @@ limitations under the License.
                 <v-list-tile-title>{{cidr}}</v-list-tile-title>
               </v-list-tile-content>
             </v-list-tile>
-            <template v-if="!!domain">
+            <template v-if="!!shootIngressDomainText">
               <v-divider class="my-2" inset></v-divider>
               <v-list-tile>
                 <v-list-tile-action>
@@ -416,6 +416,10 @@ limitations under the License.
         return get(this.item, 'spec.dns.domain')
       },
       shootIngressDomainText () {
+        const nginxIngressEnabled = get(this.item, 'spec.addons.nginx-ingress.enabled', false)
+        if (!this.domain || !nginxIngressEnabled) {
+          return undefined
+        }
         return `*.ingress.${this.domain}`
       },
       region () {


### PR DESCRIPTION
**What this PR does / why we need it**:
Ingress domain is hidden when `nginx-ingress` addon is disabled

**Which issue(s) this PR fixes**:
Fixes #191

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement user
Ingress domain is hidden on cluster details page if `nginx-ingress` addon is disabled
```
