### PR TITLE
Fix pod spec of identity deployment template

### DIFF
--- a/charts/identity/templates/deployment.yaml
+++ b/charts/identity/templates/deployment.yaml
@@ -43,6 +43,8 @@ spec:
       {{- else }}
       serviceAccountName: identity
       {{- end }}
+      dnsPolicy: ClusterFirst
+      terminationGracePeriodSeconds: 30
       containers:
         - name: dex
           command:
@@ -51,8 +53,6 @@ spec:
             - /etc/dex/config.yaml
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          dnsPolicy: ClusterFirst
-          terminationGracePeriodSeconds: 30
           livenessProbe:
             failureThreshold: 3
             httpGet:


### PR DESCRIPTION
dnsPolicy and terminationGracePeriodSeconds are parts of the pod spec
and not of container spec.

**What this PR does / why we need it**:
I could not deploy the chart in a kubernetes v1.12 cluster, since the validation failed. Small fix, did not open an issue.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
NONE
```
