### PR TITLE
[Hotfix] Temporarily add experimental Kyma addon into dashboard

### DIFF
--- a/backend/lib/routes/shoots.js
+++ b/backend/lib/routes/shoots.js
@@ -180,3 +180,15 @@ router.route('/:name/info')
       next(err)
     }
   })
+
+router.route('/:name/kyma')
+  .get(async (req, res, next) => {
+    try {
+      const user = req.user
+      const namespace = req.params.namespace
+      const name = req.params.name
+      res.send(await shoots.kyma({ user, namespace, name }))
+    } catch (err) {
+      next(err)
+    }
+  })

--- a/backend/lib/routes/shoots.js
+++ b/backend/lib/routes/shoots.js
@@ -17,6 +17,8 @@
 'use strict'
 
 const express = require('express')
+const _ = require('lodash')
+const config = require('../config')
 const { shoots } = require('../services')
 
 const router = module.exports = express.Router({
@@ -181,14 +183,16 @@ router.route('/:name/info')
     }
   })
 
-router.route('/:name/kyma')
-  .get(async (req, res, next) => {
-    try {
-      const user = req.user
-      const namespace = req.params.namespace
-      const name = req.params.name
-      res.send(await shoots.kyma({ user, namespace, name }))
-    } catch (err) {
-      next(err)
-    }
-  })
+if (_.get(config, 'frontend.features.kymaEnabled', false)) {
+  router.route('/:name/kyma')
+    .get(async (req, res, next) => {
+      try {
+        const user = req.user
+        const namespace = req.params.namespace
+        const name = req.params.name
+        res.send(await shoots.kyma({ user, namespace, name }))
+      } catch (err) {
+        next(err)
+      }
+    })
+}

--- a/backend/lib/services/shoots.js
+++ b/backend/lib/services/shoots.js
@@ -21,10 +21,11 @@ const utils = require('../utils')
 const { getSeed } = require('../cache')
 const authorization = require('./authorization')
 const logger = require('../logger')
+const { NotFound } = require('../errors')
 const _ = require('lodash')
 const yaml = require('js-yaml')
 
-const { decodeBase64, getProjectByNamespace, getSeedKubeconfig } = utils
+const { decodeBase64, getProjectByNamespace, getSeedKubeconfig, getKubeconfig } = utils
 
 function Garden ({ auth }) {
   return kubernetes.garden({ auth })
@@ -88,11 +89,14 @@ exports.list = async function ({ user, namespace, shootsWithIssuesOnly = false }
 
 exports.create = async function ({ user, namespace, body }) {
   const username = user.id
-  const finalizers = ['gardener']
   const annotations = {
     'garden.sapcloud.io/createdBy': username
   }
-  body = _.merge({}, body, { metadata: { namespace, finalizers, annotations } })
+  if (_.get(body, 'spec.addons.kyma.enabled', false)) {
+    annotations['experimental.addons.shoot.gardener.cloud/kyma'] = 'enabled'
+  }
+  body = _.merge({}, body, { metadata: { namespace, annotations } })
+  _.unset(body, 'spec.addons.kyma')
   return Garden(user).namespaces(namespace).shoots.post({ body })
 }
 
@@ -172,13 +176,45 @@ exports.replaceHibernationSchedules = async function ({ user, namespace, name, b
 }
 
 exports.replaceAddons = async function ({ user, namespace, name, body }) {
-  const addons = body
+  const { kyma = {}, ...addons } = body
   const payload = {
     spec: {
       addons
     }
   }
+  if (kyma.enabled) {
+    payload.annotations = {
+      'experimental.addons.shoot.gardener.cloud/kyma': 'enabled'
+    }
+  }
   return patch({ user, namespace, name, body: payload })
+}
+
+exports.kyma = async function ({ user, namespace, name }) {
+  const coreClient = Core(user)
+  const kubeconfig = await getKubeconfig({ coreClient, namespace, name: `${name}.kubeconfig` })
+  if (!kubeconfig) {
+    throw new NotFound('Kubeconfig for shoot does not exist')
+  }
+  const shootCoreClient = kubernetes.core(kubernetes.fromKubeconfig(utils.cleanKubeconfig(kubeconfig)))
+  const [{
+    data: {
+      'global.ingress.domainName': domain
+    }
+  }, {
+    data: {
+      email, password, username
+    }
+  }] = await Promise.all([
+    shootCoreClient.namespaces('kyma-installer').configmaps.get({ name: 'net-global-overrides' }),
+    shootCoreClient.namespaces('kyma-system').secrets.get({ name: 'admin-user' })
+  ])
+  return {
+    url: `https://console.${domain}`,
+    email: decodeBase64(email),
+    username: decodeBase64(username),
+    password: decodeBase64(password)
+  }
 }
 
 exports.replaceWorkers = async function ({ user, namespace, infrastructureKind, name, body }) {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -3920,9 +3920,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
-      "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -7722,9 +7722,9 @@
       }
     },
     "uglify-js": {
-      "version": "3.6.7",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.7.tgz",
-      "integrity": "sha512-4sXQDzmdnoXiO+xvmTzQsfIiwrjUCSA95rSP4SEd8tDb51W2TiDOlL76Hl+Kw0Ie42PSItCW8/t6pBNCF2R48A==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.2.tgz",
+      "integrity": "sha512-uhRwZcANNWVLrxLfNFEdltoPNhECUR3lc+UdJoG9CBpMcSnKyWA94tc3eAujB1GcMY5Uwq8ZMp4qWpxWYDQmaA==",
       "dev": true,
       "optional": true,
       "requires": {

--- a/backend/test/acceptance/api.shoots.spec.js
+++ b/backend/test/acceptance/api.shoots.spec.js
@@ -51,7 +51,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
 
   it('should return three shoots', async function () {
     const bearer = await user.bearer
-    k8s.stub.getShoots({bearer, namespace})
+    k8s.stub.getShoots({ bearer, namespace })
     const res = await agent
       .get(`/api/namespaces/${namespace}/shoots`)
       .set('cookie', await user.cookie)
@@ -63,22 +63,21 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
 
   it('should create a shoot', async function () {
     const bearer = await user.bearer
-    const finalizers = ['gardener']
-    k8s.stub.createShoot({bearer, namespace, name, spec, resourceVersion})
+    k8s.stub.createShoot({ bearer, namespace, name, spec, resourceVersion })
     const res = await agent
       .post(`/api/namespaces/${namespace}/shoots`)
       .set('cookie', await user.cookie)
-      .send({metadata: {
+      .send({ metadata: {
         name,
         annotations: {
           'garden.sapcloud.io/purpose': purpose
         }
       },
-      spec})
+      spec })
 
     expect(res).to.have.status(200)
     expect(res).to.be.json
-    expect(res.body.metadata).to.eql({name, namespace, resourceVersion, annotations, finalizers})
+    expect(res.body.metadata).to.eql({ name, namespace, resourceVersion, annotations })
     expect(res.body.spec).to.eql(spec)
   })
 
@@ -91,7 +90,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
 
     expect(res).to.have.status(200)
     expect(res).to.be.json
-    expect(res.body.metadata).to.eql({name, namespace, annotations})
+    expect(res.body.metadata).to.eql({ name, namespace, annotations })
     expect(res.body.spec).to.eql(spec)
   })
 
@@ -108,7 +107,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
 
     expect(res).to.have.status(200)
     expect(res).to.be.json
-    expect(res.body.metadata).to.eql({namespace, annotations: deleteAnnotations, resourceVersion})
+    expect(res.body.metadata).to.eql({ namespace, annotations: deleteAnnotations, resourceVersion })
   })
 
   it('should return shoot info', async function () {

--- a/charts/gardener-dashboard/templates/configmap.yaml
+++ b/charts/gardener-dashboard/templates/configmap.yaml
@@ -132,15 +132,24 @@ data:
 {{- if .Values.frontendConfig.gitHubRepoUrl }}
       gitHubRepoUrl: {{ .Values.frontendConfig.gitHubRepoUrl }}
 {{- end }}
-{{- if .Values.terminal }}
+{{- if .Values.terminal or .Values.frontendConfig.kyma }}
       features:
+{{- if .Values.terminal }}
         terminalEnabled: true
+{{- end }}
+{{- if .Values.frontendConfig.kyma }}
+        kymaEnabled: true
+{{- end }}
 {{- end }}
 {{- if .Values.frontendConfig.terminal }}
 {{- if .Values.frontendConfig.terminal.heartbeatIntervalSeconds }}
       terminal:
         heartbeatIntervalSeconds: {{ .Values.frontendConfig.terminal.heartbeatIntervalSeconds }}
 {{- end }}
+{{- end }}
+{{- if .Values.frontendConfig.kyma }}
+      kyma:
+{{ toYaml .Values.frontendConfig.kyma | trim | indent 8 }}
 {{- end }}
 {{- if .Values.frontendConfig.defaultHibernationSchedule }}
       defaultHibernationSchedule:

--- a/charts/gardener-dashboard/templates/configmap.yaml
+++ b/charts/gardener-dashboard/templates/configmap.yaml
@@ -132,15 +132,9 @@ data:
 {{- if .Values.frontendConfig.gitHubRepoUrl }}
       gitHubRepoUrl: {{ .Values.frontendConfig.gitHubRepoUrl }}
 {{- end }}
-{{- if or .Values.terminal .Values.frontendConfig.kyma }}
       features:
-{{- if .Values.terminal }}
-        terminalEnabled: true
-{{- end }}
-{{- if .Values.frontendConfig.kyma }}
-        kymaEnabled: true
-{{- end }}
-{{- end }}
+        terminalEnabled: {{ .Values.frontendConfig.features.terminalEnabled | default false }}
+        kymaEnabled: {{ .Values.frontendConfig.features.kymaEnabled | default false }}
 {{- if .Values.frontendConfig.terminal }}
 {{- if .Values.frontendConfig.terminal.heartbeatIntervalSeconds }}
       terminal:

--- a/charts/gardener-dashboard/templates/configmap.yaml
+++ b/charts/gardener-dashboard/templates/configmap.yaml
@@ -132,7 +132,7 @@ data:
 {{- if .Values.frontendConfig.gitHubRepoUrl }}
       gitHubRepoUrl: {{ .Values.frontendConfig.gitHubRepoUrl }}
 {{- end }}
-{{- if .Values.terminal or .Values.frontendConfig.kyma }}
+{{- if or .Values.terminal .Values.frontendConfig.kyma }}
       features:
 {{- if .Values.terminal }}
         terminalEnabled: true

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -69,6 +69,10 @@ frontendConfig:
       end: 00 08 * * 1,2,3,4,5
     production: ~
   seedCandidateDeterminationStrategy: SameRegion
+  features:
+    terminalEnabled: false
+    kymaEnabled: false
+
   # terminal:
   #   heartbeatIntervalSeconds: 60
   

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -69,10 +69,15 @@ frontendConfig:
       end: 00 08 * * 1,2,3,4,5
     production: ~
   seedCandidateDeterminationStrategy: SameRegion
-  # features:
-  #   terminalEnabled: true
   # terminal:
   #   heartbeatIntervalSeconds: 60
+  
+  # kyma:
+  #   title: Kyma
+  #   description: | 
+  #     Kyma is a platform for extending applications with serverless functions and microservices. 
+  #     It provides a selection of cloud-native projects glued together to simplify the creation and management of extensions.
+  #   enabled: false
 
 gitHub:
   apiUrl: https://api.foo-github.com

--- a/frontend/src/components/ShootAddons/AddonConfiguration.vue
+++ b/frontend/src/components/ShootAddons/AddonConfiguration.vue
@@ -24,6 +24,7 @@ limitations under the License.
     <template slot="actionComponent">
       <manage-shoot-addons
         ref="addons"
+        :isCreateMode="false"
        ></manage-shoot-addons>
     </template>
   </action-icon-dialog>

--- a/frontend/src/components/ShootAddons/AddonConfiguration.vue
+++ b/frontend/src/components/ShootAddons/AddonConfiguration.vue
@@ -20,7 +20,9 @@ limitations under the License.
     @dialogOpened="onConfigurationDialogOpened"
     ref="actionDialog"
     caption="Configure Add-ons"
-    maxWidth="900">
+    maxWidth="900"
+    max-height="60vh"
+    >
     <template slot="actionComponent">
       <manage-shoot-addons
         ref="addons"

--- a/frontend/src/components/ShootAddons/AddonConfiguration.vue
+++ b/frontend/src/components/ShootAddons/AddonConfiguration.vue
@@ -30,12 +30,14 @@ limitations under the License.
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 import ActionIconDialog from '@/dialogs/ActionIconDialog'
 import ManageShootAddons from '@/components/ShootAddons/ManageAddons'
 import { updateShootAddons } from '@/utils/api'
 import { errorDetailsFromError } from '@/utils/error'
 import { shootItem } from '@/mixins/shootItem'
 import get from 'lodash/get'
+import cloneDeep from 'lodash/cloneDeep'
 
 export default {
   name: 'addon-configuration',
@@ -49,6 +51,11 @@ export default {
     }
   },
   mixins: [shootItem],
+  computed: {
+    ...mapGetters([
+      'isKymaFeatureEnabled'
+    ])
+  },
   methods: {
     async onConfigurationDialogOpened () {
       this.reset()
@@ -71,7 +78,12 @@ export default {
     },
     reset () {
       this.$nextTick(() => {
-        this.$refs.addons.updateAddons(get(this.shootItem, 'spec.addons', {}))
+        const addons = cloneDeep(get(this.shootItem, 'spec.addons', {}))
+        if (this.isKymaFeatureEnabled) {
+          const kymaEnabled = !!get(this.shootItem, 'metadata.annotations["experimental.addons.shoot.gardener.cloud/kyma"]')
+          addons['kyma'] = { enabled: kymaEnabled }
+        }
+        this.$refs.addons.updateAddons(addons)
       })
     }
   }

--- a/frontend/src/components/ShootAddons/ManageAddons.vue
+++ b/frontend/src/components/ShootAddons/ManageAddons.vue
@@ -37,7 +37,6 @@ limitations under the License.
 <script>
 import { mapGetters, mapState } from 'vuex'
 import filter from 'lodash/filter'
-import assign from 'lodash/assign'
 import cloneDeep from 'lodash/cloneDeep'
 import { shootAddonList } from '@/utils'
 
@@ -69,7 +68,7 @@ export default {
     },
     updateAddons (addons) {
       this.resetAddonList(addons)
-      this.addons =  cloneDeep(addons)
+      this.addons = cloneDeep(addons)
     },
     resetAddonList (addons) {
       this.addonDefinitionList = filter(shootAddonList, addon => {

--- a/frontend/src/components/ShootAddons/ManageAddons.vue
+++ b/frontend/src/components/ShootAddons/ManageAddons.vue
@@ -23,7 +23,7 @@ limitations under the License.
         <v-checkbox
           color="cyan darken-2"
           v-model="addons[addonDefinition.name].enabled"
-          :disabled="addonDefinition.forbidDisable && addons[addonDefinition.name].enabled"
+          :disabled="!isCreateMode && addonDefinition.forbidDisable && addons[addonDefinition.name].enabled"
         ></v-checkbox>
       </v-list-tile-action>
       <v-list-tile-content>
@@ -43,6 +43,12 @@ import { shootAddonList } from '@/utils'
 
 export default {
   name: 'manage-shoot-addons',
+  props: {
+    isCreateMode: {
+      type: Boolean,
+      required: true
+    }
+  },
   data () {
     return {
       addons: {},

--- a/frontend/src/components/ShootAddons/ManageAddons.vue
+++ b/frontend/src/components/ShootAddons/ManageAddons.vue
@@ -69,7 +69,7 @@ export default {
     },
     updateAddons (addons) {
       this.resetAddonList(addons)
-      assign(this.addons, cloneDeep(addons))
+      this.addons =  cloneDeep(addons)
     },
     resetAddonList (addons) {
       this.addonDefinitionList = filter(shootAddonList, addon => {

--- a/frontend/src/components/ShootAddons/ManageAddons.vue
+++ b/frontend/src/components/ShootAddons/ManageAddons.vue
@@ -23,6 +23,7 @@ limitations under the License.
         <v-checkbox
           color="cyan darken-2"
           v-model="addons[addonDefinition.name].enabled"
+          :disabled="addonDefinition.forbidDisable && addons[addonDefinition.name].enabled"
         ></v-checkbox>
       </v-list-tile-action>
       <v-list-tile-content>
@@ -42,11 +43,6 @@ import { shootAddonList } from '@/utils'
 
 export default {
   name: 'manage-shoot-addons',
-  components: {
-  },
-  props: {
-
-  },
   data () {
     return {
       addons: {},

--- a/frontend/src/components/ShootAddons/ManageAddons.vue
+++ b/frontend/src/components/ShootAddons/ManageAddons.vue
@@ -15,23 +15,23 @@ limitations under the License.
 -->
 
 <template>
-  <v-list three-line class="pa-0 ma-0">
-    <v-list-tile class="list-complete-item ma-0"
-      v-for="addonDefinition in addonDefinitionList"
-      :key="addonDefinition.name">
-      <v-list-tile-action>
-        <v-checkbox
-          color="cyan darken-2"
-          v-model="addons[addonDefinition.name].enabled"
-          :disabled="!isCreateMode && addonDefinition.forbidDisable && addons[addonDefinition.name].enabled"
-        ></v-checkbox>
-      </v-list-tile-action>
-      <v-list-tile-content>
-        <v-list-tile-title >{{addonDefinition.title}}</v-list-tile-title>
-        <v-list-tile-sub-title>{{addonDefinition.description}}</v-list-tile-sub-title>
-      </v-list-tile-content>
-    </v-list-tile>
-  </v-list>
+  <v-layout column>
+    <v-flex xs12>
+      <v-layout row v-for="addonDefinition in addonDefinitionList" :key="addonDefinition.name">
+        <v-flex class="addon-action">
+          <v-checkbox
+            color="cyan darken-2"
+            v-model="addons[addonDefinition.name].enabled"
+            :disabled="!isCreateMode && addonDefinition.forbidDisable && addons[addonDefinition.name].enabled"
+          ></v-checkbox>
+        </v-flex>
+        <v-flex>
+          <div class="subheading font-weight-medium my-1" v-text="addonDefinition.title"/>
+          <div class="addon-content mb-4" v-html="addonDefinition.description"/>
+        </v-flex>
+      </v-layout>
+    </v-flex>
+  </v-layout>
 </template>
 
 <script>
@@ -79,3 +79,16 @@ export default {
   }
 }
 </script>
+
+<style scoped>
+
+.addon-content >>>  p {
+  margin-bottom: 4px;
+}
+
+.addon-action {
+  min-height: 50px;
+  min-width: 56px;
+  margin: 0;
+}
+</style>

--- a/frontend/src/components/ShootDetails/ShootAddonKymaCard.vue
+++ b/frontend/src/components/ShootDetails/ShootAddonKymaCard.vue
@@ -22,7 +22,7 @@ limitations under the License.
       </v-list-tile-action>
       <v-list-tile-content>
         <v-list-tile-title>
-          Kyma information currently not available
+          {{kymaTitle}} information currently not available
         </v-list-tile-title>
       </v-list-tile-content>
     </v-list-tile>
@@ -45,7 +45,7 @@ limitations under the License.
 
     <v-divider v-if="isConsoleTileVisible && isCredentialsTileVisible" class="my-2" inset></v-divider>
 
-    <username-password v-if="isCredentialsTileVisible" :username="email" :password="password"></username-password>
+    <username-password v-if="isCredentialsTileVisible" :email="email" :password="password"></username-password>
   </v-list>
 </template>
 
@@ -53,6 +53,7 @@ limitations under the License.
 import UsernamePassword from '@/components/UsernamePasswordListTile'
 import { shootItem } from '@/mixins/shootItem'
 import get from 'lodash/get'
+import { shootAddonByName } from '@/utils'
 
 export default {
   components: {
@@ -65,6 +66,10 @@ export default {
   },
   mixins: [shootItem],
   computed: {
+    kymaTitle () {
+      const kymaAddon = shootAddonByName('kyma')
+      return get(kymaAddon, 'title')
+    },
     shootAddonKyma () {
       return get(this.shootItem, 'addonKyma', {})
     },

--- a/frontend/src/components/ShootDetails/ShootAddonKymaCard.vue
+++ b/frontend/src/components/ShootDetails/ShootAddonKymaCard.vue
@@ -1,0 +1,107 @@
+<!--
+Copyright (c) 2019 by SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<template>
+  <v-list>
+    <v-list-tile v-show="!isAnyTileVisible">
+      <v-list-tile-action>
+        <v-icon class="cyan--text text--darken-2">mdi-alert-circle-outline</v-icon>
+      </v-list-tile-action>
+      <v-list-tile-content>
+        <v-list-tile-title>
+          Kyma information currently not available
+        </v-list-tile-title>
+      </v-list-tile-content>
+    </v-list-tile>
+
+    <v-list-tile v-if="isConsoleTileVisible">
+      <v-list-tile-action>
+        <v-icon class="cyan--text text--darken-2">developer_board</v-icon>
+      </v-list-tile-action>
+      <v-list-tile-content>
+        <v-list-tile-sub-title>Console</v-list-tile-sub-title>
+        <v-list-tile-title>
+          <v-tooltip v-if="isShootHibernated" top>
+            <span class="grey--text" slot="activator">{{consoleUrl}}</span>
+            Console is not running for hibernated clusters
+          </v-tooltip>
+          <a v-else :href="consoleUrl" target="_blank" class="cyan--text text--darken-2">{{consoleUrl}}</a>
+        </v-list-tile-title>
+      </v-list-tile-content>
+    </v-list-tile>
+
+    <v-divider v-if="isConsoleTileVisible && isCredentialsTileVisible" class="my-2" inset></v-divider>
+
+    <username-password v-if="isCredentialsTileVisible" :username="email" :password="password"></username-password>
+  </v-list>
+</template>
+
+<script>
+import UsernamePassword from '@/components/UsernamePasswordListTile'
+import { shootItem } from '@/mixins/shootItem'
+import get from 'lodash/get'
+
+export default {
+  components: {
+    UsernamePassword
+  },
+  props: {
+    shootItem: {
+      type: Object
+    }
+  },
+  mixins: [shootItem],
+  computed: {
+    shootAddonKyma () {
+      return get(this.shootItem, 'addonKyma', {})
+    },
+    consoleUrl () {
+      return this.shootAddonKyma.url || ''
+    },
+    email () {
+      return this.shootAddonKyma.email || ''
+    },
+    password () {
+      return this.shootAddonKyma.password || ''
+    },
+    isAnyTileVisible () {
+      return this.isConsoleTileVisible || this.isCredentialsTileVisible
+    },
+    isConsoleTileVisible () {
+      return !!this.consoleUrl
+    },
+    isCredentialsTileVisible () {
+      return !!this.email && !!this.password
+    }
+  }
+}
+</script>
+
+<style lang="styl" scoped>
+  .v-expansion-panel {
+    box-shadow: none;
+  }
+
+  >>> .v-expansion-panel__header {
+    cursor: auto;
+    padding: 0;
+  }
+
+  .scroll {
+    overflow-x: scroll;
+  }
+
+</style>

--- a/frontend/src/components/UsernamePasswordListTile.vue
+++ b/frontend/src/components/UsernamePasswordListTile.vue
@@ -15,8 +15,8 @@ limitations under the License.
 -->
 
 <template>
-  <div v-show="!!username && !!password">
-    <v-list-tile>
+  <div v-show="(!!username || !!email) && !!password">
+    <v-list-tile v-if="username">
       <v-list-tile-action>
         <v-icon class="cyan--text text--darken-2">perm_identity</v-icon>
       </v-list-tile-action>
@@ -24,6 +24,21 @@ limitations under the License.
         <v-list-tile-sub-title>User</v-list-tile-sub-title>
         <v-list-tile-title>{{username}}</v-list-tile-title>
       </v-list-tile-content>
+      <v-list-tile-action>
+        <copy-btn :clipboard-text="username"></copy-btn>
+      </v-list-tile-action>
+    </v-list-tile>
+    <v-list-tile v-if="email">
+      <v-list-tile-action>
+        <v-icon v-if="!username" class="cyan--text text--darken-2">perm_identity</v-icon>
+      </v-list-tile-action>
+      <v-list-tile-content>
+        <v-list-tile-sub-title>Email</v-list-tile-sub-title>
+        <v-list-tile-title>{{email}}</v-list-tile-title>
+      </v-list-tile-content>
+      <v-list-tile-action>
+        <copy-btn :clipboard-text="email"></copy-btn>
+      </v-list-tile-action>
     </v-list-tile>
     <v-list-tile>
       <v-list-tile-action>
@@ -56,6 +71,9 @@ export default {
   },
   props: {
     username: {
+      type: String
+    },
+    email: {
       type: String
     },
     password: {

--- a/frontend/src/components/VendorIcon.vue
+++ b/frontend/src/components/VendorIcon.vue
@@ -26,8 +26,7 @@ limitations under the License.
 export default {
   props: {
     value: {
-      type: String,
-      required: true
+      type: String
     },
     width: {
       type: Number

--- a/frontend/src/dialogs/ActionIconDialog.vue
+++ b/frontend/src/dialogs/ActionIconDialog.vue
@@ -28,6 +28,7 @@ limitations under the License.
       :errorMessage.sync="errorMessage"
       :detailedErrorMessage.sync="detailedErrorMessage"
       :max-width="maxWidth"
+      :maxHeight="maxHeight"
       :confirmValue="confirmValue"
       :confirmColor="dialogColor"
       :defaultColor="dialogColor"
@@ -83,6 +84,10 @@ export default {
     maxWidth: {
       type: String,
       default: '1000'
+    },
+    maxHeight: {
+      type: String,
+      default: '50vh'
     },
     loading: {
       type: Boolean,

--- a/frontend/src/mixins/shootItem.js
+++ b/frontend/src/mixins/shootItem.js
@@ -1,4 +1,5 @@
 import get from 'lodash/get'
+import cloneDeep from 'lodash/cloneDeep'
 
 import {
   getDateFormatted,
@@ -87,7 +88,12 @@ export const shootItem = {
       return get(this.shootSpec, `cloud.${this.shootCloudProviderKind}.workers`, [])
     },
     shootAddons () {
-      return get(this.shootSpec, 'addons', {})
+      const addons = cloneDeep(get(this.shootSpec, 'addons', {}))
+      const kymaAddonEnabled = !!get(this.shootAnnotations, '["experimental.addons.shoot.gardener.cloud/kyma"]')
+      if (kymaAddonEnabled) {
+        addons['kyma'] = { enabled: true }
+      }
+      return addons
     },
     shootRegion () {
       return get(this.shootSpec, 'cloud.region')

--- a/frontend/src/pages/NewShoot.vue
+++ b/frontend/src/pages/NewShoot.vue
@@ -174,7 +174,8 @@ export default {
     ...mapGetters([
       'newShootResource',
       'initialNewShootResource',
-      'infrastructureSecretsByCloudProfileName'
+      'infrastructureSecretsByCloudProfileName',
+      'isKymaFeatureEnabled'
     ]),
     valid () {
       return this.infrastructureValid &&
@@ -246,7 +247,16 @@ export default {
       set(shootResource, ['spec', 'cloud', infrastructureKind, 'workers'], workers)
 
       const addons = this.$refs.addons.getAddons()
+      const kymaEnabled = get(addons, 'kyma.enabled', false)
+      delete addons.kyma
       set(shootResource, 'spec.addons', addons)
+      if (this.isKymaFeatureEnabled) {
+        if (kymaEnabled) {
+          set(shootResource, 'metadata.annotations["experimental.addons.shoot.gardener.cloud/kyma"]', 'enabled')
+        } else {
+          unset(shootResource, 'metadata.annotations["experimental.addons.shoot.gardener.cloud/kyma"]')
+        }
+      }
 
       const { utcBegin, utcEnd } = this.$refs.maintenanceTime.getUTCMaintenanceWindow()
       const { k8sUpdates, osUpdates } = this.$refs.maintenanceComponents.getComponentUpdates()
@@ -302,7 +312,11 @@ export default {
       this.purpose = purpose
       this.$refs.clusterDetails.setDetailsData({ name, kubernetesVersion, purpose, secret, cloudProfileName })
 
-      const addons = get(shootResource, 'spec.addons')
+      const addons = cloneDeep(get(shootResource, 'spec.addons', {}))
+      if (this.isKymaFeatureEnabled) {
+        const kymaEnabled = !!get(shootResource, 'metadata.annotations["experimental.addons.shoot.gardener.cloud/kyma"]')
+        addons['kyma'] = { enabled: kymaEnabled }
+      }
       this.$refs.addons.updateAddons(addons)
 
       const utcBegin = get(shootResource, 'spec.maintenance.timeWindow.begin')

--- a/frontend/src/pages/NewShoot.vue
+++ b/frontend/src/pages/NewShoot.vue
@@ -72,6 +72,7 @@ limitations under the License.
         <v-card-text>
           <manage-shoot-addons
             ref="addons"
+            :isCreateMode="true"
            ></manage-shoot-addons>
        </v-card-text>
       </v-card>

--- a/frontend/src/pages/ShootDetails.vue
+++ b/frontend/src/pages/ShootDetails.vue
@@ -53,7 +53,7 @@ limitations under the License.
 
         <v-card v-if="isKymaFeatureEnabled && isKymaAddonEnabled">
           <v-card-title class="subheading white--text cyan darken-2 mt-3">
-            Kyma
+            {{kymaTitle}}
           </v-card-title>
           <shoot-addon-kyma-card :shootItem="item"></shoot-addon-kyma-card>
         </v-card>
@@ -82,6 +82,7 @@ import ShootLifecycleCard from '@/components/ShootDetails/ShootLifecycleCard'
 import ShootExternalToolsCard from '@/components/ShootDetails/ShootExternalToolsCard'
 import get from 'lodash/get'
 import isEmpty from 'lodash/isEmpty'
+import { shootAddonByName } from '@/utils'
 
 import 'codemirror/mode/yaml/yaml.js'
 
@@ -128,6 +129,10 @@ export default {
     },
     isKymaAddonEnabled () {
       return !!get(this.item, 'metadata.annotations["experimental.addons.shoot.gardener.cloud/kyma"]')
+    },
+    kymaTitle () {
+      const kymaAddon = shootAddonByName('kyma')
+      return get(kymaAddon, 'title')
     }
   },
   mounted () {

--- a/frontend/src/pages/ShootDetails.vue
+++ b/frontend/src/pages/ShootDetails.vue
@@ -51,6 +51,13 @@ limitations under the License.
           <shoot-logging :shootItem="item"></shoot-logging>
         </v-card>
 
+        <v-card v-if="isKymaFeatureEnabled && isKymaAddonEnabled">
+          <v-card-title class="subheading white--text cyan darken-2 mt-3">
+            Kyma
+          </v-card-title>
+          <shoot-addon-kyma-card :shootItem="item"></shoot-addon-kyma-card>
+        </v-card>
+
         <shoot-journals-card v-if="isAdmin" :journals="journals" :shootItem="item" class="mt-3"></shoot-journals-card>
 
       </v-flex>
@@ -65,6 +72,7 @@ limitations under the License.
 import { mapGetters } from 'vuex'
 import ShootControlPlane from '@/components/ShootDetails/ShootControlPlane'
 import ShootAccessCard from '@/components/ShootDetails/ShootAccessCard'
+import ShootAddonKymaCard from '@/components/ShootDetails/ShootAddonKymaCard'
 import ShootJournalsCard from '@/components/ShootDetails/ShootJournalsCard'
 import ShootMonitoringCard from '@/components/ShootDetails/ShootMonitoringCard'
 import ShootLogging from '@/components/ShootDetails/ShootLogging'
@@ -85,6 +93,7 @@ export default {
     ShootInfrastructureCard,
     ShootLifecycleCard,
     ShootAccessCard,
+    ShootAddonKymaCard,
     ShootJournalsCard,
     ShootMonitoringCard,
     ShootLogging,
@@ -95,7 +104,8 @@ export default {
       'shootByNamespaceAndName',
       'journalsByNamespaceAndName',
       'isAdmin',
-      'hasControlPlaneTerminalAccess'
+      'hasControlPlaneTerminalAccess',
+      'isKymaFeatureEnabled'
     ]),
     value () {
       return this.shootByNamespaceAndName(this.$route.params)
@@ -115,6 +125,9 @@ export default {
     },
     canRenderControlPlane () {
       return !isEmpty(this.item) && this.hasControlPlaneTerminalAccess
+    },
+    isKymaAddonEnabled () {
+      return !!get(this.item, 'metadata.annotations["experimental.addons.shoot.gardener.cloud/kyma"]')
     }
   },
   mounted () {

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -590,6 +590,7 @@ const actions = {
   },
   setConfiguration ({ commit, getters }, cfg) {
     commit('SET_CONFIGURATION', cfg)
+
     if (getters.isKymaFeatureEnabled) {
       let kymaAddon = {
         name: 'kyma',

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -24,7 +24,7 @@ import {
   displayName,
   fullDisplayName,
   getTimestampFormatted,
-  shootAddonList
+  addKymaAddon
 } from '@/utils'
 import reduce from 'lodash/reduce'
 import map from 'lodash/map'
@@ -592,19 +592,7 @@ const actions = {
     commit('SET_CONFIGURATION', cfg)
 
     if (getters.isKymaFeatureEnabled) {
-      let kymaAddon = {
-        name: 'kyma',
-        title: 'Kyma',
-        description: 'Kyma is a platform for extending applications with serverless functions and microservices. It provides a selection of cloud-native projects glued together to simplify the creation and management of extensions.',
-        visible: true,
-        enabled: false,
-        forbidDisable: true
-      }
-      if (cfg.kyma) {
-        const overwrite = pick(cfg.kyma, ['title', 'description', 'visible', 'enabled', 'forbidDisable'])
-        kymaAddon = merge(kymaAddon, overwrite)
-      }
-      shootAddonList.push(kymaAddon)
+      addKymaAddon(cfg.kyma)
     }
 
     if (get(cfg, 'alert')) {

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -19,7 +19,13 @@ import Vuex from 'vuex'
 import createLogger from 'vuex/dist/logger'
 
 import EmitterWrapper from '@/utils/Emitter'
-import { gravatarUrlGeneric, displayName, fullDisplayName, getTimestampFormatted } from '@/utils'
+import {
+  gravatarUrlGeneric,
+  displayName,
+  fullDisplayName,
+  getTimestampFormatted,
+  shootAddonList
+} from '@/utils'
 import reduce from 'lodash/reduce'
 import map from 'lodash/map'
 import flatMap from 'lodash/flatMap'
@@ -375,6 +381,9 @@ const getters = {
   },
   isTerminalEnabled (state, getters) {
     return get(state, 'cfg.features.terminalEnabled', false)
+  },
+  isKymaFeatureEnabled (state, getters) {
+    return get(state, 'cfg.features.kymaEnabled', false)
   }
 }
 
@@ -445,6 +454,12 @@ const actions = {
   },
   getShootInfo ({ dispatch, commit }, { name, namespace }) {
     return dispatch('shoots/getInfo', { name, namespace })
+      .catch(err => {
+        dispatch('setError', err)
+      })
+  },
+  getShootAddonKyma ({ dispatch, commit }, { name, namespace }) {
+    return dispatch('shoots/getAddonKyma', { name, namespace })
       .catch(err => {
         dispatch('setError', err)
       })
@@ -573,11 +588,26 @@ const actions = {
         dispatch('setError', { message: `Delete member failed. ${err.message}` })
       })
   },
-  setConfiguration ({ commit }, value) {
-    commit('SET_CONFIGURATION', value)
+  setConfiguration ({ commit, getters }, cfg) {
+    commit('SET_CONFIGURATION', cfg)
+    if (getters.isKymaFeatureEnabled) {
+      let kymaAddon = {
+        name: 'kyma',
+        title: 'Kyma',
+        description: 'Kyma is a platform for extending applications with serverless functions and microservices. It provides a selection of cloud-native projects glued together to simplify the creation and management of extensions.',
+        visible: true,
+        enabled: false,
+        forbidDisable: true
+      }
+      if (cfg.kyma) {
+        const overwrite = pick(cfg.kyma, ['title', 'description', 'visible', 'enabled', 'forbidDisable'])
+        kymaAddon = merge(kymaAddon, overwrite)
+      }
+      shootAddonList.push(kymaAddon)
+    }
 
-    if (get(value, 'alert')) {
-      commit('SET_ALERT_BANNER', get(value, 'alert'))
+    if (get(cfg, 'alert')) {
+      commit('SET_ALERT_BANNER', get(cfg, 'alert'))
     }
 
     return state.cfg

--- a/frontend/src/store/modules/shoots.js
+++ b/frontend/src/store/modules/shoots.js
@@ -310,7 +310,12 @@ const actions = {
     forEach(filter(shootAddonList, addon => addon.visible), addon => {
       set(addons, [addon.name, 'enabled'], addon.enabled)
     })
+    const kymaEnabled = get(addons, 'kyma.enabled', false)
+    delete addons.kyma
     set(shootResource, 'spec.addons', addons)
+    if (rootGetters.isKymaFeatureEnabled && kymaEnabled) {
+      set(shootResource, 'metadata.annotations["experimental.addons.shoot.gardener.cloud/kyma"]', 'enabled')
+    }
 
     const { utcBegin, utcEnd } = utcMaintenanceWindowFromLocalBegin({ localBegin: randomLocalMaintenanceBegin(), timezone: rootState.localTimezone })
     const maintenance = {

--- a/frontend/src/store/modules/shoots.js
+++ b/frontend/src/store/modules/shoots.js
@@ -38,7 +38,13 @@ import isEmpty from 'lodash/isEmpty'
 import cloneDeep from 'lodash/cloneDeep'
 import semver from 'semver'
 import store from '../'
-import { getShoot, getShootInfo, createShoot, deleteShoot } from '@/utils/api'
+import {
+  getShoot,
+  getShootInfo,
+  getShootAddonKyma,
+  createShoot,
+  deleteShoot
+} from '@/utils/api'
 import { getCloudProviderTemplate } from '@/utils/createShoot'
 import { isNotFound } from '@/utils/error'
 import { isHibernated,
@@ -185,6 +191,19 @@ const actions = {
         }
         throw error
       })
+  },
+  async getAddonKyma ({ commit, rootState }, { name, namespace }) {
+    try {
+      const { data: addonKyma } = await getShootAddonKyma({ namespace, name })
+      commit('RECEIVE_ADDON_KYMA', { name, namespace, addonKyma })
+      return addonKyma
+    } catch (error) {
+      // shoot addon kyma not found -> ignore if KubernetesError
+      if (isNotFound(error)) {
+        return
+      }
+      throw error
+    }
   },
   setSelection ({ commit, dispatch }, metadata) {
     if (!metadata) {
@@ -585,6 +604,12 @@ const mutations = {
     const item = findItem({ namespace, name })
     if (item !== undefined) {
       Vue.set(item, 'info', info)
+    }
+  },
+  RECEIVE_ADDON_KYMA (state, { namespace, name, addonKyma }) {
+    const item = findItem({ namespace, name })
+    if (item !== undefined) {
+      Vue.set(item, 'addonKyma', addonKyma)
     }
   },
   SET_SELECTION (state, metadata) {

--- a/frontend/src/utils/Emitter.js
+++ b/frontend/src/utils/Emitter.js
@@ -202,6 +202,7 @@ class ShootSubscription extends AbstractSubscription {
       const { name, namespace } = target
       throttledNsEventEmitter.flush()
       store.dispatch('getShootInfo', { name, namespace })
+      store.dispatch('getShootAddonKyma', { name, namespace })
     })
   }
 

--- a/frontend/src/utils/Emitter.js
+++ b/frontend/src/utils/Emitter.js
@@ -201,8 +201,12 @@ class ShootSubscription extends AbstractSubscription {
     this.socket.on('shootSubscriptionDone', ({ kind, target }) => {
       const { name, namespace } = target
       throttledNsEventEmitter.flush()
-      store.dispatch('getShootInfo', { name, namespace })
-      store.dispatch('getShootAddonKyma', { name, namespace })
+      Promise.all([
+        store.dispatch('getShootInfo', { name, namespace }),
+        store.dispatch('getShootAddonKyma', { name, namespace })
+      ]).catch(err => {
+        console.error('SubscribeShootDone Error:', err.message)
+      })
     })
   }
 

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -105,6 +105,12 @@ export function getShootInfo ({ namespace, name }) {
   return getResource(`/api/namespaces/${namespace}/shoots/${name}/info`)
 }
 
+export function getShootAddonKyma ({ namespace, name }) {
+  namespace = encodeURIComponent(namespace)
+  name = encodeURIComponent(name)
+  return getResource(`/api/namespaces/${namespace}/shoots/${name}/kyma`)
+}
+
 export function updateShootVersion ({ namespace, name, data }) {
   namespace = encodeURIComponent(namespace)
   name = encodeURIComponent(name)

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -19,12 +19,16 @@
 import moment from 'moment-timezone'
 import semver from 'semver'
 import md5 from 'md5'
+import DOMPurify from 'dompurify'
+import marked from 'marked'
 import capitalize from 'lodash/capitalize'
 import replace from 'lodash/replace'
 import get from 'lodash/get'
 import head from 'lodash/head'
 import keys from 'lodash/keys'
 import map from 'lodash/map'
+import merge from 'lodash/merge'
+import pick from 'lodash/pick'
 import intersection from 'lodash/intersection'
 import toLower from 'lodash/toLower'
 import toUpper from 'lodash/toUpper'
@@ -510,6 +514,39 @@ export const shootAddonList = [
     enabled: true
   }
 ]
+
+const kymaAddonDescription = `Kyma is a platform for extending applications with serverless functions and microservices. As an integrated stack of the best cloud-native projects, including Istio, Kiali, Prometheus, Grafana, Jaeger, Knative, Ory Hydra, and Loki it allows running modern microservice or serverless applications on top of Kubernetes. 
+Kyma comes with a new, lightweight Service Catalog you can use to easily connect services provided by hyperscalers such as Azure, GCP, or AWS, as well as SAP applications.  
+
+To successfully run Kyma, the minimal cluster size should be **2 nodes (4 CPU and 16GB each)**, but it is recommended to have 3-5 nodes. Additionally, make sure your Kubernetes version is **1.15.x or lower**.
+
+You can find a link to Kyma management Console UI and credentials in the shoot cluster dashboard. 
+To learn more, visit the [Kyma website](https://kyma-project.io). If you want to discuss Kyma, ask questions, and contribute, join the Kyma community in the [Slack channel](http://slack.kyma-project.io).`
+
+export function addKymaAddon (options) {
+  const kymaAddon = {
+    name: 'kyma',
+    title: 'Kyma',
+    description: kymaAddonDescription,
+    visible: true,
+    enabled: false,
+    forbidDisable: true
+  }
+  if (options) {
+    const overwrite = pick(options, ['title', 'description', 'visible', 'enabled', 'forbidDisable'])
+    merge(kymaAddon, overwrite)
+  }
+  kymaAddon.description = compileMarkdown(kymaAddon.description)
+  shootAddonList.push(kymaAddon)
+}
+
+export function compileMarkdown (text) {
+  return DOMPurify.sanitize(marked(text, {
+    gfm: true,
+    breaks: true,
+    tables: true
+  }))
+}
 
 export function shootAddonByName (name) {
   return find(shootAddonList, ['name', name])

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -511,6 +511,10 @@ export const shootAddonList = [
   }
 ]
 
+export function shootAddonByName (name) {
+  return find(shootAddonList, ['name', name])
+}
+
 export function randomLocalMaintenanceBegin () {
   // randomize maintenance time window
   const hours = ['22', '23', '00', '01', '02', '03', '04', '05']


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for the experimental Kyma addon.
- Under the Addons sections is a new entry for kyma that can be enabled.
- On the cluster's details page is a new `Kyma` card, similar like the current `Access` card, that displays the Kyma console url, email and password.

To enable the feature, edit `/charts/gardener-dashboard/values.yaml`:
```yaml
....
frontendConfig:
  ...
  feature:
    kymaEnabled: true
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```action operator
To enable kyma addon, set the feature flag as described in #531
```
```action operator
Terminals: You now have to explicitly enable the terminal feature flag `frontendConfig.features.terminalEnabled` in the `/charts/gardener-dashboard/values.yaml` file in addition to the `terminals` configuration.
```
```noteworthy user
You can now enable an experimental Kyma Addon for your cluster (if the feature flag is enabled by the landscape-admin)
```