### PR TITLE
Change autoscaler configuration

### DIFF
--- a/frontend/src/components/WorkerInputGeneric.vue
+++ b/frontend/src/components/WorkerInputGeneric.vue
@@ -57,7 +57,7 @@ limitations under the License.
 
     <v-flex xs1 class="ml-3">
       <v-text-field
-        min="1"
+        min="0"
         color="cyan darken-2"
         :error-messages="getErrorMessages('worker.autoScalerMin')"
         @input="$v.worker.autoScalerMin.$touch()"
@@ -69,7 +69,7 @@ limitations under the License.
 
     <v-flex xs1 class="ml-3">
       <v-text-field
-        min="1"
+        min="0"
         color="cyan darken-2"
         :error-messages="getErrorMessages('worker.autoScalerMax')"
         @input="$v.worker.autoScalerMax.$touch()"
@@ -132,10 +132,10 @@ limitations under the License.
         minVolumeSize: minVolumeSize(1)
       },
       autoScalerMin: {
-        minValue: minValue(1)
+        minValue: minValue(0)
       },
       autoScalerMax: {
-        minValue: minValue(1)
+        minValue: minValue(0)
       },
       machineType: {
         required
@@ -183,10 +183,10 @@ limitations under the License.
 
       innerMin: {
         get: function () {
-          return Math.max(1, this.worker.autoScalerMin)
+          return Math.max(0, this.worker.autoScalerMin)
         },
         set: function (value) {
-          this.worker.autoScalerMin = Math.max(1, parseInt(value))
+          this.worker.autoScalerMin = Math.max(0, parseInt(value))
           if (this.innerMax < this.worker.autoScalerMin) {
             this.worker.autoScalerMax = this.worker.autoScalerMin
           }
@@ -194,10 +194,10 @@ limitations under the License.
       },
       innerMax: {
         get: function () {
-          return Math.max(1, this.worker.autoScalerMax)
+          return Math.max(0, this.worker.autoScalerMax)
         },
         set: function (value) {
-          this.worker.autoScalerMax = Math.max(1, parseInt(value))
+          this.worker.autoScalerMax = Math.max(0, parseInt(value))
           if (this.innerMin > this.worker.autoScalerMax) {
             this.worker.autoScalerMin = this.worker.autoScalerMax
           }

--- a/frontend/src/components/WorkerInputOpenstack.vue
+++ b/frontend/src/components/WorkerInputOpenstack.vue
@@ -37,7 +37,7 @@ limitations under the License.
 
     <v-flex xs1 class="ml-3">
       <v-text-field
-        min="1"
+        min="0"
         color="cyan darken-2"
         :error-messages="getErrorMessages('worker.autoScalerMin')"
         @input="$v.worker.autoScalerMin.$touch()"
@@ -49,7 +49,7 @@ limitations under the License.
 
     <v-flex xs1 class="ml-3">
       <v-text-field
-        min="1"
+        min="0"
         color="cyan darken-2"
         :error-messages="getErrorMessages('worker.autoScalerMax')"
         @input="$v.worker.autoScalerMax.$touch()"
@@ -98,10 +98,10 @@ limitations under the License.
         uniqueWorkerName
       },
       autoScalerMin: {
-        minValue: minValue(1)
+        minValue: minValue(0)
       },
       autoScalerMax: {
-        minValue: minValue(1)
+        minValue: minValue(0)
       }
     }
   }
@@ -139,10 +139,10 @@ limitations under the License.
       },
       innerMin: {
         get: function () {
-          return Math.max(1, this.worker.autoScalerMin)
+          return Math.max(0, this.worker.autoScalerMin)
         },
         set: function (value) {
-          this.worker.autoScalerMin = Math.max(1, parseInt(value))
+          this.worker.autoScalerMin = Math.max(0, parseInt(value))
           if (this.innerMax < this.worker.autoScalerMin) {
             this.worker.autoScalerMax = this.worker.autoScalerMin
           }
@@ -150,10 +150,10 @@ limitations under the License.
       },
       innerMax: {
         get: function () {
-          return Math.max(1, this.worker.autoScalerMax)
+          return Math.max(0, this.worker.autoScalerMax)
         },
         set: function (value) {
-          this.worker.autoScalerMax = Math.max(1, parseInt(value))
+          this.worker.autoScalerMax = Math.max(0, parseInt(value))
           if (this.innerMin > this.worker.autoScalerMax) {
             this.worker.autoScalerMin = this.worker.autoScalerMax
           }

--- a/frontend/src/dialogs/CreateClusterDialog.vue
+++ b/frontend/src/dialogs/CreateClusterDialog.vue
@@ -988,7 +988,7 @@ limitations under the License.
           machineType: get(head(this.machineTypes), 'name'),
           volumeType: get(head(this.volumeTypes), 'name'),
           volumeSize: '50Gi',
-          autoScalerMin: 2,
+          autoScalerMin: 1,
           autoScalerMax: 2
         })
       },


### PR DESCRIPTION
**What this PR does / why we need it**:
When creating a new cluster the autoscaler min size is defaulted to 2. Most users that want to play around do not change the default values and this produces unnecessary costs, hence the default min value is changed to 1.
Also the minimum allowed value for autoscaler min and max value is changed from 1 to 0.

**Which issue(s) this PR fixes**:
Fixes #131

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy user
Changes in cluster creation dialog
- The default autoscaler min value is changed from 2 to 1
- Allow autoscaler min and max values to be 0
```
