### PR TITLE
Remove Clusterrole

### DIFF
--- a/charts/gardener-dashboard/templates/rbac.yaml
+++ b/charts/gardener-dashboard/templates/rbac.yaml
@@ -1,28 +1,3 @@
-apiVersion: {{ include "rbacversion" . }}
-kind: ClusterRole
-metadata:
-  name: dashboard.gardener.cloud:system:project-member
-  labels:
-    rbac.gardener.cloud/aggregate-to-project-member: "true"
-    app: gardener-dashboard
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
-rules:
-- apiGroups:
-  - dashboard.gardener.cloud
-  resources:
-  - terminals
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
----
 {{- if not .Values.kubeconfig }}
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRoleBinding


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR reverts the change introduced with gardener/dashboard#479.
The clusterrole `dashboard.gardener.cloud:system:project-member` is removed from the chart that should give endusers (regular project members) the permission to create terminals. The initial idea for adding it to the chart was so that the permission is added when the dashboard is deployed using the helm chart. However this does not work when having a so called virtual garden setup (like with the https://github.com/gardener/garden-setup), where the cluster that hosts the dashboard is different than the garden cluster.

Instead, the clusterrole should be created in the (virtual) garden cluster within your deploy script:
```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: dashboard.gardener.cloud:system:project-member
  labels:
    rbac.gardener.cloud/aggregate-to-project-member: "true"
rules:
- apiGroups:
  - dashboard.gardener.cloud
  resources:
  - terminals
  verbs:
  - create
  - delete
  - deletecollection
  - get
  - list
  - patch
  - update
  - watch
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```action operator
Terminals: The clusterrole `dashboard.gardener.cloud:system:project-member` was removed from the chart. Instead, it should be created in the (virtual) garden cluster within your deploy script.
```
