### PR TITLE
Support for issuer with pathname

### DIFF
--- a/charts/gardener-dashboard/Chart.yaml
+++ b/charts/gardener-dashboard/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Gardener dashboard
 name: gardener-dashboard
-version: 0.1.0
+version: 0.1.1

--- a/charts/gardener-dashboard/templates/ingress.yaml
+++ b/charts/gardener-dashboard/templates/ingress.yaml
@@ -24,9 +24,6 @@ spec:
     - host: {{ . }}
       http:
         paths:
-        {{- with $.Values.ingress.additionalHostPaths }}
-{{ toYaml . | indent 10 }}
-        {{- end }}
           - backend:
               serviceName: gardener-dashboard-service
               servicePort: {{ $.Values.servicePort }}

--- a/charts/gardener-dashboard/templates/ingress.yaml
+++ b/charts/gardener-dashboard/templates/ingress.yaml
@@ -24,6 +24,9 @@ spec:
     - host: {{ . }}
       http:
         paths:
+        {{- with $.Values.ingress.additionalHostPaths }}
+{{ toYaml . | indent 10 }}
+        {{- end }}
           - backend:
               serviceName: gardener-dashboard-service
               servicePort: {{ $.Values.servicePort }}

--- a/charts/identity/Chart.yaml
+++ b/charts/identity/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for kubernetes identity server
 name: identity
-version: 0.1.0
+version: 0.1.1

--- a/charts/identity/templates/deployment.yaml
+++ b/charts/identity/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
           livenessProbe:
             failureThreshold: 3
             httpGet:
-              path: /healthz
+              path: "{{ regexReplaceAll "https://[^/]*(/.+)?" .Values.issuerUrl "${1}/healthz" }}"
               port: {{ .Values.containerPort }}
               scheme: HTTP
             initialDelaySeconds: 5

--- a/charts/identity/templates/ingress.yaml
+++ b/charts/identity/templates/ingress.yaml
@@ -12,20 +12,18 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/use-port-in-redirects: "true"
     kubernetes.io/ingress.class: nginx
+{{- $hostname := regexReplaceAll "https://([^/]*).*" $.Values.issuerUrl "${1}" }}
+{{- $pathname := regexReplaceAll "https://[^/]*(?:/(.+))?" $.Values.issuerUrl "/${1}" }}
 spec:
   tls:
     - secretName: identity-tls
       hosts:
-      {{- range .Values.hosts }}
-        - {{ . }}
-      {{- end }}
+        - {{ $hostname }}
   rules:
-  {{- range .Values.hosts }}
-    - host: {{ . }}
+    - host: {{ $hostname }}
       http:
         paths:
           - backend:
               serviceName: identity-service
               servicePort: {{ $.Values.servicePort }}
-            path: "{{ regexReplaceAll "https://[^/]*(?:/(.+))?" $.Values.issuerUrl "/${1}" }}"
-  {{- end }}
+            path: "{{ $pathname }}"

--- a/charts/identity/templates/ingress.yaml
+++ b/charts/identity/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.hosts }}
 apiVersion: {{ include "ingressversion" . }}
 kind: Ingress
 metadata:
@@ -29,3 +30,4 @@ spec:
               servicePort: {{ $.Values.servicePort }}
             path: /
   {{- end }}
+{{- end }}

--- a/charts/identity/templates/ingress.yaml
+++ b/charts/identity/templates/ingress.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.hosts }}
 apiVersion: {{ include "ingressversion" . }}
 kind: Ingress
 metadata:
@@ -30,4 +29,3 @@ spec:
               servicePort: {{ $.Values.servicePort }}
             path: "{{ regexReplaceAll "https://[^/]*(?:/(.+))?" $.Values.issuerUrl "/${1}" }}"
   {{- end }}
-{{- end }}

--- a/charts/identity/values.yaml
+++ b/charts/identity/values.yaml
@@ -17,9 +17,6 @@ resources:
   requests:
     cpu: 100m
     memory: 64Mi
-hosts:
-  - identity.ingress.example.org
-  - identity.example.org
 issuerUrl: https://identity.ingress.example.org
 
 #kubeconfig: kubeconfig-to-external-cluster (optionally, if not given in-cluster config is used)


### PR DESCRIPTION
**What this PR does / why we need it**:
It allows you to use the same hostname for the identity ingress and the gardener-dashbaord ingress by adding a pathname to the identity issuerUrl.

Example usage in ` identity` values.yaml:
```
...
issuerUrl: https://gardener.ingress.example.org/identity
...
```

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Support for `issuerUrl` values with pathname in the identity helm chart
```
```improvement operator
The `hosts` value has been removed in the identity helm chart. The hostname is defined by the issuers hostname (`.Values.issuerUrl`)
```