### PR TITLE
fix focus on project list

### DIFF
--- a/frontend/src/components/MainNavigation.vue
+++ b/frontend/src/components/MainNavigation.vue
@@ -72,6 +72,7 @@ limitations under the License.
                 v-model="projectFilter"
                 ref="projectFilter"
                 @keyup.esc="projectFilter = ''"
+                autofocus
               >
               </v-text-field>
             </v-card-title>
@@ -269,7 +270,9 @@ limitations under the License.
     watch: {
       projectMenu (value) {
         if (value) {
-          setDelayedInputFocus(this, 'projectFilter')
+          requestAnimationFrame(() => {
+            setDelayedInputFocus(this, 'projectFilter')
+          })
         }
       }
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
If the project list gets very long (usually only an operator is affected) it can happen that the filter input field is not focused automatically.
https://github.com/vuetifyjs/vuetify/issues/1353

**Which issue(s) this PR fixes**:
Fixes #192

**Special notes for your reviewer**:
we need to generally rethink our project selection component but for now this workaround should help

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
Fixed autofocus on project selection filter when there are many projects
```
