### PR TITLE
Add namespace to ServiceAccount's kubeconfigs

### DIFF
--- a/backend/lib/services/members.js
+++ b/backend/lib/services/members.js
@@ -43,7 +43,7 @@ function fromResource ({subjects} = {}) {
     .value()
 }
 
-function getKubeconfig ({serviceaccountName, token, server, caData}) {
+function getKubeconfig ({serviceaccountName, serviceaccountNamespace, token, server, caData}) {
   const clusterName = 'garden'
   const cluster = {
     'certificate-authority-data': caData,
@@ -56,7 +56,8 @@ function getKubeconfig ({serviceaccountName, token, server, caData}) {
   const contextName = 'default'
   const context = {
     cluster: clusterName,
-    user: userName
+    user: userName,
+    namespace: serviceaccountNamespace
   }
   return yaml.safeDump({
     kind: 'Config',
@@ -233,7 +234,7 @@ exports.get = async function ({user, namespace, name: username}) {
     const token = decodeBase64(secret.data.token)
     const caData = secret.data['ca.crt']
     member.kind = 'ServiceAccount'
-    member.kubeconfig = getKubeconfig({serviceaccountName, token, caData, server})
+    member.kubeconfig = getKubeconfig({serviceaccountName, serviceaccountNamespace, token, caData, server})
   }
   return member
 }


### PR DESCRIPTION
**What this PR does / why we need it**: `ServiceAccount`created by the dashboard only has permissions to access the `Project`'s namespace and having that namespace in the kubeconfig's context simplifies end-users.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement user
ServiceAccount's kubeconfig now has namespace in its context.
```
