### PR TITLE
Adapt to new shoot condition state label

### DIFF
--- a/backend/lib/services/shoots.js
+++ b/backend/lib/services/shoots.js
@@ -57,7 +57,7 @@ const isUnreservedLabel = _.negate(isReservedLabel)
 exports.list = async function ({ user, namespace, shootsWithIssuesOnly = false }) {
   let qs
   if (shootsWithIssuesOnly) {
-    qs = { labelSelector: 'shoot.garden.sapcloud.io/unhealthy=true' }
+    qs = { labelSelector: 'shoot.garden.sapcloud.io/status' }
   }
   if (namespace) {
     return Garden(user).namespaces(namespace).shoots.get({ qs })

--- a/backend/lib/services/shoots.js
+++ b/backend/lib/services/shoots.js
@@ -57,7 +57,7 @@ const isUnreservedLabel = _.negate(isReservedLabel)
 exports.list = async function ({ user, namespace, shootsWithIssuesOnly = false }) {
   let qs
   if (shootsWithIssuesOnly) {
-    qs = { labelSelector: 'shoot.garden.sapcloud.io/status' }
+    qs = { labelSelector: 'shoot.garden.sapcloud.io/status!=healthy' }
   }
   if (namespace) {
     return Garden(user).namespaces(namespace).shoots.get({ qs })

--- a/backend/lib/utils/index.js
+++ b/backend/lib/utils/index.js
@@ -50,7 +50,7 @@ function getCloudProviderKind (object) {
 }
 
 function shootHasIssue (shoot) {
-  return _.get(shoot, ['metadata', 'labels', 'shoot.garden.sapcloud.io/unhealthy'], false)
+  return _.get(shoot, ['metadata', 'labels', 'shoot.garden.sapcloud.io/status'], 'healthy') !== 'healthy'
 }
 
 module.exports = {

--- a/frontend/src/components/StatusTag.vue
+++ b/frontend/src/components/StatusTag.vue
@@ -15,7 +15,7 @@ limitations under the License.
 -->
 
 <template>
-  <tag :chipText="chipTextShortened" :isError="isError" :isUnknown="isUnknown" :title="chipText" :message="tag.message" :time="tag.lastTransitionTime" :popperKey="popperKeyWithType" :popperPlacement="popperPlacement"></tag>
+  <tag :chipText="chipTextShortened" :isError="isError" :isUnknown="isUnknown" :isProgressing="isProgressing" :title="chipTitle" :message="tag.message" :time="tag.lastTransitionTime" :popperKey="popperKeyWithType" :popperPlacement="popperPlacement"></tag>
 </template>
 
 <script>
@@ -44,6 +44,19 @@ export default {
     chipText () {
       return this.tag.text || ''
     },
+    chipTitle () {
+      const text = this.chipText
+      if (this.isError) {
+        return `[ERROR] ${text}`
+      }
+      if (this.isUnknown) {
+        return `[UNKNOWN] ${text}`
+      }
+      if (this.isProgressing) {
+        return `[PROGRESSING] ${text}`
+      }
+      return text
+    },
     chipTextShortened () {
       if (this.$vuetify.breakpoint.mdAndDown) {
         return this.chipText.charAt(0)
@@ -57,22 +70,22 @@ export default {
       return ''
     },
     isError () {
-      switch (this.tag.status) {
-        case 'True':
-          return false
-        case 'False':
-          return true
-        default:
-          return false
+      if (this.tag.status === 'False') {
+        return true
       }
+      return false
     },
     isUnknown () {
-      switch (this.tag.status) {
-        case 'Unknown':
-          return true
-        default:
-          return false
+      if (this.tag.status === 'Unknown') {
+        return true
       }
+      return false
+    },
+    isProgressing () {
+      if (this.tag.status === 'Progressing') {
+        return true
+      }
+      return false
     },
     popperKeyWithType () {
       return `statusTag_${this.popperKey}`

--- a/frontend/src/components/Tag.vue
+++ b/frontend/src/components/Tag.vue
@@ -33,6 +33,7 @@ limitations under the License.
 
 <script>
 import GPopper from '@/components/GPopper'
+import { mapGetters } from 'vuex'
 
 export default {
   components: {
@@ -48,6 +49,10 @@ export default {
       required: true
     },
     isUnknown: {
+      type: Boolean,
+      required: false
+    },
+    isProgressing: {
       type: Boolean,
       required: false
     },
@@ -76,6 +81,9 @@ export default {
       if (this.isUnknown) {
         return 'grey lighten-1'
       }
+      if (this.isProgressing && this.isAdmin) {
+        return 'blue darken-2'
+      }
       return 'cyan darken-2'
     },
     chipTextColor () {
@@ -85,8 +93,14 @@ export default {
       if (this.isUnknown) {
         return 'grey lighten-1'
       }
+      if (this.isProgressing && this.isAdmin) {
+        return 'blue darken-2'
+      }
       return 'cyan darken-2'
-    }
+    },
+    ...mapGetters([
+      'isAdmin'
+    ])
   }
 }
 </script>

--- a/frontend/src/pages/ShootList.vue
+++ b/frontend/src/pages/ShootList.vue
@@ -83,7 +83,7 @@ limitations under the License.
                   <v-icon :color="checkboxColor(hideProgressingIssues)" v-text="checkboxIcon(hideProgressingIssues)"/>
                 </v-list-tile-action>
                 <v-list-tile-content class="grey--text text--darken-2">
-                  <v-list-tile-title>Hide progressing shoots</v-list-tile-title>
+                  <v-list-tile-title>Hide progressing clusters</v-list-tile-title>
                 </v-list-tile-content>
               </v-list-tile>
               <v-list-tile
@@ -406,9 +406,9 @@ export default {
     headlineSubtitle () {
       let subtitle = ''
       if (!this.projectScope && this.showOnlyShootsWithIssues) {
-        subtitle = 'Cluster Filters: Healthy'
+        subtitle = 'Hide: Healthy Clusters'
         if (this.isHideProgressingIssues) {
-          subtitle += ', Progressing Shoots'
+          subtitle += ', Progressing Clusters'
         }
         if (this.isHideUserIssues) {
           subtitle += ', User Errors'

--- a/frontend/src/pages/ShootList.vue
+++ b/frontend/src/pages/ShootList.vue
@@ -76,8 +76,19 @@ limitations under the License.
             </v-list-tile>
             <template v-if="isAdmin">
               <v-list-tile
+                @click.stop="toggleHideProgressingIssues"
+                :disabled="isHideProgressingIssuesHideUserIssuesHideDeactedReconciliationDisabled"
+                :class="hideUserIssuesAndHideDeactivatedReconciliationClass">
+                <v-list-tile-action>
+                  <v-icon :color="checkboxColor(hideProgressingIssues)" v-text="checkboxIcon(hideProgressingIssues)"/>
+                </v-list-tile-action>
+                <v-list-tile-content class="grey--text text--darken-2">
+                  <v-list-tile-title>Hide progressing shoots</v-list-tile-title>
+                </v-list-tile-content>
+              </v-list-tile>
+              <v-list-tile
                 @click.stop="toggleHideUserIssues"
-                :disabled="isHideUserIssuesAndHideDeactedReconciliationDisabled"
+                :disabled="isHideProgressingIssuesHideUserIssuesHideDeactedReconciliationDisabled"
                 :class="hideUserIssuesAndHideDeactivatedReconciliationClass">
                 <v-list-tile-action>
                   <v-icon :color="checkboxColor(hideUserIssues)" v-text="checkboxIcon(hideUserIssues)"/>
@@ -88,7 +99,7 @@ limitations under the License.
               </v-list-tile>
               <v-list-tile
                 @click.stop="toggleHideDeactivatedReconciliation"
-                :disabled="isHideUserIssuesAndHideDeactedReconciliationDisabled"
+                :disabled="isHideProgressingIssuesHideUserIssuesHideDeactedReconciliationDisabled"
                 :class="hideUserIssuesAndHideDeactivatedReconciliationClass">
                 <v-list-tile-action>
                   <v-icon :color="checkboxColor(hideDeactivatedReconciliation)" v-text="checkboxIcon(hideDeactivatedReconciliation)"/>
@@ -193,6 +204,7 @@ export default {
       setShootListSortParams: 'setShootListSortParams',
       setShootListSearchValue: 'setShootListSearchValue',
       setOnlyShootsWithIssues: 'setOnlyShootsWithIssues',
+      setHideProgressingIssues: 'setHideProgressingIssues',
       setHideUserIssues: 'setHideUserIssues',
       setHideDeactivatedReconciliation: 'setHideDeactivatedReconciliation'
     }),
@@ -257,6 +269,11 @@ export default {
         this.hideUserIssues = !this.hideUserIssues
       }
     },
+    toggleHideProgressingIssues () {
+      if (this.showOnlyShootsWithIssues) {
+        this.hideProgressingIssues = !this.hideProgressingIssues
+      }
+    },
     toggleHideDeactivatedReconciliation () {
       if (this.showOnlyShootsWithIssues) {
         this.hideDeactivatedReconciliation = !this.hideDeactivatedReconciliation
@@ -279,6 +296,7 @@ export default {
       selectedItem: 'selectedShoot',
       isAdmin: 'isAdmin',
       isHideUserIssues: 'isHideUserIssues',
+      isHideProgressingIssues: 'isHideProgressingIssues',
       isHideDeactivatedReconciliation: 'isHideDeactivatedReconciliation'
     }),
     ...mapState([
@@ -346,12 +364,12 @@ export default {
     items () {
       return this.cachedItems || this.mappedItems
     },
-    isHideUserIssuesAndHideDeactedReconciliationDisabled () {
+    isHideProgressingIssuesHideUserIssuesHideDeactedReconciliationDisabled () {
       return !this.showOnlyShootsWithIssues
     },
     hideUserIssues: {
       get () {
-        if (this.isHideUserIssuesAndHideDeactedReconciliationDisabled) {
+        if (this.isHideProgressingIssuesHideUserIssuesHideDeactedReconciliationDisabled) {
           return false
         }
         return this.isHideUserIssues
@@ -360,9 +378,20 @@ export default {
         this.setHideUserIssues(value)
       }
     },
+    hideProgressingIssues: {
+      get () {
+        if (this.isHideProgressingIssuesHideUserIssuesHideDeactedReconciliationDisabled) {
+          return false
+        }
+        return this.isHideProgressingIssues
+      },
+      set (value) {
+        this.setHideProgressingIssues(value)
+      }
+    },
     hideDeactivatedReconciliation: {
       get () {
-        if (this.isHideUserIssuesAndHideDeactedReconciliationDisabled) {
+        if (this.isHideProgressingIssuesHideUserIssuesHideDeactedReconciliationDisabled) {
           return false
         }
         return this.isHideDeactivatedReconciliation
@@ -372,12 +401,15 @@ export default {
       }
     },
     hideUserIssuesAndHideDeactivatedReconciliationClass () {
-      return this.isHideUserIssuesAndHideDeactedReconciliationDisabled ? 'disabled_filter' : ''
+      return this.isHideProgressingIssuesHideUserIssuesHideDeactedReconciliationDisabled ? 'disabled_filter' : ''
     },
     headlineSubtitle () {
       let subtitle = ''
       if (!this.projectScope && this.showOnlyShootsWithIssues) {
         subtitle = 'Cluster Filters: Healthy'
+        if (this.isHideProgressingIssues) {
+          subtitle += ', Progressing Shoots'
+        }
         if (this.isHideUserIssues) {
           subtitle += ', User Errors'
         }
@@ -390,6 +422,9 @@ export default {
   },
   mounted () {
     this.floatingButton = true
+    if (this.hideProgressingIssues === undefined) {
+      this.hideProgressingIssues = true
+    }
     if (this.hideUserIssues === undefined) {
       this.hideUserIssues = this.isAdmin
     }

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -227,6 +227,9 @@ const getters = {
   isHideUserIssues (state, getters) {
     return getters['shoots/isHideUserIssues']
   },
+  isHideProgressingIssues (state, getters) {
+    return getters['shoots/isHideProgressingIssues']
+  },
   isHideDeactivatedReconciliation (state, getters) {
     return getters['shoots/isHideDeactivatedReconciliation']
   }
@@ -332,6 +335,12 @@ const actions = {
   },
   setHideUserIssues ({ dispatch, commit }, value) {
     return dispatch('shoots/setHideUserIssues', value)
+      .catch(err => {
+        dispatch('setError', err)
+      })
+  },
+  setHideProgressingIssues ({ dispatch, commit }, value) {
+    return dispatch('shoots/setHideProgressingIssues', value)
       .catch(err => {
         dispatch('setError', err)
       })

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -296,9 +296,16 @@ export function isUserError (errorCodes) {
   ]
   return every(errorCodes, errorCode => includes(userErrorCodes, errorCode))
 }
+export function shootHasIssue (shoot) {
+  return get(shoot, ['metadata', 'labels', 'shoot.garden.sapcloud.io/status'], 'healthy') !== 'healthy'
+}
 
 export function isReconciliationDeactivated (metadata) {
   return get(metadata, ['annotations', 'shoot.garden.sapcloud.io/ignore']) === 'true'
+}
+
+export function isStatusProgressing (metadata) {
+  return get(metadata, ['labels', 'shoot.garden.sapcloud.io/status']) === 'progressing'
 }
 
 export function isSelfTerminationWarning (expirationTimestamp) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adapt to new shoot condition state label

**Which issue(s) this PR fixes**:
Fixes #254

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Progressing conditions are displayed in blue color (operator/admin only)
```
```improvement operator
It is now possible to show clusters with condition(s) state progressing in all shoots with issues list
```
```action operator
:warning: This Dashboard version is not compatible with Gardener versions prior 0.14.x
```
