### PR TITLE
do not inject version into source tree

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -33,7 +33,6 @@ dashboard:
       traits:
         version:
           preprocess: 'finalize'
-          inject_effective_version: true
         release:
           nextversion: 'bump_minor'
           release_callback: '.ci/prepare_release'


### PR DESCRIPTION
**What this PR does / why we need it**:
Cleans up release job definition. Source tree is no longer made dirty by injecting (unused) effective version.
