### PR TITLE
set env var NODE_END for release job

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -30,6 +30,10 @@ dashboard:
       traits:
         pull-request: ~
     release:
+      steps:
+        build:
+          vars:
+            NODE_ENV: '"production"'
       traits:
         version:
           preprocess: 'finalize'


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Passes a flag to npm to indicate the build is "productive" during release builds

