### PR TITLE
Fixed delete the hibernation start / hibernation end time

### DIFF
--- a/frontend/src/components/HibernationScheduleEvent.vue
+++ b/frontend/src/components/HibernationScheduleEvent.vue
@@ -196,13 +196,15 @@ export default {
     },
     updateTime ({ eventName, time }) {
       const momentObj = moment(time, 'HHmm')
-      const hour = momentObj.format('HH')
-      const minute = momentObj.format('mm')
+      let hour
+      let minute
       const id = this.id
       if (momentObj.isValid()) {
-        this.$emit(eventName, { hour, minute, id })
-        this.validateInput()
+        hour = momentObj.format('HH')
+        minute = momentObj.format('mm')
       }
+      this.$emit(eventName, { hour, minute, id })
+      this.validateInput()
     },
     getTime ({ hour, minute } = {}) {
       if (hour && minute) {


### PR DESCRIPTION
**What this PR does / why we need it**:
When changing an existing hibernation schedule, it is not possible to remove either the `Wake up at` time or the `Hibernate at` time

**Which issue(s) this PR fixes**:
Fixes #383

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
Fixed: When changing an existing hibernation schedule it was not possible to remove either the `Wake up at` time or the `Hibernate at` time
```
