### PR TITLE
[MASTER] [FIX] Regions without seed for azure

### DIFF
--- a/backend/lib/services/cloudprofiles.js
+++ b/backend/lib/services/cloudprofiles.js
@@ -28,8 +28,9 @@ function fromResource ({ cloudProfile: { metadata, spec }, seeds }) {
   const displayName = _.get(metadata, ['annotations', 'garden.sapcloud.io/displayName'], name)
   const resourceVersion = _.get(metadata, 'resourceVersion')
   metadata = { name, cloudProviderKind, displayName, resourceVersion }
-  const constraints = _.get(spec, `${cloudProviderKind}.constraints`)
-  const data = { seeds, keyStoneURL, ...constraints }
+  const constraints = _.get(spec, [cloudProviderKind, 'constraints'])
+  const countUpdateDomains = _.get(spec, [cloudProviderKind, 'countUpdateDomains'])
+  const data = { seeds, keyStoneURL, ...constraints, countUpdateDomains }
   return { metadata, data }
 }
 

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -145,7 +145,8 @@ const getters = {
   regionsWithoutSeedByCloudProfileName (state, getters) {
     return (cloudProfileName) => {
       const cloudProfile = getters.cloudProfileByName(cloudProfileName)
-      const allRegions = uniq(map(get(cloudProfile, 'data.zones'), 'region'))
+      const regionsInCloudProfile = get(cloudProfile, 'data.zones', get(cloudProfile, 'data.countUpdateDomains'))
+      const allRegions = uniq(map(regionsInCloudProfile, 'region'))
       const regionsWithoutSeed = difference(allRegions, getters.regionsWithSeedByCloudProfileName(cloudProfileName))
       return regionsWithoutSeed
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
Include countUpdateDomains in cloud profile returned from backend to allow frontend to show regions without seed for azure.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
NONE
```
