### PR TITLE
Added option to provide additional static clients to identity helm chart

### DIFF
--- a/charts/identity/templates/configmap.yaml
+++ b/charts/identity/templates/configmap.yaml
@@ -41,6 +41,9 @@ data:
       - dashboard
       name: Kubectl
       secret: {{ .Values.kubectlClientSecret }}
+{{- if .Values.additionalStaticClients }}
+{{ toYaml .Values.additionalStaticClients | indent 4 }}
+{{- end -}}
 {{- if .Values.staticPasswords }}
     enablePasswordDB: true
     staticPasswords:

--- a/charts/identity/values.yaml
+++ b/charts/identity/values.yaml
@@ -34,6 +34,14 @@ dashboardOrigins:
 dashboardClientSecret: sHq4vLoiQcIWbO3h
 kubectlClientSecret: if6ji0dTFE4rQfj8
 
+additionalStaticClients: ~
+# - name: additional identity example client
+#   id: exampleClient
+#   secret: changeme
+#   redirectURIs:
+#     - "https://additional.ingress.example.org"
+#     - "https://additional.example.org"
+
 connectors:
 - type: saml
   id: saml


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds an option to provide additional static clients to the identity helm chart.
This is useful for scenarios where one wants to reuse the authentication setup of the deployed dex instance.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```improvement operator
The identiy helm chart now allows to specify additional static clients for the deployed dex instance via value field `additionalStaticClients`.
See examples in the chart's respective `values.yaml` file.
```
