### PR TITLE
remove deprecated hibernation check

### DIFF
--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -267,10 +267,8 @@ export function isHibernated (spec) {
     return false
   }
 
-  const kind = getCloudProviderKind(spec.cloud)
-  const workers = get(spec, ['cloud', kind, 'workers'])
   const hibernationEnabled = get(spec, 'hibernation.enabled', false)
-  return hibernationEnabled || some(workers, worker => get(worker, 'autoScalerMax') === 0)
+  return hibernationEnabled
 }
 
 export function canLinkToSeed ({ shootNamespace }) {


### PR DESCRIPTION
**What this PR does / why we need it**:
With https://github.com/gardener/gardener/pull/471 the old hibernation logic was removed, hence we should also remove the corresponding fallback logic.

**Which issue(s) this PR fixes**:
#230

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
NONE
```
