### PR TITLE
open project/clusters when searching on enter

### DIFF
--- a/frontend/src/components/MainNavigation.vue
+++ b/frontend/src/components/MainNavigation.vue
@@ -72,6 +72,7 @@ limitations under the License.
                 v-model="projectFilter"
                 ref="projectFilter"
                 @keyup.esc="projectFilter = ''"
+                @keyup.enter="onProjectFilterSubmit()"
                 autofocus
               >
               </v-text-field>
@@ -155,6 +156,7 @@ import includes from 'lodash/includes'
 import replace from 'lodash/replace'
 import get from 'lodash/get'
 import isEmpty from 'lodash/isEmpty'
+import head from 'lodash/head'
 import { emailToDisplayName, setDelayedInputFocus, routes, namespacedRoute, routeName } from '@/utils'
 import ProjectCreateDialog from '@/dialogs/ProjectDialog'
 
@@ -260,6 +262,16 @@ export default {
     onProjectSelect (project) {
       this.projectMenu = false
       this.project = project
+    },
+    onProjectFilterSubmit () {
+      this.$nextTick(() => { // give events time to react (if v-list tile is active)
+        if (this.projectMenu) {
+          const project = head(this.sortedAndFilteredProjectList)
+          if (project) {
+            this.onProjectSelect(project)
+          }
+        }
+      })
     },
     openProjectDialog () {
       this.projectMenu = false


### PR DESCRIPTION
**What this PR does / why we need it**:
open project/clusters when searching on enter

**Which issue(s) this PR fixes**:
Fixes #381

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
Open first project from filtered project list on enter
```
