### PR TITLE
Use project name as context name in kubeconfig of technical users

### DIFF
--- a/backend/lib/services/members.js
+++ b/backend/lib/services/members.js
@@ -21,8 +21,8 @@ const yaml = require('js-yaml')
 const config = require('../config')
 const { decodeBase64 } = require('../utils')
 const kubernetes = require('../kubernetes')
-const core = kubernetes.core()
-const { Conflict, NotFound } = require('../errors.js')
+const {getProjectNameFromNamespace} = require('./projects')
+const { Conflict } = require('../errors.js')
 
 function Core ({auth}) {
   return kubernetes.core({auth})
@@ -39,17 +39,6 @@ function fromResource (project = {}) {
     .filter(['kind', 'User'])
     .map('name')
     .value()
-}
-
-async function getProjectNameFromNamespace (namespace) {
-  // read namespace
-  const ns = await core.namespaces.get({name: namespace})
-  // get name of project from namespace label
-  const name = _.get(ns, ['metadata', 'labels', 'project.garden.sapcloud.io/name'])
-  if (!name) {
-    throw new NotFound(`Namespace '${namespace}' is not related to a gardener project`)
-  }
-  return name
 }
 
 function getKubeconfig ({serviceaccountName, projectName, serviceaccountNamespace, token, server, caData}) {

--- a/backend/lib/services/members.js
+++ b/backend/lib/services/members.js
@@ -52,7 +52,7 @@ async function getProjectNameFromNamespace (namespace) {
   return name
 }
 
-function getKubeconfig ({serviceaccountName, serviceaccountNamespace, token, server, caData}) {
+function getKubeconfig ({serviceaccountName, projectName, serviceaccountNamespace, token, server, caData}) {
   const clusterName = 'garden'
   const cluster = {
     'certificate-authority-data': caData,
@@ -62,7 +62,7 @@ function getKubeconfig ({serviceaccountName, serviceaccountNamespace, token, ser
   const user = {
     token
   }
-  const contextName = 'default'
+  const contextName = projectName || 'default'
   const context = {
     cluster: clusterName,
     user: userName,
@@ -167,6 +167,7 @@ exports.get = async function ({user, namespace, name: username}) {
     const serviceaccount = await ns.serviceaccounts.get({
       name: serviceaccountName
     })
+    const projectName = await getProjectNameFromNamespace(namespace)
     const api = ns.serviceaccounts.api
     const server = _.get(config, 'apiServerUrl', api.url)
     const secret = await ns.secrets.get({
@@ -175,7 +176,7 @@ exports.get = async function ({user, namespace, name: username}) {
     const token = decodeBase64(secret.data.token)
     const caData = secret.data['ca.crt']
     member.kind = 'ServiceAccount'
-    member.kubeconfig = getKubeconfig({serviceaccountName, serviceaccountNamespace, token, caData, server})
+    member.kubeconfig = getKubeconfig({serviceaccountName, projectName, serviceaccountNamespace, token, caData, server})
   }
   return member
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #125 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement user
Use project name as context name in kubeconfig of technical users
```