### PR TITLE
Remove isAdmin and canCreateProject from cookie

### DIFF
--- a/backend/lib/routes/index.js
+++ b/backend/lib/routes/index.js
@@ -18,7 +18,7 @@
 
 module.exports = {
   '/info': require('./info'),
-  '/user': require('./userInfo'),
+  '/user': require('./user'),
   '/cloudprofiles': require('./cloudprofiles'),
   '/domains': require('./domains'),
   '/shoots': require('./shoots'),

--- a/backend/lib/routes/user.js
+++ b/backend/lib/routes/user.js
@@ -18,7 +18,7 @@
 
 const express = require('express')
 
-const { authentication, authorization } = require('../services')
+const { authorization } = require('../services')
 const router = module.exports = express.Router({
   mergeParams: true
 })
@@ -27,24 +27,20 @@ function getToken ({ auth = {} } = {}) {
   return auth.bearer
 }
 
-router.route('/')
+router.route('/privileges')
   .get(async (req, res, next) => {
     try {
       const user = req.user || {}
-      const token = getToken(user)
       const [
-        userData,
         isAdmin,
         canCreateProject
       ] = await Promise.all([
-        authentication.isAuthenticated({ token }),
         authorization.isAdmin(user),
         authorization.canCreateProject(user)
       ])
       res.send({
         isAdmin,
-        canCreateProject,
-        ...userData
+        canCreateProject
       })
     } catch (err) {
       next(err)

--- a/backend/lib/security.js
+++ b/backend/lib/security.js
@@ -26,7 +26,7 @@ const uuidv1 = require('uuid/v1')
 const base64url = require('base64url')
 const pRetry = require('p-retry')
 const pTimeout = require('p-timeout')
-const { authentication, authorization } = require('./services')
+const { authentication } = require('./services')
 const { Forbidden, Unauthorized } = require('./errors')
 const { sessionSecret, cookieMaxAge = 1800, oidc = {} } = require('./config')
 

--- a/backend/lib/security.js
+++ b/backend/lib/security.js
@@ -126,22 +126,13 @@ async function authorizationUrl (req, res) {
 async function authorizeToken (req, res) {
   const { token, expiresIn } = req.body
   const bearer = trim(token)
-  const auth = { bearer }
-  const [
-    { username: id, groups },
-    isAdmin,
-    canCreateProject
-  ] = await Promise.all([
-    authentication.isAuthenticated({ token: bearer }),
-    authorization.isAdmin({ auth }),
-    authorization.canCreateProject({ auth })
-  ])
+
+  const { username: id, groups } = await authentication.isAuthenticated({ token: bearer })
+
   const { name, email } = decode(bearer)
   const user = {
     id,
     groups,
-    isAdmin,
-    canCreateProject,
     name,
     email
   }

--- a/backend/test/acceptance/api.user.spec.js
+++ b/backend/test/acceptance/api.user.spec.js
@@ -27,17 +27,16 @@ module.exports = function ({ agent, sandbox }) {
 
   it('should return information about the user', async function () {
     const bearer = await user.bearer
-    k8s.stub.getUserInfo({ bearer, username })
+    k8s.stub.getPrivileges({ bearer })
     const res = await agent
-      .get('/api/user')
+      .get('/api/user/privileges')
       .set('cookie', await user.cookie)
 
     expect(res).to.have.status(200)
     expect(res).to.be.json
     expect(res.body).to.eql({
       isAdmin: false,
-      canCreateProject: true,
-      username
+      canCreateProject: true
     })
   })
 

--- a/backend/test/acceptance/auth.spec.js
+++ b/backend/test/acceptance/auth.spec.js
@@ -104,8 +104,7 @@ module.exports = function ({ agent, sandbox }) {
 
   it('should redirect to home after successful authorization', async function () {
     const getIssuerClientStub = sandbox.stub(security, 'getIssuerClient').callsFake(() => getIssuerClient(user))
-    const bearer = await user.bearer
-    k8s.stub.getUserInfo({ bearer })
+    k8s.stub.authorizeToken()
 
     const res = await agent
       .get(`/auth/callback?code=${OTAC}`)
@@ -139,7 +138,7 @@ module.exports = function ({ agent, sandbox }) {
 
   it('should successfully login with a given token', async function () {
     const bearer = await user.bearer
-    k8s.stub.getUserInfo({ bearer })
+    k8s.stub.authorizeToken()
 
     const res = await agent
       .post(`/auth`)

--- a/backend/test/support/nocks/k8s.js
+++ b/backend/test/support/nocks/k8s.js
@@ -988,13 +988,11 @@ const stub = {
         .reply(statusCode, version)
     ]
   },
-  getUserInfo ({ bearer }) {
+  getPrivileges ({ bearer }) {
     const scope = nockWithAuthorization(bearer)
     canDeleteShootsInAllNamespaces(scope)
     canCreateProjects(scope)
-    const adminScope = nockWithAuthorization(auth.bearer)
-    reviewToken(adminScope)
-    return [ scope, adminScope ]
+    return scope
   },
   authorizeToken () {
     const adminScope = nockWithAuthorization(auth.bearer)

--- a/backend/test/support/nocks/k8s.js
+++ b/backend/test/support/nocks/k8s.js
@@ -995,6 +995,11 @@ const stub = {
     const adminScope = nockWithAuthorization(auth.bearer)
     reviewToken(adminScope)
     return [ scope, adminScope ]
+  },
+  authorizeToken () {
+    const adminScope = nockWithAuthorization(auth.bearer)
+    reviewToken(adminScope)
+    return adminScope
   }
 }
 

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -21,7 +21,7 @@ import includes from 'lodash/includes'
 import head from 'lodash/head'
 import get from 'lodash/get'
 import concat from 'lodash/concat'
-import { getUserInfo } from '@/utils/api'
+import { getPrivileges } from '@/utils/api'
 
 /* Layouts */
 const Login = () => import('@/layouts/Login')
@@ -299,7 +299,7 @@ export default function createRouter ({ store, userManager }) {
         const user = userManager.getUser()
         const storedUser = store.state.user
         if (!storedUser || storedUser.jti !== user.jti) {
-          const { data: { isAdmin, canCreateProject } } = await getUserInfo()
+          const { data: { isAdmin, canCreateProject } } = await getPrivileges()
 
           await store.dispatch('setUser', { ...user, isAdmin, canCreateProject })
         }

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -21,6 +21,7 @@ import includes from 'lodash/includes'
 import head from 'lodash/head'
 import get from 'lodash/get'
 import concat from 'lodash/concat'
+import { getUserInfo } from '@/utils/api'
 
 /* Layouts */
 const Login = () => import('@/layouts/Login')
@@ -298,7 +299,9 @@ export default function createRouter ({ store, userManager }) {
         const user = userManager.getUser()
         const storedUser = store.state.user
         if (!storedUser || storedUser.jti !== user.jti) {
-          await store.dispatch('setUser', user)
+          const { data: { isAdmin, canCreateProject } } = await getUserInfo()
+
+          await store.dispatch('setUser', { ...user, isAdmin, canCreateProject })
         }
         return next()
       }

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -157,8 +157,8 @@ export function createTokenReview (data) {
   return createResource('/auth', data)
 }
 
-export function getUserInfo () {
-  return getResource('/api/user')
+export function getPrivileges () {
+  return getResource('/api/user/privileges')
 }
 
 export function getToken () {

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -157,6 +157,10 @@ export function createTokenReview (data) {
   return createResource('/auth', data)
 }
 
+export function getUserInfo () {
+  return getResource('/api/user')
+}
+
 export function getToken () {
   return getResource('/api/user/token')
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
We need to remove the `isAdmin` and `canCreateProject` fields from the cookie and fetch the information from the `/api/user` endpoint.
In case the permission is changed for the user, it is not properly reflected in the UI after a reload of the browser. Currently, you need to logout and login in.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
NONE
```
