### PR TITLE
omit extra newline in identity-configmap

### DIFF
--- a/charts/identity/templates/configmap.yaml
+++ b/charts/identity/templates/configmap.yaml
@@ -40,12 +40,12 @@ data:
       trustedPeers:
       - dashboard
 {{- if .Values.additionalTrustedPeers }}
-{{ toYaml .Values.additionalTrustedPeers | indent 6 }}
+{{ toYaml .Values.additionalTrustedPeers | trim | indent 6 }}
 {{- end }}
       name: Kubectl
       secret: {{ .Values.kubectlClientSecret }}
 {{- if .Values.additionalStaticClients }}
-{{ toYaml .Values.additionalStaticClients | indent 4 }}
+{{ toYaml .Values.additionalStaticClients | trim | indent 4 }}
 {{- end }}
 {{- if .Values.staticPasswords }}
     enablePasswordDB: true


### PR DESCRIPTION
**What this PR does / why we need it**:
Omits an ugly new line in certain `identity-configmap` customizations.
Unfortunately helm's `toYaml` adds an extra newline at the very end (https://github.com/helm/helm/issues/3470) so this PR adds the respective `trim` command to omit it.