### PR TITLE
[Master] Only fetch kyma info if addon is enabled

### DIFF
--- a/frontend/src/utils/Emitter.js
+++ b/frontend/src/utils/Emitter.js
@@ -198,15 +198,14 @@ class ShootSubscription extends AbstractSubscription {
         throttledNsEventEmitter.emit(kind, namespaces)
       }
     })
-    this.socket.on('shootSubscriptionDone', ({ kind, target }) => {
+    this.socket.on('shootSubscriptionDone', async ({ kind, target }) => {
       const { name, namespace } = target
       throttledNsEventEmitter.flush()
-      Promise.all([
-        store.dispatch('getShootInfo', { name, namespace }),
-        store.dispatch('getShootAddonKyma', { name, namespace })
-      ]).catch(err => {
+      try {
+        await store.dispatch('getShootInfo', { name, namespace })
+      } catch (err) {
         console.error('SubscribeShootDone Error:', err.message)
-      })
+      }
     })
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, on every access of the Shoot Details page we call the kyma info endpoint of the gardener dashboard. 
This PR fixes this issue, so that we only fetch the kyma info if the addon is enabled.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user

```
