### PR TITLE
remove robohash.org dependency

### DIFF
--- a/backend/lib/app.js
+++ b/backend/lib/app.js
@@ -35,7 +35,7 @@ const PUBLIC_DIRNAME = resolve(join(__dirname, '..', 'public'))
 const STATIC_DIRNAME = join(PUBLIC_DIRNAME, 'static')
 const INDEX_FILENAME = join(PUBLIC_DIRNAME, 'index.html')
 const issuerUrl = _.get(config, 'jwt.issuer')
-let imgSrc = ['\'self\'', 'data:', 'https://www.gravatar.com', 'https://robohash.org']
+let imgSrc = ['\'self\'', 'data:', 'https://www.gravatar.com']
 const gitHubRepoUrl = _.get(config, 'frontend.gitHubRepoUrl')
 if (gitHubRepoUrl) {
   const url = parseUrl(gitHubRepoUrl)

--- a/frontend/src/components/MainToolbar.vue
+++ b/frontend/src/components/MainToolbar.vue
@@ -115,7 +115,7 @@ limitations under the License.
 <script>
 import { mapState, mapGetters, mapActions } from 'vuex'
 import get from 'lodash/get'
-import { gravatar } from '@/utils'
+import { gravatarUrlIdenticon } from '@/utils'
 import Breadcrumb from '@/components/Breadcrumb'
 
 export default {
@@ -152,7 +152,7 @@ export default {
       return this.cfg.helpMenuItems || {}
     },
     avatar () {
-      return gravatar(this.email)
+      return gravatarUrlIdenticon(this.email)
     },
     email () {
       return this.user.profile.email

--- a/frontend/src/pages/Members.vue
+++ b/frontend/src/pages/Members.vue
@@ -26,7 +26,7 @@ limitations under the License.
       <v-list v-if="!!owner" two-line subheader>
         <v-list-tile avatar>
           <v-list-tile-avatar>
-            <img :src="avatar(owner)" />
+            <img :src="avatarUrl(owner)" />
           </v-list-tile-avatar>
           <v-list-tile-content>
             <v-list-tile-title>{{displayName(owner)}}</v-list-tile-title>
@@ -88,7 +88,7 @@ limitations under the License.
             :key="name"
           >
             <v-list-tile-avatar>
-              <img :src="avatar(name)" />
+              <img :src="avatarUrl(name)" />
             </v-list-tile-avatar>
             <v-list-tile-content>
               <v-list-tile-title>
@@ -156,7 +156,7 @@ limitations under the License.
           >
 
             <v-list-tile-avatar>
-              <img :src="`https://robohash.org/${name}`" />
+              <img :src="robohashUrl(name)" />
             </v-list-tile-avatar>
             <v-list-tile-content>
               <v-list-tile-title>
@@ -242,7 +242,12 @@ import filter from 'lodash/filter'
 import MemberAddDialog from '@/dialogs/MemberAddDialog'
 import MemberHelpDialog from '@/dialogs/MemberHelpDialog'
 import { mapState, mapActions, mapGetters } from 'vuex'
-import { emailToDisplayName, gravatar, serviceAccountToDisplayName } from '@/utils'
+import {
+  emailToDisplayName,
+  gravatarUrlIdenticon,
+  gravatarUrlRobohash,
+  serviceAccountToDisplayName
+} from '@/utils'
 import { getMember } from '@/utils/api'
 import CodeBlock from '@/components/CodeBlock'
 
@@ -343,8 +348,11 @@ export default {
     isOwner (email) {
       return this.owner === toLower(email)
     },
-    avatar (email) {
-      return gravatar(email)
+    avatarUrl (email) {
+      return gravatarUrlIdenticon(email)
+    },
+    robohashUrl (value) {
+      return gravatarUrlRobohash(value)
     },
     async downloadKubeconfig (name) {
       const namespace = this.namespace

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -141,8 +141,16 @@ export function parseSize (value) {
   return parseInt(replace(value, /(^.+\D)(\d+)(\D.+$)/i, '$2'))
 }
 
-export function gravatar (email) {
-  return `https://www.gravatar.com/avatar/${md5(toLower(email))}?d=identicon&s=128`
+export function gravatarUrlIdenticon (email) {
+  return gravatarUrl(email, 'identicon')
+}
+
+export function gravatarUrlRobohash (email) {
+  return gravatarUrl(email, 'robohash')
+}
+
+export function gravatarUrl (value, image) {
+  return `https://www.gravatar.com/avatar/${md5(toLower(value))}?d=${image}&s=128`
 }
 
 export function routes (router, includeRoutesWithProjectScope) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes the dependency to robohash.org where sometimes it took much longer to load the icons than from gravatar. With this PR we use gravatar for generating the robohash. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement user
NONE
```
