### PR TITLE
add possibility to add arbitrary labels to dashboard/identity pod template

### DIFF
--- a/charts/gardener-dashboard/templates/deployment.yaml
+++ b/charts/gardener-dashboard/templates/deployment.yaml
@@ -31,6 +31,7 @@ spec:
       labels:
         app: gardener-dashboard
         release: {{ .Release.Name }}
+{{- if .Values.podLabels }}{{ toYaml .Values.podLabels | trim | nindent 8 }}{{- end }}
     spec:
       volumes:
       - name: gardener-dashboard-config

--- a/charts/gardener-dashboard/templates/deployment.yaml
+++ b/charts/gardener-dashboard/templates/deployment.yaml
@@ -31,7 +31,9 @@ spec:
       labels:
         app: gardener-dashboard
         release: {{ .Release.Name }}
-{{- if .Values.podLabels }}{{ toYaml .Values.podLabels | trim | nindent 8 }}{{- end }}
+        {{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+        {{- end }}
     spec:
       volumes:
       - name: gardener-dashboard-config

--- a/charts/identity/templates/deployment.yaml
+++ b/charts/identity/templates/deployment.yaml
@@ -24,6 +24,7 @@ spec:
       labels:
         app: identity
         release: {{ .Release.Name }}
+{{- if .Values.podLabels }}{{ toYaml .Values.podLabels | trim | nindent 8 }}{{- end }}
     spec:
       volumes:
         - name: config

--- a/charts/identity/templates/deployment.yaml
+++ b/charts/identity/templates/deployment.yaml
@@ -24,7 +24,9 @@ spec:
       labels:
         app: identity
         release: {{ .Release.Name }}
-{{- if .Values.podLabels }}{{ toYaml .Values.podLabels | trim | nindent 8 }}{{- end }}
+        {{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+        {{- end }}
     spec:
       volumes:
         - name: config


### PR DESCRIPTION
**What this PR does / why we need it**:
It's now possible to add arbitrary labels to the pod templates of dashboard or identity by providing these labels in a `podLabels` field in the helm values file.

This is needed for network policies that allow communication to/from pods based on labels on the pods, for example.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
It's now possible to add arbitrary labels to the pod templates of dashboard or identity by providing these labels in a `podLabels` field in the helm values file.
```
