### PR TITLE
Add developer target group to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,7 @@ Fixes #
 Format of block header: <category> <target_group>
 Possible values:
 - category:       improvement|noteworthy|action
-- target_group:   user|operator
+- target_group:   user|operator|developer
 -->
 ```improvement user
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add developer target group to PR template.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
NONE
```
