### PR TITLE
Better support for other OIDC providers

### DIFF
--- a/backend/lib/app.js
+++ b/backend/lib/app.js
@@ -33,16 +33,25 @@ const jwt = require('express-jwt')
 // resolve pathnames
 const PUBLIC_DIRNAME = resolve(join(__dirname, '..', 'public'))
 const INDEX_FILENAME = join(PUBLIC_DIRNAME, 'index.html')
+// csp sources
 const connectSrc = ['\'self\'', 'wss:', 'ws:'] // TODO allow ws connections only to backend
-const issuerUrl = _.get(config, 'jwt.issuer')
-if (issuerUrl) {
-  connectSrc.push(issuerUrl)
+const authorityUrl = _.get(config, 'frontend.oidc.authority')
+if (authorityUrl) {
+  const authorityUrlOrigin = new URL(authorityUrl).origin
+  connectSrc.push(authorityUrlOrigin)
 }
-let imgSrc = ['\'self\'', 'data:', 'https://www.gravatar.com']
+const jwksUri = _.get(config, 'jwks.jwksUri')
+if (jwksUri) {
+  const jwksUriOrigin = new URL(jwksUri).origin
+  if (!_.includes(connectSrc, jwksUriOrigin)) {
+    connectSrc.push(jwksUriOrigin)
+  }
+}
+const imgSrc = ['\'self\'', 'data:', 'https://www.gravatar.com']
 const gitHubRepoUrl = _.get(config, 'frontend.gitHubRepoUrl')
 if (gitHubRepoUrl) {
   const gitHubOrigin = new URL(gitHubRepoUrl).origin
-  imgSrc = _.concat(imgSrc, gitHubOrigin)
+  imgSrc.push(gitHubOrigin)
 }
 
 // configure app

--- a/charts/gardener-dashboard/templates/configmap.yaml
+++ b/charts/gardener-dashboard/templates/configmap.yaml
@@ -72,7 +72,7 @@ data:
 {{- else }}
         scope: "openid email profile groups audience:server:client_id:{{ .Values.oidc.clientId }} audience:server:client_id:kube-kubectl"
 {{- end }}
-{{- if .Values.oidc.loadUserInfo }}
+{{- if hasKey .Values.oidc "loadUserInfo" }}
         loadUserInfo: {{ .Values.oidc.loadUserInfo }}
 {{- else }}
         loadUserInfo: false

--- a/charts/gardener-dashboard/templates/configmap.yaml
+++ b/charts/gardener-dashboard/templates/configmap.yaml
@@ -51,12 +51,32 @@ data:
       dashboardUrl:
         pathname: /api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy
       oidc:
+{{- if .Values.oidc.authority }}
+        authority: {{ .Values.oidc.authority }}
+{{- else }}
         authority: {{ .Values.oidc.issuerUrl }}
+{{- end }}
         client_id: {{ .Values.oidc.clientId }}
+{{- if .Values.oidc.redirectUri }}
+        redirect_uri: {{ .Values.oidc.redirectUri }}
+{{- else }}
         redirect_uri: "{{ .Values.oidc.issuerUrl }}/callback"
+{{- end }}
+{{- if .Values.oidc.responseType }}
+        response_type: {{ .Values.oidc.responseType }}
+{{- else }}
         response_type: "token id_token"
+{{- end }}
+{{- if .Values.oidc.scope }}
+        scope: {{ .Values.oidc.scope }}
+{{- else }}
         scope: "openid email profile groups audience:server:client_id:{{ .Values.oidc.clientId }} audience:server:client_id:kube-kubectl"
+{{- end }}
+{{- if .Values.oidc.loadUserInfo }}
+        loadUserInfo: {{ .Values.oidc.loadUserInfo }}
+{{- else }}
         loadUserInfo: false
+{{- end }}
 {{- if .Values.frontendConfig.gitHubRepoUrl }}
       gitHubRepoUrl: {{ .Values.frontendConfig.gitHubRepoUrl }}
 {{- end }}

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -24,7 +24,7 @@ function getAuthorization (user) {
       reject(new TypeError('Argument \'user\' must not be null'))
     } else {
       resolve({
-        Authorization: `${user.token_type} ${user.id_token}`
+        Authorization: `Bearer ${user.id_token}`
       })
     }
   })


### PR DESCRIPTION
**What this PR does / why we need it**:
The helm chart for the dashboard was not supposed to be used with any other OIDC provider than DEX. This PR allows to configure the frontend oidc-client via helm values. If the origin of the jwksUrl was different from the issuerUrl the oidc-client request has been blocked by the csp rule defined in the backend. This PR adds the jwksUrl to the csp rule if necessary. 
The frontend should send the `id_token` always as authorization header with `bearer` schema.

**Which issue(s) this PR fixes**:
Fixes #267

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
It is possible to configure the frontend `oidc-client` via helm values now.
```
