### PR TITLE
Dedeprecate nginx ingress-controller for now

### DIFF
--- a/frontend/src/components/ShootAddonsCard.vue
+++ b/frontend/src/components/ShootAddonsCard.vue
@@ -79,7 +79,7 @@ export default {
         {
           name: 'kubernetes-dashboard',
           title: 'Dashboard',
-          description: 'General-purpose web UI for Kubernetes clusters'
+          description: 'General-purpose web UI for Kubernetes clusters.'
         },
         {
           name: 'monocular',
@@ -89,7 +89,7 @@ export default {
         {
           name: 'nginx-ingress',
           title: 'Nginx Ingress (Deprecated)',
-          description: 'This add-on is deprecated and will be removed in the future. You can install it or an alternative ingress controller always manually. If you choose to install it with the cluster, please note that Gardener will include it in its reconciliation and you can’t configure or override it’s configuration.'
+          description: 'Default ingress-controller. Alternatively you may install any other ingress-controller of your liking. If you select this option, please note that Gardener will include it in its reconciliation and you can’t override it’s configuration.'
         }
       ]
     }

--- a/frontend/src/dialogs/CreateClusterDialog.vue
+++ b/frontend/src/dialogs/CreateClusterDialog.vue
@@ -337,14 +337,14 @@ const standardAddonDefinitionList = [
   {
     name: 'kubernetes-dashboard',
     title: 'Dashboard',
-    description: 'General-purpose web UI for Kubernetes clusters',
+    description: 'General-purpose web UI for Kubernetes clusters.',
     visible: true,
     enabled: true
   },
   {
     name: 'nginx-ingress',
     title: 'Nginx Ingress (Deprecated)',
-    description: 'This add-on is deprecated and will be removed in the future. You can install it or an alternative ingress controller always manually. If you choose to install it with the cluster, please note that Gardener will include it in its reconciliation and you can’t configure or override it’s configuration.',
+    description: 'Default ingress-controller. Alternatively you may install any other ingress-controller of your liking. If you select this option, please note that Gardener will include it in its reconciliation and you can’t override it’s configuration.',
     visible: true,
     enabled: true
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
People were complaining why we have deprecated this controller w/o replacement, so let's de-deprecate it for now again to avoid confusion.

**Release note**:
```noteworthy user
We have de-deprecated the `nginx` ingress-controller to avoid confusion until there is an alternative
```
