### PR TITLE
Remove Heapster

### DIFF
--- a/frontend/src/pages/ShootItemCards.vue
+++ b/frontend/src/pages/ShootItemCards.vue
@@ -305,11 +305,6 @@ limitations under the License.
             description: 'Cluster Autoscaler is a tool that automatically adjusts the size of the Kubernetes cluster.'
           },
           {
-            name: 'heapster',
-            title: 'Heapster',
-            description: 'Heapster enables Container Cluster Monitoring and Performance Analysis.'
-          },
-          {
             name: 'kube-lego',
             title: 'Kube Lego',
             description: 'Kube-Lego automatically requests certificates for Kubernetes Ingress resources from Let\'s Encrypt.'


### PR DESCRIPTION
**What this PR does / why we need it**:
Even for older clusters where the heapster addon was enabled it is not deployed anymore (just the heapster addon field is still there which cannot be removed due to compatibility reasons) so we also should not list it on the cluster details page

**Which issue(s) this PR fixes**:
Fixes #185

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement user
NONE
```
