### PR TITLE
Configurable namespace for dashboard helm charts

### DIFF
--- a/charts/gardener-dashboard/templates/configmap.yaml
+++ b/charts/gardener-dashboard/templates/configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: gardener-dashboard-configmap
-  namespace: garden
+  namespace: {{ .Release.Namespace }}
   labels:
     app: gardener-dashboard
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/charts/gardener-dashboard/templates/deployment.yaml
+++ b/charts/gardener-dashboard/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: {{ include "deploymentversion" . }}
 kind: Deployment
 metadata:
   name: gardener-dashboard
-  namespace: garden
+  namespace: {{ .Release.Namespace }}
   labels:
     app: gardener-dashboard
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/charts/gardener-dashboard/templates/ingress.yaml
+++ b/charts/gardener-dashboard/templates/ingress.yaml
@@ -2,7 +2,7 @@ apiVersion: {{ include "ingressversion" . }}
 kind: Ingress
 metadata:
   name: gardener-dashboard-ingress
-  namespace: garden
+  namespace: {{ .Release.Namespace }}
   labels:
     app: gardener-dashboard
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/charts/gardener-dashboard/templates/rbac.yaml
+++ b/charts/gardener-dashboard/templates/rbac.yaml
@@ -15,5 +15,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: gardener-dashboard
-  namespace: garden
+  namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/gardener-dashboard/templates/secret-github.yaml
+++ b/charts/gardener-dashboard/templates/secret-github.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: gardener-dashboard-github
-  namespace: garden
+  namespace: {{ .Release.Namespace }}
   labels:
     app: gardener-dashboard
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/charts/gardener-dashboard/templates/secret-kubeconfig.yaml
+++ b/charts/gardener-dashboard/templates/secret-kubeconfig.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: gardener-dashboard-kubeconfig
-  namespace: garden
+  namespace: {{ .Release.Namespace }}
   labels:
     app: gardener-dashboard
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/charts/gardener-dashboard/templates/secret-oidc.yaml
+++ b/charts/gardener-dashboard/templates/secret-oidc.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: gardener-dashboard-oidc
-  namespace: garden
+  namespace: {{ .Release.Namespace }}
   labels:
     app: gardener-dashboard
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/charts/gardener-dashboard/templates/secret-sessionSecret.yaml
+++ b/charts/gardener-dashboard/templates/secret-sessionSecret.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: gardener-dashboard-sessionsecret
-  namespace: garden
+  namespace: {{ .Release.Namespace }}
   labels:
     app: gardener-dashboard
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/charts/gardener-dashboard/templates/secret-tls.yaml
+++ b/charts/gardener-dashboard/templates/secret-tls.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.tlsSecretName | default "gardener-dashboard-tls" }}
-  namespace: garden
+  namespace: {{ .Release.Namespace }}
   labels:
     app: gardener-dashboard
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/charts/gardener-dashboard/templates/service.yaml
+++ b/charts/gardener-dashboard/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: gardener-dashboard-service
-  namespace: garden
+  namespace: {{ .Release.Namespace }}
   labels:
     app: gardener-dashboard
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/charts/gardener-dashboard/templates/serviceaccount.yaml
+++ b/charts/gardener-dashboard/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: gardener-dashboard
-  namespace: garden
+  namespace: {{ .Release.Namespace }}
   labels:
     app: gardener-dashboard
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"


### PR DESCRIPTION
**What this PR does / why we need it**:
For the Gardener ring two Gardener installations are needed on the same cluster in different namespaces. Therefore the namespace given by Helm should be used in the dashboard charts.