### PR TITLE
Links to external tools

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -309,6 +309,10 @@ Copyright (c) 2013 Julian Gruber <julian@juliangruber.com>\
 Copyright (c) 2014-2017 Automattic <dev@cloudup.com>\
 [MIT License](https://github.com/socketio/socket.io/blob/master/LICENSE)
 
+- [url-template](https://github.com/bramstein/url-template)\
+Copyright (c) 2012-2014, Bram Stein\
+[BSD License](https://github.com/bramstein/url-template/blob/master/LICENSE)
+
 - [uuid](https://github.com/kelektiv/node-uuid)\
 Copyright (c) 2010-2016 Robert Kieffer and other contributors\
 [MIT License](https://github.com/kelektiv/node-uuid/blob/master/LICENSE.md)

--- a/charts/gardener-dashboard/templates/configmap.yaml
+++ b/charts/gardener-dashboard/templates/configmap.yaml
@@ -119,6 +119,14 @@ data:
         target: {{ .target }}{{- end }}
       {{- end }}
 {{- end }}
+{{- if .Values.frontendConfig.externalTools }}
+      externalTools:
+      {{- range .Values.frontendConfig.externalTools }}
+      - title: {{ .title }}{{- if .icon }}
+        icon: {{ .icon }}{{- end }}
+        url: {{ .url }}
+      {{- end }}
+{{- end }}
       dashboardUrl:
         pathname: /api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy
 {{- if .Values.frontendConfig.gitHubRepoUrl }}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,6 +43,7 @@
     "semver": "^5.5.1",
     "socket.io-client": "^2.3.0",
     "typeface-roboto": "0.0.75",
+    "url-template": "^2.0.8",
     "vue": "^2.5.22",
     "vue-cookie": "^1.1.4",
     "vue-lazyload": "^1.3.3",

--- a/frontend/src/components/ShootDetails/ShootExternalToolsCard.vue
+++ b/frontend/src/components/ShootDetails/ShootExternalToolsCard.vue
@@ -1,0 +1,86 @@
+<!--
+Copyright (c) 2019 by SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<template>
+  <v-card v-if="items.length">
+    <v-card-title class="subheading white--text cyan darken-2 statusTitle">
+      External Tools
+    </v-card-title>
+    <div class="list">
+      <v-list>
+        <template v-for="({ title, url, icon = 'link' }, index) in items">
+        <v-divider v-if="index" :key="index" class="my-2" inset></v-divider>
+        <v-list-tile :key="title">
+          <v-list-tile-action>
+            <v-icon class="cyan--text text--darken-2">{{icon}}</v-icon>
+          </v-list-tile-action>
+          <v-list-tile-content>
+            <v-list-tile-sub-title>{{title}}</v-list-tile-sub-title>
+            <v-list-tile-title>
+              <a :href="expandUrl(url)" target="_blank" class="cyan--text text--darken-2">{{expandUrl(url)}}</a>
+            </v-list-tile-title>
+          </v-list-tile-content>
+        </v-list-tile>
+        </template>
+      </v-list>
+    </div>
+  </v-card>
+</template>
+
+<script>
+import get from 'lodash/get'
+import template from 'url-template'
+import { shootItem } from '@/mixins/shootItem'
+import { mapState } from 'vuex'
+
+export default {
+  mixins: [shootItem],
+  props: {
+    shootItem: {
+      type: Object
+    }
+  },
+  computed: {
+    ...mapState([
+      'cfg'
+    ]),
+    items () {
+      return get(this.cfg, 'externalTools', [])
+    }
+  },
+  methods: {
+    expandUrl (url) {
+      try {
+        return template.parse(url).expand(this.shootMetadata)
+      } catch (err) {
+        console.error(`Failed to parse URL template "${url}"`)
+        return url
+      }
+    }
+  }
+}
+</script>
+
+<style lang="styl" scoped>
+  .statusTitle {
+    line-height: 10px;
+  }
+
+  .list {
+    padding-top: 8px;
+    padding-bottom: 8px;
+  }
+</style>

--- a/frontend/src/pages/ShootDetails.vue
+++ b/frontend/src/pages/ShootDetails.vue
@@ -22,9 +22,9 @@ limitations under the License.
 
         <shoot-infrastructure-card :shootItem="item" class="mt-3"></shoot-infrastructure-card>
 
-        <shoot-lifecycle-card ref="shootLifecycle" :shootItem="item" class="mt-3"></shoot-lifecycle-card>
-
         <shoot-external-tools-card :shootItem="item" class="mt-3"></shoot-external-tools-card>
+
+        <shoot-lifecycle-card ref="shootLifecycle" :shootItem="item" class="mt-3"></shoot-lifecycle-card>
       </v-flex>
 
       <v-flex md6>

--- a/frontend/src/pages/ShootDetails.vue
+++ b/frontend/src/pages/ShootDetails.vue
@@ -23,6 +23,8 @@ limitations under the License.
         <shoot-infrastructure-card :shootItem="item" class="mt-3"></shoot-infrastructure-card>
 
         <shoot-lifecycle-card ref="shootLifecycle" :shootItem="item" class="mt-3"></shoot-lifecycle-card>
+
+        <shoot-external-tools-card :shootItem="item" class="mt-3"></shoot-external-tools-card>
       </v-flex>
 
       <v-flex md6>
@@ -69,6 +71,7 @@ import ShootLogging from '@/components/ShootDetails/ShootLogging'
 import ShootDetailsCard from '@/components/ShootDetails/ShootDetailsCard'
 import ShootInfrastructureCard from '@/components/ShootDetails/ShootInfrastructureCard'
 import ShootLifecycleCard from '@/components/ShootDetails/ShootLifecycleCard'
+import ShootExternalToolsCard from '@/components/ShootDetails/ShootExternalToolsCard'
 import get from 'lodash/get'
 import isEmpty from 'lodash/isEmpty'
 
@@ -84,7 +87,8 @@ export default {
     ShootAccessCard,
     ShootJournalsCard,
     ShootMonitoringCard,
-    ShootLogging
+    ShootLogging,
+    ShootExternalToolsCard
   },
   computed: {
     ...mapGetters([

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7851,6 +7851,11 @@ url-parse@^1.4.3:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
+url-template@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/url-template/-/url-template-2.0.8.tgz#fc565a3cccbff7730c775f5641f9555791439f21"
+  integrity sha1-/FZaPMy/93MMd19WQflVV5FDnyE=
+
 url@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the possibility for external tools to integrate with the dashboard by providing an option to configure title, link and icon in the helm chart. The url can be an [url-template](https://tools.ietf.org/html/rfc6570).  The variables `namespace` and `name` of the shoot are available when the url is expanded. The links are displayed in a dedicated card *External Tools* on the cluster details page. 

Example:
```
....
frontendConfig:
  ...
  externalTools:
  - title: Example Tool
    icon: link
    url: https://example.org/foo/bar{?namespace,name}
```
**Which issue(s) this PR fixes**:
Fixes #485 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Links to external tools can be configured
```
