### PR TITLE
Update node.js to v10.15.3 and alpine to v3.9

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,7 +21,7 @@
 !frontend/*.config.js
 !frontend/public
 !frontend/src
-!frontend/test
+!frontend/tests
 
 # include metadata files
 !LICENSE.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -27,3 +27,4 @@
 !LICENSE.md
 !NOTICE.md
 !VERSION
+!Dockefile

--- a/.dockerignore
+++ b/.dockerignore
@@ -27,4 +27,4 @@
 !LICENSE.md
 !NOTICE.md
 !VERSION
-!Dockefile
+!Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 #
 
 #### Base ####
-FROM node:10.15.3-alpine as base
+FROM node:10-alpine as base
 
 WORKDIR /usr/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 #
 
 #### Base ####
-FROM node:10-alpine as base
+FROM node:10.15.3-alpine as base
 
 WORKDIR /usr/src/app
 
@@ -53,11 +53,11 @@ RUN npm run lint \
     && npm run build
 
 # Release
-FROM alpine:3.8 as release
+FROM alpine:3.9 as release
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
-    && apk add --no-cache tini
+    && apk add --no-cache tini libstdc++
 
 WORKDIR /usr/src/app
 
@@ -67,7 +67,6 @@ ARG PORT=8080
 ENV PORT $PORT
 
 COPY --from=backend /usr/local/bin/node /usr/local/bin/
-COPY --from=backend /usr/lib/libgcc* /usr/lib/libstdc* /usr/lib/
 
 COPY --from=backend /usr/src/app/package.json ./
 COPY --from=backend /usr/src/app/dist  ./node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN npm install --only=production \
 
 COPY backend ./
 COPY VERSION ../
+COPY Dockerfile ../
 
 RUN npm run lint \
     && npm run test-cov \

--- a/backend/.eslintrc.js
+++ b/backend/.eslintrc.js
@@ -25,7 +25,6 @@ module.exports = {
     chai: true,
     expect: true,
     sinon: true,
-    nocks: true,
     support: true
   }
 }

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1973,6 +1973,15 @@
       "resolved": "https://registry.npmjs.org/dns-prefetch-control/-/dns-prefetch-control-0.1.0.tgz",
       "integrity": "sha1-YN20V3dOF48flBXwyrsOhbCzALI="
     },
+    "dockerfile-ast": {
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.0.14.tgz",
+      "integrity": "sha512-OnmQsW9Agoi/a5tnpm9qfrO5XI2K8lJFXI+HNwQzJP/iAqaijNV1E3pNIU1tSqLMJDnjpC3E/VfpHHQWDxSlqQ==",
+      "dev": true,
+      "requires": {
+        "vscode-languageserver-types": "^3.5.0"
+      }
+    },
     "doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -9709,6 +9718,12 @@
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
       }
+    },
+    "vscode-languageserver-types": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz",
+      "integrity": "sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A==",
+      "dev": true
     },
     "which": {
       "version": "1.3.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -57,6 +57,7 @@
     "chai": "^4.1.2",
     "chai-http": "^4.0.0",
     "cross-env": "^5.2.0",
+    "dockerfile-ast": "0.0.14",
     "eslint": "^5.13.0",
     "eslint-config-standard": "^12.0.0",
     "eslint-friendly-formatter": "^4.0.1",

--- a/backend/test/acceptance.spec.js
+++ b/backend/test/acceptance.spec.js
@@ -17,22 +17,30 @@
 'use strict'
 
 const app = require('../lib/app')
+const { k8s, auth, oidc, github, setup, teardown, verifyAndCleanAll } = require('./support/nocks')
 
 describe('acceptance', function () {
   const agent = global.createAgent(app)
   const sandbox = sinon.createSandbox()
-  const context = { agent, sandbox }
+  const context = { agent, sandbox, k8s, auth, oidc, github }
 
   before(function () {
-    nocks()
+    setup()
   })
 
   after(function () {
     agent.close()
+    teardown()
   })
 
   afterEach(function () {
-    global.verifyAndRestore(sandbox)
+    try {
+      verifyAndCleanAll()
+    } finally {
+      if (sandbox) {
+        sandbox.restore()
+      }
+    }
   })
 
   describe('api', function () {

--- a/backend/test/acceptance/api.cloudprofiles.spec.js
+++ b/backend/test/acceptance/api.cloudprofiles.spec.js
@@ -19,9 +19,8 @@
 const _ = require('lodash')
 const common = require('../support/common')
 
-module.exports = function ({ agent, sandbox }) {
+module.exports = function ({ agent, sandbox, auth }) {
   /* eslint no-unused-expressions: 0 */
-  const auth = nocks.auth
   const username = 'john.doe@example.org'
   const id = username
   const user = auth.createUser({ id })

--- a/backend/test/acceptance/api.domains.spec.js
+++ b/backend/test/acceptance/api.domains.spec.js
@@ -19,9 +19,8 @@
 const _ = require('lodash')
 const common = require('../support/common')
 
-module.exports = function ({ agent, sandbox }) {
+module.exports = function ({ agent, sandbox, auth }) {
   /* eslint no-unused-expressions: 0 */
-  const auth = nocks.auth
   const username = 'john.doe@example.org'
   const id = username
   const user = auth.createUser({ id })

--- a/backend/test/acceptance/api.info.spec.js
+++ b/backend/test/acceptance/api.info.spec.js
@@ -18,11 +18,8 @@
 
 const { version } = require('../../package')
 
-module.exports = function info ({ agent }) {
+module.exports = function info({ agent, k8s, auth }) {
   /* eslint no-unused-expressions: 0 */
-
-  const auth = nocks.auth
-  const k8s = nocks.k8s
   const username = 'john.doe@example.org'
   const id = username
   const aud = [ 'gardener' ]

--- a/backend/test/acceptance/api.infrastructureSecrets.spec.js
+++ b/backend/test/acceptance/api.infrastructureSecrets.spec.js
@@ -19,10 +19,8 @@
 const _ = require('lodash')
 const common = require('../support/common')
 
-module.exports = function ({ agent, sandbox }) {
+module.exports = function ({ agent, sandbox, k8s, auth }) {
   /* eslint no-unused-expressions: 0 */
-  const auth = nocks.auth
-  const k8s = nocks.k8s
   const name = 'bar'
   const project = 'foo'
   const namespace = `garden-${project}`

--- a/backend/test/acceptance/api.members.spec.js
+++ b/backend/test/acceptance/api.members.spec.js
@@ -18,10 +18,8 @@
 
 const _ = require('lodash')
 
-module.exports = function ({ agent }) {
+module.exports = function ({ agent, k8s, auth }) {
   /* eslint no-unused-expressions: 0 */
-  const auth = nocks.auth
-  const k8s = nocks.k8s
   const name = 'bar'
   const project = 'foo'
   const namespace = `garden-${project}`

--- a/backend/test/acceptance/api.projects.spec.js
+++ b/backend/test/acceptance/api.projects.spec.js
@@ -20,10 +20,8 @@ const _ = require('lodash')
 const { createReconnectorStub } = require('../support/common')
 const services = require('../../lib/services')
 
-module.exports = function ({ agent, sandbox }) {
+module.exports = function ({ agent, sandbox, k8s, auth }) {
   /* eslint no-unused-expressions: 0 */
-  const auth = nocks.auth
-  const k8s = nocks.k8s
   const name = 'foo'
   const namespace = `garden-${name}`
   const metadata = { name }

--- a/backend/test/acceptance/api.shoots.spec.js
+++ b/backend/test/acceptance/api.shoots.spec.js
@@ -18,10 +18,8 @@
 
 const common = require('../support/common')
 
-module.exports = function ({ agent, sandbox }) {
+module.exports = function ({ agent, sandbox, k8s, auth }) {
   /* eslint no-unused-expressions: 0 */
-  const auth = nocks.auth
-  const k8s = nocks.k8s
   const name = 'bar'
   const project = 'foo'
   const namespace = `garden-${project}`

--- a/backend/test/acceptance/api.user.spec.js
+++ b/backend/test/acceptance/api.user.spec.js
@@ -16,10 +16,8 @@
 
 'use strict'
 
-module.exports = function ({ agent, sandbox }) {
+module.exports = function ({ agent, sandbox, k8s, auth }) {
   /* eslint no-unused-expressions: 0 */
-  const auth = nocks.auth
-  const k8s = nocks.k8s
   const name = 'bar'
   const username = `${name}@example.org`
   const id = username

--- a/backend/test/acceptance/auth.spec.js
+++ b/backend/test/acceptance/auth.spec.js
@@ -64,11 +64,10 @@ async function getIssuerClient (user) {
   return client
 }
 
-module.exports = function ({ agent, sandbox }) {
+module.exports = function ({ agent, sandbox, k8s, auth }) {
   /* eslint no-unused-expressions: 0 */
 
-  const { createUser } = nocks.auth
-  const k8s = nocks.k8s
+  const { createUser } = auth
   const username = 'foo@example.org'
   const user = createUser({ id: username })
 

--- a/backend/test/acceptance/healthz.spec.js
+++ b/backend/test/acceptance/healthz.spec.js
@@ -16,9 +16,7 @@
 
 'use strict'
 
-const k8s = nocks.k8s
-
-module.exports = function ({ agent }) {
+module.exports = function ({ agent, k8s }) {
   /* eslint no-unused-expressions: 0 */
 
   it('should return the backend healthz status', async function () {

--- a/backend/test/acceptance/security.spec.js
+++ b/backend/test/acceptance/security.spec.js
@@ -16,11 +16,10 @@
 
 'use strict'
 
-const oidc = nocks.oidc
 const { oidc: { rejectUnauthorized, ca } = {} } = require('../../lib/config')
 const security = require('../../lib/security')
 
-module.exports = function ({ agent }) {
+module.exports = function ({ agent, oidc }) {
   /* eslint no-unused-expressions: 0 */
 
   it('should return the oidc issuer client', async function () {

--- a/backend/test/dockerfile.spec.js
+++ b/backend/test/dockerfile.spec.js
@@ -16,7 +16,6 @@
 
 'use strict'
 
-const assert = require('assert').strict
 const fs = require('fs')
 const path = require('path')
 const _ = require('lodash')
@@ -47,12 +46,12 @@ const activeNodeReleases = {
   }
 }
 
-async function getNodeDockerfile(nodeVersion) {
+async function getNodeDockerfile (nodeVersion) {
   const { body } = await httpClient.get(`/${nodeVersion}/alpine/Dockerfile`)
   return DockerfileParser.parse(body)
 }
 
-async function getDashboardDockerfile() {
+async function getDashboardDockerfile () {
   const filename = path.join(__dirname, '..', '..', 'Dockerfile')
   const data = await readFile(filename, 'utf8')
   return DockerfileParser.parse(data)
@@ -63,7 +62,7 @@ describe('dockerfile', function () {
 
   it('should have the same alpine base image as the corresponding node image', async function () {
     const dashboardDockerfile = await getDashboardDockerfile()
-    
+
     expect(dashboardDockerfile.getFROMs()).to.have.length(4)
     const buildStages = _
       .chain(dashboardDockerfile.getFROMs())

--- a/backend/test/dockerfile.spec.js
+++ b/backend/test/dockerfile.spec.js
@@ -25,41 +25,60 @@ const readFile = promisify(fs.readFile)
 const got = require('got')
 const { DockerfileParser } = require('dockerfile-ast')
 const httpClient = got.extend({
-    baseUrl: 'https://raw.githubusercontent.com/nodejs/docker-node/master',
-    timeout: 3000
+  baseUrl: 'https://raw.githubusercontent.com/nodejs/docker-node/master',
+  timeout: 3000
 })
+/* Nodejs release schedule (see https://nodejs.org/en/about/releases/) */
+const activeNodeReleases = {
+  '10': {
+    initialRelease: new Date('2018-04-24T00:00:00Z'),
+    activeLtsStart: new Date('2018-10-30T00:00:00Z'),
+    endOfLife: new Date('2021-04-01T23:59:59Z')
+  },
+  '12': {
+    initialRelease: new Date('2019-04-23T00:00:00Z'),
+    activeLtsStart: new Date('2019-10-22T00:00:00Z'),
+    endOfLife: new Date('2022-04-01T23:59:59Z')
+  },
+  '14': {
+    initialRelease: new Date('2020-04-21T00:00:00Z'),
+    activeLtsStart: new Date('2020-10-20T00:00:00Z'),
+    endOfLife: new Date('2023-04-01T23:59:59Z')
+  }
+}
 
 async function getNodeDockerfile(nodeVersion) {
-    const { body } = await httpClient.get(`/${nodeVersion}/alpine/Dockerfile`)
-    return DockerfileParser.parse(body)
+  const { body } = await httpClient.get(`/${nodeVersion}/alpine/Dockerfile`)
+  return DockerfileParser.parse(body)
 }
 
 async function getDashboardDockerfile() {
-    const filename = path.join(__dirname, '..', '..', 'Dockerfile')
-    const data = await readFile(filename, 'utf8')
-    return DockerfileParser.parse(data)
+  const filename = path.join(__dirname, '..', '..', 'Dockerfile')
+  const data = await readFile(filename, 'utf8')
+  return DockerfileParser.parse(data)
 }
 
 describe('dockerfile', function () {
-    this.timeout(5000)
+  this.timeout(5000)
 
-    it('should have the same alpine base image as the corresponding node image', async function () {
-        const dashboardDockerfile = await getDashboardDockerfile()
-        
-        expect(dashboardDockerfile.getFROMs()).to.have.length(4)
-        const buildStages = _
-            .chain(dashboardDockerfile.getFROMs())
-            .map(from => [from.getBuildStage(), from])
-            .fromPairs()
-            .value()
-        const imageTag = buildStages.base.getImageTag()
-        const [, nodeVersion] = /^(1[0-9])\-alpine$/.exec(imageTag) || []
-        expect(nodeVersion).to.not.be.undefined
-        
-        const nodeDockerfile = await getNodeDockerfile(nodeVersion)
-        expect(nodeDockerfile.getFROMs()).to.have.length(1)
-        const nodeBaseImage = _.first(nodeDockerfile.getFROMs()).getImage()
-        const dashboardReleaseBaseImage = buildStages.release.getImage()
-        expect(nodeBaseImage, 'Alpine base images of "dashboard-release" image and "node" image do not match!').to.be.equal(dashboardReleaseBaseImage)
-    })
+  it('should have the same alpine base image as the corresponding node image', async function () {
+    const dashboardDockerfile = await getDashboardDockerfile()
+    
+    expect(dashboardDockerfile.getFROMs()).to.have.length(4)
+    const buildStages = _
+      .chain(dashboardDockerfile.getFROMs())
+      .map(from => [from.getBuildStage(), from])
+      .fromPairs()
+      .value()
+    const imageTag = buildStages.base.getImageTag()
+    const [, nodeRelease] = /^(\d+(?:\.\d+)?(?:\.\d+)?)-alpine$/.exec(imageTag) || []
+    expect(_.keys(activeNodeReleases), `Node release ${nodeRelease} is not in the range of active LTS releases`).to.include(nodeRelease)
+    const endOfLife = activeNodeReleases[nodeRelease].endOfLife
+    expect(endOfLife, `Node release ${nodeRelease} reached end of life. Update node base image in Dockerfile.`).to.be.above(new Date())
+    const nodeDockerfile = await getNodeDockerfile(nodeRelease)
+    expect(nodeDockerfile.getFROMs()).to.have.length(1)
+    const nodeBaseImage = _.first(nodeDockerfile.getFROMs()).getImage()
+    const dashboardReleaseBaseImage = buildStages.release.getImage()
+    expect(nodeBaseImage, 'Alpine base images of "dashboard-release" image and "node" image do not match!').to.be.equal(dashboardReleaseBaseImage)
+  })
 })

--- a/backend/test/dockerfile.spec.js
+++ b/backend/test/dockerfile.spec.js
@@ -1,0 +1,65 @@
+//
+// Copyright (c) 2019 by SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+'use strict'
+
+const assert = require('assert').strict
+const fs = require('fs')
+const path = require('path')
+const _ = require('lodash')
+const { promisify } = require('util')
+const readFile = promisify(fs.readFile)
+const got = require('got')
+const { DockerfileParser } = require('dockerfile-ast')
+const httpClient = got.extend({
+    baseUrl: 'https://raw.githubusercontent.com/nodejs/docker-node/master',
+    timeout: 3000
+})
+
+async function getNodeDockerfile(nodeVersion) {
+    const { body } = await httpClient.get(`/${nodeVersion}/alpine/Dockerfile`)
+    return DockerfileParser.parse(body)
+}
+
+async function getDashboardDockerfile() {
+    const filename = path.join(__dirname, '..', '..', 'Dockerfile')
+    const data = await readFile(filename, 'utf8')
+    return DockerfileParser.parse(data)
+}
+
+describe('dockerfile', function () {
+    this.timeout(5000)
+
+    it('should have the same alpine base image as the corresponding node image', async function () {
+        const dashboardDockerfile = await getDashboardDockerfile()
+        
+        expect(dashboardDockerfile.getFROMs()).to.have.length(4)
+        const buildStages = _
+            .chain(dashboardDockerfile.getFROMs())
+            .map(from => [from.getBuildStage(), from])
+            .fromPairs()
+            .value()
+        const imageTag = buildStages.base.getImageTag()
+        const [, nodeVersion] = /^(1[0-9])\-alpine$/.exec(imageTag) || []
+        expect(nodeVersion).to.not.be.undefined
+        
+        const nodeDockerfile = await getNodeDockerfile(nodeVersion)
+        expect(nodeDockerfile.getFROMs()).to.have.length(1)
+        const nodeBaseImage = _.first(nodeDockerfile.getFROMs()).getImage()
+        const dashboardReleaseBaseImage = buildStages.release.getImage()
+        expect(nodeBaseImage, 'Alpine base images of "dashboard-release" image and "node" image do not match!').to.be.equal(dashboardReleaseBaseImage)
+    })
+})

--- a/backend/test/support/index.js
+++ b/backend/test/support/index.js
@@ -26,19 +26,7 @@ delete process.env.https_proxy
 /*!
  * Common modules
  */
-
 global.sinon = require('sinon')
-global.nocks = require('./nocks')()
-function verifyAndRestore (sandbox) {
-  try {
-    global.nocks.verifyAndCleanAll()
-  } finally {
-    if (sandbox) {
-      sandbox.restore()
-    }
-  }
-}
-global.verifyAndRestore = verifyAndRestore
 
 /*!
  * Attach chai to global

--- a/backend/test/support/nocks/index.js
+++ b/backend/test/support/nocks/index.js
@@ -18,18 +18,23 @@
 
 const nock = require('nock')
 
-exports = module.exports = init
+exports = module.exports = setup
 exports.auth = require('./auth')
 exports.k8s = require('./k8s')
 exports.oidc = require('./oidc')
 exports.github = require('./github')
-exports.verifyAndCleanAll = verifyAndCleanAll
 
-function init () {
+function setup () {
   nock.disableNetConnect()
   nock.enableNetConnect('127.0.0.1')
-  return exports
 }
+exports.setup = setup
+
+function teardown () {
+  nock.cleanAll()
+  nock.enableNetConnect()
+}
+exports.teardown = teardown
 
 function verifyAndCleanAll () {
   try {
@@ -42,3 +47,4 @@ function verifyAndCleanAll () {
     nock.cleanAll()
   }
 }
+exports.verifyAndCleanAll = verifyAndCleanAll


### PR DESCRIPTION
**What this PR does / why we need it**:
The official node 10-alpine image has been updated to version  v10.15.3 and with this update the alpine base image has also been updated to version 3.9. But our production base image was still alpine 3.8. This situation needs to be avoided in the future. With this PR the node image version is fully specified and has to be updated explicitly. It is important that we always use the same base image as the node alpine image.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement
- target_group:   operator
-->
```improvement operator
Update node.js to v10.15.3 and alpine OS to v3.9
```
