### PR TITLE
Use project name as context name in kubeconfig of technical users

### DIFF
--- a/backend/lib/services/projects.js
+++ b/backend/lib/services/projects.js
@@ -176,3 +176,12 @@ exports.remove = async function ({user, name}) {
   await core.namespaces.delete({name})
   return fromResource({metadata: {name}})
 }
+
+exports.projectName = async function ({user, namespace}) {
+  await authorize({user, namespace})
+  // read namespace
+  const ns = await core.namespaces.get({name: namespace})
+  // eslint-disable-next-line lodash/path-style
+  console.log(ns)
+  return _.get(ns, ['metadata', 'labels', 'project.garden.sapcloud.io/name'])
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #125 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement user
Use project name as context name in Kubeconfig of technical users
```
