### PR TITLE
fixes #244

### DIFF
--- a/backend/lib/services/projects.js
+++ b/backend/lib/services/projects.js
@@ -156,8 +156,8 @@ function isProjectReady ({status: {phase} = {}} = {}) {
   return phase === 'Ready'
 }
 
-function waitUntilProjectIsReady (projects, name) {
-  const reconnector = exports.watchProject(projects, name)
+function waitUntilProjectIsReady (name) {
+  const reconnector = exports.watchProject(name)
   const projectInitializationTimeout = exports.projectInitializationTimeout
 
   return new Promise((resolve, reject) => {
@@ -221,12 +221,12 @@ exports.create = async function ({user, body}) {
   // project name
   const name = project.metadata.name
   // wait until project is ready
-  project = await waitUntilProjectIsReady(projects, name)
+  project = await waitUntilProjectIsReady(name)
   // project is ready now
   return fromResource(project)
 }
 // needs to be exported for testing
-exports.watchProject = (projects, name) => projects.watch({name})
+exports.watchProject = name => garden.projects.watch({name})
 exports.projectInitializationTimeout = PROJECT_INITIALIZATION_TIMEOUT
 
 exports.read = async function ({user, name: namespace}) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Normal users can create projects without error. Use the serviceaccount instead of the current user to watch a newly created project.

**Which issue(s) this PR fixes**:
Fixes #244 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
The user now no longer receives the error 403 when creating a new project (fixes the issue #244)
```
