### PR TITLE
Add end user monitoring

### DIFF
--- a/backend/lib/services/shoots.js
+++ b/backend/lib/services/shoots.js
@@ -221,6 +221,7 @@ exports.info = async function ({ user, namespace, name }) {
   const loggingComponent = 'logging'
   const monitoringIngressSecretName = 'monitoring-ingress-credentials'
   const loggingIngressUserSecretName = name + '.logging'
+  const monitoringIngressUserSecretName = name + '.monitoring'
   const loggingIngressAdminSecretName = 'logging-ingress-credentials'
 
   const data = {
@@ -264,7 +265,10 @@ exports.info = async function ({ user, namespace, name }) {
       }
     }
   } else {
-    await assignComponentSecret(core, namespace, loggingComponent, loggingIngressUserSecretName, data)
+    await Promise.all([
+      assignComponentSecret(core, namespace, monitoringComponent, monitoringIngressUserSecretName, data),
+      assignComponentSecret(core, namespace, loggingComponent, loggingIngressUserSecretName, data)
+    ])
   }
 
   return data

--- a/frontend/src/components/ClusterMetrics.vue
+++ b/frontend/src/components/ClusterMetrics.vue
@@ -16,7 +16,7 @@ limitations under the License.
 
 <template>
   <v-list>
-    <v-list-tile>
+    <v-list-tile v-if="isAdmin">
       <v-list-tile-action>
         <v-icon class="cyan--text text--darken-2">developer_board</v-icon>
       </v-list-tile-action>
@@ -24,14 +24,29 @@ limitations under the License.
         <v-list-tile-sub-title>Grafana</v-list-tile-sub-title>
         <v-list-tile-title>
           <v-tooltip v-if="isHibernated" top>
-            <span slot="activator">{{grafanaUrlText}}</span>
+            <span slot="activator">{{grafanaUrlOperators}}</span>
             Grafana is not running for hibernated clusters
           </v-tooltip>
-          <a v-else :href="grafanaUrl" target="_blank" class="cyan--text text--darken-2">{{grafanaUrlText}}</a>
+          <a v-else :href="grafanaUrlOperators" target="_blank" class="cyan--text text--darken-2">{{grafanaUrlOperators}}</a>
         </v-list-tile-title>
       </v-list-tile-content>
     </v-list-tile>
-    <v-list-tile>
+    <v-list-tile v-else>
+      <v-list-tile-action>
+        <v-icon class="cyan--text text--darken-2">developer_board</v-icon>
+      </v-list-tile-action>
+      <v-list-tile-content>
+        <v-list-tile-sub-title>Grafana</v-list-tile-sub-title>
+        <v-list-tile-title>
+          <v-tooltip v-if="isHibernated" top>
+            <span slot="activator">{{grafanaUrlUsers}}</span>
+            Grafana is not running for hibernated clusters
+          </v-tooltip>
+          <a v-else :href="grafanaUrlUsers" target="_blank" class="cyan--text text--darken-2">{{grafanaUrlUsers}}</a>
+        </v-list-tile-title>
+      </v-list-tile-content>
+    </v-list-tile>
+    <v-list-tile v-if="isAdmin">
       <v-list-tile-action>
       </v-list-tile-action>
       <v-list-tile-content>
@@ -45,7 +60,7 @@ limitations under the License.
         </v-list-tile-title>
       </v-list-tile-content>
     </v-list-tile>
-    <v-list-tile>
+    <v-list-tile v-if="isAdmin">
       <v-list-tile-action>
       </v-list-tile-action>
       <v-list-tile-content>
@@ -68,6 +83,7 @@ limitations under the License.
 import get from 'lodash/get'
 import UsernamePassword from '@/components/UsernamePasswordListTile'
 import { isHibernated } from '@/utils'
+import { mapGetters } from 'vuex'
 
 export default {
   components: {
@@ -80,11 +96,14 @@ export default {
     }
   },
   computed: {
-    grafanaUrl () {
-      return get(this.shootItem, 'info.grafanaUrl', '')
+    ...mapGetters([
+      'isAdmin'
+    ]),
+    grafanaUrlOperators () {
+      return get(this.shootItem, 'info.grafanaUrlOperators', '')
     },
-    grafanaUrlText () {
-      return get(this.shootItem, 'info.grafanaUrlText', '')
+    grafanaUrlUsers () {
+      return get(this.shootItem, 'info.grafanaUrlUsers', '')
     },
     prometheusUrl () {
       return get(this.shootItem, 'info.prometheusUrl', '')

--- a/frontend/src/components/MonitoringCard.vue
+++ b/frontend/src/components/MonitoringCard.vue
@@ -48,7 +48,7 @@ limitations under the License.
           <status-tags v-else :conditions="conditions" popperPlacement="bottom"></status-tags>
         </div>
       </v-card-title>
-      <template v-if="isAdmin && seedShootIngressDomain">
+      <template v-if="seedShootIngressDomain">
         <v-divider class="my-2" inset></v-divider>
         <cluster-metrics :shootItem="shootItem"></cluster-metrics>
       </template>
@@ -65,7 +65,6 @@ import get from 'lodash/get'
 import { isHibernated,
   isReconciliationDeactivated,
   isTypeDelete } from '@/utils'
-import { mapGetters } from 'vuex'
 
 export default {
   components: {
@@ -85,9 +84,6 @@ export default {
     }
   },
   computed: {
-    ...mapGetters([
-      'isAdmin'
-    ]),
     lastOperation () {
       return get(this.shootItem, 'status.lastOperation', {})
     },

--- a/frontend/src/store/modules/shoots.js
+++ b/frontend/src/store/modules/shoots.js
@@ -152,19 +152,15 @@ const actions = {
         }
 
         if (info.seedShootIngressDomain) {
-          const grafanaPathname = get(rootState.cfg, 'grafanaUrl.pathname', '')
-          const grafanaHost = `g-operators.${info.seedShootIngressDomain}`
-          info.grafanaUrl = `https://${grafanaHost}${grafanaPathname}`
-          info.grafanaUrlText = `https://${grafanaHost}`
+          const baseHost = info.seedShootIngressDomain
+          info.grafanaUrlUsers = `https://g-users.${baseHost}`
+          info.grafanaUrlOperators = `https://g-operators.${baseHost}`
 
-          const prometheusHost = `p.${info.seedShootIngressDomain}`
-          info.prometheusUrl = `https://${prometheusHost}`
+          info.prometheusUrl = `https://p.${baseHost}`
 
-          const alertmanagerHost = `a.${info.seedShootIngressDomain}`
-          info.alertmanagerUrl = `https://${alertmanagerHost}`
+          info.alertmanagerUrl = `https://a.${baseHost}`
 
-          const kibanaHost = `k.${info.seedShootIngressDomain}`
-          info.kibanaUrl = `https://${kibanaHost}`
+          info.kibanaUrl = `https://k.${baseHost}`
         }
         return info
       })


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a link for end users so that they can access the end user Grafana. 

**Which issue(s) this PR fixes**:
#396 is partially fixed.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
Users can access Grafana dashboards for their control plane via the Gardener dashboard.
```
