### PR TITLE
show only usable machine types and volume types

### DIFF
--- a/frontend/src/components/VolumeType.vue
+++ b/frontend/src/components/VolumeType.vue
@@ -5,6 +5,9 @@
     item-text="name"
     item-value="name"
     v-model="worker.volumeType"
+    :error-messages="getErrorMessages('worker.volumeType')"
+    @input="$v.worker.volumeType.$touch()"
+    @blur="$v.worker.volumeType.$touch()"
     label="Volume Type">
     <template slot="item" slot-scope="data">
       <v-list-tile-content>
@@ -16,6 +19,23 @@
 </template>
 
 <script>
+import { required } from 'vuelidate/lib/validators'
+import { getValidationErrors } from '@/utils'
+  const validationErrors = {
+  worker: {
+    volumeType: {
+      required: 'Volume Type is required'
+    }
+  }
+}
+  const validations = {
+  worker: {
+    volumeType: {
+      required
+    }
+  }
+}
+
 export default {
   props: {
     worker: {
@@ -26,6 +46,20 @@ export default {
       type: Array,
       default: () => []
     }
+  },
+  data () {
+    return {
+      validationErrors
+    }
+  },
+  validations,
+  methods: {
+    getErrorMessages (field) {
+      return getValidationErrors(this, field)
+    }
+  },
+  mounted () {
+    this.$v.$touch()
   }
 }
 </script>

--- a/frontend/src/components/WorkerInputGeneric.vue
+++ b/frontend/src/components/WorkerInputGeneric.vue
@@ -138,6 +138,9 @@ const validations = {
     },
     machineType: {
       required
+    },
+    volumeType: {
+      required
     }
   }
 }

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -94,13 +94,14 @@ const getters = {
     return (cloudProfileName) => {
       const cloudProfile = getters.cloudProfileByName(cloudProfileName)
       const machineTypes = get(cloudProfile, 'data.machineTypes')
-      return filter(machineTypes, machineType => get(machineType, 'deprecated', false) === false)
+      return filter(machineTypes, machineType => get(machineType, 'usable', true) === true)
     }
   },
   volumeTypesByCloudProfileName (state, getters) {
     return (cloudProfileName) => {
       const cloudProfile = getters.cloudProfileByName(cloudProfileName)
-      return get(cloudProfile, 'data.volumeTypes')
+      const volumeTypes = get(cloudProfile, 'data.volumeTypes')
+      return filter(volumeTypes, volumeType => get(volumeType, 'usable', true) === true)
     }
   },
   shootList (state, getters) {


### PR DESCRIPTION
flag was changed from deprecated to usable
Only machine types and volume type with usable flag should be displayed for selection on the create cluster dialog. Default value is `true`
```yaml
    machineTypes:
    - usable: false 
      name: m4.large
      cpu: "2"
      gpu: "0"
      memory: 8Gi
    - name: m5.large
      cpu: "2"
      gpu: "0"
      memory: 8Gi
```

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #175

**Special notes for your reviewer**:
Removed support for deprecated flag introduced with #189
Gardener implementation gardener/gardener#488

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
Only machine types and volume types marked as `usable` (in the cloudprofile) will be displayed for selection on the create cluster dialog. Removed support for `deprecated` flag.
```
