### PR TITLE
Show technical id for operators

### DIFF
--- a/frontend/src/components/ShootInfrastructureCard.vue
+++ b/frontend/src/components/ShootInfrastructureCard.vue
@@ -48,16 +48,27 @@ limitations under the License.
       <template v-if="showSeedInfo">
         <v-divider class="my-2" inset></v-divider>
         <v-card-title class="listItem">
-          <v-icon class="cyan--text text--darken-2 avatar">spa</v-icon>
-          <v-flex class="pa-0">
-            <span class="grey--text">Seed</span><br>
-            <router-link v-if="canLinkToSeed" class="cyan--text text--darken-2 subheading" :to="{ name: 'ShootItem', params: { name: seed, namespace:'garden' } }">
-              <span class="subheading">{{seed}}</span>
-            </router-link>
-            <template v-else>
-              <span class="subheading">{{seed}}</span>
-            </template>
-          </v-flex>
+          <v-layout>
+            <v-flex shrink justify-center class="pr-0 pt-3">
+              <v-icon class="cyan--text text--darken-2 avatar">spa</v-icon>
+            </v-flex>
+            <v-flex class="pa-0">
+              <span class="grey--text">Seed</span><br>
+              <router-link v-if="canLinkToSeed" class="cyan--text text--darken-2 subheading" :to="{ name: 'ShootItem', params: { name: seed, namespace:'garden' } }">
+                <span class="subheading">{{seed}}</span><br>
+              </router-link>
+              <template v-else>
+                <span class="subheading">{{seed}}</span><br>
+              </template>
+              <v-layout row>
+                <v-flex>
+                  <span class="grey--text">Technical Id</span><br>
+                  <span class="subheading">{{technicalId}}</span>
+                </v-flex>
+                <copy-btn :clipboard-text="technicalId"></copy-btn>
+              </v-layout>
+            </v-flex>
+          </v-layout>
         </v-card-title>
       </template>
 
@@ -90,12 +101,16 @@ limitations under the License.
 import { mapGetters } from 'vuex'
 import get from 'lodash/get'
 import includes from 'lodash/includes'
+import CopyBtn from '@/components/CopyBtn'
 import {
   getCloudProviderKind,
   canLinkToSeed
 } from '@/utils'
 
 export default {
+  components: {
+    CopyBtn
+  },
   props: {
     shootItem: {
       type: Object
@@ -116,6 +131,9 @@ export default {
     },
     cidr () {
       return get(this.shootItem, `spec.cloud.${this.getCloudProviderKind}.networks.nodes`)
+    },
+    technicalId () {
+      return get(this.shootItem, `status.technicalID`)
     },
     seed () {
       return get(this.shootItem, 'spec.cloud.seed')

--- a/frontend/src/components/ShootListRow.vue
+++ b/frontend/src/components/ShootListRow.vue
@@ -56,6 +56,12 @@ limitations under the License.
         <span>{{row.seed}}</span>
       </template>
     </td>
+    <td class="nowrap" v-if="this.headerVisible['technicalId']">
+      <v-layout align-center justify-start row fill-height slot="activator">
+        <span>{{row.technicalId}}</span>
+        <copy-btn :clipboard-text="row.technicalId"></copy-btn>
+      </v-layout>
+    </td>
     <td class="nowrap" v-if="this.headerVisible['createdBy']">
       <account-avatar :account-name="row.createdBy"></account-avatar>
     </td>
@@ -132,6 +138,7 @@ import TimeString from '@/components/TimeString'
 import ShootVersion from '@/components/ShootVersion'
 import RetryOperation from '@/components/RetryOperation'
 import JournalLabels from '@/components/JournalLabels'
+import CopyBtn from '@/components/CopyBtn'
 import SelfTerminationWarning from '@/components/SelfTerminationWarning'
 import HibernationScheduleWarning from '@/components/HibernationScheduleWarning'
 import DeleteCluster from '@/components/DeleteCluster'
@@ -164,7 +171,8 @@ export default {
     SelfTerminationWarning,
     HibernationScheduleWarning,
     AccountAvatar,
-    DeleteCluster
+    DeleteCluster,
+    CopyBtn
   },
   props: {
     shootItem: {
@@ -208,7 +216,8 @@ export default {
         journalsLabels: this.journalsLabels(this.shootItem.metadata),
         // setting the retry annotation internally will increment "metadata.generation". If the values differ, a reconcile will be scheduled
         reconcileScheduled: get(metadata, 'generation') !== get(status, 'observedGeneration'),
-        seed: get(spec, 'cloud.seed')
+        seed: get(spec, 'cloud.seed'),
+        technicalId: get(status, 'technicalID')
       }
     },
     headerVisible () {

--- a/frontend/src/pages/ShootList.vue
+++ b/frontend/src/pages/ShootList.vue
@@ -170,6 +170,7 @@ export default {
         { text: 'NAME', value: 'name', align: 'left', checked: false, defaultChecked: true, hidden: false },
         { text: 'INFRASTRUCTURE', value: 'infrastructure', align: 'left', checked: false, defaultChecked: true, hidden: false },
         { text: 'SEED', value: 'seed', align: 'left', checked: false, defaultChecked: false, hidden: false },
+        { text: 'TECHNICAL ID', value: 'technicalId', align: 'left', checked: false, defaultChecked: false, hidden: false, adminOnly: true  },
         { text: 'CREATED BY', value: 'createdBy', align: 'left', checked: false, defaultChecked: false, hidden: false },
         { text: 'CREATED AT', value: 'createdAt', align: 'left', checked: false, defaultChecked: false, hidden: false },
         { text: 'PURPOSE', value: 'purpose', align: 'center', checked: false, defaultChecked: true, hidden: false },


### PR DESCRIPTION
**What this PR does / why we need it**:
As operator I want to quickly access the technicalId of a shoot cluster so that I can easily check the pods in the shoot namespace of the seed
- in the cluster list as extra column (default: hidden)
- on the shoot details page
A button is available to copy the text

**Which issue(s) this PR fixes**:
Fixes #410 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
You can now display the `status.technicalID` value of a Shoot in the cluster list (new column; hidden by default) and on the cluster details page
```

<img width="1846" alt="Screenshot 2019-06-13 at 17 13 51" src="https://user-images.githubusercontent.com/5526658/59444880-eda90f00-8dfe-11e9-9e16-9535452c8231.png">

<img width="1212" alt="Screenshot 2019-06-13 at 17 14 48" src="https://user-images.githubusercontent.com/5526658/59444912-fac5fe00-8dfe-11e9-9094-1e4b4d864ab7.png">
