### PR TITLE
Mask infrastructure secret identifiers

### DIFF
--- a/frontend/src/components/SecretRow.vue
+++ b/frontend/src/components/SecretRow.vue
@@ -57,7 +57,7 @@ limitations under the License.
 import { mapGetters } from 'vuex'
 import get from 'lodash/get'
 import filter from 'lodash/filter'
-import { isOwnSecretBinding } from '@/utils'
+import { isOwnSecretBinding, maskMiddle } from '@/utils'
 
 export default {
   props: {
@@ -75,7 +75,7 @@ export default {
     ]),
     secretDescriptor () {
       if (this.isOwnSecretBinding) {
-        return get(this.secret, `data.${this.secretDescriptorKey}`)
+        return maskMiddle(get(this.secret, `data.${this.secretDescriptorKey}`, ''))
       } else {
         return `Owner: ${this.secretOwner}`
       }

--- a/frontend/src/pages/Secrets.vue
+++ b/frontend/src/pages/Secrets.vue
@@ -75,7 +75,7 @@ limitations under the License.
     @delete="onDelete"
     >
       <template v-if="isOwnSecretBinding(props.secret)" slot="rowSubTitle" slot-scope="props">
-        {{props.secret.data.domainName}} / {{props.secret.data.tenantName}}
+        {{middleTruncatedOpenstackSecretDescriptor(props.secret)}}
       </template>
     </secret>
 
@@ -163,7 +163,7 @@ limitations under the License.
 <script>
 import { mapGetters } from 'vuex'
 import get from 'lodash/get'
-import { isOwnSecretBinding } from '@/utils'
+import { isOwnSecretBinding, maskMiddle } from '@/utils'
 import GcpDialog from '@/dialogs/SecretDialogGcp'
 import GcpHelpDialog from '@/dialogs/SecretDialogGcpHelp'
 import AwsHelpDialog from '@/dialogs/SecretDialogAwsHelp'
@@ -277,6 +277,9 @@ export default {
     },
     isOwnSecretBinding (secret) {
       return isOwnSecretBinding(secret)
+    },
+    middleTruncatedOpenstackSecretDescriptor (secret) {
+      return `${maskMiddle(secret.data.domainName)} / ${maskMiddle(secret.data.tenantName)}`
     }
   },
   mounted () {

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -36,6 +36,7 @@ import some from 'lodash/some'
 import store from '../store'
 import split from 'lodash/split'
 import last from 'lodash/last'
+import repeat from 'lodash/repeat'
 
 export function emailToDisplayName (email) {
   if (email) {
@@ -337,4 +338,19 @@ export function textColor (color) {
     textColor = `${textColor} text--${colorMod}`
   }
   return textColor
+}
+
+export function maskMiddle (value, frontLen = 2, backLen = 3, mask = '*') {
+  if (!value) {
+    return undefined
+  }
+  const minStringLen = frontLen + backLen + 3
+  const stringLen = value.length
+
+  if (stringLen < minStringLen) {
+    return repeat(mask, stringLen)
+  }
+
+  const charsCountToReplace = stringLen - frontLen - backLen
+  return value.substr(0, frontLen) + repeat(mask, charsCountToReplace) + value.substr(value.length - backLen)
 }

--- a/frontend/tests/unit/utils.spec.js
+++ b/frontend/tests/unit/utils.spec.js
@@ -1,0 +1,36 @@
+//
+// Copyright (c) 2018 by SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { expect } from 'chai'
+import { maskMiddle } from '@/utils'
+
+describe('utils', function () {
+  describe('#truncateMiddle', function () {
+    const input = '1234567890'
+    it('should mask the input', function () {
+      expect(maskMiddle(input, 2, 3, '*')).to.equal('12*****890')
+    })
+    it('should mask the complete input', function () {
+      expect(maskMiddle('a', 1, 0, '*')).to.equal('*')
+      expect(maskMiddle(input, 5, 5, '*')).to.equal('**********')
+      expect(maskMiddle(input, 0, 0, '*')).to.equal('**********')
+    })
+    it('should return undefined', function () {
+      expect(maskMiddle('')).to.be.undefined
+      expect(maskMiddle(undefined)).to.be.undefined
+    })
+  })
+})


### PR DESCRIPTION
**What this PR does / why we need it**:
On the secrets page we display identifiers like `AccessKeyID` or `ClientID` of a secret. 

To not expose too much details of a secret (e.g. during a demo) but still having the ability to find the correct secret in the list by searching for parts of it this PR adds the functionality to truncate the middle of the secret identifier.
E.g. the AccessKeyID `AKIAIOSFODNN7EXAMPLE`will be shown as `AK***************PLE`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
Infrastructure secret identifiers are now masked by truncating the middle
```
