### PR TITLE
Add create project route

### DIFF
--- a/frontend/src/components/MainNavigation.vue
+++ b/frontend/src/components/MainNavigation.vue
@@ -105,7 +105,7 @@ limitations under the License.
                 @click.stop="openProjectDialog"
               >
                 <v-icon>add</v-icon>
-                <span class="ml-2">Create new Project</span>
+                <span class="ml-2">Create Project</span>
               </v-btn>
               <span>You are not authorized to create projects</span>
             </v-tooltip>

--- a/frontend/src/dialogs/ProjectDialog.vue
+++ b/frontend/src/dialogs/ProjectDialog.vue
@@ -19,7 +19,7 @@ limitations under the License.
     <v-card class="project">
       <v-card-title>
         <v-icon x-large class="white--text">mdi-cube</v-icon>
-        <span v-if="isCreateMode">Create new Project</span>
+        <span v-if="isCreateMode">Create Project</span>
         <span v-else>Update Project</span>
       </v-card-title>
       <v-card-text style="height: 300px; position: relative">

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -22,10 +22,12 @@ limitations under the License.
         <v-tooltip top :disabled="canCreateProject">
           <v-btn
             slot="activator"
+            flat
+            class="text-xs-left teal--text"
             :disabled="!canCreateProject"
             @click.native.stop="projectDialog = true"
           >
-            <v-icon class="red--text text--darken-2">mdi-plus</v-icon>
+            <v-icon>add</v-icon>
             <span class="ml-2">{{createProjectBtnText}}</span>
           </v-btn>
           <span>You are not authorized to create projects</span>

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -26,7 +26,7 @@ limitations under the License.
             @click.native.stop="projectDialog = true"
           >
             <v-icon class="red--text text--darken-2">mdi-plus</v-icon>
-            <span class="ml-2">Create your first Project</span>
+            <span class="ml-2">{{createProjectBtnText}}</span>
           </v-btn>
           <span>You are not authorized to create projects</span>
         </v-tooltip>
@@ -39,6 +39,7 @@ limitations under the License.
 
 <script>
 import { mapState, mapGetters } from 'vuex'
+import isEmpty from 'lodash/isEmpty'
 import ProjectCreateDialog from '@/dialogs/ProjectDialog'
 
 export default {
@@ -59,8 +60,20 @@ export default {
     ...mapGetters([
       'username',
       'canCreateProject',
-      'namespaces'
-    ])
+      'namespaces',
+      'projectList'
+    ]),
+    hasProjects () {
+      return !isEmpty(this.projectList)
+    },
+    createProjectBtnText () {
+      return this.hasProjects ? 'Create Project' : 'Create your first Project'
+    }
+  },
+  mounted () {
+    if (this.$route.path === '/namespace/create/ui') {
+      this.projectDialog = true
+    }
   },
   methods: {
     onProjectCreated ({ metadata } = {}) {

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -143,6 +143,17 @@ export default function createRouter ({ store, userManager }) {
           }
         },
         {
+          path: 'namespace/create/ui',
+          name: 'CreateProject',
+          component: Home,
+          meta: {
+            title: 'Create Project',
+            breadcrumbTextFn: routeTitle,
+            namespaced: false,
+            projectScope: false
+          }
+        },
+        {
           path: 'namespace/:namespace/shoots',
           component: PlaceholderComponent,
           meta: {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces a new route `/namespace/create/ui` which when navigated to, displays the `Create Project` dialog on the `Home` page.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user

```
