### PR TITLE
[HOTFIX]Fix extra newline generated from 'toyaml' function

### DIFF
--- a/charts/gardener-dashboard/templates/configmap.yaml
+++ b/charts/gardener-dashboard/templates/configmap.yaml
@@ -76,7 +76,7 @@ data:
 {{- end }}
 {{- if .Values.frontendConfig.defaultHibernationSchedule }}
       defaultHibernationSchedule:
-{{ toYaml .Values.frontendConfig.defaultHibernationSchedule | indent 8 }}
+{{ toYaml .Values.frontendConfig.defaultHibernationSchedule | trim | indent 8 }}
 {{- end }}
 {{- if .Values.frontendConfig.seedCandidateDeterminationStrategy }}
       seedCandidateDeterminationStrategy: {{ .Values.frontendConfig.seedCandidateDeterminationStrategy }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix extra newline generated from 'toyaml' function in configmap.yaml.
Because of the newline the configmap looked something like
```yaml
data:
  config.yaml: "port: 8080\nlogLevel: .....
```

instead of
```yaml
data:
  config.yaml: |
    port: 8080
    logLevel: .....
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
see also helm/helm#3470

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
