### PR TITLE
Remove deprecated addon monocular

### DIFF
--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -491,11 +491,6 @@ export const shootAddonList = [
     enabled: false
   },
   {
-    name: 'monocular',
-    title: 'Monocular',
-    description: 'Monocular is a web-based UI for managing Kubernetes applications and services packaged as Helm Charts. It allows you to search and discover available charts from multiple repositories, and install them in your cluster with one click.'
-  },
-  {
     name: 'nginx-ingress',
     title: 'Nginx Ingress',
     description: 'Default ingress-controller. Alternatively you may install any other ingress-controller of your liking. If you select this option, please note that Gardener will include it in its reconciliation and you can’t override it’s configuration.',


### PR DESCRIPTION
**What this PR does / why we need it**:
Gardener has deprecated all addons except kubernetes-dashboard and nginx-ingress, hence we should remove the deprecated addons from the create cluster list.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
see gardener/gardener#471

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Removed deprecated addon `Monocular ` from cluster details page. (See also gardener/gardener#471)

```
