### PR TITLE
Support for OIDC provider that does not allow CORS on the metadata endpoint

### DIFF
--- a/backend/lib/api.js
+++ b/backend/lib/api.js
@@ -25,7 +25,7 @@ const logger = require('./logger')
 const routes = require('./routes')
 const io = require('./io')
 
-const { jwt, attachAuthorization, frontendConfig, notFound, sendError } = require('./middleware')
+const { jwt, attachAuthorization, frontendConfig, jsonWebKeySet, notFound, sendError } = require('./middleware')
 
 // configure router
 const router = express.Router()
@@ -46,5 +46,6 @@ router.use(sendError)
 module.exports = {
   router,
   io,
-  frontendConfig
+  frontendConfig,
+  jsonWebKeySet
 }

--- a/backend/lib/app.js
+++ b/backend/lib/app.js
@@ -72,6 +72,10 @@ app.use(helmet.hsts())
 app.use('/api', api.router)
 app.use('/webhook', githubWebhook.router)
 app.get('/config.json', api.frontendConfig)
+// if CORS is not supported by oidc provider proxy jwks
+if (_.get(config, 'frontend.oidc.metdata.jwks_uri') === '/keys') {
+  app.get('/keys', api.jsonWebKeySet)
+}
 
 if (_.has(config, 'prometheus.secret')) {
   app.get('/metrics',

--- a/backend/lib/middleware.js
+++ b/backend/lib/middleware.js
@@ -46,6 +46,16 @@ async function frontendConfig (req, res, next) {
   res.json(frontendConfig)
 }
 
+async function jsonWebKeySet (req, res, next) {
+  try {
+    const { jwksUri, ca, rejectUnauthorized = true } = config.jwks || {}
+    const response = await got(jwksUri, { json: true, ca, rejectUnauthorized })
+    res.json(response.body)
+  } catch (err) {
+    next(err)
+  }
+}
+
 function attachAuthorization (req, res, next) {
   const [scheme, bearer] = req.headers.authorization.split(' ')
   if (!/bearer/i.test(scheme)) {
@@ -192,6 +202,7 @@ module.exports = {
   jwtSecret,
   attachAuthorization,
   frontendConfig,
+  jsonWebKeySet,
   historyFallback,
   notFound,
   sendError,

--- a/charts/gardener-dashboard/templates/configmap.yaml
+++ b/charts/gardener-dashboard/templates/configmap.yaml
@@ -81,6 +81,14 @@ data:
 {{- else }}
         loadUserInfo: false
 {{- end }}
+{{- if .Values.oidc.metadata }}
+        metadata:
+{{ toYaml .Values.oidc.metadata | indent 10 }}
+{{- end }}
+{{- if .Values.oidc.signingKeys }}
+        signingKeys:
+{{ toYaml .Values.oidc.signingKeys | indent 8 }}
+{{- end }}
 {{- if .Values.frontendConfig.gitHubRepoUrl }}
       gitHubRepoUrl: {{ .Values.frontendConfig.gitHubRepoUrl }}
 {{- end }}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,7 @@
     "marked": "^0.5.1",
     "md5": "^2.2.1",
     "moment-timezone": "^0.5.21",
-    "oidc-client": "^1.5.2",
+    "oidc-client": "^1.5.4",
     "semver": "^5.5.1",
     "semver-sort": "0.0.4",
     "socket.io-client": "^2.2.0",

--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -18,6 +18,9 @@ module.exports = {
       },
       '/config.json': {
         target: 'http://localhost:3030'
+      },
+      '/keys': {
+        target: 'http://localhost:3030'
       }
     }
   }


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
If an OIDC provider does not allow CORS on the metadata endpoint, it should be possible to manually configure the `oidc-client` with these additional settings.
[oidc-client docs](https://github.com/IdentityModel/oidc-client-js/wiki#provider-settings-if-cors-not-supported-on-oidcoauth2-provider-metadata-endpoint)
This PR allows to configure these settings in the helm chart. It also proxies the jwks endpoint of the oidc provider if `oidc.metadata.jwks_uri === '/keys'`
 
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Support for OIDC provider that does not allow CORS on the metadata endpoint
```
