### PR TITLE
add button to hibernate and wake-up cluster

### DIFF
--- a/backend/lib/routes/shoots.js
+++ b/backend/lib/routes/shoots.js
@@ -90,6 +90,19 @@ router.route('/:name/spec/kubernetes/version')
     }
   })
 
+router.route('/:name/spec/hibernation/enabled')
+  .put(async (req, res, next) => {
+    try {
+      const user = req.user
+      const namespace = req.params.namespace
+      const name = req.params.name
+      const body = req.body
+      res.send(await shoots.replaceHibernationEnabled({user, namespace, name, body}))
+    } catch (err) {
+      next(err)
+    }
+  })
+
 router.route('/:name/metadata/annotations')
   .patch(async (req, res, next) => {
     try {

--- a/backend/lib/services/shoots.js
+++ b/backend/lib/services/shoots.js
@@ -116,6 +116,18 @@ exports.replaceVersion = async function ({user, namespace, name, body}) {
   return Garden(user).namespaces(namespace).shoots.jsonPatch({name, body: patchOperations})
 }
 
+exports.replaceHibernationEnabled = async function ({user, namespace, name, body}) {
+  const enabled = body.enabled
+  const patchOperations = [
+    {
+      op: 'replace',
+      path: '/spec/hibernation/enabled',
+      value: enabled
+    }
+  ]
+  return Garden(user).namespaces(namespace).shoots.jsonPatch({name, body: patchOperations})
+}
+
 const patchAnnotations = async function ({user, namespace, name, annotations}) {
   const body = {
     metadata: {

--- a/backend/lib/services/shoots.js
+++ b/backend/lib/services/shoots.js
@@ -117,15 +117,15 @@ exports.replaceVersion = async function ({user, namespace, name, body}) {
 }
 
 exports.replaceHibernationEnabled = async function ({user, namespace, name, body}) {
-  const enabled = body.enabled
-  const patchOperations = [
-    {
-      op: 'replace',
-      path: '/spec/hibernation/enabled',
-      value: enabled
+  const enabled = !!body.enabled
+  const payload = {
+    spec: {
+      hibernation: {
+        enabled
+      }
     }
-  ]
-  return Garden(user).namespaces(namespace).shoots.jsonPatch({name, body: patchOperations})
+  }
+  return patch({user, namespace, name, body: payload})
 }
 
 const patchAnnotations = async function ({user, namespace, name, annotations}) {

--- a/frontend/src/components/ShootHibernation.vue
+++ b/frontend/src/components/ShootHibernation.vue
@@ -24,6 +24,7 @@ limitations under the License.
     </v-tooltip>
     <confirm-dialog
       :confirm="confirm"
+      :confirmButtonText="confirmText"
       v-model="dialog"
       :cancel="hideDialog"
       :ok="updateShootHibernation"
@@ -36,7 +37,7 @@ limitations under the License.
       <template slot="affectedObjectName">{{shootName}}</template>
       <template slot="message">
         <template v-if="!isHibernated">
-          This will scale the worker nodes of your cluster down to 0.<br /><br />
+          This will scale the worker nodes of your cluster down to zero.<br /><br />
           Type <b>{{shootName}}</b> below and confirm to hibernate your cluster.<br /><br />
         </template>
         <template v-else>
@@ -77,12 +78,17 @@ limitations under the License.
       confirm () {
         return this.confirmRequired ? this.shootName : undefined
       },
+      confirmText () {
+        if (!this.isHibernated) {
+          return 'Hibernate'
+        } else {
+          return 'Wake-up'
+        }
+      },
       icon () {
         if (!this.isHibernated) {
-          console.log('mdi-pause-circle-outline')
           return 'mdi-pause-circle-outline'
         } else {
-          console.log('mdi-play-circle-outline')
           return 'mdi-play-circle-outline'
         }
       },

--- a/frontend/src/components/ShootHibernation.vue
+++ b/frontend/src/components/ShootHibernation.vue
@@ -1,0 +1,145 @@
+<!--
+Copyright (c) 2018 by SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<template>
+  <div>
+    <v-tooltip top>
+      <v-btn slot="activator" icon @click="showDialog">
+        <v-icon medium>{{icon}}</v-icon>
+      </v-btn>
+      {{caption}}
+    </v-tooltip>
+    <confirm-dialog
+      :confirm="confirm"
+      v-model="dialog"
+      :cancel="hideDialog"
+      :ok="updateShootHibernation"
+      :errorMessage.sync="hibernationErrorMessage"
+      :detailedErrorMessage.sync="hibernationDetailedErrorMessage"
+      confirmColor="orange"
+      defaultColor="orange"
+      >
+      <template slot="caption">{{caption}}</template>
+      <template slot="affectedObjectName">{{shootName}}</template>
+      <template slot="message">
+        <template v-if="!isHibernated">
+          This will scale the worker nodes of your cluster down to 0.<br /><br />
+          Type <b>{{shootName}}</b> below and confirm to hibernate your cluster.<br /><br />
+        </template>
+        <template v-else>
+          This will wake-up your cluster and scale the worker nodes up to their previous count.<br /><br />
+        </template>
+      </template>
+    </confirm-dialog>
+  </div>
+</template>
+
+<script>
+  import ConfirmDialog from '@/dialogs/ConfirmDialog'
+  import { isHibernated } from '@/utils'
+  import { updateShootHibernation } from '@/utils/api'
+  import get from 'lodash/get'
+
+  export default {
+    components: {
+      ConfirmDialog
+    },
+    props: {
+      shootItem: {
+        type: Object
+      }
+    },
+    data () {
+      return {
+        dialog: false,
+        hibernationErrorMessage: null,
+        hibernationDetailedErrorMessage: null,
+        hibernate: false
+      }
+    },
+    computed: {
+      confirmRequired () {
+        return !this.isHibernated
+      },
+      confirm () {
+        return this.confirmRequired ? this.shootName : undefined
+      },
+      icon () {
+        if (!this.isHibernated) {
+          console.log('mdi-pause-circle-outline')
+          return 'mdi-pause-circle-outline'
+        } else {
+          console.log('mdi-play-circle-outline')
+          return 'mdi-play-circle-outline'
+        }
+      },
+      caption () {
+        if (!this.isHibernated) {
+          return 'Hibernate Cluster'
+        } else {
+          return 'Wake-up Cluster'
+        }
+      },
+      isHibernated () {
+        return isHibernated(get(this.shootItem, 'spec'))
+      },
+      shootName () {
+        return get(this.shootItem, 'metadata.name')
+      },
+      shootNamespace () {
+        return get(this.shootItem, 'metadata.namespace')
+      }
+    },
+    methods: {
+      showDialog () {
+        this.dialog = true
+        this.enableHibernation = !this.isHibernated
+      },
+      hideDialog () {
+        this.dialog = false
+        this.hibernationErrorMessage = null
+        this.hibernationDetailedErrorMessage = null
+      },
+      updateShootHibernation () {
+        const user = this.$store.state.user
+        updateShootHibernation({namespace: this.shootNamespace, name: this.shootName, user, data: {enabled: this.enableHibernation}})
+          .then(() => this.hideDialog())
+          .catch((err) => {
+            let msg
+            if (!this.isHibernated) {
+              msg = 'Could not hibernate cluster'
+            } else {
+              msg = 'Could not wake up cluster from hibernation'
+            }
+            this.hibernationErrorMessage = msg
+            this.hibernationDetailedErrorMessage = err.message
+            console.error(msg, err)
+          })
+      }
+    },
+    created () {
+      this.$bus.$on('esc-pressed', () => {
+        this.hideDialog()
+      })
+    },
+    watch: {
+      isHibernated (value) {
+        // hide dialog if hibernation state changes
+        this.hideDialog()
+      }
+    }
+  }
+</script>

--- a/frontend/src/components/ShootHibernation.vue
+++ b/frontend/src/components/ShootHibernation.vue
@@ -68,7 +68,7 @@ limitations under the License.
         dialog: false,
         hibernationErrorMessage: null,
         hibernationDetailedErrorMessage: null,
-        hibernate: false
+        enableHibernation: false
       }
     },
     computed: {

--- a/frontend/src/components/ShootHibernation.vue
+++ b/frontend/src/components/ShootHibernation.vue
@@ -136,11 +136,6 @@ limitations under the License.
           })
       }
     },
-    created () {
-      this.$bus.$on('esc-pressed', () => {
-        this.hideDialog()
-      })
-    },
     watch: {
       isHibernated (value) {
         // hide dialog if hibernation state changes

--- a/frontend/src/components/ShootStatus.vue
+++ b/frontend/src/components/ShootStatus.vue
@@ -20,10 +20,10 @@ limitations under the License.
       <v-tooltip top>
         <template slot="activator">
           <v-progress-circular v-if="showProgress" class="cursor-pointer progress-circular" :size="27" :width="3" :value="operation.progress" :color="color" :rotate="-90">
-            <v-icon v-if="isUserError" class="cursor-pointer progress-icon-user-error" color="error">mdi-account-alert</v-icon>
+            <v-icon v-if="isHibernated" class="cursor-pointer progress-icon" :color="color">mdi-sleep</v-icon>
+            <v-icon v-else-if="isUserError" class="cursor-pointer progress-icon-user-error" color="error">mdi-account-alert</v-icon>
             <v-icon v-else-if="shootDeleted" class="cursor-pointer progress-icon" :color="color">mdi-delete</v-icon>
             <v-icon v-else-if="isTypeCreate" class="cursor-pointer progress-icon" :color="color">mdi-plus</v-icon>
-            <v-icon v-else-if="isHibernated" class="cursor-pointer progress-icon" :color="color">mdi-sleep</v-icon>
             <span v-else-if="isTypeReconcile && isError" class="error-exclamation-mark">!</span>
             <v-icon v-else-if="isTypeReconcile" class="cursor-pointer progress-icon-check" :color="color">mdi-check</v-icon>
             <span v-else-if="isError" class="error-exclamation-mark">!</span>

--- a/frontend/src/components/ShootStatus.vue
+++ b/frontend/src/components/ShootStatus.vue
@@ -23,18 +23,19 @@ limitations under the License.
             <v-icon v-if="isUserError" class="cursor-pointer progress-icon-user-error" color="error">mdi-account-alert</v-icon>
             <v-icon v-else-if="shootDeleted" class="cursor-pointer progress-icon" :color="color">mdi-delete</v-icon>
             <v-icon v-else-if="isTypeCreate" class="cursor-pointer progress-icon" :color="color">mdi-plus</v-icon>
+            <v-icon v-else-if="isHibernated" class="cursor-pointer progress-icon" :color="color">mdi-sleep</v-icon>
             <span v-else-if="isTypeReconcile && isError" class="error-exclamation-mark">!</span>
             <v-icon v-else-if="isTypeReconcile" class="cursor-pointer progress-icon-check" :color="color">mdi-check</v-icon>
             <span v-else-if="isError" class="error-exclamation-mark">!</span>
             <template v-else>{{operation.progress}}</template>
           </v-progress-circular>
+          <v-icon v-else-if="isHibernated" class="cursor-pointer status-icon" :color="color">mdi-sleep</v-icon>
           <v-icon v-else-if="reconciliationDeactivated" class="cursor-pointer status-icon" :color="color">mdi-block-helper</v-icon>
           <v-icon v-else-if="isAborted && shootDeleted" class="cursor-pointer status-icon" :color="color">mdi-delete</v-icon>
           <v-icon v-else-if="isAborted && isTypeCreate" class="cursor-pointer status-icon" :color="color">mdi-plus</v-icon>
           <v-icon v-else-if="isUserError" class="cursor-pointer status-icon" :color="color">mdi-account-alert</v-icon>
           <v-icon v-else-if="isError" class="cursor-pointer status-icon" :color="color">mdi-alert-outline</v-icon>
           <v-progress-circular v-else-if="isPending" class="cursor-pointer" :size="27" :width="3" indeterminate :color="color"></v-progress-circular>
-          <v-icon v-else-if="isHibernated" class="cursor-pointer status-icon" :color="color">mdi-sleep</v-icon>
           <v-icon v-else class="cursor-pointer status-icon-check" :color="color">mdi-check-circle-outline</v-icon>
         </template>
         <div>{{ tooltipText }}</div>

--- a/frontend/src/components/ShootVersion.vue
+++ b/frontend/src/components/ShootVersion.vue
@@ -146,11 +146,6 @@ limitations under the License.
             console.error('Update shoot version failed with error:', err)
           })
       }
-    },
-    created () {
-      this.$bus.$on('esc-pressed', () => {
-        this.hideUpdateDialog()
-      })
     }
   }
 </script>

--- a/frontend/src/components/ShootVersion.vue
+++ b/frontend/src/components/ShootVersion.vue
@@ -37,6 +37,7 @@ limitations under the License.
     </v-tooltip>
     <confirm-dialog
       :confirm="confirm"
+      confirmButtonText="Update"
       v-model="updateDialog"
       :cancel="hideUpdateDialog"
       :ok="versionUpdateConfirmed"

--- a/frontend/src/dialogs/ConfirmDialog.vue
+++ b/frontend/src/dialogs/ConfirmDialog.vue
@@ -15,7 +15,7 @@ limitations under the License.
  -->
 
 <template>
-  <v-dialog v-model="value" persistent max-width="500" lazy>
+  <v-dialog v-model="value" persistent max-width="500" lazy @keydown.esc="cancel">
   <v-card>
     <v-card-title :class="titleColorClass">
       <div class="headline">

--- a/frontend/src/dialogs/ConfirmDialog.vue
+++ b/frontend/src/dialogs/ConfirmDialog.vue
@@ -47,7 +47,7 @@ limitations under the License.
     <v-card-actions>
       <v-spacer></v-spacer>
       <v-btn flat @click.native.stop="cancelClicked()">Cancel</v-btn>
-      <v-btn @click.native.stop="okClicked()" :disabled="!valid" :class="textColorClass" flat>Confirm</v-btn>
+      <v-btn @click.native.stop="okClicked()" :disabled="!valid" :class="textColorClass" flat>{{confirmButtonText}}</v-btn>
     </v-card-actions>
   </v-card>
   </v-dialog>
@@ -94,6 +94,10 @@ limitations under the License.
       },
       defaultColor: {
         type: String
+      },
+      confirmButtonText: {
+        type: String,
+        default: 'Confirm'
       }
     },
     data () {

--- a/frontend/src/pages/Administration.vue
+++ b/frontend/src/pages/Administration.vue
@@ -188,11 +188,6 @@ limitations under the License.
     },
     mounted () {
       this.floatingButton = true
-    },
-    created () {
-      this.$bus.$on('esc-pressed', () => {
-        this.hide()
-      })
     }
   }
 </script>

--- a/frontend/src/pages/ShootItemCards.vue
+++ b/frontend/src/pages/ShootItemCards.vue
@@ -44,9 +44,7 @@ limitations under the License.
               <v-list-tile-content>
                 <v-list-tile-sub-title>Kubernetes Version</v-list-tile-sub-title>
               </v-list-tile-content>
-              <v-list-tile-avatar>
-                <shoot-version :k8sVersion="k8sVersion" :shootName="metadata.name" :shootNamespace="metadata.namespace" :availableK8sUpdates="availableK8sUpdates"></shoot-version>
-              </v-list-tile-avatar>
+              <shoot-version class="pr-3" :k8sVersion="k8sVersion" :shootName="metadata.name" :shootNamespace="metadata.namespace" :availableK8sUpdates="availableK8sUpdates"></shoot-version>
             </v-list-tile>
 
             <v-divider class="my-2" inset></v-divider>
@@ -86,6 +84,17 @@ limitations under the License.
                 </v-list-tile-content>
               </v-list-tile>
             </template>
+
+            <v-divider class="my-2" inset></v-divider>
+            <v-list-tile>
+              <v-list-tile-action>
+                <v-icon class="cyan--text text--darken-2">mdi-sleep</v-icon>
+              </v-list-tile-action>
+              <v-list-tile-content>
+                <v-list-tile-sub-title>Hibernation</v-list-tile-sub-title>
+              </v-list-tile-content>
+              <shoot-hibernation :shootItem="item"></shoot-hibernation>
+            </v-list-tile>
 
           </v-list>
         </v-card>
@@ -257,6 +266,7 @@ limitations under the License.
   import ShootVersion from '@/components/ShootVersion'
   import StatusCard from '@/components/StatusCard'
   import SelfTerminationWarning from '@/components/SelfTerminationWarning'
+  import ShootHibernation from '@/components/ShootHibernation'
   import get from 'lodash/get'
   import includes from 'lodash/includes'
   import find from 'lodash/find'
@@ -283,7 +293,8 @@ limitations under the License.
       TimeString,
       ShootVersion,
       StatusCard,
-      SelfTerminationWarning
+      SelfTerminationWarning,
+      ShootHibernation
     },
     data () {
       return {

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -103,6 +103,10 @@ export function updateShootVersion ({namespace, name, user, data}) {
   return updateResource(`/api/namespaces/${namespace}/shoots/${name}/spec/kubernetes/version`, user, data)
 }
 
+export function updateShootHibernation ({namespace, name, user, data}) {
+  return updateResource(`/api/namespaces/${namespace}/shoots/${name}/spec/hibernation/enabled`, user, data)
+}
+
 /* Cloud Profiles */
 
 export function getCloudprofiles ({user}) {

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -255,10 +255,15 @@ export function getCreatedBy (metadata) {
 }
 
 export function isHibernated (spec) {
+  if (!spec) {
+    return false
+  }
+
   const kind = getCloudProviderKind(spec.cloud)
   // eslint-disable-next-line
   const workers = get(spec, ['cloud', kind, 'workers'])
-  return some(workers, worker => get(worker, 'autoScalerMax') === 0)
+  const hibernationEnabled = get(spec, 'hibernation.enabled', false)
+  return hibernationEnabled || some(workers, worker => get(worker, 'autoScalerMax') === 0)
 }
 
 export function canLinkToSeed ({shootNamespace}) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Added ability to to hibernate (and wake-up) clusters to save costs when they are temporarily not needed.

**Which issue(s) this PR fixes**:
Fixes #28

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy user
You can now hibernate and wake-up clusters on the cluster details page
```
