### PR TITLE
Add Seed column to cluster list

### DIFF
--- a/frontend/src/components/ShootListRow.vue
+++ b/frontend/src/components/ShootListRow.vue
@@ -50,9 +50,12 @@ limitations under the License.
       </v-tooltip>
     </td>
     <td class="nowrap" v-if="this.headerVisible['seed']">
-      <div>
-        {{row.seed}}
-      </div>
+      <router-link v-if="canLinkToSeed" class="cyan--text text--darken-2" :to="{ name: 'ShootItem', params: { name: row.seed, namespace:'garden' } }">
+        <span>{{row.seed}}</span>
+      </router-link>
+      <template v-else>
+        <span>{{row.seed}}</span>
+      </template>
     </td>
     <td class="nowrap" v-if="this.headerVisible['createdBy']">
       <account-avatar :account-name="row.createdBy"></account-avatar>
@@ -136,7 +139,8 @@ import DeleteCluster from '@/components/DeleteCluster'
 import forEach from 'lodash/forEach'
 import get from 'lodash/get'
 import includes from 'lodash/includes'
-import { getTimestampFormatted,
+import {
+  getTimestampFormatted,
   getCloudProviderKind,
   getCreatedBy,
   isHibernated,
@@ -144,7 +148,9 @@ import { getTimestampFormatted,
   isShootMarkedForDeletion,
   isTypeDelete,
   getProjectName,
-  isShootHasNoHibernationScheduleWarning } from '@/utils'
+  isShootHasNoHibernationScheduleWarning,
+  canLinkToSeed
+} from '@/utils'
 
 export default {
   components: {
@@ -264,6 +270,9 @@ export default {
     },
     isShootHasNoHibernationScheduleWarning () {
       return isShootHasNoHibernationScheduleWarning(this.shootItem)
+    },
+    canLinkToSeed () {
+      return canLinkToSeed({ shootNamespace: this.row.namespace })
     }
   },
   methods: {

--- a/frontend/src/components/ShootListRow.vue
+++ b/frontend/src/components/ShootListRow.vue
@@ -49,6 +49,11 @@ limitations under the License.
         <span>{{ row.kind }} [{{ row.region }}]</span>
       </v-tooltip>
     </td>
+    <td class="nowrap" v-if="this.headerVisible['seed']">
+      <div>
+        {{row.seed}}
+      </div>
+    </td>
     <td class="nowrap" v-if="this.headerVisible['createdBy']">
       <account-avatar :account-name="row.createdBy"></account-avatar>
     </td>
@@ -197,7 +202,8 @@ export default {
         lastUpdatedJournalTimestamp: this.lastUpdatedJournalByNameAndNamespace(this.shootItem.metadata),
         journalsLabels: this.journalsLabels(this.shootItem.metadata),
         // setting the retry annotation internally will increment "metadata.generation". If the values differ, a reconcile will be scheduled
-        reconcileScheduled: get(metadata, 'generation') !== get(status, 'observedGeneration')
+        reconcileScheduled: get(metadata, 'generation') !== get(status, 'observedGeneration'),
+        seed: get(spec, 'cloud.seed')
       }
     },
     headerVisible () {

--- a/frontend/src/pages/ShootList.vue
+++ b/frontend/src/pages/ShootList.vue
@@ -169,6 +169,7 @@ export default {
         { text: 'PROJECT', value: 'project', align: 'left', checked: false, defaultChecked: true, hidden: false },
         { text: 'NAME', value: 'name', align: 'left', checked: false, defaultChecked: true, hidden: false },
         { text: 'INFRASTRUCTURE', value: 'infrastructure', align: 'left', checked: false, defaultChecked: true, hidden: false },
+        { text: 'SEED', value: 'seed', align: 'left', checked: false, defaultChecked: false, hidden: false },
         { text: 'CREATED BY', value: 'createdBy', align: 'left', checked: false, defaultChecked: false, hidden: false },
         { text: 'CREATED AT', value: 'createdAt', align: 'left', checked: false, defaultChecked: false, hidden: false },
         { text: 'PURPOSE', value: 'purpose', align: 'center', checked: false, defaultChecked: true, hidden: false },

--- a/frontend/src/store/modules/shoots.js
+++ b/frontend/src/store/modules/shoots.js
@@ -254,6 +254,8 @@ const getRawVal = (item, column) => {
       return getCloudProviderKind(spec.cloud)
     case 'infrastructure_search':
       return `${get(spec, 'cloud.region')} ${getCloudProviderKind(spec.cloud)}`
+    case 'seed':
+      return get(spec, 'cloud.seed')
     case 'journalLabels':
       const labels = store.getters.journalsLabels(metadata)
       return join(map(labels, 'name'), ' ')
@@ -389,6 +391,9 @@ const setFilteredAndSortedItems = (state, rootState) => {
           return
         }
         if (includes(getRawVal(item, 'infrastructure_search'), value)) {
+          return
+        }
+        if (includes(getRawVal(item, 'seed'), value)) {
           return
         }
         if (includes(getRawVal(item, 'project'), value)) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces a new seed column to the cluster list, that can be enabled via the table options

**Which issue(s) this PR fixes**:
Fixes #341 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Added new `Seed` column to the cluster list table. You can enable the column in the table options menu (three dots).
```
