### PR TITLE
Allow to sort cluster list by readiness

### DIFF
--- a/frontend/src/pages/ShootList.vue
+++ b/frontend/src/pages/ShootList.vue
@@ -174,7 +174,7 @@ export default {
         { text: 'PURPOSE', value: 'purpose', align: 'center', checked: false, defaultChecked: true, hidden: false },
         { text: 'STATUS', value: 'lastOperation', align: 'left', checked: false, defaultChecked: true, hidden: false },
         { text: 'VERSION', value: 'k8sVersion', align: 'center', checked: false, defaultChecked: true, hidden: false },
-        { text: 'READINESS', value: 'readiness', sortable: false, align: 'center', checked: false, defaultChecked: true, hidden: false },
+        { text: 'READINESS', value: 'readiness', sortable: true, align: 'center', checked: false, defaultChecked: true, hidden: false },
         { text: 'JOURNAL', value: 'journal', sortable: false, align: 'left', checked: false, defaultChecked: false, hidden: false, adminOnly: true },
         { text: 'JOURNAL LABELS', value: 'journalLabels', sortable: false, align: 'left', checked: false, defaultChecked: true, hidden: false, adminOnly: true },
         { text: 'ACTIONS', value: 'actions', sortable: false, align: 'right', checked: false, defaultChecked: true, hidden: false }

--- a/frontend/src/store/modules/shoots.js
+++ b/frontend/src/store/modules/shoots.js
@@ -369,7 +369,6 @@ const setSortedItems = (state, rootState) => {
           return -1 * inverse
         }
       })
-      console.log('radiness')
       state.sortedShoots = sortedShoots
     } else {
       state.sortedShoots = orderBy(shoots(state), [item => getSortVal(item, sortBy), 'metadata.name'], [descending, 'asc'])

--- a/frontend/src/store/modules/shoots.js
+++ b/frontend/src/store/modules/shoots.js
@@ -31,6 +31,7 @@ import filter from 'lodash/filter'
 import includes from 'lodash/includes'
 import split from 'lodash/split'
 import join from 'lodash/join'
+import head from 'lodash/head'
 import semver from 'semver'
 import store from '../'
 import { getShoot, getShootInfo, createShoot, deleteShoot } from '@/utils/api'
@@ -236,6 +237,7 @@ const difference = (object, base) => {
 const getRawVal = (item, column) => {
   const metadata = item.metadata
   const spec = item.spec
+  const status = item.status
   switch (column) {
     case 'purpose':
       return get(metadata, ['annotations', 'garden.sapcloud.io/purpose'])
@@ -256,6 +258,10 @@ const getRawVal = (item, column) => {
     case 'journalLabels':
       const labels = store.getters.journalsLabels(metadata)
       return join(map(labels, 'name'), ' ')
+    case 'readiness':
+      const errorConditions = filter(get(status, 'conditions'), condition => get(condition, 'status') !== 'True')
+      const lastErrorTransitionTime = head(orderBy(map(errorConditions, 'lastTransitionTime')))
+      return lastErrorTransitionTime
     default:
       return metadata[column]
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow to sort cluster list by readiness, this allows to sort unhealthy clusters by time of occurrence of the events

**Which issue(s) this PR fixes**:
Fixes #264

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Allow to sort cluster list by readiness, this allows to sort unhealthy clusters by time of occurrence of the events
```
