### PR TITLE
[WIP] Support for Gardener Landscape End-User HTTP Sessions

### DIFF
--- a/backend/lib/config/gardener.js
+++ b/backend/lib/config/gardener.js
@@ -25,6 +25,7 @@ const { join: joinPath } = require('path')
 
 const environmentVariableDefinitions = {
   SESSION_SECRET: 'sessionSecret', // pragma: whitelist secret
+  AUTH_COOKIE_DOMAIN: 'auth.cookieDomain',
   OIDC_ISSUER: 'oidc.issuer',
   OIDC_CLIENT_ID: 'oidc.client_id',
   OIDC_CLIENT_SECRET: 'oidc.client_secret', // pragma: whitelist secret


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the Session Management in the Gardener Dashboard in a way, that the HTTP Session Cookies will be sent to a specified domain and all of its subdomains. This can be achieved by setting the environment variable `AUTH_COOKIE_DOMAIN` or the configuration property `auth.cookieDomain`. If this is done the cookie `gTkn` is sent to all subdomains of the specified domain. The initialization process of the session can be started from external applications or Istio by redirecting to the dashbaord /auth endpoint e.g. `https://dashboard.garden.dev.k8s.ondemand.com/auth?successRedirect=https://test.dev.k8s.ondemand.com/&failureRedirect=https://test.dev.k8s.ondemand.com/error`. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user

```
