### PR TITLE
Fix issue when replacing an infrastructure secret

### DIFF
--- a/backend/lib/services/infrastructureSecrets.js
+++ b/backend/lib/services/infrastructureSecrets.js
@@ -93,7 +93,7 @@ function toSecretResource ({ metadata, data }) {
   const type = 'Opaque'
   metadata = _
     .chain(metadata)
-    .pick(['namespace', 'name', 'resourceVersion'])
+    .pick(['namespace', 'name'])
     .value()
   try {
     data = _.mapValues(data, encodeBase64)
@@ -118,7 +118,7 @@ function toSecretBindingResource ({ metadata }) {
 
   metadata = _
     .chain(metadata)
-    .pick(['namespace', 'resourceVersion'])
+    .pick(['namespace'])
     .assign({ name, labels })
     .value()
   return { apiVersion, kind, metadata, secretRef }

--- a/backend/test/acceptance/api.infrastructureSecrets.spec.js
+++ b/backend/test/acceptance/api.infrastructureSecrets.spec.js
@@ -27,7 +27,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
   const bindingName = `${name}-sb`
   const cloudProfileName = 'infra1-profileName'
   const cloudProviderKind = 'infra1'
-  const metadata = {name, bindingName, cloudProfileName}
+  const metadata = { namespace, name, bindingName, cloudProfileName, cloudProviderKind }
   const username = `${name}@example.org`
   const id = username
   const user = auth.createUser({ id })
@@ -79,7 +79,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
 
     expect(res).to.have.status(200)
     expect(res).to.be.json
-    expect(res.body.metadata).to.eql({name, resourceVersion, bindingName, bindingNamespace: namespace, cloudProfileName, cloudProviderKind})
+    expect(res.body.metadata).to.eql({name, namespace, resourceVersion, bindingName, bindingNamespace: namespace, cloudProfileName, cloudProviderKind})
     expect(res.body.data).to.have.own.property('key')
     expect(res.body.data).to.have.own.property('secret')
   })

--- a/backend/test/support/nocks/k8s.js
+++ b/backend/test/support/nocks/k8s.js
@@ -670,11 +670,13 @@ const stub = {
 
     return nockWithAuthorization(bearer)
       .post(`/api/v1/namespaces/${namespace}/secrets`, body => {
+        expect(body).to.not.have.nested.property('metadata.resourceVersion')
         _.assign(resultSecret.metadata, body.metadata)
         return true
       })
       .reply(200, () => resultSecret)
       .post(`/apis/garden.sapcloud.io/v1beta1/namespaces/${namespace}/secretbindings`, body => {
+        expect(body).to.not.have.nested.property('metadata.resourceVersion')
         _.assign(resultSecretBinding.metadata, body.metadata)
         _.assign(resultSecretBinding.secretRef, body.secretRef)
         return true
@@ -699,6 +701,7 @@ const stub = {
       .get(`/apis/garden.sapcloud.io/v1beta1/namespaces/${bindingNamespace}/secretbindings/${bindingName}`)
       .reply(200, () => resultSecretBinding)
       .patch(`/api/v1/namespaces/${namespace}/secrets/${name}`, body => {
+        expect(body).to.not.have.nested.property('metadata.resourceVersion')
         _.assign(resultSecret.metadata, body.metadata)
         return true
       })


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the problem when a user is replacing an infrastructure secret immediately after creation without reloading the browser window.

**Which issue(s) this PR fixes**:
Fixes #475 

**Special notes for your reviewer**:


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
NONE
```
