### PR TITLE
Properly handle navigation between projects

### DIFF
--- a/frontend/src/components/Breadcrumb.vue
+++ b/frontend/src/components/Breadcrumb.vue
@@ -37,20 +37,6 @@ import last from 'lodash/last'
 import size from 'lodash/size'
 import assign from 'lodash/assign'
 
-/**
- * @typedef {number} Breadcrumb
- **/
-
-/**
- * @readonly
- * @enum {Breadcrumb}
- */
-export const BreadcrumbEnum = {
-  USE_ROUTE_TITLE: 1,
-  USE_ROUTE_PARAM_NAME: 2,
-  FALSE: -1
-}
-
 export default {
   name: 'breadcrumb',
   computed: {
@@ -62,17 +48,10 @@ export default {
       const namespace = this.namespace
       const matched = this.$route.matched
       matched.forEach((matchedRoute) => {
-        const breadcrumb = get(matchedRoute, 'meta.breadcrumb')
-        if (breadcrumb && breadcrumb !== BreadcrumbEnum.FALSE) {
+        if (get(matchedRoute, 'meta.breadcrumbTextFn')) {
+          const text = matchedRoute.meta.breadcrumbTextFn(this.$route)
           const to = namespacedRoute(matchedRoute, namespace)
-
-          if (breadcrumb === BreadcrumbEnum.USE_ROUTE_PARAM_NAME) {
-            const text = this.routeParamName
-            crumbs.push({ text, to })
-          } else if (breadcrumb === BreadcrumbEnum.USE_ROUTE_TITLE) {
-            const text = get(matchedRoute, 'meta.title')
-            crumbs.push({ text, to })
-          }
+          crumbs.push({ text, to })
         }
       })
 

--- a/frontend/src/components/MainNavigation.vue
+++ b/frontend/src/components/MainNavigation.vue
@@ -154,6 +154,7 @@ import toLower from 'lodash/toLower'
 import includes from 'lodash/includes'
 import replace from 'lodash/replace'
 import get from 'lodash/get'
+import isEmpty from 'lodash/isEmpty'
 import { emailToDisplayName, setDelayedInputFocus, routes, namespacedRoute, routeName } from '@/utils'
 import ProjectCreateDialog from '@/dialogs/ProjectDialog'
 
@@ -267,11 +268,14 @@ export default {
     getProjectMenuTargetRoute (namespace) {
       let name = routeName(this.$route)
       const nsHasProjectScope = namespace !== this.allProjectsItem.metadata.namespace
+      const fallback = 'ShootList'
       if (!nsHasProjectScope) {
         const thisProjectScoped = this.routeMeta.projectScope
         if (thisProjectScoped) {
-          name = 'ShootList'
+          name = fallback
         }
+      } else if (!isEmpty(this.$route, 'params.name')) {
+        name = fallback
       }
       return !this.namespaced ? { name, query: { namespace } } : { name, params: { namespace } }
     }

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -162,9 +162,11 @@ export function routes (router, includeRoutesWithProjectScope) {
 
 export function namespacedRoute (route, namespace) {
   const name = routeName(route)
+
   const params = {
     namespace: namespace
   }
+
   return { name, params }
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The dashboard does not properly handle the navigation between projects in case e.g. the cluster details page is shown  - when the new project is selected, the clusters from the newly selected project should to be listed. See #324 for more details.

**Which issue(s) this PR fixes**:
Fixes #326

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
Fixed navigation between projects when showing cluster details. You are now redirected to the cluster list of the newly selected project.
```
