### PR TITLE
Adapt to new project resource behavior

### DIFF
--- a/backend/.eslintrc.js
+++ b/backend/.eslintrc.js
@@ -25,6 +25,7 @@ module.exports = {
     sinon: true,
     nocks: true,
     support: true,
-    createServer: true
+    createServer: true,
+    verifyAndRestore: true
   }
 }

--- a/backend/lib/errors.js
+++ b/backend/lib/errors.js
@@ -191,3 +191,10 @@ class ServiceUnavailable extends HttpServerError {
   }
 }
 exports.ServiceUnavailable = ServiceUnavailable
+
+class GatewayTimeout extends HttpServerError {
+  constructor (message) {
+    super(504, 'Gateway Timeout', message)
+  }
+}
+exports.GatewayTimeout = GatewayTimeout

--- a/backend/lib/kubernetes/Resources.js
+++ b/backend/lib/kubernetes/Resources.js
@@ -64,7 +64,12 @@ module.exports = {
   },
   Quota: {
     name: 'quotas',
-    kind: 'Quotas',
+    kind: 'Quota',
+    apiVersion: 'garden.sapcloud.io/v1beta1'
+  },
+  Project: {
+    name: 'projects',
+    kind: 'Project',
     apiVersion: 'garden.sapcloud.io/v1beta1'
   }
 }

--- a/backend/lib/kubernetes/index.js
+++ b/backend/lib/kubernetes/index.js
@@ -123,18 +123,21 @@ module.exports = {
     return new Batch(credentials(options))
   },
   garden (options) {
+    const resources = [
+      Resources.Shoot.name,
+      Resources.Seed.name,
+      Resources.CloudProfile.name,
+      Resources.SecretBinding.name,
+      Resources.Quota.name,
+      Resources.Project.name
+    ]
     options = assign(options, {
-      group: 'garden.sapcloud.io',
+      path: 'apis/garden.sapcloud.io',
       version: 'v1beta1',
-      resources: [
-        Resources.Shoot.name,
-        Resources.Seed.name,
-        Resources.CloudProfile.name,
-        Resources.SecretBinding.name,
-        Resources.Quota.name
-      ]
+      namespaceResources: resources,
+      groupResources: resources
     })
-    return new CustomResourceDefinitions(credentials(options))
+    return new ApiGroup(credentials(options))
   },
   authorization (options) {
     options = assign(options, {

--- a/backend/lib/kubernetes/watch.js
+++ b/backend/lib/kubernetes/watch.js
@@ -134,6 +134,8 @@ function wrap (emitter, ws) {
     .on('close', onClose)
 
   emitter.websocket = ws
+  emitter.end = () => ws.terminate()
+
   return emitter
 }
 

--- a/backend/lib/services/projects.js
+++ b/backend/lib/services/projects.js
@@ -21,7 +21,7 @@ const kubernetes = require('../kubernetes')
 const Resources = kubernetes.Resources
 const garden = kubernetes.garden()
 const core = kubernetes.core()
-const { PreconditionFailed, NotFound } = require('../errors')
+const { PreconditionFailed, NotFound, GatewayTimeout, InternalServerError } = require('../errors')
 const logger = require('../logger')
 const shoots = require('./shoots')
 const administrators = require('./administrators')
@@ -144,7 +144,7 @@ function waitUntilProjectIsReady (projects, name) {
   return new Promise((resolve, reject) => {
     const timeoutId = setTimeout(() => {
       const duration = `${projectInitializationTimeout} ms`
-      done(new Error(`Project could not be initialized within ${duration}`))
+      done(new GatewayTimeout(`Project could not be initialized within ${duration}`))
     }, projectInitializationTimeout)
 
     function done (err, project) {
@@ -173,7 +173,7 @@ function waitUntilProjectIsReady (projects, name) {
           }
           break
         case 'DELETED':
-          done(new Error(`Project "${name}" has been deleted`))
+          done(new InternalServerError(`Project "${name}" has been deleted`))
           break
       }
     }
@@ -183,7 +183,7 @@ function waitUntilProjectIsReady (projects, name) {
     }
 
     function onDisconnect (err) {
-      done(err || new Error(`Watch for project "${name}" has been disconnected`))
+      done(err || new InternalServerError(`Watch for project "${name}" has been disconnected`))
     }
 
     reconnector.on('event', onEvent)

--- a/backend/lib/watches/namespaces.js
+++ b/backend/lib/watches/namespaces.js
@@ -16,15 +16,15 @@
 
 'use strict'
 
-const core = require('../kubernetes').core()
+const garden = require('../kubernetes').garden()
 const { registerHandler } = require('./common')
 
 module.exports = io => {
-  const labelSelector = 'garden.sapcloud.io/role=project'
-  const emitter = core.namespaces.watch({qs: {labelSelector}})
+  const emitter = garden.projects.watch()
   registerHandler(emitter, event => {
     if (event.type === 'ADDED') {
-      const namespace = event.object.metadata.name
+      const namespace = event.object.spec.namespace
+      // initialize the room
       io.of('/shoots').to(namespace).emit('ping')
     }
   })

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -2737,7 +2737,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {
@@ -3099,6 +3099,15 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
       "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
     },
+    "fast-json-patch": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-2.0.7.tgz",
+      "integrity": "sha512-DQeoEyPYxdTtfmB3yDlxkLyKTdbJ6ABfFGcMynDqjvGhPYLto/pZyb/dG2Nyd/n9CArjEWN9ZST++AFmgzgbGw==",
+      "dev": true,
+      "requires": {
+        "deep-equal": "^1.0.1"
+      }
+    },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -3321,14 +3330,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3343,20 +3350,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3473,8 +3477,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3486,7 +3489,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3501,7 +3503,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3509,14 +3510,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3535,7 +3534,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3616,8 +3614,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3629,7 +3626,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3751,7 +3747,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -63,6 +63,7 @@
     "eslint-plugin-node": "^7.0.1",
     "eslint-plugin-promise": "^3.8.0",
     "eslint-plugin-standard": "^3.1.0",
+    "fast-json-patch": "^2.0.7",
     "jsonwebtoken": "^8.3.0",
     "keypair": "^1.0.1",
     "mocha": "^5.2.0",

--- a/backend/test/acceptance/gardener.api.cloudprofiles.spec.js
+++ b/backend/test/acceptance/gardener.api.cloudprofiles.spec.js
@@ -37,9 +37,7 @@ describe('gardener', function () {
       })
 
       afterEach(function () {
-        nocks.verify()
-        nocks.reset()
-        sandbox.restore()
+        verifyAndRestore(sandbox)
       })
 
       it('should return all cloudprofiles', function () {

--- a/backend/test/acceptance/gardener.api.domains.spec.js
+++ b/backend/test/acceptance/gardener.api.domains.spec.js
@@ -37,9 +37,7 @@ describe('gardener', function () {
       })
 
       afterEach(function () {
-        nocks.verify()
-        nocks.reset()
-        sandbox.restore()
+        verifyAndRestore(sandbox)
       })
 
       it('should return all domains', function () {

--- a/backend/test/acceptance/gardener.api.info.spec.js
+++ b/backend/test/acceptance/gardener.api.info.spec.js
@@ -36,8 +36,7 @@ describe('gardener', function () {
       })
 
       afterEach(function () {
-        nocks.verify()
-        nocks.reset()
+        verifyAndRestore()
       })
 
       it('should reject requests without authorization header', async function () {

--- a/backend/test/acceptance/gardener.api.infrastructureSecrets.spec.js
+++ b/backend/test/acceptance/gardener.api.infrastructureSecrets.spec.js
@@ -51,9 +51,7 @@ describe('gardener', function () {
       })
 
       afterEach(function () {
-        nocks.verify()
-        nocks.reset()
-        sandbox.restore()
+        verifyAndRestore(sandbox)
       })
 
       it('should return three infrastructure secrets', function () {

--- a/backend/test/acceptance/gardener.api.members.spec.js
+++ b/backend/test/acceptance/gardener.api.members.spec.js
@@ -48,8 +48,7 @@ describe('gardener', function () {
       })
 
       afterEach(function () {
-        nocks.verify()
-        nocks.reset()
+        verifyAndRestore()
       })
 
       it('should return two project members', function () {

--- a/backend/test/acceptance/gardener.api.members.spec.js
+++ b/backend/test/acceptance/gardener.api.members.spec.js
@@ -27,12 +27,7 @@ describe('gardener', function () {
       const name = 'bar'
       const project = 'foo'
       const namespace = `garden-${project}`
-      const members = _
-        .chain(k8s.projectMembersList)
-        .find(['metadata.namespace', namespace])
-        .get('subjects', [])
-        .map('name')
-        .value()
+      const members = k8s.readProjectMembers(namespace)
       const metadata = {}
       const username = `${name}@example.org`
       const email = username
@@ -65,7 +60,7 @@ describe('gardener', function () {
           })
       })
 
-      it('should return empty member list', function () {
+      it('should not return members but respond "Namespace not found"', function () {
         const namespace = 'garden-baz'
         oidc.stub.getKeys()
         k8s.stub.getMembers({bearer, namespace})
@@ -74,9 +69,9 @@ describe('gardener', function () {
           .set('authorization', `Bearer ${bearer}`)
           .catch(err => err.response)
           .then(res => {
-            expect(res).to.have.status(200)
+            expect(res).to.have.status(404)
             expect(res).to.be.json
-            expect(res.body).to.eql([])
+            expect(res.body.message).to.equal('Namespace not found')
           })
       })
 

--- a/backend/test/acceptance/gardener.api.projects.spec.js
+++ b/backend/test/acceptance/gardener.api.projects.spec.js
@@ -46,8 +46,7 @@ describe('gardener', function () {
       })
 
       afterEach(function () {
-        nocks.verify()
-        nocks.reset()
+        verifyAndRestore()
       })
 
       it('should return two projects', function () {
@@ -81,7 +80,7 @@ describe('gardener', function () {
       it('should return the foo project', function () {
         const resourceVersion = 42
         oidc.stub.getKeys()
-        k8s.stub.getProject({bearer, namespace})
+        k8s.stub.getProject({bearer, name, namespace})
         return chai.request(app)
           .get(`/api/namespaces/${namespace}`)
           .set('authorization', `Bearer ${bearer}`)
@@ -93,10 +92,10 @@ describe('gardener', function () {
           })
       })
 
-      it('should reject request with authorization error', function () {
+      it.only('should reject request with authorization error', function () {
         const bearer = oidc.sign({email: 'baz@example.org'})
         oidc.stub.getKeys()
-        k8s.stub.getProject({bearer, namespace, unauthorized: true})
+        k8s.stub.getProject({bearer, name, namespace, unauthorized: true})
         return chai.request(app)
           .get(`/api/namespaces/${namespace}`)
           .set('authorization', `Bearer ${bearer}`)

--- a/backend/test/acceptance/gardener.api.shoots.spec.js
+++ b/backend/test/acceptance/gardener.api.shoots.spec.js
@@ -67,9 +67,7 @@ describe('gardener', function () {
       })
 
       afterEach(function () {
-        nocks.verify()
-        nocks.reset()
-        sandbox.restore()
+        verifyAndRestore(sandbox)
       })
 
       it('should return three shoots', function () {

--- a/backend/test/acceptance/gardener.webhook.spec.js
+++ b/backend/test/acceptance/gardener.webhook.spec.js
@@ -67,7 +67,6 @@ describe('gardener', function () {
     const sandbox = sinon.createSandbox()
 
     before(function () {
-      nocks.reset()
       app = global.createServer()
     })
 
@@ -82,9 +81,7 @@ describe('gardener', function () {
     })
 
     afterEach(function () {
-      nocks.verify()
-      nocks.reset()
-      sandbox.restore()
+      verifyAndRestore(sandbox)
     })
 
     it('should initialize the cache with all open issues', function () {

--- a/backend/test/support/index.js
+++ b/backend/test/support/index.js
@@ -26,8 +26,19 @@ delete process.env.https_proxy
 /*!
  * Common modules
  */
+
 global.sinon = require('sinon')
 global.nocks = require('./nocks')()
+function verifyAndRestore (sandbox) {
+  try {
+    global.nocks.verifyAndCleanAll()
+  } finally {
+    if (sandbox) {
+      sandbox.restore()
+    }
+  }
+}
+global.verifyAndRestore = verifyAndRestore
 
 /*!
  * Attach chai to global

--- a/backend/test/support/nocks/index.js
+++ b/backend/test/support/nocks/index.js
@@ -22,8 +22,7 @@ exports = module.exports = init
 exports.oidc = require('./oidc')
 exports.k8s = require('./k8s')
 exports.github = require('./github')
-exports.verify = verify
-exports.reset = reset
+exports.verifyAndCleanAll = verifyAndCleanAll
 
 function init () {
   nock.disableNetConnect()
@@ -31,15 +30,14 @@ function init () {
   return exports
 }
 
-function verify () {
-  /* eslint no-unused-expressions: 0 */
-  const isDone = nock.isDone()
-  if (!isDone) {
-    console.error('pending mocks: %j', nock.pendingMocks())
+function verifyAndCleanAll () {
+  try {
+    // eslint-disable-next-line no-unused-expressions
+    expect(nock.isDone()).to.be.true
+  } catch (err) {
+    console.error('pending mocks:', nock.pendingMocks())
+    throw err
+  } finally {
+    nock.cleanAll()
   }
-  expect(isDone).to.be.true
-}
-
-function reset () {
-  nock.cleanAll()
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The new project resource has the `gardener` as initializer. The corresponding namespace and the RBAC role bindings are created later on. The dashboard has to wait until the initializer is ready before the project can be used. Only the project owner is allowed to modify the project. Project members are only allowed to read the project. Every authenticated user can create project resources.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```improvement user
Project members are not allowed to modify the project anymore. This can only be done by the owner. Project creation takes some time (a few seconds).
```
