### PR TITLE
Only display Alertmanager link when shoot has an alertmanager

### DIFF
--- a/frontend/src/components/ClusterMetrics.vue
+++ b/frontend/src/components/ClusterMetrics.vue
@@ -60,7 +60,7 @@ limitations under the License.
         </v-list-tile-title>
       </v-list-tile-content>
     </v-list-tile>
-    <v-list-tile v-if="isAdmin">
+    <v-list-tile v-if="hasAlertmanager">
       <v-list-tile-action>
       </v-list-tile-action>
       <v-list-tile-content>
@@ -82,6 +82,7 @@ limitations under the License.
 <script>
 import get from 'lodash/get'
 import UsernamePassword from '@/components/UsernamePasswordListTile'
+import { hasAlertmanager } from '@/utils'
 import { mapGetters } from 'vuex'
 import { shootItem } from '@/mixins/shootItem'
 
@@ -117,6 +118,9 @@ export default {
     },
     password () {
       return get(this.shootItem, 'info.monitoring_password', '')
+    },
+    hasAlertmanager () {
+      return hasAlertmanager(get(this.shootItem, 'metadata'))
     }
   }
 }

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -324,6 +324,13 @@ export function getCreatedBy (metadata) {
   return get(metadata, ['annotations', 'garden.sapcloud.io/createdBy'])
 }
 
+export function hasAlertmanager (metadata) {
+  if (get(metadata, ['annotations', 'garden.sapcloud.io/operatedBy'])) {
+    return true
+  }
+  return false
+}
+
 export function getProjectName (metadata) {
   const namespace = get(metadata, ['namespace'])
   const projectList = store.getters.projectList


### PR DESCRIPTION
**What this PR does / why we need it**:
Only shows a link to the Alertmanager if the shoot is annotated with the `garden.sapcloud.io/operatedBy` annotation.

**Which issue(s) this PR fixes**:
Fixes #423 

**Special notes for your reviewer**:
`isAdmin` is removed because users should also have access to an Alertmanager if they annotated their shoot.
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
NONE
```
