### PR TITLE
remove old deletion logic

### DIFF
--- a/backend/lib/services/shoots.js
+++ b/backend/lib/services/shoots.js
@@ -144,22 +144,7 @@ exports.remove = async function ({user, namespace, name}) {
   }
   await patchAnnotations({user, namespace, name, annotations})
 
-  await Garden(user).namespaces(namespace).shoots.delete({name})
-
-  /* TODO: Kept the following lines for backwards compatibility
-   * (delete them once the DeletionConfirmation admission controller becomes
-   * enabled by default and the gardener logic has been adapted properly)
-   */
-  const {metadata} = await this.read({user, namespace, name})
-  const body = {
-    metadata: {
-      annotations: {
-        'confirmation.garden.sapcloud.io/deletionTimestamp': metadata.deletionTimestamp,
-        'action.garden.sapcloud.io/delete': name
-      }
-    }
-  }
-  return patch({user, namespace, name, body})
+  return Garden(user).namespaces(namespace).shoots.delete({name})
 }
 
 exports.info = async function ({user, namespace, name}) {

--- a/backend/test/acceptance/gardener.api.shoots.spec.js
+++ b/backend/test/acceptance/gardener.api.shoots.spec.js
@@ -125,14 +125,12 @@ describe('gardener', function () {
       })
 
       it('should delete a shoot', function () {
-        const deletionTimestamp = '1970-01-01T00:00:00Z'
         const deleteAnnotations = {
-          'action.garden.sapcloud.io/delete': name,
-          'confirmation.garden.sapcloud.io/deletionTimestamp': deletionTimestamp
+          'confirmation.garden.sapcloud.io/deletion': 'true'
         }
 
         oidc.stub.getKeys()
-        k8s.stub.deleteShoot({bearer, namespace, name, deleteAnnotations, deletionTimestamp, resourceVersion})
+        k8s.stub.deleteShoot({bearer, namespace, name, resourceVersion})
         return chai.request(app)
           .delete(`/api/namespaces/${namespace}/shoots/${name}`)
           .set('authorization', `Bearer ${bearer}`)

--- a/backend/test/support/nocks/k8s.js
+++ b/backend/test/support/nocks/k8s.js
@@ -370,13 +370,11 @@ const stub = {
       })
       .reply(200, () => result)
   },
-  deleteShoot ({bearer, namespace, name, project, createdBy, purpose, kind, region, bindingName, deletionTimestamp, resourceVersion = 42}) {
+  deleteShoot ({bearer, namespace, name, resourceVersion = 42}) {
     const metadata = {
       resourceVersion,
       namespace
     }
-    const shoot = getShoot({name, project, createdBy, purpose, kind, region, bindingName, deletionTimestamp})
-    shoot.metadata.deletionTimestamp = deletionTimestamp
     const result = {metadata}
 
     return nockWithAuthorization(bearer)
@@ -386,13 +384,6 @@ const stub = {
       })
       .reply(200)
       .delete(`/apis/garden.sapcloud.io/v1beta1/namespaces/${namespace}/shoots/${name}`)
-      .reply(200)
-      .get(`/apis/garden.sapcloud.io/v1beta1/namespaces/${namespace}/shoots/${name}`)
-      .reply(200, shoot)
-      .patch(`/apis/garden.sapcloud.io/v1beta1/namespaces/${namespace}/shoots/${name}`, body => {
-        _.assign(metadata, body.metadata)
-        return true
-      })
       .reply(200, () => result)
   },
   getShootInfo ({


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes old deletion logic that was removed with [gardener 0.8.0](https://github.com/gardener/gardener/releases/tag/0.8.0)

**Which issue(s) this PR fixes**:
Fixes #113

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement user
NONE
```
