### PR TITLE
[Hotfix] Fix volume not found hotfix

### DIFF
--- a/frontend/src/components/ShootWorkers/VolumeType.vue
+++ b/frontend/src/components/ShootWorkers/VolumeType.vue
@@ -2,17 +2,20 @@
   <v-select
     color="cyan darken-2"
     :items="volumeTypeItems"
-    item-text="displayName"
+    item-text="name"
     item-value="name"
     v-model="worker.volumeType"
     :error-messages="getErrorMessages('worker.volumeType')"
     @input="onInputVolumeType"
     @blur="$v.worker.volumeType.$touch()"
-    label="Volume Type">
+    label="Volume Type"
+    :hint="hint"
+    persistent-hint
+    >
     <template slot="item" slot-scope="data">
       <v-list-tile-content>
         <v-list-tile-title>{{data.item.name}}</v-list-tile-title>
-        <v-list-tile-sub-title>Class: {{data.item.class}}</v-list-tile-sub-title>
+        <v-list-tile-sub-title v-if="data.item.class">Class: {{data.item.class}}</v-list-tile-sub-title>
       </v-list-tile-content>
     </template>
   </v-select>
@@ -27,18 +30,14 @@ import map from 'lodash/map'
 const validationErrors = {
   worker: {
     volumeType: {
-      required: 'Volume Type is required',
-      notUnsupported: 'This volume type is not supported, please choose a different one'
+      required: 'Volume Type is required'
     }
   }
 }
 const validations = {
   worker: {
     volumeType: {
-      required,
-      notUnsupported () {
-        return !this.unsupported
-      }
+      required
     }
   }
 }
@@ -62,22 +61,23 @@ export default {
   },
   computed: {
     volumeTypeItems () {
-      const volumeTypes = map(this.volumeTypes, volumeType => {
-        volumeType.displayName = volumeType.name
-        return volumeType
-      })
-      if (this.unsupported) {
+      const volumeTypes = this.volumeTypes.slice()
+      if (this.notInCloudProfile) {
         volumeTypes.push({
-          name: this.worker.volumeType,
-          displayName: `${this.worker.volumeType} [unsupported]`,
-          class: 'Not supported'
+          name: this.worker.volumeType
         })
       }
       this.onInputVolumeType()
       return volumeTypes
     },
-    unsupported () {
+    notInCloudProfile () {
       return !includes(map(this.volumeTypes, 'name'), this.worker.volumeType)
+    },
+    hint () {
+      if (this.notInCloudProfile) {
+        return 'This volume type may not be supported by your worker'
+      }
+      return undefined
     }
   },
   validations,

--- a/frontend/src/components/ShootWorkers/VolumeType.vue
+++ b/frontend/src/components/ShootWorkers/VolumeType.vue
@@ -24,8 +24,7 @@
 <script>
 import { required } from 'vuelidate/lib/validators'
 import { getValidationErrors } from '@/utils'
-import includes from 'lodash/includes'
-import map from 'lodash/map'
+import find from 'lodash/find'
 
 const validationErrors = {
   worker: {
@@ -71,7 +70,7 @@ export default {
       return volumeTypes
     },
     notInCloudProfile () {
-      return !includes(map(this.volumeTypes, 'name'), this.worker.volumeType)
+      return !find(this.volumeTypes, ['name', this.worker.volumeType])
     },
     hint () {
       if (this.notInCloudProfile) {

--- a/frontend/src/components/ShootWorkers/VolumeType.vue
+++ b/frontend/src/components/ShootWorkers/VolumeType.vue
@@ -1,8 +1,8 @@
 <template>
   <v-select
     color="cyan darken-2"
-    :items="volumeTypes"
-    item-text="name"
+    :items="volumeTypeItems"
+    item-text="displayName"
     item-value="name"
     v-model="worker.volumeType"
     :error-messages="getErrorMessages('worker.volumeType')"
@@ -27,14 +27,18 @@ import map from 'lodash/map'
 const validationErrors = {
   worker: {
     volumeType: {
-      required: 'Volume Type is required'
+      required: 'Volume Type is required',
+      notUnsupported: 'This volume type is not supported, please choose a different one'
     }
   }
 }
 const validations = {
   worker: {
     volumeType: {
-      required
+      required,
+      notUnsupported () {
+        return !this.unsupported
+      }
     }
   }
 }
@@ -54,6 +58,26 @@ export default {
     return {
       validationErrors,
       valid: undefined
+    }
+  },
+  computed: {
+    volumeTypeItems () {
+      const volumeTypes = map(this.volumeTypes, volumeType => {
+        volumeType.displayName = volumeType.name
+        return volumeType
+      })
+      if (this.unsupported) {
+        volumeTypes.push({
+          name: this.worker.volumeType,
+          displayName: `${this.worker.volumeType} [unsupported]`,
+          class: 'Not supported'
+        })
+      }
+      this.onInputVolumeType()
+      return volumeTypes
+    },
+    unsupported () {
+      return !includes(map(this.volumeTypes, 'name'), this.worker.volumeType)
     }
   },
   validations,
@@ -76,14 +100,6 @@ export default {
   mounted () {
     this.$v.$touch()
     this.validateInput()
-  },
-  watch: {
-    volumeTypes (updatedVolumeTypes) {
-      if (!includes(map(updatedVolumeTypes, 'name'), this.worker.volumeType)) {
-        this.worker.volumeType = undefined
-        this.onInputVolumeType()
-      }
-    }
   }
 }
 </script>

--- a/frontend/src/components/ShootWorkers/WorkerGroup.vue
+++ b/frontend/src/components/ShootWorkers/WorkerGroup.vue
@@ -27,9 +27,19 @@ limitations under the License.
      :key="index"
      fill-height
      align-center>
-     <span class="ma-1"><span class="font-weight-bold">{{line.title}}:</span> {{line.value}} {{line.description}}</span>
+     <span class="ma-1">
+       <span class="font-weight-bold">{{line.title}}:</span> {{line.value}} {{line.description}}
+       <span v-if="line.unsupported">| <span class="orange--text text--darken-2">{{line.unsupported}}</span></span>
+     </span>
     </v-layout>
-    <v-chip slot="popperRef" small class="cursor-pointer my-0 ml-0" outline color="cyan darken-2">{{workerGroup.name}}</v-chip>
+    <v-chip
+      slot="popperRef"
+      small
+      class="cursor-pointer my-0 ml-0"
+      outline
+      :color="chipColor">
+      {{workerGroup.name}}
+    </v-chip>
   </g-popper>
 </template>
 
@@ -85,11 +95,19 @@ export default {
       }
       if (this.workerGroup.volumeType && this.workerGroup.volumeSize) {
         const volumeType = find(this.volumeTypes, { name: this.workerGroup.volumeType })
-        description.push({
-          title: 'Volume Type',
-          value: `${volumeType.name} / ${this.workerGroup.volumeSize}`,
-          description: `(Class: ${volumeType.class})`
-        })
+        if (volumeType) {
+          description.push({
+            title: 'Volume Type',
+            value: `${volumeType.name} / ${this.workerGroup.volumeSize}`,
+            description: `(Class: ${volumeType.class})`
+          })
+        } else {
+          description.push({
+            title: 'Volume Type',
+            value: this.workerGroup.volumeType,
+            unsupported: 'This volume type is no longer supported'
+          })
+        }
       }
       if (this.workerGroup.machineImage) {
         const machineImage = find(this.machineImages, { name: this.workerGroup.machineImage.name })
@@ -115,6 +133,15 @@ export default {
         })
       }
       return description
+    },
+    unsupported () {
+      return find(this.description, line => { return line.unsupported !== undefined })
+    },
+    chipColor () {
+      if (this.unsupported) {
+        return 'orange darken-2'
+      }
+      return 'cyan darken-2'
     }
   }
 }

--- a/frontend/src/components/ShootWorkers/WorkerGroup.vue
+++ b/frontend/src/components/ShootWorkers/WorkerGroup.vue
@@ -29,7 +29,6 @@ limitations under the License.
      align-center>
      <span class="ma-1">
        <span class="font-weight-bold">{{line.title}}:</span> {{line.value}} {{line.description}}
-       <span v-if="line.unsupported">| <span class="orange--text text--darken-2">{{line.unsupported}}</span></span>
      </span>
     </v-layout>
     <v-chip
@@ -37,7 +36,7 @@ limitations under the License.
       small
       class="cursor-pointer my-0 ml-0"
       outline
-      :color="chipColor">
+      color="cyan darken-2">
       {{workerGroup.name}}
     </v-chip>
   </g-popper>
@@ -104,8 +103,7 @@ export default {
         } else {
           description.push({
             title: 'Volume Type',
-            value: this.workerGroup.volumeType,
-            unsupported: 'This volume type is no longer supported'
+            value: this.workerGroup.volumeType
           })
         }
       }
@@ -133,15 +131,6 @@ export default {
         })
       }
       return description
-    },
-    unsupported () {
-      return find(this.description, line => { return line.unsupported !== undefined })
-    },
-    chipColor () {
-      if (this.unsupported) {
-        return 'orange darken-2'
-      }
-      return 'cyan darken-2'
     }
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
If an landscape administrator changes the names of volumes defined in the cloud profile or deletes them completely, the dashboard currently has issues rendering worker groups on the cluster details page. This PR addresses the issue.

**Which issue(s) this PR fixes**:
Fixes #490

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Fixed: Volume types that are no longer supported for a cluster are now displayed correctly
```
