### PR TITLE
Allow providing a dedicated kubeconfig in dashboard chart

### DIFF
--- a/charts/gardener-dashboard/templates/deployment.yaml
+++ b/charts/gardener-dashboard/templates/deployment.yaml
@@ -54,7 +54,15 @@ spec:
           - key: webhookSecret
             path: webhookSecret
       {{- end }}
+      {{- if .Values.kubeconfig }}
+      - name: gardener-dashboard-secret-kubeconfig
+        secret:
+          secretName: gardener-dashboard-kubeconfig
+      {{- end }}
       serviceAccountName: gardener-dashboard
+      {{- if .Values.kubeconfig }}
+      automountServiceAccountToken: false
+      {{- end }}
       containers:
         - name: gardener-dashboard
           command:
@@ -67,6 +75,11 @@ spec:
             - name: http
               containerPort: {{ .Values.containerPort }}
               protocol: TCP
+          {{- if .Values.kubeconfig }}
+          env:
+          - name: KUBECONFIG
+            value: /etc/gardener-dashboard/secrets/kubeconfig/kubeconfig
+          {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           volumeMounts:
@@ -80,6 +93,11 @@ spec:
           {{- if .Values.gitHub }}
           - name: gardener-dashboard-secret-github
             mountPath: /etc/gardener-dashboard/secrets/gitHub
+            readOnly: true
+          {{- end }}
+          {{- if .Values.kubeconfig }}
+          - name: gardener-dashboard-secret-kubeconfig
+            mountPath: /etc/gardener-dashboard/secrets/kubeconfig
             readOnly: true
           {{- end }}
       restartPolicy: Always

--- a/charts/gardener-dashboard/templates/secret-kubeconfig.yaml
+++ b/charts/gardener-dashboard/templates/secret-kubeconfig.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.kubeconfig }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gardener-dashboard-kubeconfig
+  namespace: garden
+  labels:
+    app: gardener-dashboard
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  kubeconfig: {{ required ".Values.kubeconfig is required" (b64enc .Values.kubeconfig) }}
+{{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**: Allow providing a dedicated kubeconfig in dashboard chart

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
NONE
```
