### PR TITLE
[Master][Terminals]  Shorten kube-apiserver ingress host

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$|^.secrets.baseline_temp$",
     "lines": null
   },
-  "generated_at": "2019-11-08T16:13:01Z",
+  "generated_at": "2019-11-14T22:24:05Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -151,7 +151,7 @@
         "hashed_secret": "30118aa1aa8a06fa5365743b3a5db69fc62b9760",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 112,
+        "line_number": 111,
         "type": "Secret Keyword"
       }
     ],

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -256,6 +256,10 @@ Copyright (c) 2013-2014 Roman Shtylman <shtylman+expressjs@gmail.com>\
 Copyright (c) 2014-2015 Douglas Christopher Wilson <doug@somethingdoug.com>\
 [MIT License](https://github.com/expressjs/express/blob/master/LICENSE)
 
+- [fnv-plus](https://github.com/tjwebb/fnv-plus)\
+Copyright (c) Travis Webb\
+[MIT License](https://github.com/tjwebb/fnv-plus/blob/master/README.md)
+
 - [got](https://github.com/sindresorhus/got)\
 Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)\
 [MIT License](https://github.com/sindresorhus/got/blob/master/license)

--- a/backend/lib/services/terminals/terminalBootstrap.js
+++ b/backend/lib/services/terminals/terminalBootstrap.js
@@ -261,7 +261,7 @@ async function ensureTrustedCertForShootApiServer ({ gardenClient, coreClient, n
   const projectsClient = kubernetes.gardener().projects
   const namespacesClient = coreClient.namespaces
   const shootIngressDomain = await getShootIngressDomain(projectsClient, namespacesClient, shootResource, seedResource)
-  const apiServerIngressHost = `k8.${shootIngressDomain}`
+  const apiServerIngressHost = `k-${shootIngressDomain}`
 
   const seedShootNS = _.get(shootResource, 'status.technicalID')
   if (!seedShootNS) {
@@ -321,8 +321,6 @@ async function ensureTrustedCertForGardenTerminalHostApiServer () {
 
 async function ensureTrustedCertForSeedApiServer ({ coreClient, seed }) {
   const seedName = seed.metadata.name
-  const projectsClient = kubernetes.gardener().projects
-  const namespacesClient = coreClient.namespaces
 
   const seedKubeconfig = await getSeedKubeconfig({ coreClient, seed })
   const seedClientConfig = kubernetes.fromKubeconfig(seedKubeconfig)
@@ -331,8 +329,8 @@ async function ensureTrustedCertForSeedApiServer ({ coreClient, seed }) {
 
   const namespace = 'garden'
   const seedApiServerHostname = new URL(seedClientConfig.url).hostname
-  const seedIngressDomain = await getSeedIngressDomain(projectsClient, namespacesClient, seed)
-  const seedApiServerIngressHost = `k8.${seedIngressDomain}`
+  const seedIngressDomain = await getSeedIngressDomain(seed)
+  const seedApiServerIngressHost = `k-${seedIngressDomain}`
   const ingressAnnotations = _.get(config, 'terminal.bootstrap.apiServerIngress.annotations')
 
   await ensureTrustedCertForApiServer({

--- a/backend/lib/services/terminals/utils.js
+++ b/backend/lib/services/terminals/utils.js
@@ -107,10 +107,10 @@ async function getKubeApiServerHostForSeed ({ gardenClient, coreClient, shootsSe
     const shootResource = await shootsService.read({ gardenClient, namespace, name })
     ingressDomain = await getShootIngressDomain(projectsClient, namespacesClient, shootResource)
   } else {
-    ingressDomain = await getSeedIngressDomain(projectsClient, namespacesClient, seed)
+    ingressDomain = await getSeedIngressDomain(seed)
   }
 
-  return `k8.${ingressDomain}`
+  return `k-${ingressDomain}`
 }
 
 async function getKubeApiServerHostForShoot ({ gardenClient, coreClient, shootResource }) {
@@ -118,7 +118,7 @@ async function getKubeApiServerHostForShoot ({ gardenClient, coreClient, shootRe
   const namespacesClient = coreClient.namespaces
 
   const ingressDomain = await getShootIngressDomain(projectsClient, namespacesClient, shootResource)
-  return `k8.${ingressDomain}`
+  return `k-${ingressDomain}`
 }
 
 function getGardenTerminalHostClusterRefType () {

--- a/backend/lib/utils/index.js
+++ b/backend/lib/utils/index.js
@@ -24,6 +24,7 @@ const yaml = require('js-yaml')
 const { NotFound } = require('../errors')
 const config = require('../config')
 const assert = require('assert').strict
+const fnv = require('fnv-plus')
 
 function resolve (pathname) {
   return path.resolve(__dirname, '../..', pathname)
@@ -88,17 +89,15 @@ async function getShootIngressDomain (projects, namespaces, shoot, seed = undefi
 
   const ingressDomain = _.get(seed, 'spec.dns.ingressDomain')
   const projectName = await getProjectNameFromNamespace(projects, namespaces, namespace)
+  const hash = fnv.hash(`${name}.${projectName}`, 32).str()
 
-  return `${name}.${projectName}.${ingressDomain}`
+  return `${hash}.${ingressDomain}`
 }
 
-async function getSeedIngressDomain (projects, namespaces, seed) {
-  const namespace = 'garden'
-
+async function getSeedIngressDomain (seed) {
   const ingressDomain = _.get(seed, 'spec.dns.ingressDomain')
-  const projectName = await getProjectNameFromNamespace(projects, namespaces, namespace)
 
-  return `${projectName}.${ingressDomain}`
+  return `g.${ingressDomain}`
 }
 
 async function getSeedKubeconfig ({ coreClient, seed }) {

--- a/backend/package.json
+++ b/backend/package.json
@@ -33,6 +33,7 @@
     "cookie-parser": "^1.4.4",
     "es6-error": "^4.1.1",
     "express": "^4.17.1",
+    "fnv-plus": "^1.2.12",
     "got": "^9.6.0",
     "helmet": "^3.21.2",
     "js-yaml": "^3.13.1",

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -2455,6 +2455,13 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08"
   integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
 
+fnv-plus@^1.2.12:
+  version "1.2.12"
+  resolved "https://registry.yarnpkg.com/fnv-plus/-/fnv-plus-1.2.12.tgz#00752fc2d80761bacda9bfb9ea098f44cb3746be"
+  integrity sha1-AHUvwtgHYbrNqb+56gmPRMs3Rr4=
+  dependencies:
+    jsbn "~0.0.0"
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -3392,6 +3399,11 @@ js-yaml@^3.10.0, js-yaml@^3.13.0, js-yaml@^3.13.1:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+jsbn@~0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.0.0.tgz#c52701bdcedbdf7084e1cfc701a7f86464ad7828"
+  integrity sha1-xScBvc7b33CE4c/HAaf4ZGSteCg=
 
 jsbn@~0.1.0:
   version "0.1.1"


### PR DESCRIPTION
**What this PR does / why we need it**:
**Terminal feature:**
There is currently an issue with too long / too many segments of seed ingress domains where we would see the following error message when e.g. the `cert-managament` component tries to request certificates.
```
Cannot issue for "[redacted.domain]":
    Domain name has more than 10 labels (parts)
```

For the ingresses that we create for the kube-apiserver for the terminal feature we build the `host` as following:
- Shoot: `k8.{shoot_name}.{project_name}.{seed_ingress_domain}`
  - `shoot_name` and `project_name` has a length of up to 10 characters
- Seed: `k8.garden.{seed_ingress_domain}`

Which means that we have a limitation of a seed ingress domain of max `7` segments and max length of `38` characters.

With this PR we hash parts of the domain and try to avoid adding more segments and build the `host` as following:
- Shoot: `k-${fnv32({shoot_name}.{project_name})}.{seed_ingress_domain}`
  - the hash has a length of up to `7` characters
- Seed: `k-g.{seed_ingress_domain}`

The new limitations  of a seed ingress domain is now max `9` segments and max length of `53` characters



**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
