### PR TITLE
Use anchor element for breadcrumb

### DIFF
--- a/frontend/src/components/Breadcrumb.vue
+++ b/frontend/src/components/Breadcrumb.vue
@@ -22,7 +22,6 @@ limitations under the License.
       slot="item"
       :to="item.to"
       :class="textClass(item)"
-      tag="span"
     >
       {{ item.text }}
     </router-link>
@@ -88,6 +87,7 @@ export default {
 
   .breadcrumb {
     color: black;
+    text-decoration:none;
   }
 
 </style>


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently it's not possible to open a breadcrumb item in a new tab. This PR will render the breadcrumb item as anchor element and not as span

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
NONE
```
