### PR TITLE
Disable create button if user has not enough priviliges

### DIFF
--- a/backend/lib/io.js
+++ b/backend/lib/io.js
@@ -21,8 +21,9 @@ const socketIO = require('socket.io')
 const socketIOAuth = require('socketio-auth')
 const logger = require('./logger')
 const { jwt } = require('./middleware')
-const { projects, shoots, journals, administrators } = require('./services')
+const { projects, shoots, journals, authorization } = require('./services')
 const { getIssueComments } = journals
+const { isAdmin } = authorization
 const watches = require('./watches')
 const { EventsEmitter, NamespacedBatchEmitter } = require('./utils/batchEmitter')
 const { getJournalCache } = require('./cache')
@@ -205,7 +206,7 @@ function setupShootsNamespace (shootsNsp) {
         const projectList = await projects.list({user})
         const namespaces = _.map(projectList, 'metadata.namespace')
 
-        if (await administrators.isAdmin(user)) {
+        if (await isAdmin(user)) {
           subscribeShootsAdmin({socket, user, namespaces, filter})
         } else {
           const namespacesAndFilters = _.map(namespaces, (namespace) => { return { namespace, filter } })
@@ -280,7 +281,7 @@ function setupJournalsNamespace (journalsNsp) {
 
       const user = getUserFromSocket(socket)
       try {
-        if (await administrators.isAdmin(user)) {
+        if (await isAdmin(user)) {
           joinRoom(socket, 'issues')
 
           const batchEmitter = new EventsEmitter({kind, socket})
@@ -301,7 +302,7 @@ function setupJournalsNamespace (journalsNsp) {
 
       const user = getUserFromSocket(socket)
       try {
-        if (await administrators.isAdmin(user)) {
+        if (await isAdmin(user)) {
           const room = `comments_${namespace}/${name}`
           joinRoom(socket, room)
 

--- a/backend/lib/kubernetes/Resources.js
+++ b/backend/lib/kubernetes/Resources.js
@@ -27,6 +27,11 @@ module.exports = {
     kind: 'Secret',
     apiVersion: 'v1'
   },
+  SelfSubjectAccessReview: {
+    name: 'selfsubjectaccessreviews',
+    kind: 'SelfSubjectAccessReview',
+    apiVersion: 'authorization.k8s.io/v1'
+  },
   RoleBinding: {
     name: 'rolebindings',
     kind: 'RoleBinding',

--- a/backend/lib/routes/userInfo.js
+++ b/backend/lib/routes/userInfo.js
@@ -18,7 +18,7 @@
 
 const express = require('express')
 
-const { administrators } = require('../services')
+const { authorization } = require('../services')
 const router = module.exports = express.Router({
   mergeParams: true
 })
@@ -27,8 +27,16 @@ router.route('/')
   .get(async (req, res, next) => {
     try {
       const user = req.user
+      const [
+        isAdmin,
+        canCreateProject
+      ] = await Promise.all([
+        authorization.isAdmin(user),
+        authorization.canCreateProject(user)
+      ])
       res.send({
-        isAdmin: await administrators.isAdmin(user)
+        isAdmin,
+        canCreateProject
       })
     } catch (err) {
       next(err)

--- a/backend/lib/services/authorization.js
+++ b/backend/lib/services/authorization.js
@@ -35,6 +35,7 @@ async function hasAuthorization (user, resourceAttributes) {
 }
 
 exports.isAdmin = async function (user) {
+  // if someone is allowed to delete shoots in all namespaces he is considered to be an administrator
   return hasAuthorization(user, {
     verb: 'delete',
     group: 'garden.sapcloud.io',

--- a/backend/lib/services/authorization.js
+++ b/backend/lib/services/authorization.js
@@ -18,28 +18,34 @@
 
 const _ = require('lodash')
 const kubernetes = require('../kubernetes')
+const Resources = kubernetes.Resources
 
 function Authorization ({auth}) {
   return kubernetes.authorization({auth})
 }
 
-exports.isAdmin = async function (user) {
+async function hasAuthorization (user, resourceAttributes) {
   if (!user) {
     return false
   }
-  // if someone is allowed to delete shoots in all namespaces he is considered to be an administrator
-  const body = {
-    kind: 'SelfSubjectAccessReview',
-    apiVersion: 'authorization.k8s.io/v1',
-    spec: {
-      resourceAttributes: {
-        verb: 'delete',
-        group: 'garden.sapcloud.io',
-        resource: 'shoots'
-      }
-    }
-  }
+  const { apiVersion, kind } = Resources.SelfSubjectAccessReview
+  const body = { kind, apiVersion, spec: { resourceAttributes } }
   const response = await Authorization(user).selfsubjectaccessreviews.post({ body })
-  const isAdmin = _.get(response, 'status.allowed', false)
-  return isAdmin
+  return _.get(response, 'status.allowed', false)
+}
+
+exports.isAdmin = async function (user) {
+  return hasAuthorization(user, {
+    verb: 'delete',
+    group: 'garden.sapcloud.io',
+    resource: 'shoots'
+  })
+}
+
+exports.canCreateProject = async function (user) {
+  return hasAuthorization(user, {
+    verb: 'create',
+    group: 'garden.sapcloud.io',
+    resource: 'projects'
+  })
 }

--- a/backend/lib/services/index.js
+++ b/backend/lib/services/index.js
@@ -21,7 +21,7 @@ module.exports = {
   shoots: require('./shoots'),
   infrastructureSecrets: require('./infrastructureSecrets'),
   members: require('./members'),
-  administrators: require('./administrators'),
+  authorization: require('./authorization'),
   journals: require('./journals'),
   customAddonDefinitions: require('./customAddonDefinitions')
 }

--- a/backend/lib/services/projects.js
+++ b/backend/lib/services/projects.js
@@ -24,7 +24,7 @@ const core = kubernetes.core()
 const { PreconditionFailed, NotFound, GatewayTimeout, InternalServerError } = require('../errors')
 const logger = require('../logger')
 const shoots = require('./shoots')
-const administrators = require('./administrators')
+const authorization = require('./authorization')
 
 const PROJECT_INITIALIZATION_TIMEOUT = 30 * 1000
 
@@ -116,7 +116,7 @@ exports.list = async function ({user, qs = {}}) {
     isAdmin
   ] = await Promise.all([
     garden.projects.get(),
-    administrators.isAdmin(user)
+    authorization.isAdmin(user)
   ])
 
   const isMemberOf = project => _

--- a/backend/lib/services/shoots.js
+++ b/backend/lib/services/shoots.js
@@ -19,7 +19,7 @@
 const kubernetes = require('../kubernetes')
 const { decodeBase64 } = require('../utils')
 const { getSeeds } = require('../cache')
-const administrators = require('./administrators')
+const authorization = require('./authorization')
 const _ = require('lodash')
 
 function Garden ({auth}) {
@@ -62,7 +62,7 @@ exports.list = async function ({user, namespace, shootsWithIssuesOnly = false}) 
   if (namespace) {
     return Garden(user).namespaces(namespace).shoots.get({qs})
   } else {
-    // only works if user is member of garden-administrators (admin)
+    // only works if user is member of garden-authorization (admin)
     return Garden(user).shoots.get({qs})
   }
 }
@@ -209,7 +209,7 @@ exports.info = async function ({user, namespace, name}) {
     data.serverUrl = kubernetes.fromKubeconfig(data.kubeconfig).url
   }
 
-  const isAdmin = await administrators.isAdmin(user)
+  const isAdmin = await authorization.isAdmin(user)
   if (isAdmin) {
     const seedSecretName = _.get(seed, 'spec.secretRef.name')
     const seedSecretNamespace = _.get(seed, 'spec.secretRef.namespace')

--- a/backend/lib/services/shoots.js
+++ b/backend/lib/services/shoots.js
@@ -62,7 +62,7 @@ exports.list = async function ({user, namespace, shootsWithIssuesOnly = false}) 
   if (namespace) {
     return Garden(user).namespaces(namespace).shoots.get({qs})
   } else {
-    // only works if user is member of garden-authorization (admin)
+    // only works if user is member of garden-administrators (admin)
     return Garden(user).shoots.get({qs})
   }
 }

--- a/frontend/src/components/MainNavigation.vue
+++ b/frontend/src/components/MainNavigation.vue
@@ -94,10 +94,20 @@ limitations under the License.
             </v-list-tile>
           </v-list>
           <v-card-actions class="grey lighten-3">
-            <v-btn flat block class="project-add text-xs-left teal--text" :disabled="!canCreateProject" @click.stop="openProjectDialog">
-              <v-icon>add</v-icon>
-              <span class="ml-2">Create new Project</span>
-            </v-btn>
+            <v-tooltip top :disabled="canCreateProject" style="width: 100%">
+              <v-btn
+                slot="activator"
+                flat
+                block
+                class="project-add text-xs-left teal--text"
+                :disabled="!canCreateProject"
+                @click.stop="openProjectDialog"
+              >
+                <v-icon>add</v-icon>
+                <span class="ml-2">Create new Project</span>
+              </v-btn>
+              <span>You are not authorized to create projects</span>
+            </v-tooltip>
           </v-card-actions>
         </v-card>
       </v-menu>

--- a/frontend/src/components/MainNavigation.vue
+++ b/frontend/src/components/MainNavigation.vue
@@ -94,7 +94,7 @@ limitations under the License.
             </v-list-tile>
           </v-list>
           <v-card-actions class="grey lighten-3">
-            <v-btn flat block class="project-add text-xs-left teal--text" @click.stop="openProjectDialog">
+            <v-btn flat block class="project-add text-xs-left teal--text" :disabled="!canCreateProject" @click.stop="openProjectDialog">
               <v-icon>add</v-icon>
               <span class="ml-2">Create new Project</span>
             </v-btn>
@@ -168,6 +168,7 @@ export default {
       'cfg'
     ]),
     ...mapGetters([
+      'canCreateProject',
       'projectList'
     ]),
     footerLogoUrl () {

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -19,9 +19,17 @@ limitations under the License.
     <v-card class="mt-2">
       <v-card-text>
         <h3>Let's get started</h3>
-        <v-btn :disabled="!canCreateProject" @click.native.stop="projectDialog = true">
-          <v-icon class="red--text text--darken-2">mdi-plus</v-icon> Create your first Project
-        </v-btn>
+        <v-tooltip top :disabled="canCreateProject">
+          <v-btn
+            slot="activator"
+            :disabled="!canCreateProject"
+            @click.native.stop="projectDialog = true"
+          >
+            <v-icon class="red--text text--darken-2">mdi-plus</v-icon>
+            <span class="ml-2">Create your first Project</span>
+          </v-btn>
+          <span>You are not authorized to create projects</span>
+        </v-tooltip>
       </v-card-text>
       <project-create-dialog @submit="onProjectCreated" v-model="projectDialog">
       </project-create-dialog>

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -19,7 +19,7 @@ limitations under the License.
     <v-card class="mt-2">
       <v-card-text>
         <h3>Let's get started</h3>
-        <v-btn @click.native.stop="projectDialog = true">
+        <v-btn :disabled="!canCreateProject" @click.native.stop="projectDialog = true">
           <v-icon class="red--text text--darken-2">mdi-plus</v-icon> Create your first Project
         </v-btn>
       </v-card-text>
@@ -50,6 +50,7 @@ export default {
     ]),
     ...mapGetters([
       'username',
+      'canCreateProject',
       'namespaces'
     ])
   },

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -142,7 +142,8 @@ export default function createRouter ({ store, userManager }) {
           meta: {
             title: 'Home',
             namespaced: false,
-            projectScope: false
+            projectScope: false,
+            breadcrumb: true
           }
         },
         {

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -192,6 +192,9 @@ const getters = {
   isAdmin (state) {
     return get(state.user, 'info.isAdmin', false)
   },
+  canCreateProject (state) {
+    return get(state.user, 'info.canCreateProject', false)
+  },
   journalList (state) {
     return state.journals.all
   },


### PR DESCRIPTION
**What this PR does / why we need it**:
If a user has not enough privileges to create a project, the create project button is disabled.

**Which issue(s) this PR fixes**:
Fixes #234 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
The create project button is only enabled, if a user has not enough privileges to create a project (this fixes issue #234).
```
