### PR TITLE
keep all values when saving a worker group

### DIFF
--- a/frontend/src/components/ManageWorkers.vue
+++ b/frontend/src/components/ManageWorkers.vue
@@ -70,7 +70,7 @@ import forEach from 'lodash/forEach'
 import get from 'lodash/get'
 import find from 'lodash/find'
 import head from 'lodash/head'
-import pick from 'lodash/pick'
+import omit from 'lodash/omit'
 import assign from 'lodash/assign'
 const uuidv4 = require('uuid/v4')
 
@@ -177,7 +177,7 @@ export default {
     getWorkers () {
       const workers = []
       forEach(this.internalWorkers, internalWorker => {
-        const worker = pick(internalWorker, 'name', 'machineType', 'volumeType', 'volumeSize', 'autoScalerMin', 'autoScalerMax')
+        const worker = omit(internalWorker, 'id')
         workers.push(worker)
       })
       return workers


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #389

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
Fixed: When editing worker groups with the Dashboard, not all values were retained
```
