### PR TITLE
[Hotfix] Fix manage worker

### DIFF
--- a/frontend/src/components/ShootWorkers/WorkerConfiguration.vue
+++ b/frontend/src/components/ShootWorkers/WorkerConfiguration.vue
@@ -63,8 +63,6 @@ export default {
       switch (this.shootCloudProviderKind) {
         case 'azure':
           return get(this.shootItem, 'spec.provider.infrastructureConfig.zoned', false)
-        case 'metal':
-          return false
         default:
           return true
       }

--- a/frontend/src/components/ShootWorkers/WorkerConfiguration.vue
+++ b/frontend/src/components/ShootWorkers/WorkerConfiguration.vue
@@ -58,6 +58,18 @@ export default {
     }
   },
   mixins: [shootItem],
+  computed: {
+    isZonedCluster () {
+      switch (this.shootCloudProviderKind) {
+        case 'azure':
+          return get(this.shootItem, 'spec.provider.infrastructureConfig.zoned', false)
+        case 'metal':
+          return false
+        default:
+          return true
+      }
+    }
+  },
   methods: {
     async onConfigurationDialogOpened () {
       this.reset()
@@ -83,8 +95,8 @@ export default {
 
       const workers = cloneDeep(this.shootWorkerGroups)
       const zonesNetworkConfiguration = get(this.shootItem, 'spec.provider.infrastructureConfig.networks.zones')
-      const zonedCluster = get(this.shootItem, 'spec.provider.infrastructureConfig.zoned', false)
-      this.$refs.manageWorkers.setWorkersData({ workers, cloudProfileName: this.shootCloudProfileName, region: this.shootRegion, zonesNetworkConfiguration, zonedCluster })
+
+      this.$refs.manageWorkers.setWorkersData({ workers, cloudProfileName: this.shootCloudProfileName, region: this.shootRegion, zonesNetworkConfiguration, zonedCluster: this.isZonedCluster })
     },
     onWorkersValid (value) {
       this.workersValid = value

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -165,6 +165,9 @@ const getters = {
     }
 
     return ({ type, cloudProfileName, region, zones }) => {
+      if (!cloudProfileName) {
+        return []
+      }
       const cloudProfile = getters.cloudProfileByName(cloudProfileName)
       const items = cloudProfile.data[type]
       if (!region || !zones) {

--- a/frontend/tests/unit/store.index.spec.js
+++ b/frontend/tests/unit/store.index.spec.js
@@ -287,4 +287,10 @@ describe('Store', function () {
     dashboardVolumeTypes = getters.volumeTypesByCloudProfileNameAndRegionAndZones({}, storeGetters)({ cloudProfileName: 'foo', region: 'region2', zones: ['zone1'] })
     expect(dashboardVolumeTypes).to.have.length(3)
   })
+
+  it('should return an empty machineType / volumeType array if no cloud profile is provided', function () {
+    const items = getters.machineTypesOrVolumeTypesByCloudProfileNameAndRegionAndZones({}, getters)({ })
+    expect(items).to.be.an.instanceof(Array)
+    expect(items).to.have.length(0)
+  })
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes command line errors on create cluster page.
Also fixes worker configuration for existing workers: Zones for zoned clusters were not visible / could not be configured

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Fixed: Zones for existing zoned clusters were not visible / could not be configured on `Configure Workers` dialog
```
