### PR TITLE
adds additionalTrustedPeers to identity helm chart

### DIFF
--- a/charts/identity/templates/configmap.yaml
+++ b/charts/identity/templates/configmap.yaml
@@ -39,11 +39,14 @@ data:
       public: true
       trustedPeers:
       - dashboard
+{{- if .Values.additionalTrustedPeers }}
+{{ toYaml .Values.additionalTrustedPeers | indent 6 }}
+{{- end }}
       name: Kubectl
       secret: {{ .Values.kubectlClientSecret }}
 {{- if .Values.additionalStaticClients }}
 {{ toYaml .Values.additionalStaticClients | indent 4 }}
-{{- end -}}
+{{- end }}
 {{- if .Values.staticPasswords }}
     enablePasswordDB: true
     staticPasswords:

--- a/charts/identity/values.yaml
+++ b/charts/identity/values.yaml
@@ -42,6 +42,10 @@ additionalStaticClients: ~
 #     - "https://additional.ingress.example.org"
 #     - "https://additional.example.org"
 
+additionalTrustedPeers: ~
+# - exampleClient
+# - anotherClient
+
 connectors:
 - type: saml
   id: saml


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows to customize the identity configmap by adding additional trusted peers to the configmaps `trustedPeers` field.
In addition this fixes a potentially missing line end for field `additionalStaticClients`.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```improvement user
The identiy helm chart now allows to specify additional trusted peers for the deployed dex instance via value field `additionalTrustedPeers`.
See examples in the chart's respective values.yaml file.
```
