### PR TITLE
[WIP]Enhance Dashboard with Viewers

### DIFF
--- a/backend/lib/routes/index.js
+++ b/backend/lib/routes/index.js
@@ -25,5 +25,6 @@ module.exports = {
   '/namespaces': require('./namespaces'),
   '/namespaces/:namespace/shoots': require('./shoots'),
   '/namespaces/:namespace/infrastructure-secrets': require('./infrastructureSecrets'),
-  '/namespaces/:namespace/members': require('./members')
+  '/namespaces/:namespace/members': require('./members'),
+  '/namespaces/:namespace/viewers': require('./viewers')
 }

--- a/backend/lib/routes/viewers.js
+++ b/backend/lib/routes/viewers.js
@@ -1,0 +1,67 @@
+//
+// Copyright (c) 2019 by SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+'use strict'
+
+const express = require('express')
+const { viewers } = require('../services')
+
+const router = module.exports = express.Router({
+  mergeParams: true
+})
+
+router.route('/')
+  .get(async (req, res, next) => {
+    try {
+      const user = req.user
+      const namespace = req.params.namespace
+      res.send(await viewers.list({ user, namespace }))
+    } catch (err) {
+      next(err)
+    }
+  })
+  .post(async (req, res, next) => {
+    try {
+      const user = req.user
+      const namespace = req.params.namespace
+      const body = req.body
+      res.send(await viewers.create({ user, namespace, body }))
+    } catch (err) {
+      next(err)
+    }
+  })
+
+router.route('/:name')
+  .get(async (req, res, next) => {
+    try {
+      const user = req.user
+      const namespace = req.params.namespace
+      const name = req.params.name
+      res.send(await viewers.get({ user, namespace, name }))
+    } catch (err) {
+      next(err)
+    }
+  })
+  .delete(async (req, res, next) => {
+    try {
+      const user = req.user
+      const namespace = req.params.namespace
+      const name = req.params.name
+      res.send(await viewers.remove({ user, namespace, name }))
+    } catch (err) {
+      next(err)
+    }
+  })

--- a/backend/lib/services/index.js
+++ b/backend/lib/services/index.js
@@ -21,6 +21,7 @@ module.exports = {
   shoots: require('./shoots'),
   infrastructureSecrets: require('./infrastructureSecrets'),
   members: require('./members'),
+  viewers: require('./viewers'),
   authorization: require('./authorization'),
   authentication: require('./authentication'),
   journals: require('./journals'),

--- a/backend/lib/services/viewers.js
+++ b/backend/lib/services/viewers.js
@@ -1,0 +1,239 @@
+//
+// Copyright (c) 2019 by SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+'use strict'
+
+const _ = require('lodash')
+const yaml = require('js-yaml')
+const config = require('../config')
+const { decodeBase64, getProjectByNamespace } = require('../utils')
+const kubernetes = require('../kubernetes')
+const { Conflict, NotFound } = require('../errors.js')
+
+function Core ({ auth }) {
+  return kubernetes.core({ auth })
+}
+
+function Garden ({ auth }) {
+  return kubernetes.garden({ auth })
+}
+
+function toServiceAccountName ({ metadata: { name, namespace } }) {
+  return `system:serviceaccount:${namespace}:${name}`
+}
+
+function fromResource (project = {}, serviceAccounts = []) {
+  const serviceAccountsMetadata = _
+    .chain(serviceAccounts)
+    .map(serviceAccount => [
+      toServiceAccountName(serviceAccount),
+      {
+        createdBy: _.get(serviceAccount, ['metadata', 'annotations', 'garden.sapcloud.io/createdBy']),
+        creationTimestamp: serviceAccount.metadata.creationTimestamp
+      }
+    ])
+    .fromPairs()
+    .value()
+
+  return _
+    .chain(project)
+    .get('spec.viewers')
+    .filter(['kind', 'User'])
+    .map('name')
+    .map(username => ({
+      username,
+      ...serviceAccountsMetadata[username]
+    }))
+    .value()
+}
+
+function getKubeconfig ({ serviceaccountName, serviceaccountNamespace, projectName = 'default', token, server, caData }) {
+  const clusterName = 'garden'
+  const cluster = {
+    'certificate-authority-data': caData,
+    server
+  }
+  const userName = serviceaccountName
+  const user = {
+    token
+  }
+  const contextName = `${clusterName}-${projectName}-${userName}`
+  const context = {
+    cluster: clusterName,
+    user: userName,
+    namespace: serviceaccountNamespace
+  }
+  return yaml.safeDump({
+    kind: 'Config',
+    clusters: [{
+      cluster,
+      name: clusterName
+    }],
+    users: [{
+      user,
+      name: userName
+    }],
+    contexts: [{
+      context,
+      name: contextName
+    }],
+    'current-context': contextName
+  })
+}
+
+function createServiceaccount (core, namespace, name, user) {
+  const body = {
+    metadata: {
+      name,
+      namespace,
+      annotations: {
+        'garden.sapcloud.io/createdBy': user.id
+      }
+    }
+  }
+  return core.namespaces(namespace).serviceaccounts.post({
+    body
+  })
+}
+
+function deleteServiceaccount (core, namespace, name) {
+  return core.namespaces(namespace).serviceaccounts.delete({
+    name
+  })
+    .catch(err => {
+      if (err.code === 404 || err.code === 410) {
+        return { metadata: { name, namespace } }
+      }
+      throw err
+    })
+}
+
+async function setProjectViewer (projects, namespaces, namespace, username) {
+  // get project
+  const project = await getProjectByNamespace(projects, namespaces, namespace)
+  // get project viewers from project
+  const viewers = _.slice(project.spec.viewers, 0)
+  if (_.find(viewers, ['name', username])) {
+    throw new Conflict(`User '${username}' is already viewer of this project`)
+  }
+  viewers.push({
+    kind: 'User',
+    name: username,
+    apiGroup: 'rbac.authorization.k8s.io'
+  })
+  const body = {
+    spec: {
+      viewers
+    }
+  }
+  return projects.mergePatch({ name: project.metadata.name, body })
+}
+
+async function unsetProjectViewer (projects, namespaces, namespace, username) {
+  // get project
+  const project = await getProjectByNamespace(projects, namespaces, namespace)
+  // get project viewers from project
+  const viewers = _.slice(project.spec.viewers, 0)
+  if (!_.find(viewers, ['name', username])) {
+    return project
+  }
+  _.remove(viewers, ['name', username])
+  const body = {
+    spec: {
+      viewers
+    }
+  }
+  return projects.mergePatch({ name: project.metadata.name, body })
+}
+
+// list, create and remove is done with the user
+exports.list = async function ({ user, namespace }) {
+  const projects = Garden(user).projects
+  const core = Core(user)
+  const namespaces = core.namespaces
+
+  const project = await getProjectByNamespace(projects, namespaces, namespace)
+  const { items: serviceAccountList } = await core.namespaces(namespace).serviceaccounts.get({})
+
+  // get project viewers from project
+  return fromResource(project, serviceAccountList)
+}
+
+exports.get = async function ({ user, namespace, name: username }) {
+  const projects = Garden(user).projects
+  const namespaces = Core(user).namespaces
+
+  const project = await getProjectByNamespace(projects, namespaces, namespace)
+
+  const projectName = project.metadata.name
+  // find viewer of project
+  const viewer = _.find(project.spec.viewers, {
+    name: username,
+    kind: 'User'
+  })
+  if (!viewer) {
+    throw new NotFound(`User ${username} is not a viewer of project ${projectName}`)
+  }
+  const [, serviceaccountNamespace, serviceaccountName] = /^system:serviceaccount:([^:]+):([^:]+)$/.exec(username) || []
+  if (serviceaccountNamespace === namespace) {
+    const core = Core(user)
+    const ns = core.namespaces(namespace)
+    const serviceaccount = await ns.serviceaccounts.get({
+      name: serviceaccountName
+    })
+    const api = ns.serviceaccounts.api
+    const server = _.get(config, 'apiServerUrl', api.url)
+    const secret = await ns.secrets.get({
+      name: _.first(serviceaccount.secrets).name
+    })
+    const token = decodeBase64(secret.data.token)
+    const caData = secret.data['ca.crt']
+    viewer.kind = 'ServiceAccount'
+    viewer.kubeconfig = getKubeconfig({ serviceaccountName, serviceaccountNamespace, projectName, token, caData, server })
+  }
+  return viewer
+}
+
+exports.create = async function ({ user, namespace, body: { name: username } }) {
+  const [, serviceaccountNamespace, serviceaccountName] = /^system:serviceaccount:([^:]+):([^:]+)$/.exec(username) || []
+  const core = Core(user)
+  if (serviceaccountNamespace === namespace) {
+    await createServiceaccount(core, serviceaccountNamespace, serviceaccountName, user)
+  }
+  const projects = Garden(user).projects
+  const namespaces = core.namespaces
+
+  // assign user to project
+  const project = await setProjectViewer(projects, namespaces, namespace, username)
+  const { items: serviceAccountList } = await core.namespaces(namespace).serviceaccounts.get({})
+  return fromResource(project, serviceAccountList)
+}
+
+exports.remove = async function ({ user, namespace, name: username }) {
+  const projects = Garden(user).projects
+  const core = Core(user)
+  const namespaces = core.namespaces
+
+  // unassign user from project
+  const project = await unsetProjectViewer(projects, namespaces, namespace, username)
+  const [, serviceaccountNamespace, serviceaccountName] = /^system:serviceaccount:([^:]+):([^:]+)$/.exec(username) || []
+  if (serviceaccountNamespace === namespace) {
+    await deleteServiceaccount(core, serviceaccountNamespace, serviceaccountName)
+  }
+
+  const { items: serviceAccountList } = await core.namespaces(namespace).serviceaccounts.get({})
+  return fromResource(project, serviceAccountList)
+}

--- a/backend/test/acceptance.spec.js
+++ b/backend/test/acceptance.spec.js
@@ -64,6 +64,10 @@ describe('acceptance', function () {
       require('./acceptance/api.members.spec.js')(context)
     })
 
+    describe('viewers', function () {
+      require('./acceptance/api.viewers.spec.js')(context)
+    })
+
     describe('projects', function () {
       require('./acceptance/api.projects.spec.js')(context)
     })

--- a/backend/test/acceptance/api.viewers.spec.js
+++ b/backend/test/acceptance/api.viewers.spec.js
@@ -1,0 +1,123 @@
+//
+// Copyright (c) 2019 by SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+'use strict'
+
+const _ = require('lodash')
+
+module.exports = function ({ agent, k8s, auth }) {
+  /* eslint no-unused-expressions: 0 */
+  const name = 'bar'
+  const project = 'foo'
+  const namespace = `garden-${project}`
+  const viewers = k8s.readProjectViewers(namespace)
+  const metadata = {}
+  const username = `${name}@example.org`
+  const id = username
+  const user = auth.createUser({ id })
+
+  it('should return two project viewers', async function () {
+    const bearer = await user.bearer
+    k8s.stub.getViewers({ bearer, namespace })
+    const res = await agent
+      .get(`/api/namespaces/${namespace}/viewers`)
+      .set('cookie', await user.cookie)
+
+    expect(res).to.have.status(200)
+    expect(res).to.be.json
+    expect(res.body).to.eql(viewers)
+  })
+
+  it('should not return viewers but respond "Namespace not found"', async function () {
+    const bearer = await user.bearer
+    const namespace = 'garden-baz'
+    k8s.stub.getViewers({ bearer, namespace })
+    const res = await agent
+      .get(`/api/namespaces/${namespace}/viewers`)
+      .set('cookie', await user.cookie)
+
+    expect(res).to.have.status(404)
+    expect(res).to.be.json
+    expect(res.body.message).to.equal('Namespace not found')
+  })
+
+  it('should return a service account', async function () {
+    const bearer = await user.bearer
+    const serviceAccountName = 'robot'
+    const name = `system:serviceaccount:${namespace}:${serviceAccountName}`
+    k8s.stub.getViewer({ bearer, namespace, name })
+    const res = await agent
+      .get(`/api/namespaces/${namespace}/viewers/${name}`)
+      .set('cookie', await user.cookie)
+
+    expect(res).to.have.status(200)
+    expect(res).to.be.json
+    expect(res.body.name).to.equal(name)
+    expect(res.body.kind).to.equal('ServiceAccount')
+    expect(res.body).to.have.property('kubeconfig')
+  })
+
+  it('should add a project viewer', async function () {
+    const bearer = await user.bearer
+    const name = 'baz@example.org'
+    k8s.stub.addViewer({ bearer, namespace, name })
+    const res = await agent
+      .post(`/api/namespaces/${namespace}/viewers`)
+      .set('cookie', await user.cookie)
+      .send({ metadata, name })
+
+    expect(res).to.have.status(200)
+    expect(res).to.be.json
+    expect(res.body).to.eql(_.concat(viewers, { username: 'baz@example.org' }))
+  })
+
+  it('should not add viewer that is already a project viewer', async function () {
+    const bearer = await user.bearer
+    const name = 'foo@example.org'
+    k8s.stub.addViewer({ bearer, namespace, name })
+    const res = await agent
+      .post(`/api/namespaces/${namespace}/viewers`)
+      .set('cookie', await user.cookie)
+      .send({ metadata, name })
+    expect(res).to.have.status(409)
+  })
+
+  it('should delete a project viewer', async function () {
+    const bearer = await user.bearer
+    const name = 'bar@example.org'
+    k8s.stub.removeViewer({ bearer, namespace, name })
+    const res = await agent
+      .delete(`/api/namespaces/${namespace}/viewers/${name}`)
+      .set('cookie', await user.cookie)
+
+    expect(res).to.have.status(200)
+    expect(res).to.be.json
+    expect(res.body).to.eql(_.filter(viewers, ({ username }) => username !== name))
+  })
+
+  it('should not delete viewer that is not a project viewer', async function () {
+    const bearer = await user.bearer
+    const name = 'baz@example.org'
+    k8s.stub.removeViewer({ bearer, namespace, name })
+    const res = await agent
+      .delete(`/api/namespaces/${namespace}/viewers/${name}`)
+      .set('cookie', await user.cookie)
+
+    expect(res).to.have.status(200)
+    expect(res).to.be.json
+    expect(res.body).to.eql(viewers)
+  })
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1079,7 +1079,7 @@
     },
     "acorn-jsx": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "optional": true,
@@ -1089,7 +1089,7 @@
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
-          "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true,
           "optional": true
@@ -1251,7 +1251,7 @@
     },
     "array-flatten": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
       "dev": true
     },
@@ -1466,7 +1466,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -1787,7 +1787,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -1824,7 +1824,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -1869,7 +1869,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
@@ -1924,7 +1924,7 @@
     },
     "cacache": {
       "version": "10.0.4",
-      "resolved": "http://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
       "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
       "dev": true,
       "requires": {
@@ -2037,7 +2037,7 @@
     },
     "callsites": {
       "version": "0.2.0",
-      "resolved": "http://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
@@ -2591,7 +2591,7 @@
     },
     "commander": {
       "version": "2.15.1",
-      "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
       "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
       "dev": true
     },
@@ -2947,7 +2947,7 @@
       "dependencies": {
         "css-color-names": {
           "version": "0.0.1",
-          "resolved": "http://registry.npmjs.org/css-color-names/-/css-color-names-0.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.1.tgz",
           "integrity": "sha1-XQVI+iVkVu3kqaDCrHqxnT6xrYE="
         }
       }
@@ -3602,7 +3602,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
@@ -4132,7 +4132,7 @@
         },
         "doctrine": {
           "version": "1.5.0",
-          "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
@@ -4288,7 +4288,7 @@
     },
     "espree": {
       "version": "3.5.4",
-      "resolved": "http://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
       "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "dev": true,
       "optional": true,
@@ -6316,7 +6316,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
@@ -6413,7 +6413,7 @@
     },
     "is-empty": {
       "version": "0.0.1",
-      "resolved": "http://registry.npmjs.org/is-empty/-/is-empty-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-empty/-/is-empty-0.0.1.tgz",
       "integrity": "sha1-Cf3D1kndpZaRVsCFOpt2vXgcWjM="
     },
     "is-extendable": {
@@ -6751,7 +6751,7 @@
     },
     "json5": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
@@ -6860,7 +6860,7 @@
         },
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -7062,7 +7062,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
@@ -7226,7 +7226,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
@@ -7283,7 +7283,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -7911,7 +7911,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -8070,7 +8070,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -9056,7 +9056,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
@@ -9130,13 +9130,13 @@
     },
     "regjsgen": {
       "version": "0.2.0",
-      "resolved": "http://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
       "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
       "dev": true
     },
     "regjsparser": {
       "version": "0.1.5",
-      "resolved": "http://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
       "requires": {
@@ -9145,7 +9145,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
           "dev": true
         }
@@ -9300,7 +9300,7 @@
     },
     "require-uncached": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
@@ -9456,7 +9456,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -9699,7 +9699,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
@@ -10296,7 +10296,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
@@ -10320,7 +10320,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -10390,13 +10390,13 @@
         },
         "sax": {
           "version": "0.5.8",
-          "resolved": "http://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
           "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE=",
           "dev": true
         },
         "source-map": {
           "version": "0.1.43",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
           "dev": true,
           "requires": {
@@ -10791,7 +10791,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -11505,7 +11505,7 @@
     },
     "wcag-contrast": {
       "version": "0.1.0",
-      "resolved": "http://registry.npmjs.org/wcag-contrast/-/wcag-contrast-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wcag-contrast/-/wcag-contrast-0.1.0.tgz",
       "integrity": "sha1-auN5VOQElBcY7aGh2OJw2bVnGTQ=",
       "requires": {
         "hex-rgb": "~1.0.0",
@@ -12570,7 +12570,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {

--- a/frontend/src/components/ViewerServiceAccountsRow.vue
+++ b/frontend/src/components/ViewerServiceAccountsRow.vue
@@ -1,0 +1,162 @@
+<!--
+Copyright (c) 2019 by SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ -->
+
+<template^>
+  <div>
+    <v-divider v-if="!firstRow" inset></v-divider>
+    <v-list-tile avatar>
+      <v-list-tile-avatar>
+        <img :src="avatarUrl" />
+      </v-list-tile-avatar>
+      <v-list-tile-content>
+        <g-popper
+          :title="displayName"
+          toolbarColor="cyan darken-2"
+          :popperKey="`viewer_sa_${username}`"
+
+        >
+          <v-list-tile-title slot="popperRef" class="cursor-pointer">
+            {{displayName}}
+          </v-list-tile-title>
+          <v-layout row
+            slot="content-before"
+            fill-height
+            align-center
+          >
+            <span class="mr-2">Created by</span><span :class="createdByClasses"><account-avatar :account-name="createdBy"></account-avatar></span>
+          </v-layout>
+          <v-layout row
+            slot="content-before"
+            fill-height
+            align-center
+          >
+            <span class="mr-3">Created at</span>
+            <v-tooltip top>
+              <span slot="activator" class="font-weight-bold"><time-string :date-time="creationTimestamp" :pointInTime="-1"></time-string></span>
+              {{created}}
+            </v-tooltip>
+          </v-layout>
+        </g-popper>
+        <v-list-tile-sub-title>
+          {{username}}
+        </v-list-tile-sub-title>
+      </v-list-tile-content>
+      <v-list-tile-action v-if="isServiceAccountFromCurrentNamespace">
+        <v-tooltip top>
+          <v-btn slot="activator" icon class="blue-grey--text" @click.native.stop="onDownload">
+            <v-icon>mdi-download</v-icon>
+          </v-btn>
+          <span>Download Kubeconfig</span>
+        </v-tooltip>
+      </v-list-tile-action>
+      <v-list-tile-action v-if="isServiceAccountFromCurrentNamespace">
+        <v-tooltip top>
+          <v-btn slot="activator" small icon class="blue-grey--text" @click="onKubeconfig">
+            <v-icon>visibility</v-icon>
+          </v-btn>
+          <span>Show Kubeconfig</span>
+        </v-tooltip>
+      </v-list-tile-action>
+      <v-list-tile-action>
+        <v-tooltip top>
+          <v-btn slot="activator" icon class="red--text" @click.native.stop="onDelete">
+            <v-icon>mdi-delete</v-icon>
+          </v-btn>
+          <span>Delete Service Account</span>
+        </v-tooltip>
+      </v-list-tile-action>
+    </v-list-tile>
+  </div>
+</template>
+
+<script>
+import { mapState } from 'vuex'
+import TimeString from '@/components/TimeString'
+import GPopper from '@/components/GPopper'
+import AccountAvatar from '@/components/AccountAvatar'
+import {
+  displayName,
+  gravatarUrlGeneric,
+  isServiceAccount,
+  isServiceAccountFromNamespace,
+  getTimestampFormatted
+} from '@/utils'
+
+export default {
+  name: 'viewers',
+  components: {
+    TimeString,
+    GPopper,
+    AccountAvatar
+  },
+  props: {
+    viewer: {
+      type: Object,
+      required: true
+    },
+    firstRow: {
+      type: Boolean,
+      default: false
+    }
+  },
+  computed: {
+    ...mapState([
+      'namespace'
+    ]),
+    username () {
+      return this.viewer.username
+    },
+    created () {
+      return getTimestampFormatted(this.creationTimestamp)
+    },
+    createdBy () {
+      return this.viewer.createdBy
+    },
+    creationTimestamp () {
+      return this.viewer.creationTimestamp
+    },
+    displayName () {
+      return displayName(this.username)
+    },
+    avatarUrl () {
+      return gravatarUrlGeneric(this.username)
+    },
+    isServiceAccountFromCurrentNamespace () {
+      return isServiceAccountFromNamespace(this.username, this.namespace)
+    },
+    createdByClasses () {
+      return !!this.createdBy ? ['font-weight-bold'] : ['grey--text']
+    }
+  },
+  methods: {
+    async onDownload () {
+      this.$emit('onDownload', this.username)
+    },
+    async onKubeconfig () {
+      this.$emit('onKubeconfig', this.username)
+    },
+    onDelete (username) {
+      this.$emit('onDelete', this.username)
+    }
+  }
+}
+</script>
+
+<style lang="styl" scoped>
+  .cursor-pointer {
+    cursor: pointer;
+  }
+</style>

--- a/frontend/src/dialogs/ProjectDialog.vue
+++ b/frontend/src/dialogs/ProjectDialog.vue
@@ -181,7 +181,8 @@ export default {
   computed: {
     ...mapGetters([
       'projectList',
-      'memberList'
+      'memberList',
+      'viewerList'
     ]),
     visible: {
       get () {

--- a/frontend/src/dialogs/ViewerAddDialog.vue
+++ b/frontend/src/dialogs/ViewerAddDialog.vue
@@ -1,0 +1,323 @@
+<!--
+Copyright (c) 2019 by SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ -->
+
+<template >
+  <v-dialog v-model="visible" max-width="650">
+    <v-card class="add_viewer" :class="cardClass">
+      <v-card-title>
+        <v-icon x-large class="white--text">mdi-account-plus</v-icon>
+        <span v-if="isUserDialog">Add user to Project</span>
+        <span v-if="isServiceDialog">Add Service Account to Project</span>
+      </v-card-title>
+
+      <v-card-text>
+          <v-text-field
+            v-if="isUserDialog"
+            color="green darken-2"
+            ref="username"
+            label="User"
+            v-model="username"
+            :error-messages="usernameErrors"
+            @input="$v.username.$touch()"
+            @keyup.enter="submit()"
+            hint="Enter the username who should become viewer of this project"
+            persistent-hint
+            tabindex="1"
+          ></v-text-field>
+          <v-text-field
+            v-if="isServiceDialog"
+            color="blue-grey"
+            ref="serviceAccountName"
+            label="Service Account"
+            v-model="serviceAccountName"
+            :error-messages="serviceAccountNameErrors"
+            @input="$v.serviceAccountName.$touch()"
+            @keyup.enter="submit()"
+            hint="Enter the name of a Kubernetes Service Account"
+            persistent-hint
+            tabindex="1"
+          ></v-text-field>
+          <alert color="error" :message.sync="errorMessage" :detailedMessage.sync="detailedErrorMessage"></alert>
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn flat @click.stop="cancel" tabindex="3">Cancel</v-btn>
+        <v-btn flat @click.stop="submit" :disabled="!valid" :class="buttonClass" tabindex="2">Add</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+import toLower from 'lodash/toLower'
+import { mapActions, mapState, mapGetters } from 'vuex'
+import { required } from 'vuelidate/lib/validators'
+import { resourceName, unique } from '@/utils/validators'
+import Alert from '@/components/Alert'
+import { errorDetailsFromError, isConflict } from '@/utils/error'
+import { serviceAccountToDisplayName, isServiceAccount } from '@/utils'
+import filter from 'lodash/filter'
+import map from 'lodash/map'
+import includes from 'lodash/includes'
+
+const defaultUsername = ''
+const defaultServiceName = 'viewer'
+
+export default {
+  name: 'add-viewer-dialog',
+  components: {
+    Alert
+  },
+  props: {
+    value: {
+      type: Boolean,
+      required: true
+    },
+    type: {
+      type: String,
+      required: true
+    }
+  },
+  data () {
+    return {
+      username: defaultUsername,
+      serviceAccountName: undefined,
+      errorMessage: undefined,
+      detailedErrorMessage: undefined
+    }
+  },
+  validations () {
+    if (this.isUserDialog) {
+      return {
+        username: {
+          required,
+          unique: unique('projectViewersNames')
+        }
+      }
+    } else if (this.isServiceDialog) {
+      return {
+        serviceAccountName: {
+          required,
+          resourceName,
+          unique: unique('serviceAccountNames')
+        }
+      }
+    }
+  },
+  computed: {
+    ...mapState([
+      'namespace'
+    ]),
+    ...mapGetters([
+      'viewerList',
+      'projectList'
+    ]),
+    visible: {
+      get () {
+        return this.value
+      },
+      set (value) {
+        this.$emit('input', value)
+      }
+    },
+    usernameErrors () {
+      const errors = []
+      if (!this.$v.username.$dirty) {
+        return errors
+      }
+      if (!this.$v.username.required) {
+        errors.push('User is required')
+      }
+      if (!this.$v.username.unique) {
+        errors.push(`User '${this.username}' is already viewer of this project.`)
+      }
+      return errors
+    },
+    serviceAccountNameErrors () {
+      const errors = []
+      if (!this.$v.serviceAccountName.$dirty) {
+        return errors
+      }
+      if (!this.$v.serviceAccountName.required) {
+        errors.push('Service Account is required')
+      }
+      if (!this.$v.serviceAccountName.resourceName) {
+        errors.push('Must contain only alphanumeric characters or hypen')
+      }
+      if (!this.$v.serviceAccountName.unique) {
+        errors.push(`Service Account '${this.serviceAccountDisplayName(this.serviceAccountName)}' already exists. Please try a different name.`)
+      }
+      return errors
+    },
+    valid () {
+      return !this.$v.$invalid
+    },
+    isUserDialog () {
+      return this.type === 'user'
+    },
+    isServiceDialog () {
+      return this.type === 'service'
+    },
+    textField () {
+      if (this.isUserDialog) {
+        return this.$refs.username
+      } else if (this.isServiceDialog) {
+        return this.$refs.serviceAccountName
+      }
+      return undefined
+    },
+    cardClass () {
+      if (this.isUserDialog) {
+        return 'add_user'
+      } else if (this.isServiceDialog) {
+        return 'add_service'
+      }
+      return ''
+    },
+    buttonClass () {
+      if (this.isUserDialog) {
+        return 'green--text darken-2'
+      } else if (this.isServiceDialog) {
+        return 'blue-grey--text'
+      }
+      return ''
+    },
+    serviceAccountNames () {
+      return map(filter(this.viewerList, isServiceAccount), serviceAccountName => this.serviceAccountDisplayName(serviceAccountName))
+    },
+    projectViewersNames () {
+      return filter(this.viewerList, ({ username }) => !isServiceAccount(username))
+    }
+  },
+  methods: {
+    ...mapActions([
+      'addViewer'
+    ]),
+    hide () {
+      this.visible = false
+    },
+    async submit () {
+      this.$v.$touch()
+      if (this.valid) {
+        try {
+          await this.save()
+          this.hide()
+        } catch (err) {
+          const errorDetails = errorDetailsFromError(err)
+          if (isConflict(err)) {
+            if (this.isUserDialog) {
+              this.errorMessage = `User '${this.username}' is already viewer of this project.`
+            } else if (this.isServiceDialog) {
+              this.errorMessage = `Service account '${this.serviceAccountDisplayName(this.serviceAccountName)}' already exists. Please try a different name.`
+            }
+          } else {
+            this.errorMessage = 'Failed to add project viewer'
+          }
+          this.detailedErrorMessage = errorDetails.detailedMessage
+          console.error(this.errorMessage, errorDetails.errorCode, errorDetails.detailedMessage, err)
+        }
+      }
+    },
+    cancel () {
+      this.$v.$reset()
+      this.$nextTick(() => this.hide())
+    },
+    reset () {
+      this.$v.$reset()
+      this.username = defaultUsername
+      this.serviceAccountName = this.defaultServiceName()
+
+      this.errorMessage = undefined
+      this.detailedMessage = undefined
+
+      this.setFocusAndSelection()
+    },
+    setFocusAndSelection () {
+      if (this.textField) {
+        const input = this.textField.$refs.input
+        this.$nextTick(() => {
+          input.focus()
+        })
+      }
+    },
+    save () {
+      if (this.isUserDialog) {
+        const username = toLower(this.username)
+        return this.addViewer(username)
+      } else if (this.isServiceDialog) {
+        const namespace = this.namespace
+        const name = toLower(this.serviceAccountName)
+        return this.addViewer(`system:serviceaccount:${namespace}:${name}`)
+      }
+    },
+    serviceAccountDisplayName (serviceAccountName) {
+      return serviceAccountToDisplayName(serviceAccountName)
+    },
+    defaultServiceName () {
+      let name = defaultServiceName
+      let counter = 1
+      while (includes(this.serviceAccountNames, name)) {
+        name = `${defaultServiceName}-${counter}`
+        counter++
+      }
+
+      return name
+    }
+  },
+  watch: {
+    value: function (value) {
+      if (value) {
+        this.reset()
+      }
+    }
+  },
+  mounted () {
+    if (this.textField) {
+      const input = this.textField.$refs.input
+      input.style.textTransform = 'lowercase'
+    }
+  }
+}
+</script>
+
+<style lang="styl" scoped>
+  .add_viewer {
+    .v-card__title{
+      background-size: cover;
+      color:white;
+      height:130px;
+      span{
+        font-size:25px !important
+        padding-left:30px
+        font-weight:400 !important
+        padding-top:15px !important
+      }
+      .icon {
+        font-size: 50px !important;
+      }
+    }
+  }
+  .add_user {
+    .v-card__title{
+      background-image: url(../assets/add_user_background.svg);
+    }
+  }
+  .add_service {
+    .v-card__title{
+      background-image: url(../assets/add_service_background.svg);
+    }
+  }
+</style>

--- a/frontend/src/dialogs/ViewerHelpDialog.vue
+++ b/frontend/src/dialogs/ViewerHelpDialog.vue
@@ -1,0 +1,129 @@
+<!--
+Copyright (c) 2019 by SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ -->
+
+<template >
+  <v-dialog v-model="visible" max-width="650">
+    <v-card class="help_viewer" :class="cardClass">
+      <v-card-title>
+        <v-icon x-large class="white--text">mdi-account-plus</v-icon>
+        <span v-if="isUserDialog">Project Viewers</span>
+        <span v-if="isServiceDialog">Service Accounts</span>
+      </v-card-title>
+      <v-card-text>
+        <template v-if="isUserDialog">
+          <div class="title grey--text text--darken-1 my-3">Add viewers to your project.</div>
+          <p class="body-1">
+            Adding viewers to your project allows you to collaborate across your team.
+            Project viewers have read-only access to all resources within your project and no access to secrets.
+          </p>
+        </template>
+        <template v-if="isServiceDialog">
+          <div class="title grey--text text--darken-1 my-3">Add service accounts to your project.</div>
+          <p class="body-1">
+            Adding service accounts with viewer role to your project allows you to automate processes in your project.
+            Service accounts have read-only access to all resources within your project and no access to secrets.
+          </p>
+        </template>
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn flat @click.stop="hide" :class="buttonClass" tabindex="2">Ok</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+export default {
+  name: 'help-viewer-dialog',
+  props: {
+    value: {
+      type: Boolean,
+      required: true
+    },
+    type: {
+      type: String,
+      required: true
+    }
+  },
+  computed: {
+    visible: {
+      get () {
+        return this.value
+      },
+      set (value) {
+        this.$emit('input', value)
+      }
+    },
+    isUserDialog () {
+      return this.type === 'user'
+    },
+    isServiceDialog () {
+      return this.type === 'service'
+    },
+    cardClass () {
+      if (this.isUserDialog) {
+        return 'help_user'
+      } else if (this.isServiceDialog) {
+        return 'help_service'
+      }
+      return ''
+    },
+    buttonClass () {
+      if (this.isUserDialog) {
+        return 'green--text darken-2'
+      } else if (this.isServiceDialog) {
+        return 'blue-grey--text'
+      }
+      return ''
+    }
+  },
+  methods: {
+    hide () {
+      this.visible = false
+    }
+  }
+}
+</script>
+
+<style lang="styl" scoped>
+  .help_viewer {
+    .v-card__title{
+      background-size: cover;
+      color:white;
+      height:130px;
+      span{
+        font-size:25px !important
+        padding-left:30px
+        font-weight:400 !important
+        padding-top:15px !important
+      }
+      .icon {
+        font-size: 50px !important;
+      }
+    }
+  }
+  .help_user {
+    .v-card__title{
+      background-image: url(../assets/add_user_background.svg);
+    }
+  }
+  .help_service {
+    .v-card__title{
+      background-image: url(../assets/add_service_background.svg);
+    }
+  }
+</style>

--- a/frontend/src/pages/Viewers.vue
+++ b/frontend/src/pages/Viewers.vue
@@ -1,0 +1,396 @@
+<!--
+Copyright (c) 2019 by SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ -->
+
+<template>
+  <v-container fluid>
+    <v-card class="mr-extra">
+      <v-toolbar card color="teal darken-2">
+        <v-icon class="white--text pr-2">mdi-account</v-icon>
+        <v-toolbar-title class="subheading white--text">
+          Main Contact
+        </v-toolbar-title>
+      </v-toolbar>
+      <v-list v-if="!!owner" two-line subheader>
+        <v-list-tile avatar>
+          <v-list-tile-avatar>
+            <img :src="avatarUrl(owner)" />
+          </v-list-tile-avatar>
+          <v-list-tile-content>
+            <v-list-tile-title>{{displayName(owner)}}</v-list-tile-title>
+            <v-list-tile-sub-title><a :href="'mailto:'+owner" class="cyan--text text--darken-2">{{owner}}</a></v-list-tile-sub-title>
+          </v-list-tile-content>
+        </v-list-tile>
+      </v-list>
+      <v-list v-else two-line subheader>
+        <v-list-tile avatar>
+          <v-list-tile-content>
+            <v-list-tile-title>This project has no main contact configured.</v-list-tile-title>
+            <v-list-tile-sub-title>You can set a main contact on the <router-link :to="{ name: 'Administration', params: { namespace:project.metadata.namespace } }">administration</router-link> page by selecting one of the members from the list below.</v-list-tile-sub-title>
+          </v-list-tile-content>
+        </v-list-tile>
+      </v-list>
+    </v-card>
+
+    <v-card class="mr-extra mt-4">
+      <v-toolbar card color="green darken-2">
+        <v-icon class="white--text pr-2">mdi-account-multiple</v-icon>
+        <v-toolbar-title class="subheading white--text">
+          Project Viewers
+        </v-toolbar-title>
+        <v-spacer></v-spacer>
+        <v-text-field v-if="viewerListWithoutOwner.length > 3"
+          class="searchField"
+          prepend-inner-icon="search"
+          color="green darken-2"
+          label="Search"
+          solo
+          clearable
+          v-model="userFilter"
+          @keyup.esc="userFilter=''"
+        ></v-text-field>
+        <v-btn v-if="allEmails" icon :href="`mailto:${allEmails}`">
+          <v-icon class="white--text">mdi-email-outline</v-icon>
+        </v-btn>
+        <v-btn icon @click.native.stop="openViewerAddDialog">
+          <v-icon class="white--text">add</v-icon>
+        </v-btn>
+        <v-btn icon @click.native.stop="openViewerHelpDialog">
+          <v-icon class="white--text">mdi-help-circle-outline</v-icon>
+        </v-btn>
+      </v-toolbar>
+
+      <v-card-text v-if="!viewerListWithoutOwner.length">
+        <div class="title grey--text text--darken-1 my-3">Add viewers to your project.</div>
+        <p class="body-1">
+          Adding viewers to your project allows you to collaborate across your team.
+          Project viewers have read-only access to all resources within your project and no access to secrets.
+        </p>
+      </v-card-text>
+      <v-list two-line subheader v-else>
+        <template v-for="({ username }, index) in sortedAndFilteredViewerList">
+          <v-divider
+            v-if="index > 0"
+            inset
+            :key="`${username}-dividerKey`"
+          ></v-divider>
+          <v-list-tile
+            avatar
+            :key="username"
+          >
+            <v-list-tile-avatar>
+              <img :src="avatarUrl(username)" />
+            </v-list-tile-avatar>
+            <v-list-tile-content>
+              <v-list-tile-title>
+                {{displayName(username)}}
+              </v-list-tile-title>
+              <v-list-tile-sub-title>
+                <a v-if="isEmail(username)" :href="`mailto:${username}`" class="cyan--text text--darken-2">{{username}}</a>
+                <span v-else class="pl-2">{{username}}</span>
+              </v-list-tile-sub-title>
+            </v-list-tile-content>
+            <v-list-tile-action>
+              <v-tooltip top>
+                <v-btn slot="activator" icon class="red--text" @click.native.stop="onDelete(username)">
+                  <v-icon>mdi-delete</v-icon>
+                </v-btn>
+                <span>Delete Viewer</span>
+              </v-tooltip>
+            </v-list-tile-action>
+          </v-list-tile>
+        </template>
+      </v-list>
+    </v-card>
+
+    <v-card class="mr-extra mt-4">
+      <v-toolbar card color="blue-grey">
+        <v-icon class="white--text pr-2">mdi-monitor-multiple</v-icon>
+        <v-toolbar-title class="subheading white--text">
+          Service Accounts
+        </v-toolbar-title>
+        <v-spacer></v-spacer>
+        <v-text-field v-if="serviceAccountList.length > 3"
+          class="searchField"
+          prepend-inner-icon="search"
+          color="green darken-2"
+          label="Search"
+          solo
+          clearable
+          v-model="serviceAccountFilter"
+          @keyup.esc="serviceAccountFilter=''"
+        ></v-text-field>
+        <v-btn icon @click.native.stop="openServiceAccountAddDialog">
+          <v-icon class="white--text">add</v-icon>
+        </v-btn>
+        <v-btn icon @click.native.stop="openServiceAccountHelpDialog">
+          <v-icon class="white--text">mdi-help-circle-outline</v-icon>
+        </v-btn>
+      </v-toolbar>
+
+      <v-card-text v-if="!serviceAccountList.length">
+        <div class="title grey--text text--darken-1 my-3">Add service accounts to your project.</div>
+        <p class="body-1">
+          Adding service accounts with viewer role to your project allows you to automate processes in your project.
+          Service accounts have read-only access to all resources within your project and no access to secrets.
+        </p>
+      </v-card-text>
+      <v-list two-line subheader v-else>
+        <viewer-service-accounts-row
+          v-for="(viewer, index) in sortedAndFilteredServiceAccountList"
+          :viewer="viewer"
+          :firstRow="index === 0"
+          :key="viewer.username"
+          @onDownload="onDownload"
+          @onKubeconfig="onKubeconfig"
+          @onDelete="onDelete"
+        ></viewer-service-accounts-row>
+      </v-list>
+    </v-card>
+
+    <viewer-add-dialog type="user" v-model="viewerAddDialog"></viewer-add-dialog>
+    <viewer-add-dialog type="service" v-model="serviceAccountAddDialog"></viewer-add-dialog>
+    <viewer-help-dialog type="user" v-model="viewerHelpDialog"></viewer-help-dialog>
+    <viewer-help-dialog type="service" v-model="serviceAccountHelpDialog"></viewer-help-dialog>
+    <v-dialog v-model="kubeconfigDialog" persistent max-width="67%">
+      <v-card>
+        <v-card-title class="teal darken-2 grey--text text--lighten-4">
+          <div class="headline">Kubeconfig <code class="serviceAccount_name">{{currentServiceAccountDisplayName}}</code></div>
+          <v-spacer></v-spacer>
+          <v-btn icon class="grey--text text--lighten-4" @click.native="kubeconfigDialog = false">
+            <v-icon>close</v-icon>
+          </v-btn>
+        </v-card-title>
+        <v-card-text>
+          <code-block lang="yaml" :content="currentServiceAccountKubeconfig"></code-block>
+        </v-card-text>
+      </v-card>
+    </v-dialog>
+    <v-fab-transition>
+      <v-speed-dial v-model="fab" v-show="floatingButton" fixed bottom right direction="top" transition="slide-y-reverse-transition"  >
+        <v-btn slot="activator" v-model="fab" color="teal darken-2" dark fab>
+          <v-icon>add</v-icon>
+          <v-icon>close</v-icon>
+        </v-btn>
+        <v-btn fab small color="grey lighten-2" light @click="openServiceAccountAddDialog">
+          <v-icon color="blue-grey darken-2">mdi-monitor</v-icon>
+        </v-btn>
+        <v-btn fab small color="grey lighten-2" @click="openViewerAddDialog">
+          <v-icon color="green darken-2">person</v-icon>
+        </v-btn>
+      </v-speed-dial>
+    </v-fab-transition>
+  </v-container>
+</template>
+
+<script>
+import includes from 'lodash/includes'
+import toLower from 'lodash/toLower'
+import replace from 'lodash/replace'
+import sortBy from 'lodash/sortBy'
+import find from 'lodash/find'
+import download from 'downloadjs'
+import filter from 'lodash/filter'
+import forEach from 'lodash/forEach'
+import join from 'lodash/join'
+import ViewerAddDialog from '@/dialogs/ViewerAddDialog'
+import ViewerHelpDialog from '@/dialogs/ViewerHelpDialog'
+import CodeBlock from '@/components/CodeBlock'
+import ViewerServiceAccountsRow from '@/components/ViewerServiceAccountsRow'
+import { mapState, mapActions, mapGetters } from 'vuex'
+import {
+  displayName,
+  gravatarUrlGeneric,
+  isEmail,
+  serviceAccountToDisplayName,
+  isServiceAccount
+} from '@/utils'
+import { getViewer } from '@/utils/api'
+
+export default {
+  name: 'viewers',
+  components: {
+    ViewerAddDialog,
+    ViewerHelpDialog,
+    CodeBlock,
+    ViewerServiceAccountsRow
+  },
+  data () {
+    return {
+      viewerAddDialog: false,
+      serviceAccountAddDialog: false,
+      viewerHelpDialog: false,
+      serviceAccountHelpDialog: false,
+      kubeconfigDialog: false,
+      userFilter: '',
+      serviceAccountFilter: '',
+      fab: false,
+      floatingButton: false,
+      currentServiceAccountName: undefined,
+      currentServiceAccountKubeconfig: undefined
+    }
+  },
+  computed: {
+    ...mapState([
+      'user',
+      'namespace'
+    ]),
+    ...mapGetters([
+      'viewerList',
+      'projectList'
+    ]),
+    project () {
+      const predicate = project => project.metadata.namespace === this.namespace
+      return find(this.projectList, predicate)
+    },
+    projectData () {
+      return this.project.data || {}
+    },
+    owner () {
+      return toLower(this.projectData.owner)
+    },
+    serviceAccountList () {
+      return filter(this.viewerList, ({ username }) => isServiceAccount(username))
+    },
+    viewerListWithoutOwner () {
+      const predicate = ({ username }) => !this.isOwner(username) && !isServiceAccount(username)
+      return filter(this.viewerList, predicate)
+    },
+    sortedAndFilteredViewerList () {
+      const predicate = ({ username }) => {
+        if (!this.userFilter) {
+          return true
+        }
+        const name = replace(username, /@.*$/, '')
+        return includes(toLower(name), toLower(this.userFilter))
+      }
+      return sortBy(filter(this.viewerListWithoutOwner, predicate))
+    },
+    allEmails () {
+      const emails = []
+      forEach(this.viewerList, ({ username }) => {
+        if (!isEmail(username)) {
+          return false
+        }
+        emails.push(username)
+      })
+      return join(emails, ';')
+    },
+    sortedAndFilteredServiceAccountList () {
+      const predicate = ({ username }) => {
+        if (!this.serviceAccountFilter) {
+          return true
+        }
+        const name = serviceAccountToDisplayName(username)
+        return includes(toLower(name), toLower(this.serviceAccountFilter))
+      }
+      return sortBy(filter(this.serviceAccountList, predicate))
+    },
+    currentServiceAccountDisplayName () {
+      return serviceAccountToDisplayName(this.currentServiceAccountName)
+    }
+  },
+  methods: {
+    ...mapActions([
+      'addViewer',
+      'deleteViewer',
+      'setError'
+    ]),
+    openViewerAddDialog () {
+      this.viewerAddDialog = true
+    },
+    openViewerHelpDialog () {
+      this.viewerHelpDialog = true
+    },
+    openServiceAccountAddDialog () {
+      this.serviceAccountAddDialog = true
+    },
+    openServiceAccountHelpDialog () {
+      this.serviceAccountHelpDialog = true
+    },
+    displayName (username) {
+      return displayName(username)
+    },
+    isOwner (username) {
+      return this.owner === toLower(username)
+    },
+    isEmail (username) {
+      return isEmail(username)
+    },
+    avatarUrl (username) {
+      return gravatarUrlGeneric(username)
+    },
+    async downloadKubeconfig (name) {
+      const namespace = this.namespace
+      const user = this.user
+      try {
+        const { data } = await getViewer({ namespace, name, user }) // This action should be deactivated for users with viewer role
+        if (!data.kubeconfig) {
+          this.setError({ message: 'Failed to fetch Kubeconfig' })
+        } else {
+          return data.kubeconfig
+        }
+      } catch (err) {
+        this.setError(err)
+      }
+    },
+    async onDownload (name) {
+      const kubeconfig = await this.downloadKubeconfig(name)
+      if (kubeconfig) {
+        download(kubeconfig, 'kubeconfig.yaml', 'text/yaml')
+      }
+    },
+    async onKubeconfig (name) {
+      const kubeconfig = await this.downloadKubeconfig(name)
+      if (kubeconfig) {
+        this.currentServiceAccountName = name
+        this.currentServiceAccountKubeconfig = kubeconfig
+        this.kubeconfigDialog = true
+      }
+    },
+    onDelete (username) {
+      this.deleteViewer(username)
+    }
+  },
+  mounted () {
+    this.floatingButton = true
+  },
+  created () {
+    this.$bus.$on('esc-pressed', () => {
+      this.viewerAddDialog = false
+      this.viewerHelpDialog = false
+      this.serviceAccountAddDialog = false
+      this.serviceAccountHelpDialog = false
+      this.kubeconfigDialog = false
+      this.fab = false
+    })
+  }
+}
+</script>
+
+<style lang="styl" scoped>
+
+  .searchField {
+    margin-right: 20px !important;
+  }
+
+  >>> .v-input__slot {
+    margin: 0px;
+  }
+
+  .serviceAccount_name {
+    color: rgb(0, 137, 123);
+  }
+</style>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -35,6 +35,7 @@ const ShootItemCards = () => import('@/pages/ShootItemCards')
 const ShootItemEditor = () => import('@/pages/ShootItemEditor')
 const Secrets = () => import('@/pages/Secrets')
 const Members = () => import('@/pages/Members')
+const Viewers = () => import('@/pages/Viewers')
 const Account = () => import('@/pages/Account')
 const Administration = () => import('@/pages/Administration')
 
@@ -256,6 +257,21 @@ export default function createRouter ({ store, userManager }) {
           }
         },
         {
+          path: 'namespace/:namespace/viewers',
+          name: 'Viewers',
+          component: Viewers,
+          meta: {
+            namespaced: true,
+            projectScope: true,
+            title: 'Viewers',
+            menu: {
+              title: 'Viewers',
+              icon: 'mdi-account-multiple-outline'
+            },
+            breadcrumbTextFn: routeTitle
+          }
+        },
+        {
           path: 'namespace/:namespace/administration',
           name: 'Administration',
           component: Administration,
@@ -414,6 +430,13 @@ export default function createRouter ({ store, userManager }) {
             return Promise
               .all([
                 store.dispatch('fetchMembers'),
+                store.dispatch('subscribeShoots')
+              ])
+              .then(() => undefined)
+          case 'Viewers':
+            return Promise
+              .all([
+                store.dispatch('fetchViewers'),
                 store.dispatch('subscribeShoots')
               ])
               .then(() => undefined)

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -37,6 +37,7 @@ import cloudProfiles from './modules/cloudProfiles'
 import domains from './modules/domains'
 import projects from './modules/projects'
 import members from './modules/members'
+import viewers from './modules/viewers'
 import infrastructureSecrets from './modules/infrastructureSecrets'
 import journals from './modules/journals'
 
@@ -121,6 +122,9 @@ const getters = {
   },
   memberList (state, getters) {
     return state.members.all
+  },
+  viewerList (state, getters) {
+    return state.viewers.all
   },
   infrastructureSecretList (state) {
     return state.infrastructureSecrets.all
@@ -303,6 +307,12 @@ const actions = {
         dispatch('setError', err)
       })
   },
+  fetchViewers ({ dispatch, commit }) {
+    return dispatch('viewers/getAll')
+      .catch(err => {
+        dispatch('setError', err)
+      })
+  },
   fetchInfrastructureSecrets ({ dispatch, commit }) {
     return dispatch('infrastructureSecrets/getAll')
       .catch(err => {
@@ -464,6 +474,23 @@ const actions = {
         dispatch('setError', { message: `Delete member failed. ${err.message}` })
       })
   },
+  addViewer ({ dispatch, commit }, name) {
+    return dispatch('viewers/add', name)
+      .then(res => {
+        dispatch('setAlert', { message: 'Viewer added', type: 'success' })
+        return res
+      })
+  },
+  deleteViewer ({ dispatch, commit }, name) {
+    return dispatch('viewers/delete', name)
+      .then(res => {
+        dispatch('setAlert', { message: 'Viewer deleted', type: 'success' })
+        return res
+      })
+      .catch(err => {
+        dispatch('setError', { message: `Delete viewer failed. ${err.message}` })
+      })
+  },
   setConfiguration ({ commit }, value) {
     commit('SET_CONFIGURATION', value)
 
@@ -592,6 +619,7 @@ const store = new Vuex.Store({
   modules: {
     projects,
     members,
+    viewers,
     cloudProfiles,
     domains,
     shoots,

--- a/frontend/src/store/modules/viewers.js
+++ b/frontend/src/store/modules/viewers.js
@@ -1,0 +1,74 @@
+//
+// Copyright (c) 2019 by SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { getViewers, addViewer, deleteViewer } from '@/utils/api'
+
+// initial state
+const state = {
+  all: []
+}
+
+// getters
+const getters = {}
+
+// actions
+const actions = {
+  getAll: ({ commit, rootState }) => {
+    const namespace = rootState.namespace
+    return getViewers({ namespace })
+      .then(res => {
+        commit('RECEIVE', res.data)
+        return state.all
+      })
+      .catch(error => {
+        commit('CLEAR')
+        throw error
+      })
+  },
+  add: ({ commit, rootState }, name) => {
+    const namespace = rootState.namespace
+    const data = { name }
+    return addViewer({ namespace, data })
+      .then(res => {
+        commit('RECEIVE', res.data)
+      })
+  },
+  delete: ({ commit, rootState }, name) => {
+    const namespace = rootState.namespace
+    return deleteViewer({ namespace, name })
+      .then(res => {
+        commit('RECEIVE', res.data)
+      })
+  }
+}
+
+// mutations
+const mutations = {
+  RECEIVE (state, items) {
+    state.all = items
+  },
+  CLEAR (state) {
+    state.all = []
+  }
+}
+
+export default {
+  namespaced: true,
+  state,
+  getters,
+  actions,
+  mutations
+}

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -152,6 +152,24 @@ export function deleteMember ({ namespace, name }) {
   return deleteResource(`/api/namespaces/${namespace}/members/${name}`)
 }
 
+/* Viewers */
+
+export function getViewers ({ namespace }) {
+  return getResource(`/api/namespaces/${namespace}/viewers`)
+}
+
+export function addViewer ({ namespace, data }) {
+  return createResource(`/api/namespaces/${namespace}/viewers`, data)
+}
+
+export function getViewer ({ namespace, name }) {
+  return getResource(`/api/namespaces/${namespace}/viewers/${name}`)
+}
+
+export function deleteViewer ({ namespace, name }) {
+  return deleteResource(`/api/namespaces/${namespace}/viewers/${name}`)
+}
+
 /* User */
 export function createTokenReview (data) {
   return createResource('/auth', data)


### PR DESCRIPTION
**What this PR does / why we need it**:
Add support for project.viewers to the Gardener Dashboard

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The Gardener support Users/Groups/ServiceAccounts as part of the `Project` resource called `viewers`. Those subjects are given with read-only access to the API called.
See https://github.com/gardener/gardener/pull/1004 
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
The Gardener Dashboard now supports the Project Viewers.
```
