### PR TITLE
Fix regex named groups error in Firefox

### DIFF
--- a/frontend/src/components/HibernationSchedule.vue
+++ b/frontend/src/components/HibernationSchedule.vue
@@ -128,23 +128,19 @@ export default {
     reset () {
       this.parseSchedules(this.scheduleCrontab)
     },
-    parsedScheduleEventFromCrontabBlock (crontabBlock) {
-      const cronStart = get(crontabBlock, 'start')
-      const cronEnd = get(crontabBlock, 'end')
-      const startRegexResult = scheduleCrontabRegex.exec(cronStart)
-      const endRegexResult = scheduleCrontabRegex.exec(cronEnd)
-      const objFromRegexResult = (regexResult) => {
-        if (regexResult && regexResult.length === 4) {
-          return {
-            minute: regexResult[1],
-            hour: regexResult[2],
-            weekdays: regexResult[3]
-          }
-        }
-        return undefined
+    scheduleEventObjFromRegex (regex) {
+      const regexResult = scheduleCrontabRegex.exec(regex)
+      if (regexResult) {
+        const [, minute, hour, weekdays] = regexResult
+        return { minute, hour, weekdays }
       }
-      const start = objFromRegexResult(startRegexResult)
-      const end = objFromRegexResult(endRegexResult)
+      return undefined
+    },
+    parsedScheduleEventFromCrontabBlock (crontabBlock) {
+      const cronStart = crontabBlock.start
+      const cronEnd = crontabBlock.end
+      const start = this.scheduleEventObjFromRegex(cronStart)
+      const end = this.scheduleEventObjFromRegex(cronEnd)
 
       if (cronStart && !start) {
         console.warn(`Could not parse start crontab line: ${cronStart}`)

--- a/frontend/src/components/HibernationSchedule.vue
+++ b/frontend/src/components/HibernationSchedule.vue
@@ -82,7 +82,7 @@ import moment from 'moment-timezone'
 import { mapState } from 'vuex'
 const uuidv4 = require('uuid/v4')
 
-const scheduleCrontabRegex = /^(?<minute>\d{0,2})\s(?<hour>\d{0,2})\s\*\s\*\s(?<weekdays>[0-6,]+)$/
+const scheduleCrontabRegex = /^(\d{0,2})\s(\d{0,2})\s\*\s\*\s([0-6,]+)$/
 
 export default {
   name: 'hibernation-schedule',
@@ -131,8 +131,20 @@ export default {
     parsedScheduleEventFromCrontabBlock (crontabBlock) {
       const cronStart = get(crontabBlock, 'start')
       const cronEnd = get(crontabBlock, 'end')
-      const start = get(scheduleCrontabRegex.exec(cronStart), 'groups')
-      const end = get(scheduleCrontabRegex.exec(cronEnd), 'groups')
+      const startRegexResult = scheduleCrontabRegex.exec(cronStart)
+      const endRegexResult = scheduleCrontabRegex.exec(cronEnd)
+      const objFromRegexResult = (regexResult) => {
+        if (regexResult && regexResult.length === 4) {
+          return {
+            minute: regexResult[1],
+            hour: regexResult[2],
+            weekdays: regexResult[3]
+          }
+        }
+        return undefined
+      }
+      const start = objFromRegexResult(startRegexResult)
+      const end = objFromRegexResult(endRegexResult)
 
       if (cronStart && !start) {
         console.warn(`Could not parse start crontab line: ${cronStart}`)


### PR DESCRIPTION
**What this PR does / why we need it**:
Use old style index based regex access as firefox does not support ES2018 named groups (yet)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
NONE
```
