### PR TITLE
[Hotfix] Use shoot status for hibernation flag

### DIFF
--- a/frontend/src/components/ShootDetails/ShootAddonKymaCard.vue
+++ b/frontend/src/components/ShootDetails/ShootAddonKymaCard.vue
@@ -34,7 +34,7 @@ limitations under the License.
       <v-list-tile-content>
         <v-list-tile-sub-title>Console</v-list-tile-sub-title>
         <v-list-tile-title>
-          <v-tooltip v-if="isShootHibernated" top>
+          <v-tooltip v-if="isShootStatusHibernated" top>
             <span class="grey--text" slot="activator">{{consoleUrl}}</span>
             Console is not running for hibernated clusters
           </v-tooltip>

--- a/frontend/src/mixins/shootItem.js
+++ b/frontend/src/mixins/shootItem.js
@@ -72,7 +72,7 @@ export const shootItem = {
       return get(this.shootSpec, 'hibernation.enabled', false)
     },
     isShootStatusHibernated () {
-      return isShootStatusHibernated(this.shootItem.status)
+      return isShootStatusHibernated(get(this.shootItem), 'status')
     },
     isShootStatusHibernationProgressing () {
       return this.isShootSettingHibernated !== this.isShootStatusHibernated


### PR DESCRIPTION
**What this PR does / why we need it**:
Use shoot status for hibernation flag
(cherry picked from commit 7d8fedecfbf67c5af1d8a3341a39bc0aa8822aea)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user

```
