### PR TITLE
make dashboard tls secret configurable

### DIFF
--- a/charts/gardener-dashboard/templates/ingress.yaml
+++ b/charts/gardener-dashboard/templates/ingress.yaml
@@ -14,7 +14,7 @@ metadata:
   {{- end }}
 spec:
   tls:
-    - secretName: gardener-dashboard-tls
+    - secretName: {{ .Values.tlsSecretName | default "gardener-dashboard-tls" }}
       hosts:
       {{- range .Values.hosts }}
         - {{ . }}

--- a/charts/gardener-dashboard/templates/secret-tls.yaml
+++ b/charts/gardener-dashboard/templates/secret-tls.yaml
@@ -1,7 +1,8 @@
+{{- if .Values.tls }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: gardener-dashboard-tls
+  name: {{ .Values.tlsSecretName | default "gardener-dashboard-tls" }}
   namespace: garden
   labels:
     app: gardener-dashboard
@@ -12,3 +13,4 @@ type: kubernetes.io/tls
 data:
   tls.crt: {{ required ".Values.tls.crt is required" (b64enc .Values.tls.crt) }}
   tls.key: {{ required ".Values.tls.key is required" (b64enc .Values.tls.key) }}
+{{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This is basically the same as https://github.com/gardener/dashboard/pull/399, only for the dashboard tls secret. Same motivation, same effects.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
The dashboard helm chart can now be configured to not deploy the tls secret. Furthermore, the name of that secret can be configured by overwriting `tlsSecretName` in the values file.
```