### PR TITLE
Fixed: Cluster list does not get cleared on error

### DIFF
--- a/frontend/src/store/modules/shoots.js
+++ b/frontend/src/store/modules/shoots.js
@@ -502,6 +502,7 @@ const mutations = {
   CLEAR_ALL (state) {
     state.shoots = {}
     state.sortedShoots = []
+    state.filteredAndSortedShoots = []
   },
   SET_HIDE_USER_ISSUES (state, { rootState, value }) {
     state.hideUserIssues = value

--- a/frontend/src/utils/Emitter.js
+++ b/frontend/src/utils/Emitter.js
@@ -193,7 +193,9 @@ class ShootsSubscription extends AbstractSubscription {
     })
   }
 
-  subscribeShoots ({ namespace, filter }) {
+  async subscribeShoots ({ namespace, filter }) {
+    // immediately clear, also if not authenticated to avoid outdated content is shown to the user
+    await store.dispatch('clearShoots')
     this.subscribeOnNextTrigger({ namespace, filter })
     this.subscribe()
   }
@@ -201,10 +203,7 @@ class ShootsSubscription extends AbstractSubscription {
   async _subscribe () {
     const { namespace, filter } = this.subscribeTo
 
-    await Promise.all([
-      store.dispatch('clearShoots'),
-      store.dispatch('setShootsLoading')
-    ])
+    await store.dispatch('setShootsLoading')
     if (namespace === '_all') {
       this.socket.emit('subscribeAllShoots', { filter })
     } else if (namespace) {


### PR DESCRIPTION
**What this PR does / why we need it**:
When a user switches the current active project, the cluster list does not get  cleared in the local store in case there is an error with the websocket communication

**Which issue(s) this PR fixes**:
Fixes #291 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
Fixed: Cluster list does not get cleared upon project change in case an error occurs
```
