### PR TITLE
Refactor kubeconfig ui element

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1803,9 +1803,9 @@
       }
     },
     "@mdi/font": {
-      "version": "2.8.94",
-      "resolved": "https://registry.npmjs.org/@mdi/font/-/font-2.8.94.tgz",
-      "integrity": "sha512-QSmuK0BedRMDSgh7RCOc0yO+cAHAaAKfj11BPv0XDxvGKNNKGRqDJcJKdrWUpVmO1/xiFLWfPEmqMi/PKwvjcg=="
+      "version": "3.0.39",
+      "resolved": "https://registry.npmjs.org/@mdi/font/-/font-3.0.39.tgz",
+      "integrity": "sha512-VnPxEXsiV+YP9NO7XyQEvs1tBxkmtPzib9dRq/1CqubaZy9oeP7Jmgd/IEya8Z3bVyj+NZpwS0YGZW1kvx2eFQ=="
     },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.0.0-rc.1",
-    "@mdi/font": "^2.8.94",
+    "@mdi/font": "^3.0.39",
     "axios": "^0.18.0",
     "clipboard": "^2.0.1",
     "codemirror": "^5.40.2",

--- a/frontend/src/components/ClusterAccess.vue
+++ b/frontend/src/components/ClusterAccess.vue
@@ -37,26 +37,33 @@ limitations under the License.
       <v-divider class="my-2" inset></v-divider>
       <v-expansion-panel :value="expandKubeconfigIndex" readonly>
         <v-expansion-panel-content hide-actions>
-          <v-container slot="header" class="pt-0 pb-0">
-            <v-layout align-center row fill-height class="ma-0">
-              <v-icon class="kubeconfig-icon cyan--text text--darken-2">insert_drive_file</v-icon>
-              <span>KUBECONFIG</span>
-              <v-spacer></v-spacer>
+          <v-list-tile slot="header">
+            <v-list-tile-action>
+              <v-icon class="cyan--text text--darken-2">insert_drive_file</v-icon>
+            </v-list-tile-action>
+            <v-list-tile-content>
+            <span>KUBECONFIG</span>
+            </v-list-tile-content>
+            <v-list-tile-action>
               <v-tooltip top>
                 <v-btn slot="activator" icon @click.native.stop="onDownload">
                   <v-icon>mdi-download</v-icon>
                 </v-btn>
                 <span>Download Kubeconfig</span>
               </v-tooltip>
+            </v-list-tile-action>
+            <v-list-tile-action>
               <copy-btn :clipboard-text="kubeconfig"></copy-btn>
+            </v-list-tile-action>
+            <v-list-tile-action>
               <v-tooltip top>
                 <v-btn slot="activator" icon @click.native.stop="isKubeconfigVisible ? hideKubekonfig() : showKubeconfig()">
                   <v-icon>{{visibilityIconKubeconfig}}</v-icon>
                 </v-btn>
                 <span>{{kubeconfigVisibilityTitle}}</span>
               </v-tooltip>
-            </v-layout>
-          </v-container>
+            </v-list-tile-action>
+          </v-list-tile>
           <v-card>
             <code-block lang="yaml" :content="info.kubeconfig" :show-copy-button="false"></code-block>
           </v-card>
@@ -185,10 +192,6 @@ export default {
   >>> .v-expansion-panel__header {
     cursor: auto;
     padding: 0;
-  }
-
-  .kubeconfig-icon {
-    padding-right: 30px;
   }
 
 </style>

--- a/frontend/src/components/ClusterAccess.vue
+++ b/frontend/src/components/ClusterAccess.vue
@@ -172,7 +172,7 @@ export default {
     onDownload () {
       const kubeconfig = this.kubeconfig
       if (kubeconfig) {
-        download(kubeconfig, this.getQualifiedName, 'text/plain')
+        download(kubeconfig, this.getQualifiedName, 'text/yaml')
       }
     }
   },

--- a/frontend/src/components/CodeBlock.vue
+++ b/frontend/src/components/CodeBlock.vue
@@ -20,13 +20,18 @@ limitations under the License.
       <pre><code :class="lang" ref="block"></code></pre>
       <span class="copied" :class="{ 'active': showMessage }">Copied!</span>
     </div>
-    <v-btn icon ref="copy">
-      <v-icon>content_copy</v-icon>
-    </v-btn>
+    <copy-btn
+      v-if="showCopyButton"
+      class="copy-button"
+      :clipboard-text="content"
+      @copy="onCopy"
+      :user-feedback="false"
+    ></copy-btn>
   </div>
 </template>
 
 <script>
+import CopyBtn from '@/components/CopyBtn'
 import trim from 'lodash/trim'
 import split from 'lodash/split'
 import replace from 'lodash/replace'
@@ -35,12 +40,14 @@ import highlightJSON from 'highlight.js/lib/languages/json'
 import highlightYAML from 'highlight.js/lib/languages/yaml'
 import highlightJavascript from 'highlight.js/lib/languages/javascript'
 import highlightBash from 'highlight.js/lib/languages/bash'
-import Clipboard from 'clipboard'
 highlight.registerLanguage('json', highlightJSON)
 highlight.registerLanguage('yaml', highlightYAML)
 highlight.registerLanguage('javascript', highlightJavascript)
 highlight.registerLanguage('bash', highlightBash)
 export default {
+  components: {
+    CopyBtn
+  },
   props: {
     lang: String,
     height: {
@@ -50,30 +57,18 @@ export default {
     content: {
       type: String,
       default: ''
+    },
+    showCopyButton: {
+      type: Boolean,
+      default: true
     }
+
   },
   data: () => ({
     showMessage: false,
     clipboard: undefined
   }),
   methods: {
-    enableCopy () {
-      if (this.clipboard) {
-        this.clipboard.destroy()
-      }
-      const target = this.$refs.block
-      const btn = this.$refs.copy.$el
-      this.clipboard = new Clipboard(btn, {
-        target: () => target
-      })
-      this.clipboard.on('success', (event) => {
-        event.clearSelection()
-        this.showMessage = true
-        window.setTimeout(() => {
-          this.showMessage = false
-        }, 2000)
-      })
-    },
     prettyPrint (textContent) {
       const block = this.$refs.block
       if (textContent) {
@@ -95,10 +90,15 @@ export default {
       }
       highlight.highlightBlock(block)
       this.$emit('highlightBlock')
+    },
+    onCopy () {
+      this.showMessage = true
+      window.setTimeout(() => {
+        this.showMessage = false
+      }, 2000)
     }
   },
   mounted () {
-    this.enableCopy()
     this.prettyPrint(this.content)
   },
   watch: {
@@ -127,7 +127,7 @@ export default {
       &:after {
         opacity: 0;
       }
-      .v-btn {
+      .copy-button {
         opacity: 1;
       }
     }
@@ -173,7 +173,7 @@ export default {
     padding: 16px;
     overflow: auto;
   }
-  .v-btn {
+  .copy-button {
     position: absolute;
     top: 12px;
     right: 12px;

--- a/frontend/src/components/CopyBtn.vue
+++ b/frontend/src/components/CopyBtn.vue
@@ -1,0 +1,109 @@
+<!--
+Copyright (c) 2018 by SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<template>
+  <div>
+    <v-snackbar
+      v-if="userFeedback"
+      :bottom="true"
+      v-model="snackbar"
+      :success="true"
+      :absolute="true"
+      :timeout="2000"
+      :color="snackbarColor"
+    >
+      {{snackbarText}}
+    </v-snackbar>
+    <v-tooltip top>
+      <v-btn slot="activator" icon ref="copy">
+        <v-icon :small="true">content_copy</v-icon>
+      </v-btn>
+      <span>{{tooltipText}}</span>
+    </v-tooltip>
+  </div>
+</template>
+
+<script>
+import Clipboard from 'clipboard'
+
+export default {
+  components: {
+    Clipboard
+  },
+  props: {
+    clipboardText: {
+      type: String,
+      default: ''
+    },
+    copySuccessText: {
+      type: String,
+      default: 'Copied to clipboard'
+    },
+    copyFailedText: {
+      type: String,
+      default: 'Copy to clipboard failed'
+    },
+    tooltipText: {
+      type: String,
+      default: 'Copy to clipboard'
+    },
+    userFeedback: {
+      type: Boolean,
+      default: true
+    }
+  },
+  data () {
+    return {
+      snackbar: false,
+      clipboard: undefined,
+      copyFailed: false
+    }
+  },
+  computed: {
+    snackbarText () {
+      return this.copyFailed ? this.copyFailedText : this.copySuccessText
+    },
+    snackbarColor () {
+      return this.copyFailed ? 'error' : undefined
+    }
+  },
+  methods: {
+    enableCopy () {
+      if (this.clipboard) {
+        this.clipboard.destroy()
+      }
+
+      this.clipboard = new Clipboard(this.$refs.copy.$el, {
+        text: () => this.clipboardText
+      })
+      this.clipboard.on('success', (event) => {
+        this.snackbar = true
+        this.copyFailed = false
+        this.$emit('copy')
+      })
+      this.clipboard.on('error', err => {
+        console.error('error', err)
+        this.copyFailed = true
+        this.snackbar = true
+        this.$emit('copyFailed')
+      })
+    }
+  },
+  mounted () {
+    this.enableCopy()
+  }
+}
+</script>

--- a/frontend/src/components/ShootListRow.vue
+++ b/frontend/src/components/ShootListRow.vue
@@ -90,16 +90,10 @@ limitations under the License.
     <td class="action-button-group text-xs-right" v-if="this.headerVisible['actions']">
       <div class="hidden-md-and-down">
         <v-tooltip top>
-          <v-btn small icon class="green--text" slot="activator" :disabled="isDashboardDialogDisabled" @click="showDialog('dashboard')">
+          <v-btn small icon class="green--text" slot="activator" :disabled="isClusterAccessDialogDisabled" @click="showDialog('access')">
             <v-icon>dashboard</v-icon>
           </v-btn>
-          <span>{{showDashboardActionTitle}}</span>
-        </v-tooltip>
-        <v-tooltip top>
-          <v-btn small icon class="blue--text" slot="activator" :disabled="isKubeconfigDialogDisabled" @click="showDialog('kubeconfig')">
-            <v-icon>settings</v-icon>
-          </v-btn>
-          <span>{{showKubeconfigActionTitle}}</span>
+          <span>{{showClusterAccessActionTitle}}</span>
         </v-tooltip>
         <v-tooltip top>
           <v-btn small icon class="red--text" slot="activator" :disabled="isShootMarkedForDeletion" @click="showDialog('delete')">
@@ -114,17 +108,11 @@ limitations under the License.
             <v-icon>more_vert</v-icon>
           </v-btn>
           <v-list>
-            <v-list-tile :disabled="isDashboardDialogDisabled" @click="showDialog('dashboard', isDashboardDialogDisabled)">
+            <v-list-tile :disabled="isClusterAccessDialogDisabled" @click="showDialog('access', isClusterAccessDialogDisabled)">
               <v-list-tile-action>
                 <v-icon class="green--text">dashboard</v-icon>
               </v-list-tile-action>
-              <v-list-tile-title>{{showDashboardActionTitle}}</v-list-tile-title>
-            </v-list-tile>
-            <v-list-tile :disabled="isKubeconfigDialogDisabled" @click="showDialog('kubeconfig', isKubeconfigDialogDisabled)">
-              <v-list-tile-action>
-                <v-icon class="blue--text">settings</v-icon>
-              </v-list-tile-action>
-              <v-list-tile-title>{{showKubeconfigActionTitle}}</v-list-tile-title>
+              <v-list-tile-title>{{showClusterAccessActionTitle}}</v-list-tile-title>
             </v-list-tile>
             <v-list-tile :disabled="isShootMarkedForDeletion" @click="showDialog('delete', isShootMarkedForDeletion)">
               <v-list-tile-action>
@@ -263,19 +251,12 @@ export default {
     isTypeDelete () {
       return isTypeDelete(this.row.lastOperation)
     },
-    isDashboardDialogDisabled () {
+    isClusterAccessDialogDisabled () {
       const itemInfo = this.row.info || {}
 
       if (itemInfo.dashboardUrl) {
         return false
       }
-
-      // disabled if info is NOT available
-      return !this.isInfoAvailable
-    },
-    isKubeconfigDialogDisabled () {
-      const itemInfo = this.row.info || {}
-
       if (itemInfo.kubeconfig) {
         return false
       }
@@ -283,15 +264,10 @@ export default {
       // disabled if info is NOT available
       return !this.isInfoAvailable
     },
-    showDashboardActionTitle () {
-      return this.isDashboardDialogDisabled
-        ? 'Dashboard not avialable'
-        : 'Show Dashboard'
-    },
-    showKubeconfigActionTitle () {
-      return this.isKubeconfigDialogDisabled
-        ? 'Kubeconfig not available'
-        : 'Show Kubeconfig'
+    showClusterAccessActionTitle () {
+      return this.isClusterAccessDialogDisabled
+        ? 'Cluster Access'
+        : 'Show Cluster Access'
     },
     deleteClusterActionTitle () {
       return this.isShootMarkedForDeletion

--- a/frontend/src/components/ShootListRow.vue
+++ b/frontend/src/components/ShootListRow.vue
@@ -90,8 +90,8 @@ limitations under the License.
     <td class="action-button-group text-xs-right" v-if="this.headerVisible['actions']">
       <div class="hidden-md-and-down">
         <v-tooltip top>
-          <v-btn small icon class="green--text" slot="activator" :disabled="isClusterAccessDialogDisabled" @click="showDialog('access')">
-            <v-icon>dashboard</v-icon>
+          <v-btn small icon class="cyan--text text--darken-2" slot="activator" :disabled="isClusterAccessDialogDisabled" @click="showDialog('access')">
+            <v-icon>mdi-shield-key-outline</v-icon>
           </v-btn>
           <span>{{showClusterAccessActionTitle}}</span>
         </v-tooltip>
@@ -110,7 +110,7 @@ limitations under the License.
           <v-list>
             <v-list-tile :disabled="isClusterAccessDialogDisabled" @click="showDialog('access', isClusterAccessDialogDisabled)">
               <v-list-tile-action>
-                <v-icon class="green--text">dashboard</v-icon>
+                <v-icon class="cyan--text text--darken-2">mdi-shield-key-outline</v-icon>
               </v-list-tile-action>
               <v-list-tile-title>{{showClusterAccessActionTitle}}</v-list-tile-title>
             </v-list-tile>

--- a/frontend/src/components/ShootVersion.vue
+++ b/frontend/src/components/ShootVersion.vue
@@ -169,6 +169,8 @@ export default {
   .update_btn {
     min-width: 0px;
     margin: 0px;
+    padding-left: 8px;
+    padding-right: 8px;
   }
 
   .update_btn >>> i {

--- a/frontend/src/components/UsernamePasswordListTile.vue
+++ b/frontend/src/components/UsernamePasswordListTile.vue
@@ -32,13 +32,17 @@ limitations under the License.
         <v-list-tile-sub-title>Password</v-list-tile-sub-title>
         <v-list-tile-title>{{passwordText}}</v-list-tile-title>
       </v-list-tile-content>
-      <copy-btn :clipboard-text="password"></copy-btn>
-      <v-tooltip top>
-        <v-btn slot="activator" icon @click.native.stop="showPassword = !showPassword">
-          <v-icon>{{visibilityIcon}}</v-icon>
-        </v-btn>
-        <span>{{passwordVisibilityTitle}}</span>
-      </v-tooltip>
+      <v-list-tile-action>
+        <copy-btn :clipboard-text="password"></copy-btn>
+      </v-list-tile-action>
+      <v-list-tile-action>
+        <v-tooltip top>
+          <v-btn slot="activator" icon @click.native.stop="showPassword = !showPassword">
+            <v-icon>{{visibilityIcon}}</v-icon>
+          </v-btn>
+          <span>{{passwordVisibilityTitle}}</span>
+        </v-tooltip>
+      </v-list-tile-action>
     </v-list-tile>
   </div>
 </template>

--- a/frontend/src/components/UsernamePasswordListTile.vue
+++ b/frontend/src/components/UsernamePasswordListTile.vue
@@ -31,16 +31,8 @@ limitations under the License.
       <v-list-tile-content>
         <v-list-tile-sub-title>Password</v-list-tile-sub-title>
         <v-list-tile-title>{{passwordText}}</v-list-tile-title>
-        <v-snackbar :bottom="true" v-model="snackbar" :success="true" :absolute="true" :timeout="2000">
-          Copied to clipboard!
-        </v-snackbar>
       </v-list-tile-content>
-      <v-tooltip top>
-        <v-btn slot="activator" icon ref="copy">
-          <v-icon>content_copy</v-icon>
-        </v-btn>
-        <span>Copy to clipboard</span>
-      </v-tooltip>
+      <copy-btn :clipboard-text="password"></copy-btn>
       <v-tooltip top>
         <v-btn slot="activator" icon @click.native.stop="showPassword = !showPassword">
           <v-icon>{{visibilityIcon}}</v-icon>
@@ -52,11 +44,11 @@ limitations under the License.
 </template>
 
 <script>
-import Clipboard from 'clipboard'
+import CopyBtn from '@/components/CopyBtn'
 
 export default {
   components: {
-    Clipboard
+    CopyBtn
   },
   props: {
     username: {
@@ -68,22 +60,11 @@ export default {
   },
   data () {
     return {
-      snackbar: false,
-      showPassword: false,
-      clipboard: undefined
+      showPassword: false
     }
   },
   methods: {
-    enableCopy () {
-      this.clipboard = new Clipboard(this.$refs.copy.$el, {
-        text: () => this.password
-      })
-      this.clipboard.on('success', (event) => {
-        this.snackbar = true
-      })
-    },
     reset () {
-      this.snackbar = false
       this.showPassword = false
     }
   },
@@ -114,9 +95,6 @@ export default {
     password (value) {
       this.reset()
     }
-  },
-  mounted () {
-    this.enableCopy()
   }
 }
 </script>

--- a/frontend/src/pages/Account.vue
+++ b/frontend/src/pages/Account.vue
@@ -18,22 +18,11 @@ limitations under the License.
   <v-container fluid>
 
     <v-card class="mt-2">
-      <v-snackbar :timeout="5000" top right v-model="showMessage">
-        <div>Copied ID Token to clipboard!</div>
-      </v-snackbar>
       <v-toolbar card class="teal darken-1" dark>
         <v-icon class="white--text pr-2">mdi-account</v-icon>
         <v-toolbar-title>User Details</v-toolbar-title>
         <v-spacer></v-spacer>
-        <v-btn
-          ref="copy"
-          icon
-          class="mr-3"
-          :data-clipboard-text="idToken"
-        >
-          <v-icon class="white--text">mdi-content-copy</v-icon>
-        </v-btn>
-
+        <copy-btn :clipboard-text="idToken" copy-success-text="Copied ID Token to clipboard!"></copy-btn>
       </v-toolbar>
       <v-card-text>
        <v-layout row wrap>
@@ -56,11 +45,14 @@ limitations under the License.
 </template>
 
 <script>
+import CopyBtn from '@/components/CopyBtn'
 import { mapState, mapGetters } from 'vuex'
-import Clipboard from 'clipboard'
 import moment from 'moment-timezone'
 
 export default {
+  components: {
+    CopyBtn
+  },
   name: 'profile',
   data () {
     return {
@@ -90,19 +82,6 @@ export default {
     expiresAt () {
       return moment(this.user.expires_at * 1000).format('MMMM Do YYYY, H:mm:ss')
     }
-  },
-  mounted () {
-    const clipboard = new Clipboard(this.$refs.copy.$el)
-    clipboard.on('success', event => {
-      event.clearSelection()
-      this.showMessage = true
-      window.setTimeout(() => {
-        this.showMessage = false
-      }, 2000)
-    })
-    clipboard.on('error', err => {
-      console.error('error', err)
-    })
   }
 }
 </script>

--- a/frontend/src/pages/Members.vue
+++ b/frontend/src/pages/Members.vue
@@ -64,7 +64,7 @@ limitations under the License.
         <v-btn icon @click.native.stop="openAddMemberDialog">
           <v-icon class="white--text">add</v-icon>
         </v-btn>
-        <v-btn icon @click.native.stop="openMemberHelpDialog" class="mr-1">
+        <v-btn icon @click.native.stop="openMemberHelpDialog">
           <v-icon class="white--text">mdi-help-circle-outline</v-icon>
         </v-btn>
       </v-toolbar>
@@ -98,12 +98,14 @@ limitations under the License.
                 <a :href="'mailto:'+name" class="cyan--text text--darken-2">{{name}}</a>
               </v-list-tile-sub-title>
             </v-list-tile-content>
-            <v-tooltip top>
-              <v-btn slot="activator" icon class="red--text" @click.native.stop="onDelete(name)">
-                <v-icon>mdi-delete</v-icon>
-              </v-btn>
-              <span>Delete Member</span>
-            </v-tooltip>
+            <v-list-tile-action>
+              <v-tooltip top>
+                <v-btn slot="activator" icon class="red--text" @click.native.stop="onDelete(name)">
+                  <v-icon>mdi-delete</v-icon>
+                </v-btn>
+                <span>Delete Member</span>
+              </v-tooltip>
+            </v-list-tile-action>
           </v-list-tile>
         </template>
       </v-list>
@@ -129,7 +131,7 @@ limitations under the License.
         <v-btn icon @click.native.stop="openAddserviceAccountDialog">
           <v-icon class="white--text">add</v-icon>
         </v-btn>
-        <v-btn icon @click.native.stop="openserviceAccountHelpDialog" class="mr-1">
+        <v-btn icon @click.native.stop="openserviceAccountHelpDialog">
           <v-icon class="white--text">mdi-help-circle-outline</v-icon>
         </v-btn>
       </v-toolbar>
@@ -164,24 +166,30 @@ limitations under the License.
                 {{name}}
               </v-list-tile-sub-title>
             </v-list-tile-content>
-            <v-tooltip top>
-              <v-btn slot="activator" icon class="blue-grey--text" @click.native.stop="onDownload(name)">
-                <v-icon>mdi-download</v-icon>
-              </v-btn>
-              <span>Download Kubeconfig</span>
-            </v-tooltip>
-            <v-tooltip top>
-              <v-btn slot="activator" small icon class="blue-grey--text" @click="onKubeconfig(name)">
-                <v-icon>visibility</v-icon>
-              </v-btn>
-              <span>Show Kubeconfig</span>
-            </v-tooltip>
-            <v-tooltip top>
-              <v-btn slot="activator" icon class="red--text" @click.native.stop="onDelete(name)">
-                <v-icon>mdi-delete</v-icon>
-              </v-btn>
-              <span>Delete Service Account</span>
-            </v-tooltip>
+            <v-list-tile-action>
+              <v-tooltip top>
+                <v-btn slot="activator" icon class="blue-grey--text" @click.native.stop="onDownload(name)">
+                  <v-icon>mdi-download</v-icon>
+                </v-btn>
+                <span>Download Kubeconfig</span>
+              </v-tooltip>
+            </v-list-tile-action>
+            <v-list-tile-action>
+              <v-tooltip top>
+                <v-btn slot="activator" small icon class="blue-grey--text" @click="onKubeconfig(name)">
+                  <v-icon>visibility</v-icon>
+                </v-btn>
+                <span>Show Kubeconfig</span>
+              </v-tooltip>
+            </v-list-tile-action>
+            <v-list-tile-action>
+              <v-tooltip top>
+                <v-btn slot="activator" icon class="red--text" @click.native.stop="onDelete(name)">
+                  <v-icon>mdi-delete</v-icon>
+                </v-btn>
+                <span>Delete Service Account</span>
+              </v-tooltip>
+            </v-list-tile-action>
           </v-list-tile>
         </template>
       </v-list>

--- a/frontend/src/pages/Members.vue
+++ b/frontend/src/pages/Members.vue
@@ -64,7 +64,7 @@ limitations under the License.
         <v-btn icon @click.native.stop="openAddMemberDialog">
           <v-icon class="white--text">add</v-icon>
         </v-btn>
-        <v-btn icon @click.native.stop="openMemberHelpDialog">
+        <v-btn icon @click.native.stop="openMemberHelpDialog" class="mr-1">
           <v-icon class="white--text">mdi-help-circle-outline</v-icon>
         </v-btn>
       </v-toolbar>
@@ -98,14 +98,12 @@ limitations under the License.
                 <a :href="'mailto:'+name" class="cyan--text text--darken-2">{{name}}</a>
               </v-list-tile-sub-title>
             </v-list-tile-content>
-            <v-list-tile-action>
-              <v-tooltip top>
-                <v-btn slot="activator" icon class="red--text" @click.native.stop="onDelete(name)">
-                  <v-icon>mdi-delete</v-icon>
-                </v-btn>
-                <span>Delete Member</span>
-              </v-tooltip>
-            </v-list-tile-action>
+            <v-tooltip top>
+              <v-btn slot="activator" icon class="red--text" @click.native.stop="onDelete(name)">
+                <v-icon>mdi-delete</v-icon>
+              </v-btn>
+              <span>Delete Member</span>
+            </v-tooltip>
           </v-list-tile>
         </template>
       </v-list>
@@ -131,7 +129,7 @@ limitations under the License.
         <v-btn icon @click.native.stop="openAddserviceAccountDialog">
           <v-icon class="white--text">add</v-icon>
         </v-btn>
-        <v-btn icon @click.native.stop="openserviceAccountHelpDialog">
+        <v-btn icon @click.native.stop="openserviceAccountHelpDialog" class="mr-1">
           <v-icon class="white--text">mdi-help-circle-outline</v-icon>
         </v-btn>
       </v-toolbar>
@@ -166,30 +164,24 @@ limitations under the License.
                 {{name}}
               </v-list-tile-sub-title>
             </v-list-tile-content>
-            <v-list-tile-action>
-              <v-tooltip top>
-                <v-btn slot="activator" small icon class="blue-grey--text" @click="onKubeconfig(name)">
-                  <v-icon>settings</v-icon>
-                </v-btn>
-                <span>Show Kubeconfig</span>
-              </v-tooltip>
-            </v-list-tile-action>
-            <v-list-tile-action>
-              <v-tooltip top>
-                <v-btn slot="activator" icon class="blue-grey--text" @click.native.stop="onDownload(name)">
-                  <v-icon>mdi-download</v-icon>
-                </v-btn>
-                <span>Download Kubeconfig</span>
-              </v-tooltip>
-            </v-list-tile-action>
-            <v-list-tile-action>
-              <v-tooltip top>
-                <v-btn slot="activator" icon class="red--text" @click.native.stop="onDelete(name)">
-                  <v-icon>mdi-delete</v-icon>
-                </v-btn>
-                <span>Delete Service Account</span>
-              </v-tooltip>
-            </v-list-tile-action>
+            <v-tooltip top>
+              <v-btn slot="activator" icon class="blue-grey--text" @click.native.stop="onDownload(name)">
+                <v-icon>mdi-download</v-icon>
+              </v-btn>
+              <span>Download Kubeconfig</span>
+            </v-tooltip>
+            <v-tooltip top>
+              <v-btn slot="activator" small icon class="blue-grey--text" @click="onKubeconfig(name)">
+                <v-icon>visibility</v-icon>
+              </v-btn>
+              <span>Show Kubeconfig</span>
+            </v-tooltip>
+            <v-tooltip top>
+              <v-btn slot="activator" icon class="red--text" @click.native.stop="onDelete(name)">
+                <v-icon>mdi-delete</v-icon>
+              </v-btn>
+              <span>Delete Service Account</span>
+            </v-tooltip>
           </v-list-tile>
         </template>
       </v-list>

--- a/frontend/src/pages/Members.vue
+++ b/frontend/src/pages/Members.vue
@@ -363,7 +363,7 @@ export default {
     async onDownload (name) {
       const kubeconfig = await this.downloadKubeconfig(name)
       if (kubeconfig) {
-        download(kubeconfig, 'kubeconfig.yaml', 'text/plain')
+        download(kubeconfig, 'kubeconfig.yaml', 'text/yaml')
       }
     },
     async onKubeconfig (name) {

--- a/frontend/src/pages/ShootItemCards.vue
+++ b/frontend/src/pages/ShootItemCards.vue
@@ -44,7 +44,9 @@ limitations under the License.
               <v-list-tile-content>
                 <v-list-tile-sub-title>Kubernetes Version</v-list-tile-sub-title>
               </v-list-tile-content>
-              <shoot-version class="pr-3" :k8sVersion="k8sVersion" :shootName="metadata.name" :shootNamespace="metadata.namespace" :availableK8sUpdates="availableK8sUpdates"></shoot-version>
+              <v-list-tile-action>
+                <shoot-version :k8sVersion="k8sVersion" :shootName="metadata.name" :shootNamespace="metadata.namespace" :availableK8sUpdates="availableK8sUpdates"></shoot-version>
+              </v-list-tile-action>
             </v-list-tile>
 
             <v-divider class="my-2" inset></v-divider>
@@ -93,7 +95,9 @@ limitations under the License.
               <v-list-tile-content>
                 <v-list-tile-sub-title>Hibernation</v-list-tile-sub-title>
               </v-list-tile-content>
-              <shoot-hibernation :shootItem="item"></shoot-hibernation>
+              <v-list-tile-action>
+                <shoot-hibernation :shootItem="item"></shoot-hibernation>
+              </v-list-tile-action>
             </v-list-tile>
 
           </v-list>

--- a/frontend/src/pages/ShootItemCards.vue
+++ b/frontend/src/pages/ShootItemCards.vue
@@ -125,7 +125,7 @@ limitations under the License.
                     /
                     <v-tooltip top open-delay="500">
                       <router-link slot="activator" class="cyan--text text--darken-2" :to="{ name: 'Secret', params: { name: secret, namespace } }">
-                        <span>{{secret}} </span>
+                        <span>{{secret}}</span>
                       </router-link>
                       <span>Used Credential</span>
                     </v-tooltip>
@@ -231,20 +231,6 @@ limitations under the License.
             Access
           </v-card-title>
           <cluster-access :item="item"></cluster-access>
-          <template v-if="!!kubeconfig">
-            <v-divider class="my-2" inset></v-divider>
-            <v-expansion-panel>
-              <v-expansion-panel-content>
-                <div slot="header" class="kubeconfig-title">
-                  <v-icon class="cyan--text text--darken-2">insert_drive_file</v-icon>
-                  <span>KUBECONFIG</span>
-                </div>
-                <v-card>
-                  <code-block lang="yaml" :content="info.kubeconfig"></code-block>
-                </v-card>
-              </v-expansion-panel-content>
-            </v-expansion-panel>
-          </template>
         </v-card>
 
         <journals v-if="isAdmin" :journals="journals" :shoot="item"></journals>
@@ -259,7 +245,6 @@ limitations under the License.
 
 <script>
 import { mapGetters } from 'vuex'
-import CodeBlock from '@/components/CodeBlock'
 import ClusterAccess from '@/components/ClusterAccess'
 import Journals from '@/components/Journals'
 import TimeString from '@/components/TimeString'
@@ -287,7 +272,6 @@ import 'codemirror/mode/yaml/yaml.js'
 export default {
   name: 'shoot-item',
   components: {
-    CodeBlock,
     ClusterAccess,
     Journals,
     TimeString,
@@ -392,9 +376,6 @@ export default {
     },
     item () {
       return get(this, 'value', {})
-    },
-    kubeconfig () {
-      return get(this, 'info.kubeconfig')
     },
     isInfoAvailable () {
       return !!this.info
@@ -510,33 +491,5 @@ export default {
 <style lang="styl" scoped>
   .subheading.v-card__title {
     height: 42px;
-  }
-
-  .v-expansion-panel {
-    box-shadow: none;
-    display: initial;
-
-    >>> li {
-      border: none;
-
-      .v-expansion-panel__header {
-        padding: 16px 32px 16px 16px !important;
-
-        .material-icons {
-          justify-content: flex-start;
-        }
-
-        .kubeconfig-title {
-          .material-icons {
-            padding-right: 30px;
-          }
-
-          span {
-            font-size: 13px;
-          }
-        }
-
-      }
-    }
   }
 </style>

--- a/frontend/src/pages/ShootItemEditor.vue
+++ b/frontend/src/pages/ShootItemEditor.vue
@@ -69,12 +69,15 @@ limitations under the License.
           </v-tooltip>
         </v-flex >
         <v-flex d-flex class="divider-right">
-          <v-tooltip top>
-            <v-btn icon slot="activator" ref="btnCopy">
-              <v-icon small>content_copy</v-icon>
-            </v-btn>
-            <span>Copy</span>
-          </v-tooltip>
+          <copy-btn
+            :clipboard-text="getContent()"
+            @click.native.stop="focus"
+            tooltip-text='Copy'
+            :user-feedback="false"
+            @copy="onCopy"
+            @copyFailed="onCopyFailed"
+          >
+          </copy-btn>
         </v-flex>
         <v-flex d-flex xs12>
         </v-flex>
@@ -110,9 +113,9 @@ limitations under the License.
 </template>
 
 <script>
+import CopyBtn from '@/components/CopyBtn'
 import { mapGetters } from 'vuex'
 import { replaceShoot } from '@/utils/api'
-import Clipboard from 'clipboard'
 import download from 'downloadjs'
 
 // codemirror
@@ -141,6 +144,9 @@ function safeDump (value) {
 }
 
 export default {
+  components: {
+    CopyBtn
+  },
   name: 'shoot-item-editor',
   data () {
     return {
@@ -401,6 +407,16 @@ export default {
           resolve
         })
       })
+    },
+    onCopy () {
+      this.snackbarColor = undefined
+      this.snackbarText = 'Copied content to clipboard'
+      this.snackbar = true
+    },
+    onCopyFailed () {
+      this.snackbarColor = 'error'
+      this.snackbarText = 'Copy to clipboard failed'
+      this.snackbar = true
     }
   },
   mounted () {
@@ -409,25 +425,6 @@ export default {
     this.createInstance(this.$refs.container)
     this.update(this.value)
     this.refresh()
-    // clipboard
-    const vm = this
-    const clipboard = new Clipboard(vm.$refs.btnCopy.$el, {
-      text () {
-        return vm.getContent()
-      }
-    })
-    clipboard.on('success', e => {
-      this.snackbarColor = undefined
-      this.snackbarText = 'Copied content to clipboard'
-      this.snackbar = true
-      e.clearSelection()
-      this.focus()
-    })
-    clipboard.on('error', e => {
-      this.snackbarColor = 'error'
-      this.snackbarText = 'Copy to clipboard failed'
-      this.snackbar = true
-    })
   },
   watch: {
     value: {

--- a/frontend/src/pages/ShootList.vue
+++ b/frontend/src/pages/ShootList.vue
@@ -279,7 +279,7 @@ export default {
       },
       set (value) {
         if (!value) {
-          this.dialog = null
+          this.hideDialog()
         }
       }
     },
@@ -289,7 +289,7 @@ export default {
       },
       set (value) {
         if (!value) {
-          this.dialog = null
+          this.hideDialog()
         }
       }
     },
@@ -299,7 +299,7 @@ export default {
       },
       set (value) {
         if (!value) {
-          this.dialog = null
+          this.hideDialog()
         }
       }
     },

--- a/frontend/src/pages/ShootList.vue
+++ b/frontend/src/pages/ShootList.vue
@@ -98,7 +98,7 @@ limitations under the License.
       <v-dialog v-model="clusterAccessDialog" max-width="600" lazy>
         <v-card>
           <v-card-title class="teal darken-1 grey--text text--lighten-4">
-            <div class="headline">Kube-Cluster Access <code class="cluster_name">{{currentName}}</code></div>
+            <div class="headline">Cluster Access <code class="cluster_name">{{currentName}}</code></div>
             <v-spacer></v-spacer>
             <v-btn icon class="grey--text text--lighten-4" @click.native="hideDialog">
               <v-icon>close</v-icon>

--- a/frontend/src/pages/ShootList.vue
+++ b/frontend/src/pages/ShootList.vue
@@ -95,22 +95,7 @@ limitations under the License.
         </template>
       </v-data-table>
 
-      <v-dialog v-model="kubeconfigDialog" persistent max-width="67%" lazy>
-        <v-card>
-          <v-card-title class="teal darken-1 grey--text text--lighten-4">
-            <div class="headline">Kubeconfig <code class="cluster_name">{{currentName}}</code></div>
-            <v-spacer></v-spacer>
-            <v-btn icon class="grey--text text--lighten-4" @click.native="hideDialog">
-              <v-icon>close</v-icon>
-            </v-btn>
-          </v-card-title>
-          <v-card-text>
-            <code-block lang="yaml" :content="currentKubeconfig"></code-block>
-          </v-card-text>
-        </v-card>
-      </v-dialog>
-
-      <v-dialog v-model="dashboardDialog" max-width="600" lazy>
+      <v-dialog v-model="clusterAccessDialog" max-width="600" lazy>
         <v-card>
           <v-card-title class="teal darken-1 grey--text text--lighten-4">
             <div class="headline">Kube-Cluster Access <code class="cluster_name">{{currentName}}</code></div>
@@ -143,7 +128,6 @@ import find from 'lodash/find'
 import zipObject from 'lodash/zipObject'
 import map from 'lodash/map'
 import get from 'lodash/get'
-import CodeBlock from '@/components/CodeBlock'
 import GPopper from '@/components/GPopper'
 import ShootListRow from '@/components/ShootListRow'
 import CreateClusterDialog from '@/dialogs/CreateClusterDialog'
@@ -154,7 +138,6 @@ import { getCreatedBy } from '@/utils'
 export default {
   name: 'shoot-list',
   components: {
-    CodeBlock,
     CreateClusterDialog,
     DeleteClusterDialog,
     GPopper,
@@ -210,8 +193,7 @@ export default {
     }),
     showDialog (args) {
       switch (args.action) {
-        case 'kubeconfig':
-        case 'dashboard':
+        case 'access':
         case 'delete':
           this.setSelectedShoot(args.shootItem.metadata)
             .then(() => {
@@ -311,19 +293,9 @@ export default {
         }
       }
     },
-    kubeconfigDialog: {
+    clusterAccessDialog: {
       get () {
-        return this.dialog === 'kubeconfig'
-      },
-      set (value) {
-        if (!value) {
-          this.dialog = null
-        }
-      }
-    },
-    dashboardDialog: {
-      get () {
-        return this.dialog === 'dashboard'
+        return this.dialog === 'access'
       },
       set (value) {
         if (!value) {
@@ -348,9 +320,6 @@ export default {
     },
     currentInfo () {
       return get(this.selectedItem, 'info', {})
-    },
-    currentKubeconfig () {
-      return get(this.selectedItem, 'info.kubeconfig')
     },
     currentLog () {
       return get(this.selectedItem, 'spec.status.lastOperation.description')

--- a/frontend/tests/unit/CodeBlock.spec.js
+++ b/frontend/tests/unit/CodeBlock.spec.js
@@ -17,8 +17,13 @@
 import { expect } from 'chai'
 import { mount } from '@vue/test-utils'
 import CodeBlock from '@/components/CodeBlock.vue'
-import VIcon from 'vuetify/es5/components/VIcon'
-import VBtn from 'vuetify/es5/components/VBtn'
+import Vue from 'vue'
+import Vuetify from 'vuetify'
+
+Vue.use(Vuetify, {
+  iconfont: 'md'
+})
+document.body.setAttribute('data-app', true)
 
 describe('CodeBlock.vue', function () {
   it('should render correct contents', function () {
@@ -30,11 +35,7 @@ describe('CodeBlock.vue', function () {
         bar: 42`
     }
     const wrapper = mount(CodeBlock, {
-      propsData,
-      components: {
-        VIcon,
-        VBtn
-      }
+      propsData
     })
     const vm = wrapper.vm
     return new Promise(resolve => vm.$nextTick(resolve))


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR it is possible to download the kubeconfig for a shoot. Also the ui element has been changed a bit so that you don't need to view the kubeconfig in order to copy it.
With these changes we could also get rid of the show kubeconfig action on the cluster list as this is now part of the cluster access dialog (see screenshot below)

**Cluster Details**
<img width="822" alt="screenshot 2018-10-18 at 16 29 53" src="https://user-images.githubusercontent.com/5526658/47161839-1d952680-d2f3-11e8-8e4c-1942c15289b0.png">

**Cluster List**
<img width="636" alt="screenshot 2018-10-18 at 16 34 37" src="https://user-images.githubusercontent.com/5526658/47162162-be83e180-d2f3-11e8-9feb-f1150ba71ff5.png">


**Which issue(s) this PR fixes**:
Fixes #148 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement user
Kubeconfig improvements:
- You can download the kubeconfig for your cluster
- You can copy the kubeconfig for your cluster without viewing it
```
