### PR TITLE
[HOTFIX] Changed countUpdateDomains to countFaultDomains

### DIFF
--- a/backend/lib/services/cloudprofiles.js
+++ b/backend/lib/services/cloudprofiles.js
@@ -29,8 +29,8 @@ function fromResource ({ cloudProfile: { metadata, spec }, seeds }) {
   const resourceVersion = _.get(metadata, 'resourceVersion')
   metadata = { name, cloudProviderKind, displayName, resourceVersion }
   const constraints = _.get(spec, [cloudProviderKind, 'constraints'])
-  const countUpdateDomains = _.get(spec, [cloudProviderKind, 'countUpdateDomains'])
-  const data = { seeds, keyStoneURL, ...constraints, countUpdateDomains }
+  const countFaultDomains = _.get(spec, [cloudProviderKind, 'countFaultDomains'])
+  const data = { seeds, keyStoneURL, ...constraints, countFaultDomains }
   return { metadata, data }
 }
 

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -145,7 +145,7 @@ const getters = {
   regionsWithoutSeedByCloudProfileName (state, getters) {
     return (cloudProfileName) => {
       const cloudProfile = getters.cloudProfileByName(cloudProfileName)
-      const regionsInCloudProfile = get(cloudProfile, 'data.zones', get(cloudProfile, 'data.countUpdateDomains'))
+      const regionsInCloudProfile = get(cloudProfile, 'data.zones', get(cloudProfile, 'data.countFaultDomains'))
       const allRegions = uniq(map(regionsInCloudProfile, 'region'))
       const regionsWithoutSeed = difference(allRegions, getters.regionsWithSeedByCloudProfileName(cloudProfileName))
       return regionsWithoutSeed


### PR DESCRIPTION
**What this PR does / why we need it**:
Include countUpdateDomains in cloud profile returned from backend to allow frontend to show regions without seed for azure.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
Fixed: Show regions without API server when creating a new cluster on Azure infrastructure
```
