### PR TITLE
Remove deprecated addons

### DIFF
--- a/frontend/src/dialogs/CreateClusterDialog.vue
+++ b/frontend/src/dialogs/CreateClusterDialog.vue
@@ -439,25 +439,11 @@ const validationErrors = {
 
 const standardAddonDefinitionList = [
   {
-    name: 'cluster-autoscaler',
-    title: 'Cluster Autoscaler',
-    description: 'Cluster Autoscaler is a tool that automatically adjusts the size of the Kubernetes cluster.',
-    visible: false,
-    enabled: true
-  },
-  {
     name: 'kubernetes-dashboard',
     title: 'Dashboard',
     description: 'General-purpose web UI for Kubernetes clusters.',
     visible: true,
     enabled: true
-  },
-  {
-    name: 'monocular',
-    title: 'Monocular',
-    description: 'Monocular is a web-based UI for managing Kubernetes applications and services packaged as Helm Charts. It allows you to search and discover available charts from multiple repositories, and install them in your cluster with one click.',
-    visible: true,
-    enabled: false
   },
   {
     name: 'nginx-ingress',

--- a/frontend/src/pages/ShootItemCards.vue
+++ b/frontend/src/pages/ShootItemCards.vue
@@ -350,16 +350,6 @@ export default {
     return {
       addonList: [
         {
-          name: 'cluster-autoscaler',
-          title: 'Cluster Autoscaler',
-          description: 'Cluster Autoscaler is a tool that automatically adjusts the size of the Kubernetes cluster.'
-        },
-        {
-          name: 'kube-lego',
-          title: 'Kube Lego',
-          description: 'Kube-Lego automatically requests certificates for Kubernetes Ingress resources from Let\'s Encrypt.'
-        },
-        {
           name: 'kubernetes-dashboard',
           title: 'Dashboard',
           description: 'General-purpose web UI for Kubernetes clusters.'


### PR DESCRIPTION
**What this PR does / why we need it**:
Gardener has deprecated all addons except `kubernetes-dashboard` and `nginx-ingress`, hence we should remove the deprecated addons from the create cluster list.
On the cluster details page show the addons `kubernetes-dashboard` and `nginx-ingress` if enabled. For "old" clusters, the deprecated  `monocular` addon is shown if enabled.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
see https://github.com/gardener/gardener/pull/471

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
Removed deprecated addons from create cluster dialog and cluster details page. (See also gardener/gardener#471)
```
