### PR TITLE
Use new grafana urls for operators

### DIFF
--- a/frontend/src/store/modules/shoots.js
+++ b/frontend/src/store/modules/shoots.js
@@ -153,7 +153,7 @@ const actions = {
 
         if (info.seedShootIngressDomain) {
           const grafanaPathname = get(rootState.cfg, 'grafanaUrl.pathname', '')
-          const grafanaHost = `g.${info.seedShootIngressDomain}`
+          const grafanaHost = `g-operators.${info.seedShootIngressDomain}`
           info.grafanaUrl = `https://${grafanaHost}${grafanaPathname}`
           info.grafanaUrlText = `https://${grafanaHost}`
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The grafana url for operators will change to g-operators.<shoot-name>.<project-name>.<ingress-url-of-seed-cluster>. See also https://github.com/gardener/gardener/pull/1000#issuecomment-500812890

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Merge after https://github.com/gardener/gardener/pull/1000 has been merged
Ensure that the release notes are correct (referenced gardener version)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```action operator
:warning: This Dashboard version is not compatible with Gardener versions prior 0.25.x
```
