### PR TITLE
display cluster name in breadcrumb

### DIFF
--- a/frontend/src/components/Breadcrumb.vue
+++ b/frontend/src/components/Breadcrumb.vue
@@ -37,6 +37,20 @@ import last from 'lodash/last'
 import size from 'lodash/size'
 import assign from 'lodash/assign'
 
+/**
+ * @typedef {number} Breadcrumb
+ **/
+
+/**
+ * @readonly
+ * @enum {Breadcrumb}
+ */
+export const BreadcrumbEnum = {
+    USE_ROUTE_TITLE: 1,
+    USE_ROUTE_PARAM_NAME: 2,
+    FALSE: -1
+  }
+
 export default {
   name: 'breadcrumb',
   computed: {
@@ -47,12 +61,19 @@ export default {
       var crumbs = []
       const namespace = this.namespace
       const matched = this.$route.matched
-      matched.forEach(function (matchedRoute) {
-        const hasBreadcrumb = get(matchedRoute, 'meta.breadcrumb')
-        if (hasBreadcrumb) {
-          const text = get(matchedRoute, 'meta.title')
+      matched.forEach((matchedRoute) => {
+        const breadcrumb = get(matchedRoute, 'meta.breadcrumb')
+        if (breadcrumb && breadcrumb !== BreadcrumbEnum.FALSE) {
           const to = namespacedRoute(matchedRoute, namespace)
-          crumbs.push({ text, to })
+
+          if (breadcrumb === BreadcrumbEnum.USE_ROUTE_PARAM_NAME) {
+            const text = this.routeParamName
+            console.log(text, matchedRoute, to)
+            crumbs.push({text, to})
+          } else if (breadcrumb === BreadcrumbEnum.USE_ROUTE_TITLE) {
+            const text = get(matchedRoute, 'meta.title')
+            crumbs.push({text, to})
+          }
         }
       })
 
@@ -69,6 +90,9 @@ export default {
           return 'breadcrumb subheading pointer'
         }
       }
+    },
+    routeParamName () {
+      return get(this.$route.params, 'name')
     }
   }
 }

--- a/frontend/src/components/Breadcrumb.vue
+++ b/frontend/src/components/Breadcrumb.vue
@@ -68,7 +68,6 @@ export default {
 
           if (breadcrumb === BreadcrumbEnum.USE_ROUTE_PARAM_NAME) {
             const text = this.routeParamName
-            console.log(text, matchedRoute, to)
             crumbs.push({text, to})
           } else if (breadcrumb === BreadcrumbEnum.USE_ROUTE_TITLE) {
             const text = get(matchedRoute, 'meta.title')

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -21,6 +21,7 @@ import { signinCallback, signout, isUserLoggedIn } from '@/utils/auth'
 import includes from 'lodash/includes'
 import head from 'lodash/head'
 import concat from 'lodash/concat'
+import { BreadcrumbEnum } from '@/components/Breadcrumb'
 
 /* Layouts */
 const Login = () => import('@/layouts/Login')
@@ -92,7 +93,7 @@ export default function createRouter ({ store, userManager }) {
       }
     },
     {
-      title: 'YAML',
+      title: 'YAML Editor',
       to: ({ params }) => {
         return {
           name: 'ShootItemEditor',
@@ -105,16 +106,16 @@ export default function createRouter ({ store, userManager }) {
   /**
    * Route Meta fields type definition
    * @typedef {Object} RouteMeta
-   * @prop {boolean} [public]       - Determines whether route needs authorization.
-   * @prop {boolean} [namespaced]   - Determines whether route is namespace specific and has namespace in path.
-   * @prop {boolean} [projectScope] - Determines whether route can be accessed in context of mutiple projects (_all).
-   * @prop {string}  [toRouteName]  - Sets "to" target name in case navigation is triggered (e.g. due to project change),
+   * @prop {boolean} [public]         - Determines whether route needs authorization.
+   * @prop {boolean} [namespaced]     - Determines whether route is namespace specific and has namespace in path.
+   * @prop {boolean} [projectScope]   - Determines whether route can be accessed in context of mutiple projects (_all).
+   * @prop {string}  [toRouteName]    - Sets "to" target name in case navigation is triggered (e.g. due to project change),
    *                                  this way it is possible to e.g. navigate back to shoot list from shoot details on project change.
    *                                  Furthermore, it is possible to set a default child route for a top level item.
-   * @prop {string}  [title]        - Main menu title.
-   * @prop {string}  [icon]         - Main menu icon.
-   * @prop {boolean} [breadcrumb]   - Determines if breadcrumb is visible for route.
-   * @prop {Tab[]}   [tabs]         - Determines the tabs to displayed in the main toolbar extenstion slot.
+   * @prop {string}  [title]          - Main menu title.
+   * @prop {string}  [icon]           - Main menu icon.
+   * @prop {Breadcrumb} [breadcrumb]  - Determines if breadcrumb is visible for route.
+   * @prop {Tab[]}   [tabs]           - Determines the tabs to displayed in the main toolbar extenstion slot.
    */
 
   const routes = [
@@ -153,7 +154,7 @@ export default function createRouter ({ store, userManager }) {
             title: 'Home',
             namespaced: false,
             projectScope: false,
-            breadcrumb: true
+            breadcrumb: BreadcrumbEnum.USE_ROUTE_TITLE
           }
         },
         {
@@ -162,7 +163,7 @@ export default function createRouter ({ store, userManager }) {
           component: Account,
           meta: {
             title: 'Account',
-            breadcrumb: true,
+            breadcrumb: BreadcrumbEnum.USE_ROUTE_TITLE,
             namespaced: false,
             projectScope: false
           }
@@ -179,7 +180,7 @@ export default function createRouter ({ store, userManager }) {
             projectScope: false,
             title: 'Project Clusters',
             toRouteName: 'ShootList',
-            breadcrumb: true
+            breadcrumb: BreadcrumbEnum.USE_ROUTE_TITLE
           },
           children: [
             {
@@ -200,8 +201,8 @@ export default function createRouter ({ store, userManager }) {
                 namespaced: true,
                 projectScope: true,
                 title: 'Cluster Details',
-                toRouteName: 'ShootList',
-                breadcrumb: true,
+                toRouteName: 'ShootItem',
+                breadcrumb: BreadcrumbEnum.USE_ROUTE_PARAM_NAME,
                 tabs: shootItemTabs
               }
             },
@@ -213,8 +214,8 @@ export default function createRouter ({ store, userManager }) {
                 namespaced: true,
                 projectScope: true,
                 title: 'Cluster Editor',
-                toRouteName: 'ShootList',
-                breadcrumb: true,
+                toRouteName: 'ShootItemEditor',
+                breadcrumb: BreadcrumbEnum.USE_ROUTE_PARAM_NAME,
                 tabs: shootItemTabs
               }
             }
@@ -232,7 +233,7 @@ export default function createRouter ({ store, userManager }) {
             projectScope: true,
             title: 'Secrets',
             toRouteName: 'Secrets',
-            breadcrumb: true
+            breadcrumb: BreadcrumbEnum.USE_ROUTE_TITLE
           },
           children: [
             {
@@ -270,7 +271,7 @@ export default function createRouter ({ store, userManager }) {
               title: 'Members',
               icon: 'mdi-account-multiple-outline'
             },
-            breadcrumb: true
+            breadcrumb: BreadcrumbEnum.USE_ROUTE_TITLE
           }
         },
         {
@@ -285,7 +286,7 @@ export default function createRouter ({ store, userManager }) {
               title: 'Administration',
               icon: 'mdi-settings'
             },
-            breadcrumb: true
+            breadcrumb: BreadcrumbEnum.USE_ROUTE_TITLE
           }
         }
       ]


### PR DESCRIPTION
**What this PR does / why we need it**:
When looking at the cluster details or the YAML editor, it is not directly obvious which cluster you are looking at, in particular if you have scrolled on the page.
<img width="1872" alt="screenshot 2019-01-08 at 13 59 42" src="https://user-images.githubusercontent.com/5526658/50832409-5ec73080-134e-11e9-911b-5b3d2bc0c507.png">

With this PR the name of the cluster is shown in the breadcrumb
<img width="385" alt="screenshot 2019-01-08 at 14 07 21" src="https://user-images.githubusercontent.com/5526658/50832514-bfef0400-134e-11e9-8dbf-586ea452485e.png">


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
The cluster name on the details page is shown in the breadcrumb
```
