### PR TITLE
Adjust shoot cp ingress endpoints

### DIFF
--- a/backend/lib/services/shoots.js
+++ b/backend/lib/services/shoots.js
@@ -248,16 +248,16 @@ exports.info = async function ({ user, namespace, name }) {
     })
   ])
 
-  const project = await client.getProjectByNamespace(namespace)
-  const projectName = project.metadata.name
-
   const data = {}
   let seed
   if (shoot.status && shoot.status.seed) {
     seed = getSeed(getSeedNameFromShoot(shoot))
-    const ingressDomain = _.get(seed, 'spec.dns.ingressDomain')
-    if (ingressDomain) {
-      data.seedShootIngressDomain = `${name}.${projectName}.${ingressDomain}`
+    const prefix = _.replace(shoot.status.technicalID, /^shoot--/, '')
+    if (prefix) {
+      const ingressDomain = _.get(seed, 'spec.dns.ingressDomain')
+      if (ingressDomain) {
+        data.seedShootIngressDomain = `${prefix}.${ingressDomain}`
+      }
     }
   }
 

--- a/backend/test/acceptance/api.shoots.spec.js
+++ b/backend/test/acceptance/api.shoots.spec.js
@@ -119,7 +119,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
     const loggingPassword = 'loggingBarPwd'
     const seedClusterName = `${region}.${kind}.example.org`
     const shootServerUrl = 'https://seed.foo.bar:443'
-    const seedShootIngressDomain = `${name}.${project}.ingress.${seedClusterName}`
+    const seedShootIngressDomain = `${project}--${name}.ingress.${seedClusterName}`
     const cleanKubeconfigSpy = sandbox.spy(kubeconfig, 'cleanKubeconfig')
 
     common.stub.getCloudProfiles(sandbox)

--- a/backend/test/support/nocks/k8s.js
+++ b/backend/test/support/nocks/k8s.js
@@ -558,10 +558,6 @@ const stub = {
     }
 
     return [nockWithAuthorization(bearer)
-      .get(`/api/v1/namespaces/${namespace}`)
-      .reply(200, () => getProjectNamespace(namespace))
-      .get(`/apis/core.gardener.cloud/v1alpha1/projects/${project}`)
-      .reply(200, () => projectResource)
       .get(`/apis/core.gardener.cloud/v1alpha1/namespaces/${namespace}/shoots/${name}`)
       .reply(200, () => shootResult)
       .get(`/api/v1/namespaces/${namespace}/secrets/${name}.kubeconfig`)

--- a/frontend/src/store/modules/shoots.js
+++ b/frontend/src/store/modules/shoots.js
@@ -164,14 +164,14 @@ const actions = {
 
         if (info.seedShootIngressDomain) {
           const baseHost = info.seedShootIngressDomain
-          info.grafanaUrlUsers = `https://gu.${baseHost}`
-          info.grafanaUrlOperators = `https://go.${baseHost}`
+          info.grafanaUrlUsers = `https://gu-${baseHost}`
+          info.grafanaUrlOperators = `https://go-${baseHost}`
 
-          info.prometheusUrl = `https://p.${baseHost}`
+          info.prometheusUrl = `https://p-${baseHost}`
 
-          info.alertmanagerUrl = `https://au.${baseHost}`
+          info.alertmanagerUrl = `https://au-${baseHost}`
 
-          info.kibanaUrl = `https://k.${baseHost}`
+          info.kibanaUrl = `https://k-${baseHost}`
         }
         return info
       })


### PR DESCRIPTION
**What this PR does / why we need it**:
Several endpoints for shoot control plane components have changed with https://github.com/gardener/gardener/pull/1769.

This PR adapts to that change.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
The new URLs for `AlertManager`, `Kibana`, `Grafana` and `Prometheus` (introduced by https://github.com/gardener/gardener/pull/1769) are now shown on the cluster overview page
```
```action operator
:warning: This Dashboard version is not compatible with Gardener versions prior 0.34.x
```