### PR TITLE
Fix journal comment linebreak for chrome

### DIFF
--- a/frontend/src/components/JournalComment.vue
+++ b/frontend/src/components/JournalComment.vue
@@ -95,7 +95,11 @@ export default {
   }
   .comment-body {
     padding: 5px;
+
+    /* not needed for chrome, but kept for firefox */
     word-wrap: break-word;
+    /* does not work with firefox */
+    word-break: break-word; 
   }
 
   >>> .flex {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix journal comment linebreak for chrome

**Which issue(s) this PR fixes**:
Fixes #310 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
