### PR TITLE
log on error when fetching monitoring secret

### DIFF
--- a/backend/lib/services/shoots.js
+++ b/backend/lib/services/shoots.js
@@ -20,6 +20,7 @@ const kubernetes = require('../kubernetes')
 const { decodeBase64 } = require('../utils')
 const { getSeeds } = require('../cache')
 const authorization = require('./authorization')
+const logger = require('../logger')
 const _ = require('lodash')
 
 function Garden ({ auth }) {
@@ -231,6 +232,7 @@ exports.info = async function ({ user, namespace, name }) {
             if (err.code === 404) {
               return
             }
+            logger.error('failed to fetch monitoring secret: %s', err)
             throw err
           })
         if (monitoringSecret) {


### PR DESCRIPTION
**What this PR does / why we need it**:
As operator/admin, when calling the `/api/namespaces/garden-myproject/shoots/myshoot/info` endpoint the dashboard backend also fetches the monitoring secret from the seed. If this call fails, the error is just thrown up the stack, however the context get's lost and it makes it harder to read the logs.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
NONE
```
