### PR TITLE
Make identity tls secret configurable

### DIFF
--- a/charts/identity/templates/ingress.yaml
+++ b/charts/identity/templates/ingress.yaml
@@ -16,7 +16,7 @@ metadata:
 {{- $pathname := regexReplaceAll "https://[^/]*(?:/(.+))?" $.Values.issuerUrl "/${1}" }}
 spec:
   tls:
-    - secretName: identity-tls
+    - secretName: {{ .Values.tlsSecretName | default "identity-tls" }}
       hosts:
         - {{ $hostname }}
   rules:

--- a/charts/identity/templates/secret.yaml
+++ b/charts/identity/templates/secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: identity-tls
+  name: {{ .Values.tlsSecretName | default "identity-tls" }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: identity

--- a/charts/identity/templates/secret.yaml
+++ b/charts/identity/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.tls }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -12,3 +13,4 @@ type: kubernetes.io/tls
 data:
   tls.crt: {{ required ".Values.tls.crt is required" (b64enc .Values.tls.crt) }}
   tls.key: {{ required ".Values.tls.key is required" (b64enc .Values.tls.key) }}
+{{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
If you create a secret containing a valid certificate for the dashboard and that secret is maintained/updated by another instance - as for example the case with the cert-manager - there is currently no nice way to use this secret as tls secret for identity. The identity deployment will either overwrite it, or you copy the data from that secret to the `identity-tls` secret and have to keep it in sync, which requires an extra controller.

This PR does two things:
First, it makes the deployment of the `identity-tls` secret optional. By setting `tls` in the values file to something that helm evaluates to `false`, the secret won't be deployed anymore. Take care that you'll have to provide the secret yourself in that case, otherwise you'll be left with an incorrect configuration.
Second, a new value `tlsSecretName` in the values file allows to configure the name of the secret. This was done so the component that creates the secret (if not deployed by identity) does not have to rely on a name hardcoded in the identity helm chart, but can guarantee that identity uses the secret it creates.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
The identity helm chart can now be configured to not deploy the tls secret. Furthermore, the name of that secret can be configured by overwriting `tlsSecretName` in the values file.
```
