### PR TITLE
Shorten monitoring subdomains

### DIFF
--- a/frontend/src/store/modules/shoots.js
+++ b/frontend/src/store/modules/shoots.js
@@ -158,12 +158,12 @@ const actions = {
 
         if (info.seedShootIngressDomain) {
           const baseHost = info.seedShootIngressDomain
-          info.grafanaUrlUsers = `https://g-users.${baseHost}`
-          info.grafanaUrlOperators = `https://g-operators.${baseHost}`
+          info.grafanaUrlUsers = `https://gu.${baseHost}`
+          info.grafanaUrlOperators = `https://go.${baseHost}`
 
           info.prometheusUrl = `https://p.${baseHost}`
 
-          info.alertmanagerUrl = `https://a.${baseHost}`
+          info.alertmanagerUrl = `https://au.${baseHost}`
 
           info.kibanaUrl = `https://k.${baseHost}`
         }


### PR DESCRIPTION
**What this PR does / why we need it**:
The monitoring subdomains were shortened. 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Only merge once [#1417](https://github.com/gardener/gardener/pull/1417) has been merged.
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
The subdomain for the the user monitoring has changed from `g-users` to `gu`.
```
```improvement operator
The subdomain for the the operator monitoring has changed from `g-operators` to `go`.
```

