### PR TITLE
[Hotfix]Terminal: Use wildcard certificates for each seed

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$|^.secrets.baseline_temp$",
     "lines": null
   },
-  "generated_at": "2019-11-15T11:30:30Z",
+  "generated_at": "2019-11-21T13:56:09Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -151,7 +151,7 @@
         "hashed_secret": "30118aa1aa8a06fa5365743b3a5db69fc62b9760",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 122,
+        "line_number": 100,
         "type": "Secret Keyword"
       }
     ],

--- a/backend/lib/services/terminals/index.js
+++ b/backend/lib/services/terminals/index.js
@@ -31,7 +31,7 @@ const {
   toTerminalResource
 } = require('./terminalResources')
 const {
-  getKubeApiServerHostForSeed,
+  getKubeApiServerHostForSeedOrShootedSeed,
   getKubeApiServerHostForShoot,
   getGardenTerminalHostClusterSecretRef,
   getGardenHostClusterKubeApiServer
@@ -247,7 +247,7 @@ async function getSeedHostCluster ({ gardenClient, gardenCoreClient, namespace, 
 
   hostCluster.namespace = seedShootNS
   hostCluster.secretRef = _.get(seed, 'spec.secretRef')
-  hostCluster.kubeApiServer = await getKubeApiServerHostForSeed({ gardenClient, coreClient: gardenCoreClient, shootsService: shoots, seed })
+  hostCluster.kubeApiServer = await getKubeApiServerHostForSeedOrShootedSeed({ gardenClient, coreClient: gardenCoreClient, shootsService: shoots, seed })
   return hostCluster
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When terminal bootstrapping is enabled, an ingress resource is created for each `kube-apiserver` of a shoot or seed and a corresponding browser trusted certificate is requested. 
This can cause rate limiting issues for landscapes with a large number of shoots or when a lot of shoots are created and deleted when running integration tests.
With this PR, we make use of wildcard certificates. This means that the number of required certificates corresponds to the number of seeds in a landscape.

**Which issue(s) this PR fixes**:
Fixes #509

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Terminal: Now using wildcard certificates for seed ingress domains
```
