### PR TITLE
Fix logger module

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -241,6 +241,10 @@ Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>\
 Copyright (c) 2014-2015 Douglas Christopher Wilson <doug@somethingdoug.com>\
 [MIT License](https://github.com/expressjs/body-parser/blob/master/LICENSE)
 
+- [chalk](https://github.com/chalk/chalk)\
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)\
+[MIT License](https://github.com/chalk/chalk/blob/master/license)
+
 - [cookie-parser](https://github.com/expressjs/cookie-parser)\
 Copyright (c) 2014 TJ Holowaychuk <tj@vision-media.ca>\
 Copyright (c) 2015 Douglas Christopher Wilson <doug@somethingdoug.com>\

--- a/backend/lib/logger/Logger.js
+++ b/backend/lib/logger/Logger.js
@@ -31,6 +31,7 @@ class Logger {
     this.logLevel = LEVELS[logLevel] || 3
     this.logHttpRequestBody = logHttpRequestBody === true
     this.silent = /^test/.test(process.env.NODE_ENV)
+    this.console = console
   }
   isDisabled (level) {
     return this.silent || level < this.logLevel
@@ -55,7 +56,7 @@ class Logger {
       if (this.logHttpRequestBody && body) {
         msg += ' ' + body.toString('utf8')
       }
-      console.log(chalk.black.bgGreen('req ') + ': ' + msg)
+      this.console.log(chalk.black.bgGreen('req ') + ': ' + msg)
     }
   }
   response ({ id, statusCode, statusMessage = '', httpVersion = '1.1', headers, body }) {
@@ -64,42 +65,42 @@ class Logger {
       if (body && statusCode >= 300) {
         msg += ' ' + body.toString('utf8')
       }
-      console.log(chalk.black.bgBlue('res ') + ': ' + msg)
+      this.console.log(chalk.black.bgBlue('res ') + ': ' + msg)
     }
   }
   http (msg, ...args) {
     if (!this.isDisabled(LEVELS.info)) {
-      console.log(chalk.magenta('http') + ': ' + msg, ...args)
+      this.console.log(chalk.magenta('http') + ': ' + msg, ...args)
     }
   }
   log (msg, ...args) {
     if (!this.isDisabled(LEVELS.warn)) {
-      console.log(chalk.whiteBright('log') + ': ' + msg, ...args)
+      this.console.log(chalk.whiteBright('log') + ': ' + msg, ...args)
     }
   }
   trace (msg, ...args) {
     if (!this.isDisabled(LEVELS.trace)) {
-      console.log(chalk.cyan('trace') + ': ' + msg, ...args)
+      this.console.log(chalk.cyan('trace') + ': ' + msg, ...args)
     }
   }
   debug (msg, ...args) {
     if (!this.isDisabled(LEVELS.debug)) {
-      console.debug(chalk.blue('debug') + ': ' + msg, ...args)
+      this.console.debug(chalk.blue('debug') + ': ' + msg, ...args)
     }
   }
   info (msg, ...args) {
     if (!this.isDisabled(LEVELS.info)) {
-      console.info(chalk.green('info') + ': ' + msg, ...args)
+      this.console.info(chalk.green('info') + ': ' + msg, ...args)
     }
   }
   warn (msg, ...args) {
     if (!this.isDisabled(LEVELS.warn)) {
-      console.warn(chalk.yellow('warn') + ': ' + msg, ...args)
+      this.console.warn(chalk.yellow('warn') + ': ' + msg, ...args)
     }
   }
   error (msg, ...args) {
     if (!this.isDisabled(LEVELS.error)) {
-      console.error(chalk.red('error') + ': ' + msg, ...args)
+      this.console.error(chalk.red('error') + ': ' + msg, ...args)
     }
   }
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -30,6 +30,7 @@
     "base64url": "^3.0.1",
     "better-queue": "^3.8.10",
     "body-parser": "^1.19.0",
+    "chalk": "^3.0.0",
     "cookie-parser": "^1.4.4",
     "es6-error": "^4.1.1",
     "express": "^4.17.1",

--- a/backend/test/logger.spec.js
+++ b/backend/test/logger.spec.js
@@ -1,0 +1,143 @@
+//
+// Copyright (c) 2019 by SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+'use strict'
+
+const chalk = require('chalk')
+const Logger = require('../lib/logger/Logger')
+const LEVELS = Logger.LEVELS
+
+class ConsoleStub {
+  constructor () {
+    this.args = []
+  }
+  debug (...args) {
+    this.args.push(...args)
+  }
+  log (...args) {
+    this.args.push(...args)
+  }
+  info (...args) {
+    this.args.push(...args)
+  }
+  warn (...args) {
+    this.args.push(...args)
+  }
+  error (...args) {
+    this.args.push(...args)
+  }
+  static create () {
+    return new ConsoleStub()
+  }
+}
+
+function createNoisyLogger (logLevel = 'trace', logHttpRequestBody = true) {
+  const logger = new Logger({ logLevel, logHttpRequestBody })
+  logger.silent = false
+  logger.console = ConsoleStub.create()
+  return logger
+}
+
+describe('logger', function () {
+  const sandbox = sinon.createSandbox()
+  const msg = 'foo'
+  const args = ['bar', 1, true]
+  const method = 'GET'
+  const user = { type: 'email', id: 'bar@foo.org' }
+  const id = 1
+  const headers = { 'x-request-id': id }
+  const uri = new URL('https://foo.org/bar')
+  const body = 'body'
+  const requestArgs = { uri, method, user, headers, body }
+  const statusCode = 404
+  const statusMessage = 'Not found'
+  const responseArgs = { id, statusCode, statusMessage, body }
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  it('should create a silent Logger', function () {
+    const logger = new Logger({ logLevel: 'info', logHttpRequestBody: true })
+    expect(logger.logLevel).to.be.equal(LEVELS.info)
+    expect(logger.logHttpRequestBody).to.be.equal(true)
+    expect(logger.silent).to.be.equal(true)
+    expect(logger.isDisabled(LEVELS.info)).to.equal(true)
+  })
+
+  it('should create a noisy Logger', function () {
+    sandbox.stub(process.env, 'NODE_ENV').value('foo')
+    const logger = new Logger({ logLevel: 'info', logHttpRequestBody: true })
+    expect(logger.isDisabled(LEVELS.info)).to.equal(false)
+    expect(logger.isDisabled(LEVELS.debug)).to.equal(true)
+  })
+
+  it('should log a trace message', function () {
+    const logger = createNoisyLogger()
+    logger.trace(msg, ...args)
+    expect(logger.console.args).to.eql([chalk.cyan('trace') + ': ' + msg, ...args])
+  })
+
+  it('should log a debug message', function () {
+    const logger = createNoisyLogger()
+    logger.debug(msg, ...args)
+    expect(logger.console.args).to.eql([chalk.blue('debug') + ': ' + msg, ...args])
+  })
+
+  it('should log a log message', function () {
+    const logger = createNoisyLogger()
+    logger.log(msg, ...args)
+    expect(logger.console.args).to.eql([chalk.whiteBright('log') + ': ' + msg, ...args])
+  })
+
+  it('should log an info message', function () {
+    const logger = createNoisyLogger()
+    logger.info(msg, ...args)
+    expect(logger.console.args).to.eql([chalk.green('info') + ': ' + msg, ...args])
+  })
+
+  it('should log a warn message', function () {
+    const logger = createNoisyLogger()
+    logger.warn(msg, ...args)
+    expect(logger.console.args).to.eql([chalk.yellow('warn') + ': ' + msg, ...args])
+  })
+
+  it('should log an error message', function () {
+    const logger = createNoisyLogger()
+    logger.error(msg, ...args)
+    expect(logger.console.args).to.eql([chalk.red('error') + ': ' + msg, ...args])
+  })
+
+  it('should log a http message', function () {
+    const logger = createNoisyLogger()
+    logger.http(msg, ...args)
+    expect(logger.console.args).to.eql([chalk.magenta('http') + ': ' + msg, ...args])
+  })
+
+  it('should log a request message', function () {
+    const logger = createNoisyLogger()
+    logger.request(requestArgs)
+    const msg = `${method} ${uri.pathname} HTTP/1.1 [${id}] ${user.type}=${user.id} ${uri.host} ${body}`
+    expect(logger.console.args).to.eql([chalk.black.bgGreen('req ') + ': ' + msg])
+  })
+
+  it('should log a response message', function () {
+    const logger = createNoisyLogger()
+    logger.response(responseArgs)
+    const msg = `HTTP/1.1 ${statusCode} ${statusMessage} [${id}] ${body}`
+    expect(logger.console.args).to.eql([chalk.black.bgBlue('res ') + ': ' + msg])
+  })
+})

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -808,6 +808,11 @@
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.0.tgz#2478260021408dec32c123a7cad3414beb811a07"
   integrity sha512-zw8UvoBEImn392tLjxoavuonblX/4Yb9ha4KBU10FirCfwgzhKO0dvyJSF9ByxV1xK1r2AgnAi/tvQaLgxQqxA==
 
+"@types/color-name@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
+  integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
+
 "@types/cookiejar@*":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@types/cookiejar/-/cookiejar-2.1.1.tgz#90b68446364baf9efd8e8349bb36bd3852b75b80"
@@ -934,6 +939,14 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
   dependencies:
     color-convert "^1.9.0"
+
+ansi-styles@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.0.tgz#5681f0dcf7ae5880a7841d8831c4724ed9cc0172"
+  integrity sha512-7kFQgnEaMdRtwf6uSfUnVr9gSGC7faurn+J/Mv90/W+iTtN0405/nLdopfMWwchyxhbGYl6TC4Sccn9TUkGAgg==
+  dependencies:
+    "@types/color-name" "^1.1.1"
+    color-convert "^2.0.1"
 
 anymatch@^2.0.0:
   version "2.0.0"
@@ -1386,6 +1399,14 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+chalk@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
+  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
@@ -1498,10 +1519,22 @@ color-convert@^1.9.0:
   dependencies:
     color-name "1.1.3"
 
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+  dependencies:
+    color-name "~1.1.4"
+
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 combined-stream@^1.0.6:
   version "1.0.8"
@@ -2711,6 +2744,11 @@ has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
+
+has-flag@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
 has-symbols@^1.0.0:
   version "1.0.0"
@@ -5239,6 +5277,13 @@ supports-color@^6.1.0:
   integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
   dependencies:
     has-flag "^3.0.0"
+
+supports-color@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.1.0.tgz#68e32591df73e25ad1c4b49108a2ec507962bfd1"
+  integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
+  dependencies:
+    has-flag "^4.0.0"
 
 table@^5.2.3:
   version "5.4.6"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the missing logger dependency [`chalk`](https://github.com/chalk/chalk) and adds unit test for the logger module.
```
Statements   : 65.76% ( 1974/3002 )
Branches     : 43.64% ( 367/841 )
Functions    : 66.94% ( 401/599 )
Lines        : 65.86% ( 1950/2961 )
```
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer

```
