### PR TITLE
Fix journals closed multiple times

### DIFF
--- a/backend/lib/github/index.js
+++ b/backend/lib/github/index.js
@@ -40,6 +40,14 @@ function searchIssues ({ state, title } = {}) {
   })
 }
 
+function getIssue ({ number }) {
+  return octokit.issues.get({
+    owner,
+    repo,
+    number
+  })
+}
+
 function closeIssue ({ number }) {
   return octokit.issues.edit({
     owner,
@@ -69,6 +77,7 @@ function createComment ({ number }, body) {
 module.exports = {
   searchIssues,
   closeIssue,
+  getIssue,
   getComments,
   createComment
 }

--- a/backend/lib/github/webhook.js
+++ b/backend/lib/github/webhook.js
@@ -129,6 +129,11 @@ function handleComment ({ action, issue, comment }) {
   } = issue = fromIssue(issue) || {}
   comment = fromComment(issueNumber, name, namespace, comment)
 
+  if (!cache.getIssue(issueNumber)) {
+    logger.debug('skipping github event issue_comment for issue number %s', issueNumber)
+    return
+  }
+
   cache.addOrUpdateIssue({ issue })
 
   if (action === 'deleted') {

--- a/backend/lib/services/journals.js
+++ b/backend/lib/services/journals.js
@@ -103,13 +103,12 @@ function getOpenIssues ({ name, namespace } = {}) {
 }
 exports.getOpenIssues = getOpenIssues
 
-function loadOpenIssues (...args) {
+async function loadOpenIssues (...args) {
   return getOpenIssues(...args)
     .reduce((cache, issues) => {
       cache.addOrUpdateIssues({ issues })
       return cache
     }, getJournalCache())
-    .then(() => undefined)
 }
 exports.loadOpenIssues = exports.list = loadOpenIssues
 
@@ -149,12 +148,11 @@ function getIssueComments ({ number }) {
 }
 exports.getIssueComments = getIssueComments
 
-function loadIssueComments ({ number }) {
+async function loadIssueComments ({ number }) {
   return getIssueComments({ number })
     .reduce((cache, comments) => {
       _.forEach(comments, comment => cache.addOrUpdateComment({ issueNumber: number, comment }))
       return cache
     }, getJournalCache())
-    .then(() => undefined)
 }
 exports.loadIssueComments = loadIssueComments

--- a/frontend/src/dialogs/CreateClusterDialog.vue
+++ b/frontend/src/dialogs/CreateClusterDialog.vue
@@ -800,7 +800,7 @@ export default {
 
       this.activeTab = 'tab-infra'
 
-      this.selectedSecret = undefined  // pragma: whitelist secret
+      this.selectedSecret = undefined // pragma: whitelist secret
       this.shootDefinition = cloneDeep(defaultShootDefinition)
 
       this.setDefaultInfrastructureKind()

--- a/frontend/src/pages/Secrets.vue
+++ b/frontend/src/pages/Secrets.vue
@@ -212,7 +212,7 @@ export default {
   },
   data () {
     return {
-      selectedSecret: {},  // pragma: whitelist secret
+      selectedSecret: {}, // pragma: whitelist secret
       dialogState: {
         aws: {
           visible: false,
@@ -268,16 +268,16 @@ export default {
       this.dialogState[infrastructureKind].help = false
     },
     onAdd (infrastructureKind) {
-      this.selectedSecret = undefined  // pragma: whitelist secret
+      this.selectedSecret = undefined // pragma: whitelist secret
       this.dialogState[infrastructureKind].visible = true
     },
     onUpdate (row) {
       const kind = row.metadata.cloudProviderKind
-      this.selectedSecret = row  // pragma: whitelist secret
+      this.selectedSecret = row // pragma: whitelist secret
       this.dialogState[kind].visible = true
     },
     onDelete (row) {
-      this.selectedSecret = row  // pragma: whitelist secret
+      this.selectedSecret = row // pragma: whitelist secret
       this.dialogState.deleteConfirm = true
     },
     backgroundForCloudProviderKind (kind) {


### PR DESCRIPTION
**What this PR does / why we need it**:
- On `issue_comment` event, do not add issue to cache if it does not exist
- Before commenting an issue, check if it is not closed

**Which issue(s) this PR fixes**:
Fixes #351 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Journals: Improved handling when cluster was deleted and GitHub issue is auto-closed by the gardener dashboard
```
