### PR TITLE
[Master]Add alert banner config to chart

### DIFF
--- a/charts/gardener-dashboard/templates/configmap.yaml
+++ b/charts/gardener-dashboard/templates/configmap.yaml
@@ -152,3 +152,8 @@ data:
 {{- if .Values.frontendConfig.seedCandidateDeterminationStrategy }}
       seedCandidateDeterminationStrategy: {{ .Values.frontendConfig.seedCandidateDeterminationStrategy }}
 {{- end }}
+{{- if .Values.frontendConfig.alert }}
+      alert:
+        type: {{ .Values.frontendConfig.alert.type }}
+        message: {{ .Values.frontendConfig.alert.message }}
+{{- end }}

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -72,6 +72,9 @@ frontendConfig:
   features:
     terminalEnabled: false
     kymaEnabled: false
+  # alert:
+  #   type: error
+  #   message: This is an **alert** banner
 
   # terminal:
   #   heartbeatIntervalSeconds: 60


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the alert banner configuration to the helm chart.

<img width="1086" alt="Screenshot 2020-01-24 at 16 29 14" src="https://user-images.githubusercontent.com/5526658/73080836-c6530e00-3ec6-11ea-8b49-fcc0b1ecd6a2.png">

Example `values.yaml`:
```yaml
frontendConfig:
...
  alert:
    type: error
    message: This is an **alert** banner # can be markdown
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
