### PR TITLE
Optional additional annotations for identity-ingress

### DIFF
--- a/charts/identity/templates/ingress.yaml
+++ b/charts/identity/templates/ingress.yaml
@@ -8,15 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- with .Values.ingress.annotations }}
   annotations:
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/use-port-in-redirects: "true"
-    kubernetes.io/ingress.class: nginx
-{{- if .Values.ingressAnnotations }}
-  {{- range $key, $value := .Values.ingressAnnotations }}
-    {{ $key }}: {{ $value | quote }}
+{{ toYaml . | indent 4 }}
   {{- end }}
-{{- end }}
 {{- $hostname := regexReplaceAll "https://([^/]*).*" $.Values.issuerUrl "${1}" }}
 {{- $pathname := regexReplaceAll "https://[^/]*(?:/(.+))?" $.Values.issuerUrl "/${1}" }}
 spec:

--- a/charts/identity/templates/ingress.yaml
+++ b/charts/identity/templates/ingress.yaml
@@ -12,6 +12,11 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/use-port-in-redirects: "true"
     kubernetes.io/ingress.class: nginx
+{{- if .Values.ingressAnnotations }}
+  {{- range $key, $value := .Values.ingressAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}
 {{- $hostname := regexReplaceAll "https://([^/]*).*" $.Values.issuerUrl "${1}" }}
 {{- $pathname := regexReplaceAll "https://[^/]*(?:/(.+))?" $.Values.issuerUrl "/${1}" }}
 spec:

--- a/charts/identity/values.yaml
+++ b/charts/identity/values.yaml
@@ -18,6 +18,7 @@ resources:
     cpu: 100m
     memory: 64Mi
 issuerUrl: https://identity.ingress.example.org
+ingressAnnotations: {}
 
 #kubeconfig: kubeconfig-to-external-cluster (optionally, if not given in-cluster config is used)
 
@@ -55,3 +56,4 @@ tls:
     -----BEGIN RSA PRIVATE KEY-----
     Li4u
     -----END RSA PRIVATE KEY-----
+    

--- a/charts/identity/values.yaml
+++ b/charts/identity/values.yaml
@@ -18,7 +18,12 @@ resources:
     cpu: 100m
     memory: 64Mi
 issuerUrl: https://identity.ingress.example.org
-ingressAnnotations: {}
+
+ingress:
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/use-port-in-redirects: "true"
+    kubernetes.io/ingress.class: nginx
 
 #kubeconfig: kubeconfig-to-external-cluster (optionally, if not given in-cluster config is used)
 
@@ -56,4 +61,3 @@ tls:
     -----BEGIN RSA PRIVATE KEY-----
     Li4u
     -----END RSA PRIVATE KEY-----
-    


### PR DESCRIPTION
**What this PR does / why we need it**:
Needed for reusing Helm charts for Gardener Ring

**Which issue(s) this PR fixes**:

**Release note**:
NONE