### PR TITLE
Respect the value of the ignore annotation

### DIFF
--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -368,7 +368,8 @@ export function shootHasIssue (shoot) {
 }
 
 export function isReconciliationDeactivated (metadata) {
-  return get(metadata, ['annotations', 'shoot.garden.sapcloud.io/ignore']) === 'true'
+  const truthyValues = ['1', 't', 'T', 'true', 'TRUE', 'True']
+  return includes(truthyValues, get(metadata, ['annotations', 'shoot.garden.sapcloud.io/ignore']))
 }
 
 export function isStatusProgressing (metadata) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Until now the shoot ignore (is reconcile deactivated) check was to check if shoot.garden.sapcloud.io/ignore annotation is `'true'`. This PR modifies the check to respect the value of the annotation. Truthy values are `'1'`, `'t'`, `'T'`, `'true'`, `'TRUE'`, `'True'`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
See related PR in gardener https://github.com/gardener/gardener/pull/878

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
Improved check if cluster reconciliation is deactivated
```
