### PR TITLE
Add route53 ListHostedZones permission

### DIFF
--- a/frontend/src/dialogs/SecretDialogAwsHelp.vue
+++ b/frontend/src/dialogs/SecretDialogAwsHelp.vue
@@ -109,7 +109,8 @@ export default {
               'route53:GetChange',
               'route53:GetHostedZone',
               'route53:ListResourceRecordSets',
-              'route53:ChangeResourceRecordSets'
+              'route53:ChangeResourceRecordSets',
+              'route53:ListHostedZones'
             ],
             'Resource': '*'
           }


### PR DESCRIPTION
**What this PR does / why we need it**:
In case of custom managed domains the permission `route53:ListHostedZones` is required.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
NONE
```
