### PR TITLE
Use labels to aggregate ClusterRole for project-viewer

### DIFF
--- a/charts/gardener-dashboard/templates/rbac.yaml
+++ b/charts/gardener-dashboard/templates/rbac.yaml
@@ -1,3 +1,28 @@
+apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRole
+metadata:
+  name: dashboard.gardener.cloud:system:project-member
+  labels:
+    rbac.gardener.cloud/aggregate-to-project-member: "true"
+    app: gardener-dashboard
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+rules:
+- apiGroups:
+  - dashboard.gardener.cloud
+  resources:
+  - terminals
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
 {{- if not .Values.kubeconfig }}
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRoleBinding


### PR DESCRIPTION
**What this PR does / why we need it**:

It's easier for individual components to use aggregated roles and not to touch the parent role.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
See https://github.com/gardener/gardener/pull/1539
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
The dashboard now uses ClusterRole aggregation to enhance the project-members with permissions to work with the terminals. See https://github.com/gardener/gardener/pull/1539 for more details.
```
