### PR TITLE
[master] Healthz check for dashboard pod only

### DIFF
--- a/backend/lib/healthz/index.js
+++ b/backend/lib/healthz/index.js
@@ -22,15 +22,17 @@ const {
   isHttpError
 } = require('../kubernetes-client')
 
-async function healthCheck () {
-  try {
-    await dashboardClient.healthz.get()
-  } catch (err) {
-    if (isHttpError(err)) {
-      const response = err.response
-      throw new Error(fmt('Kubernetes apiserver is not healthy. Healthz endpoint returned: %s (Status code: %s)', response.body, response.statusCode))
+async function healthCheck (transitive = false) {
+  if (transitive === true) {
+    try {
+      await dashboardClient.healthz.get()
+    } catch (err) {
+      if (isHttpError(err)) {
+        const response = err.response
+        throw new Error(fmt('Kubernetes apiserver is not healthy. Healthz endpoint returned: %s (Status code: %s)', response.body, response.statusCode))
+      }
+      throw new Error(fmt('Could not reach Kubernetes apiserver healthz endpoint. Request failed with error: %s', err))
     }
-    throw new Error(fmt('Could not reach Kubernetes apiserver healthz endpoint. Request failed with error: %s', err))
   }
 }
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -30,7 +30,8 @@ const server = http.createServer(app)
 io.attach(server)
 createTerminus(server, {
   healthChecks: {
-    '/healthz': healthCheck
+    '/healthz': () => healthCheck(false),
+    '/healthz-transitive': () => healthCheck(true)
   },
   beforeShutdown,
   onSignal,

--- a/backend/test/acceptance/healthz.spec.js
+++ b/backend/test/acceptance/healthz.spec.js
@@ -19,8 +19,17 @@
 module.exports = function ({ agent, k8s }) {
   /* eslint no-unused-expressions: 0 */
 
-  it('should return the backend healthz status', async function () {
+  it('should return the backend transitive healthz status', async function () {
     k8s.stub.healthz()
+    const res = await agent
+      .get('/healthz-transitive')
+
+    expect(res).to.have.status(200)
+    expect(res).to.be.json
+    expect(res.body).to.eql({ status: 'ok' })
+  })
+
+  it('should return the backend healthz status', async function () {
     const res = await agent
       .get('/healthz')
 

--- a/backend/test/support/TestAgent.js
+++ b/backend/test/support/TestAgent.js
@@ -26,37 +26,44 @@ class TestAgent {
     if (typeof healthCheck === 'function') {
       const signal = 'SIGTERM'
       const healthChecks = {
-        '/healthz': healthCheck
+        '/healthz': () => healthCheck(false),
+        '/healthz-transitive': () => healthCheck(true)
       }
       process.removeAllListeners(signal)
       this.server = createTerminus(this.server, { signal, healthChecks })
     }
   }
+
   get (url) {
     return chai.request(this.server)
       .get(url)
       .set('x-requested-with', 'XMLHttpRequest')
   }
+
   put (url) {
     return chai.request(this.server)
       .put(url)
       .set('x-requested-with', 'XMLHttpRequest')
   }
+
   patch (url) {
     return chai.request(this.server)
       .patch(url)
       .set('x-requested-with', 'XMLHttpRequest')
   }
+
   delete (url) {
     return chai.request(this.server)
       .delete(url)
       .set('x-requested-with', 'XMLHttpRequest')
   }
+
   post (url) {
     return chai.request(this.server)
       .post(url)
       .set('x-requested-with', 'XMLHttpRequest')
   }
+
   close () {
     this.server.close()
   }

--- a/backend/test/support/common.js
+++ b/backend/test/support/common.js
@@ -167,12 +167,15 @@ class Reconnector extends EventEmitter {
     this.disconnected = false
     this.events = []
   }
+
   disconnect () {
     this.disconnected = true
   }
+
   pushEvent (type, object, delay = 10) {
     this.events.push({ delay, event: { type, object } })
   }
+
   start () {
     const emit = (event) => {
       return () => {

--- a/backend/test/support/nocks/k8s.js
+++ b/backend/test/support/nocks/k8s.js
@@ -174,8 +174,8 @@ function getServiceAccountSecret (namespace, serviceAccountName) {
   }
   const data = {}
   data['ca.crt'] = encodeBase64('ca.crt')
-  data['namespace'] = encodeBase64(namespace)
-  data['token'] = encodeBase64(name)
+  data.namespace = encodeBase64(namespace)
+  data.token = encodeBase64(name)
   return {
     metadata,
     data
@@ -214,7 +214,7 @@ function prepareSecretAndBindingMeta ({ name, namespace, data, resourceVersion, 
 
 function canCreateProjects (scope) {
   return scope
-    .post(`/apis/authorization.k8s.io/v1/selfsubjectaccessreviews`, body => {
+    .post('/apis/authorization.k8s.io/v1/selfsubjectaccessreviews', body => {
       const { namespace, verb, resource, group } = body.spec.resourceAttributes
       return !namespace && group === 'core.gardener.cloud' && resource === 'projects' && verb === 'create'
     })
@@ -251,7 +251,7 @@ function reviewToken (scope) {
 
 function canGetSecretsInAllNamespaces (scope) {
   return scope
-    .post(`/apis/authorization.k8s.io/v1/selfsubjectaccessreviews`, body => {
+    .post('/apis/authorization.k8s.io/v1/selfsubjectaccessreviews', body => {
       const { namespace, verb, resource, group } = body.spec.resourceAttributes
       return !namespace && group === '' && resource === 'secrets' && verb === 'get'
     })
@@ -561,7 +561,7 @@ const stub = {
       .reply(200, () => shootResult)
       .get(`/api/v1/namespaces/${namespace}/secrets/${name}.kubeconfig`)
       .reply(200, () => kubecfgResult)
-      .post(`/apis/authorization.k8s.io/v1/selfsubjectaccessreviews`)
+      .post('/apis/authorization.k8s.io/v1/selfsubjectaccessreviews')
       .reply(200, () => isAdminResult)
       .get(`/api/v1/namespaces/garden/secrets/${seedSecretName}`)
       .reply(200, () => seedSecretResult),
@@ -900,7 +900,7 @@ const stub = {
   deleteTerminal ({ bearer, username, namespace, name }) {
     const scope = nockWithAuthorization(bearer)
     canGetSecretsInAllNamespaces(scope)
-    let terminal = {
+    const terminal = {
       metadata: {
         namespace,
         name,
@@ -978,7 +978,7 @@ const stub = {
     ]
   },
   deleteProject ({ bearer, namespace }) {
-    let project = readProject(namespace)
+    const project = readProject(namespace)
     const name = _.get(project, 'metadata.name')
     const confirmationPath = ['metadata', 'annotations', 'confirmation.garden.sapcloud.io/deletion']
     return [
@@ -1103,7 +1103,7 @@ const stub = {
   },
   healthz () {
     return nockWithAuthorization(auth.bearer)
-      .get(`/healthz`)
+      .get('/healthz')
       .reply(200, 'ok')
   },
   fetchGardenerVersion ({ version }) {
@@ -1120,7 +1120,7 @@ const stub = {
         .get('/apis/apiregistration.k8s.io/v1/apiservices/v1alpha1.core.gardener.cloud')
         .reply(200, body),
       nock(serviceUrl)
-        .get(`/version`)
+        .get('/version')
         .reply(statusCode, version)
     ]
   },


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the behavior of the healthz check that is does not fail if the kube apiserver is down.

An additional healthz endpoint is introduced under the path `/healthz-transitive` that fails if the kube apiserver is down.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user

```
