### PR TITLE
Moved ingress annotations to values file to allow custom annotations

### DIFF
--- a/charts/gardener-dashboard/templates/ingress.yaml
+++ b/charts/gardener-dashboard/templates/ingress.yaml
@@ -8,10 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- with .Values.annotations }}
   annotations:
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/use-port-in-redirects: "true"
-    kubernetes.io/ingress.class: nginx
+{{ toYaml . | indent 4 }}
+  {{- end }}
 spec:
   tls:
     - secretName: gardener-dashboard-tls

--- a/charts/gardener-dashboard/templates/ingress.yaml
+++ b/charts/gardener-dashboard/templates/ingress.yaml
@@ -8,7 +8,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  {{- with .Values.annotations }}
+  {{- with .Values.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}
   {{- end }}

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -22,7 +22,10 @@ resources:
 hosts:
   - dashboard.ingress.example.org
   - dashboard.example.org
-
+annotations:
+  nginx.ingress.kubernetes.io/ssl-redirect: "true"
+  nginx.ingress.kubernetes.io/use-port-in-redirects: "true"
+  kubernetes.io/ingress.class: nginx
 tls:
   crt: |
     -----BEGIN CERTIFICATE-----

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -22,10 +22,11 @@ resources:
 hosts:
   - dashboard.ingress.example.org
   - dashboard.example.org
-annotations:
-  nginx.ingress.kubernetes.io/ssl-redirect: "true"
-  nginx.ingress.kubernetes.io/use-port-in-redirects: "true"
-  kubernetes.io/ingress.class: nginx
+ingress:
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/use-port-in-redirects: "true"
+    kubernetes.io/ingress.class: nginx
 tls:
   crt: |
     -----BEGIN CERTIFICATE-----


### PR DESCRIPTION
**What this PR does / why we need it**:
Changed the ingress annotations to allow for custom annotations.
The is useful if specific annotations need to be set, for instance for lets encrypt. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```improvement operator
Added the ability to add custom ingress annotations in helm chart
```
