### PR TITLE
Removed default CIDR ranges for pods and services networks

### DIFF
--- a/frontend/src/dialogs/CreateClusterDialog.vue
+++ b/frontend/src/dialogs/CreateClusterDialog.vue
@@ -802,11 +802,9 @@ export default {
                     '10.250.112.0/22'
                   ],
                   nodes: '10.250.0.0/16',
-                  pods: '100.96.0.0/11',
                   public: [
                     '10.250.96.0/22'
                   ],
-                  services: '100.64.0.0/13',
                   workers: [
                     '10.250.0.0/19'
                   ]
@@ -826,8 +824,6 @@ export default {
                     cidr: '10.250.0.0/16'
                   },
                   nodes: '10.250.0.0/19',
-                  pods: '100.96.0.0/11',
-                  services: '100.64.0.0/13',
                   public: '10.250.96.0/22',
                   workers: '10.250.0.0/19'
                 },
@@ -842,8 +838,6 @@ export default {
               this.infrastructureData = {
                 networks: {
                   nodes: '10.250.0.0/19',
-                  pods: '100.96.0.0/11',
-                  services: '100.64.0.0/13',
                   workers: [
                     '10.250.0.0/19'
                   ]
@@ -860,8 +854,6 @@ export default {
               this.infrastructureData = {
                 networks: {
                   nodes: '10.250.0.0/19',
-                  pods: '100.96.0.0/11',
-                  services: '100.64.0.0/13',
                   workers: [
                     '10.250.0.0/19'
                   ]
@@ -881,8 +873,6 @@ export default {
                     cidr: '10.250.0.0/16'
                   },
                   nodes: '10.250.0.0/16',
-                  pods: '100.128.0.0/11',
-                  services: '100.0.0.0/13',
                   workers: [
                     '10.250.0.0/19'
                   ]


### PR DESCRIPTION
**What this PR does / why we need it**:
Removed default CIDR ranges for pods and services networks

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Removed default CIDR ranges for `pods` and `services` networks when creating a cluster, so that Gardener can set the defaults
```
