### PR TITLE
Add iam:CreateServiceLinkedRole to the required AWS permissions

### DIFF
--- a/frontend/src/dialogs/SecretDialogAwsHelp.vue
+++ b/frontend/src/dialogs/SecretDialogAwsHelp.vue
@@ -87,6 +87,7 @@ export default {
               'iam:CreatePolicy',
               'iam:CreatePolicyVersion',
               'iam:CreateRole',
+              'iam:CreateServiceLinkedRole',
               'iam:AddRoleToInstanceProfile',
               'iam:AttachRolePolicy',
               'iam:DetachRolePolicy',


### PR DESCRIPTION
**What this PR does / why we need it**: Another `iam` permission is needed for AWS shoots.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy user
The required permissions for AWS shoot clusters have been updated. Please take a look at the AWS help dialog on the secrets page.
```
