### PR TITLE
Machine/Volume type drop list now changes with the zone selected for alicloud

### DIFF
--- a/frontend/src/components/MachineType.vue
+++ b/frontend/src/components/MachineType.vue
@@ -70,6 +70,7 @@ export default {
       this.validateInput()
     },
     validateInput () {
+      this.valid = this.valid && this.worker.valid && !this.$v.$invalid
       if (this.valid !== !this.$v.$invalid) {
         this.valid = !this.$v.$invalid
         this.$emit('valid', { id: this.worker.id, valid: this.valid })

--- a/frontend/src/components/VolumeType.vue
+++ b/frontend/src/components/VolumeType.vue
@@ -64,6 +64,7 @@ export default {
       this.validateInput()
     },
     validateInput () {
+      this.valid = this.valid && this.worker.valid && !this.$v.$invalid
       if (this.valid !== !this.$v.$invalid) {
         this.valid = !this.$v.$invalid
         this.$emit('valid', { id: this.worker.id, valid: this.valid })

--- a/frontend/src/dialogs/CreateClusterDialog.vue
+++ b/frontend/src/dialogs/CreateClusterDialog.vue
@@ -198,6 +198,7 @@ limitations under the License.
               ref="manageWorkers"
               :infrastructureKind="infrastructureKind"
               :cloudProfileName="cloudProfileName"
+              :zone="zone"
               @valid="onWorkersValid"
              ></manage-workers>
            </v-container>
@@ -559,6 +560,7 @@ export default {
       },
       set (zone) {
         this.infrastructureData.zones = [zone]
+        this.removeInvalidWorkerMachineTypesAndVolumeTypes()
       }
     },
     purpose: {
@@ -911,6 +913,11 @@ export default {
       } else {
         this.infrastructureData.zones = []
       }
+    },
+    removeInvalidWorkerMachineTypesAndVolumeTypes () {
+      this.$nextTick(() => {
+        this.$refs.manageWorkers.removeInvalidWorkerMachineTypesAndVolumeTypes()
+      })
     },
     getErrorMessages (field) {
       return getValidationErrors(this, field)


### PR DESCRIPTION
Machine/Volume type drop list now changes in accordance to the zone selected in shoot creation dialog for alicloud.
Remove invalid machine/volume types when zone is changed in shoot creation dialog for alicloud profile

**What this PR does / why we need it**:
_why we need it_

In Alicloud (not sure if other cloud providers have the same problem), different zones may have different available machine types and volume types. However, current create shoot cluster dialog code does not filter available types in worker tab's drop list.
This will cause the problem that when a user selects a zone and configures its workers, some machine types and volume types that this specific zone does not support are listed in the drop lists. The user can select such types, however, when clicking create button, error messages are shown, indicating that these types are not supported.

Alicloud cloud profile example: https://github.com/gardener/gardener/blob/master/example/30-cloudprofile-alicloud.yaml
Note that each machine type and volume type can have its individual zone setting.

_what this pr does_
- The changes are currently only for alicloud.
- The machine type drop list and volume type drop list now changes according to the zone selected.
- When user changes the zone in create shoot cluster dialog, corresponding changes in worker tab occur. The changes are listed below:
1. The options in machine type drop list and volume type drop list change in accordance to the selected zone.
2. If previously selected machine type or volume type is unavailable in the new zone, the selection will be revoked, and the worker group setting becomes invalid, and thus the shoot creation button becomes disabled. User has to re-select the types to be able to create the cluster.

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:
As can be seen in the code, alicloud is specified for this change. I'm not sure if it is also needed by other cloud providers, and if all the cloud profiles can be dealt with the same way.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user

```
