### PR TITLE
 align kubernetes version on cluster details with other tiles

### DIFF
--- a/frontend/src/components/ShootListRow.vue
+++ b/frontend/src/components/ShootListRow.vue
@@ -93,7 +93,7 @@ limitations under the License.
       <v-layout align-center justify-end row fill-height>
         <v-tooltip top>
           <v-btn small icon class="cyan--text text--darken-2" slot="activator" :disabled="isClusterAccessDialogDisabled" @click="showDialog('access')">
-            <v-icon>mdi-shield-key-outline</v-icon>
+            <v-icon size="22">mdi-key</v-icon>
           </v-btn>
           <span>{{showClusterAccessActionTitle}}</span>
         </v-tooltip>

--- a/frontend/src/components/ShootListRow.vue
+++ b/frontend/src/components/ShootListRow.vue
@@ -66,7 +66,7 @@ limitations under the License.
       </div>
     </td>
     <td class="nowrap text-xs-center" v-if="this.headerVisible['k8sVersion']">
-      <shoot-version :k8sVersion="row.k8sVersion" :shootName="row.name" :shootNamespace="row.namespace" :availableK8sUpdates="row.availableK8sUpdates"></shoot-version>
+      <shoot-version :shoot-item="shootItem"></shoot-version>
     </td>
     <td class="nowrap text-xs-center" v-if="this.headerVisible['readiness']">
       <status-tags :conditions="row.conditions"></status-tags>
@@ -122,7 +122,6 @@ import get from 'lodash/get'
 import includes from 'lodash/includes'
 import { getTimestampFormatted,
   getCloudProviderKind,
-  availableK8sUpdatesForShoot,
   getCreatedBy,
   isHibernated,
   isReconciliationDeactivated,
@@ -179,8 +178,6 @@ export default {
         region: get(spec, 'cloud.region'),
         isHibernated: isHibernated(spec),
         info,
-        availableK8sUpdates: availableK8sUpdatesForShoot(spec),
-        k8sVersion: get(spec, 'kubernetes.version'),
         purpose: get(metadata, ['annotations', 'garden.sapcloud.io/purpose']),
         lastUpdatedJournalTimestamp: this.lastUpdatedJournalByNameAndNamespace(this.shootItem.metadata),
         journalsLabels: this.journalsLabels(this.shootItem.metadata),

--- a/frontend/src/components/ShootVersion.vue
+++ b/frontend/src/components/ShootVersion.vue
@@ -18,6 +18,7 @@ limitations under the License.
   <div>
     <v-tooltip top>
       <v-btn
+        v-if="chipStyle"
         slot="activator"
         class="update_btn"
         :class="buttonInactive"
@@ -26,14 +27,24 @@ limitations under the License.
         @click="showUpdateDialog"
         :outline="!k8sPatchAvailable"
         :dark="k8sPatchAvailable"
+        :ripple="canUpdate"
         depressed
-        color="cyan darken-2">
-          <v-icon small v-if="availableK8sUpdates">arrow_drop_up</v-icon>
-          {{k8sVersion}}
+        color="cyan darken-2"
+      >
+        <v-icon small v-if="availableK8sUpdates">arrow_drop_up</v-icon>
+        {{k8sVersion}}
       </v-btn>
-      <span v-if="k8sPatchAvailable">Kubernetes patch available</span>
-      <span v-else-if="availableK8sUpdates">Kubernetes upgrade available</span>
-      <span v-else>Kubernetes version up to date</span>
+      <v-btn
+        v-else-if="!!availableK8sUpdates"
+        slot="activator"
+        @click="showUpdateDialog"
+        icon
+        :disabled="isShootMarkedForDeletion"
+      >
+        <v-icon v-if="k8sPatchAvailable">mdi-arrow-up-bold-circle</v-icon>
+        <v-icon v-else>mdi-arrow-up-bold-circle-outline</v-icon>
+      </v-btn>
+      <span>{{tooltipText}}</span>
     </v-tooltip>
     <confirm-dialog
       :confirm="confirm"
@@ -76,8 +87,12 @@ limitations under the License.
 <script>
 import ShootVersionUpdate from '@/components/ShootVersionUpdate'
 import ConfirmDialog from '@/dialogs/ConfirmDialog'
-import get from 'lodash/get'
 import { updateShootVersion } from '@/utils/api'
+import {
+  availableK8sUpdatesForShoot,
+  isShootMarkedForDeletion
+} from '@/utils'
+import get from 'lodash/get'
 
 export default {
   components: {
@@ -85,17 +100,12 @@ export default {
     ConfirmDialog
   },
   props: {
-    availableK8sUpdates: {
+    shootItem: {
       type: Object
     },
-    k8sVersion: {
-      type: String
-    },
-    shootName: {
-      type: String
-    },
-    shootNamespace: {
-      type: String
+    chipStyle: {
+      type: Boolean,
+      default: true
     }
   },
   data () {
@@ -117,10 +127,39 @@ export default {
       return false
     },
     buttonInactive () {
-      return this.availableK8sUpdates ? '' : 'update_btn_inactive'
+      return this.canUpdate ? '' : 'update_btn_inactive'
+    },
+    canUpdate () {
+      return !!this.availableK8sUpdates && !this.isShootMarkedForDeletion
     },
     confirm () {
       return this.confirmRequired ? this.shootName : undefined
+    },
+    k8sVersion () {
+      return get(this.shootItem, 'spec.kubernetes.version')
+    },
+    availableK8sUpdates () {
+      return availableK8sUpdatesForShoot(get(this.shootItem, 'spec'))
+    },
+    shootName () {
+      return get(this.shootItem, 'metadata.name')
+    },
+    shootNamespace () {
+      return get(this.shootItem, 'metadata.namespace')
+    },
+    isShootMarkedForDeletion () {
+      return isShootMarkedForDeletion(get(this.shootItem, 'metadata'))
+    },
+    tooltipText () {
+      if (this.k8sPatchAvailable) {
+        return 'Kubernetes patch available'
+      }
+      else if (this.availableK8sUpdates) {
+        return 'Kubernetes upgrade available'
+      }
+      else {
+        return 'Kubernetes version up to date'
+      }
     }
   },
   methods: {
@@ -137,7 +176,7 @@ export default {
       this.confirmRequired = value
     },
     showUpdateDialog () {
-      if (this.availableK8sUpdates) {
+      if (this.canUpdate) {
         this.updateDialog = true
       }
     },

--- a/frontend/src/pages/ShootItemCards.vue
+++ b/frontend/src/pages/ShootItemCards.vue
@@ -59,13 +59,14 @@ limitations under the License.
             <v-divider class="my-2" inset></v-divider>
             <v-list-tile>
               <v-list-tile-action>
-                <v-icon class="cyan--text text--darken-2">mdi-ship-wheel</v-icon>
+                <v-icon class="cyan--text text--darken-2">mdi-cube-outline</v-icon>
               </v-list-tile-action>
               <v-list-tile-content>
-                <v-list-tile-title>Kubernetes Version</v-list-tile-title>
+                <v-list-tile-sub-title>Kubernetes Version</v-list-tile-sub-title>
+                <v-list-tile-title>{{k8sVersion}}</v-list-tile-title>
               </v-list-tile-content>
               <v-list-tile-action>
-                <shoot-version :k8sVersion="k8sVersion" :shootName="metadata.name" :shootNamespace="metadata.namespace" :availableK8sUpdates="availableK8sUpdates"></shoot-version>
+                <shoot-version :shoot-item="item" :chip-style="false"></shoot-version>
               </v-list-tile-action>
             </v-list-tile>
 
@@ -324,7 +325,6 @@ import {
   getDateFormatted,
   getCloudProviderKind,
   canLinkToSeed,
-  availableK8sUpdatesForShoot,
   isSelfTerminationWarning,
   isValidTerminationDate,
   getTimeStringTo
@@ -492,9 +492,6 @@ export default {
       } catch (err) {
         return []
       }
-    },
-    availableK8sUpdates () {
-      return availableK8sUpdatesForShoot(get(this.item, 'spec'))
     },
     k8sVersion () {
       return get(this.item, 'spec.kubernetes.version')


### PR DESCRIPTION
**What this PR does / why we need it**:
align kubernetes version on cluster details with other tiles

**Which issue(s) this PR fixes**:
Fixes #214

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
NONE
```
