### PR TITLE
Remove the user from all api calls

### DIFF
--- a/frontend/src/store/modules/infrastructureSecrets.js
+++ b/frontend/src/store/modules/infrastructureSecrets.js
@@ -40,8 +40,7 @@ const getters = {
 const actions = {
   getAll: ({ commit, rootState }) => {
     const namespace = rootState.namespace
-    const user = rootState.user
-    return getInfrastructureSecrets({ user, namespace })
+    return getInfrastructureSecrets({ namespace })
       .then(res => {
         commit('RECEIVE', res.data)
         return state.all
@@ -52,19 +51,17 @@ const actions = {
       })
   },
   update: ({ commit, rootState }, { metadata, data }) => {
-    const user = rootState.user
     const namespace = metadata.namespace || rootState.namespace
     const bindingName = metadata.bindingName
-    return updateInfrastructureSecret({ user, namespace, bindingName, data: { metadata, data } })
+    return updateInfrastructureSecret({ namespace, bindingName, data: { metadata, data } })
       .then(res => {
         commit('ITEM_PUT', res.data)
         return res.data
       })
   },
   create: ({ commit, rootState }, { metadata, data }) => {
-    const user = rootState.user
     const namespace = metadata.namespace || rootState.namespace
-    return createInfrastructureSecret({ user, namespace, data: { metadata, data } })
+    return createInfrastructureSecret({ namespace, data: { metadata, data } })
       .then(res => {
         commit('ITEM_PUT', res.data)
         return res.data
@@ -72,8 +69,7 @@ const actions = {
   },
   delete ({ dispatch, commit, rootState }, bindingName) {
     const namespace = rootState.namespace
-    const user = rootState.user
-    return deleteInfrastructureSecret({ namespace, bindingName, user })
+    return deleteInfrastructureSecret({ namespace, bindingName })
       .then(res => {
         commit('ITEM_DELETED', res.data)
         return res.data

--- a/frontend/src/store/modules/members.js
+++ b/frontend/src/store/modules/members.js
@@ -28,8 +28,7 @@ const getters = {}
 const actions = {
   getAll: ({ commit, rootState }) => {
     const namespace = rootState.namespace
-    const user = rootState.user
-    return getMembers({ namespace, user })
+    return getMembers({ namespace })
       .then(res => {
         commit('RECEIVE', res.data)
         return state.all
@@ -41,17 +40,15 @@ const actions = {
   },
   add: ({ commit, rootState }, name) => {
     const namespace = rootState.namespace
-    const user = rootState.user
     const data = { name }
-    return addMember({ namespace, user, data })
+    return addMember({ namespace, data })
       .then(res => {
         commit('RECEIVE', res.data)
       })
   },
   delete: ({ commit, rootState }, name) => {
     const namespace = rootState.namespace
-    const user = rootState.user
-    return deleteMember({ namespace, name, user })
+    return deleteMember({ namespace, name })
       .then(res => {
         commit('RECEIVE', res.data)
       })

--- a/frontend/src/store/modules/projects.js
+++ b/frontend/src/store/modules/projects.js
@@ -48,18 +48,16 @@ const actions = {
       })
   },
   update ({ commit, rootState }, { metadata, data }) {
-    const user = rootState.user
     const namespace = metadata.namespace || rootState.namespace
-    return updateProject({ namespace, user, data: { metadata, data } })
+    return updateProject({ namespace, data: { metadata, data } })
       .then(res => {
         commit('ITEM_PUT', res.data)
         return res.data
       })
   },
   delete: ({ commit, rootState }, { metadata }) => {
-    const user = rootState.user
     const namespace = metadata.namespace
-    return deleteProject({ namespace, user })
+    return deleteProject({ namespace })
       .then(res => {
         commit('ITEM_DELETED', metadata)
         return state.all

--- a/frontend/src/store/modules/shoots.js
+++ b/frontend/src/store/modules/shoots.js
@@ -105,11 +105,9 @@ const actions = {
     return getters.items
   },
   get ({ dispatch, commit, rootState }, { name, namespace }) {
-    const user = rootState.user
-
     const getShootIfNecessary = new Promise(async (resolve, reject) => {
       if (!findItem({ name, namespace })) {
-        getShoot({ namespace, name, user })
+        getShoot({ namespace, name })
           .then(res => {
             const item = res.data
             commit('ITEM_PUT', { newItem: item, rootState })
@@ -132,20 +130,17 @@ const actions = {
   },
   create ({ dispatch, commit, rootState }, data) {
     const namespace = data.metadata.namespace || rootState.namespace
-    const user = rootState.user
-    return createShoot({ namespace, user, data })
+    return createShoot({ namespace, data })
   },
   delete ({ dispatch, commit, rootState }, { name, namespace }) {
-    const user = rootState.user
-    return deleteShoot({ namespace, name, user })
+    return deleteShoot({ namespace, name })
   },
   /**
    * Return the given info for a single shoot with the namespace/name.
    * This ends always in a server/backend call.
    */
   getInfo ({ commit, rootState }, { name, namespace }) {
-    const user = rootState.user
-    return getShootInfo({ namespace, name, user })
+    return getShootInfo({ namespace, name })
       .then(res => res.data)
       .then(info => {
         if (info.serverUrl) {


### PR DESCRIPTION
**What this PR does / why we need it**:
There are still api calls which which pass the use as parameter. That is not a problem but makes no sense. Removed the user in all these cases.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
NONE
```
