### PR TITLE
Adapt some labels and annotations to the new API group

### DIFF
--- a/backend/lib/services/projects.js
+++ b/backend/lib/services/projects.js
@@ -185,7 +185,7 @@ exports.remove = async function ({ user, name: namespace }) {
   const project = await client.getProjectByNamespace(namespace)
   const name = project.metadata.name
   const annotations = _.assign({
-    'confirmation.garden.sapcloud.io/deletion': 'true'
+    'confirmation.gardener.cloud/deletion': 'true'
   }, project.metadata.annotations)
   const body = { metadata: { annotations } }
   await client['core.gardener.cloud'].projects.mergePatch(name, body)

--- a/backend/lib/services/shoots.js
+++ b/backend/lib/services/shoots.js
@@ -46,7 +46,7 @@ exports.create = async function ({ user, namespace, body }) {
   const username = user.id
 
   const annotations = {
-    'garden.sapcloud.io/createdBy': username
+    'gardener.cloud/created-by': username
   }
   if (_.get(body, 'spec.addons.kyma.enabled', false)) {
     annotations['experimental.addons.shoot.gardener.cloud/kyma'] = 'enabled'
@@ -223,7 +223,7 @@ exports.patchAnnotations = patchAnnotations
 exports.remove = async function ({ user, namespace, name }) {
   const client = user.client
   const annotations = {
-    'confirmation.garden.sapcloud.io/deletion': 'true'
+    'confirmation.gardener.cloud/deletion': 'true'
   }
   await patchAnnotations({ user, namespace, name, annotations })
 

--- a/backend/test/acceptance/api.shoots.spec.js
+++ b/backend/test/acceptance/api.shoots.spec.js
@@ -96,7 +96,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
   it('should delete a shoot', async function () {
     const bearer = await user.bearer
     const deleteAnnotations = {
-      'confirmation.garden.sapcloud.io/deletion': 'true'
+      'confirmation.gardener.cloud/deletion': 'true'
     }
 
     k8s.stub.deleteShoot({ bearer, namespace, name, resourceVersion })
@@ -148,7 +148,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
     const bearer = await user.bearer
     const metadata = {
       annotations: {
-        'garden.sapcloud.io/createdBy': 'baz@example.org',
+        'gardener.cloud/created-by': 'baz@example.org',
         'garden.sapcloud.io/purpose': 'evaluation'
       },
       labels: {
@@ -174,7 +174,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
     const actPurpose = body.metadata.annotations['garden.sapcloud.io/purpose']
     const expPurpose = metadata.annotations['garden.sapcloud.io/purpose']
     expect(actPurpose).to.equal(expPurpose)
-    const actCreatedBy = body.metadata.annotations['garden.sapcloud.io/createdBy']
+    const actCreatedBy = body.metadata.annotations['gardener.cloud/created-by']
     const expCreatedBy = 'baz@example.org'
     expect(actCreatedBy).to.equal(expCreatedBy)
   })

--- a/backend/test/support/nocks/k8s.js
+++ b/backend/test/support/nocks/k8s.js
@@ -408,7 +408,7 @@ function getShoot ({
     status: {}
   }
   if (createdBy) {
-    shoot.metadata.annotations['garden.sapcloud.io/createdBy'] = createdBy
+    shoot.metadata.annotations['gardener.cloud/created-by'] = createdBy
   }
   if (project) {
     shoot.status.technicalID = `shoot--${project}--${name}`
@@ -1046,7 +1046,7 @@ const stub = {
   deleteProject ({ bearer, namespace }) {
     const project = readProject(namespace)
     const name = _.get(project, 'metadata.name')
-    const confirmationPath = ['metadata', 'annotations', 'confirmation.garden.sapcloud.io/deletion']
+    const confirmationPath = ['metadata', 'annotations', 'confirmation.gardener.cloud/deletion']
     return [
       nockWithAuthorization(bearer)
         .get(`/api/v1/namespaces/${namespace}`)

--- a/frontend/src/components/ReconcileStart.vue
+++ b/frontend/src/components/ReconcileStart.vue
@@ -83,7 +83,7 @@ export default {
       this.reconcileTriggered = true
       this.currentGeneration = get(this.shootItem, 'metadata.generation')
 
-      const reconcile = { 'shoot.garden.sapcloud.io/operation': 'reconcile' }
+      const reconcile = { 'gardener.cloud/operation': 'reconcile' }
       try {
         await addShootAnnotation({ namespace: this.shootNamespace, name: this.shootName, data: reconcile })
       } catch (err) {

--- a/frontend/src/components/RetryOperation.vue
+++ b/frontend/src/components/RetryOperation.vue
@@ -59,7 +59,7 @@ export default {
       const namespace = this.shootNamespace
       const name = this.shootName
 
-      const retryAnnotation = { 'shoot.garden.sapcloud.io/operation': 'retry' }
+      const retryAnnotation = { 'gardener.cloud/operation': 'retry' }
       try {
         await addShootAnnotation({ namespace, name, data: retryAnnotation })
       } catch (err) {

--- a/frontend/src/components/RotateKubeconfigStart.vue
+++ b/frontend/src/components/RotateKubeconfigStart.vue
@@ -84,7 +84,7 @@ export default {
     async start () {
       this.actionTriggered = true
 
-      const data = { 'shoot.garden.sapcloud.io/operation': 'rotate-kubeconfig-credentials' }
+      const data = { 'gardener.cloud/operation': 'rotate-kubeconfig-credentials' }
       try {
         await addShootAnnotation({ namespace: this.shootNamespace, name: this.shootName, data })
       } catch (err) {

--- a/frontend/src/components/ShootDetails/ShootDetailsCard.vue
+++ b/frontend/src/components/ShootDetails/ShootDetailsCard.vue
@@ -174,7 +174,7 @@ export default {
   mixins: [shootItem],
   computed: {
     expirationTimestamp () {
-      return this.shootAnnotations['shoot.garden.sapcloud.io/expirationTimestamp']
+      return this.shootAnnotations['shoot.gardener.cloud/expiration-timestamp'] || this.shootAnnotations['shoot.garden.sapcloud.io/expirationTimestamp']
     },
     selfTerminationMessage () {
       if (this.isValidTerminationDate) {

--- a/frontend/src/components/ShootMaintenance/MaintenanceStart.vue
+++ b/frontend/src/components/ShootMaintenance/MaintenanceStart.vue
@@ -92,7 +92,7 @@ export default {
     async startMaintenance () {
       this.maintenanceTriggered = true
 
-      const maintain = { 'shoot.garden.sapcloud.io/operation': 'maintain' }
+      const maintain = { 'gardener.cloud/operation': 'maintain' }
       try {
         await addShootAnnotation({ namespace: this.shootNamespace, name: this.shootName, data: maintain })
       } catch (err) {

--- a/frontend/src/mixins/shootItem.js
+++ b/frontend/src/mixins/shootItem.js
@@ -23,7 +23,8 @@ export const shootItem = {
       return this.shootMetadata.namespace
     },
     isShootMarkedForDeletion () {
-      const confirmation = get(this.shootAnnotations, ['confirmation.garden.sapcloud.io/deletion'], 'false')
+      const confirmationDeprecated = get(this.shootAnnotations, ['confirmation.garden.sapcloud.io/deletion'], 'false')
+      const confirmation = get(this.shootAnnotations, ['confirmation.gardener.cloud/deletion'], confirmationDeprecated)
       const deletionTimestamp = this.shootDeletionTimestamp
 
       return !!deletionTimestamp && confirmation === 'true'
@@ -54,13 +55,13 @@ export const shootItem = {
       return get(this.shootMetadata, 'annotations', {})
     },
     shootGardenOperation () {
-      return this.shootAnnotations['shoot.garden.sapcloud.io/operation']
+      return this.shootAnnotations['gardener.cloud/operation']
     },
     shootPurpose () {
       return this.shootAnnotations['garden.sapcloud.io/purpose']
     },
     shootExpirationTimestamp () {
-      return this.shootAnnotations['shoot.garden.sapcloud.io/expirationTimestamp']
+      return this.shootAnnotations['shoot.gardener.cloud/expiration-timestamp'] || this.shootAnnotations['shoot.garden.sapcloud.io/expirationTimestamp']
     },
     isShootActionsDisabledForPurpose () {
       return this.shootPurpose === 'infrastructure'

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -321,7 +321,7 @@ export function availableK8sUpdatesForShoot (spec) {
 }
 
 export function getCreatedBy (metadata) {
-  return get(metadata, ['annotations', 'garden.sapcloud.io/createdBy'])
+  return get(metadata, ['annotations', 'gardener.cloud/created-by']) || get(metadata, ['annotations', 'garden.sapcloud.io/createdBy'])
 }
 
 export function hasAlertmanager (metadata) {
@@ -372,7 +372,9 @@ export function shootHasIssue (shoot) {
 
 export function isReconciliationDeactivated (metadata) {
   const truthyValues = ['1', 't', 'T', 'true', 'TRUE', 'True']
-  return includes(truthyValues, get(metadata, ['annotations', 'shoot.garden.sapcloud.io/ignore']))
+  const ignoreDeprecated = get(metadata, ['annotations', 'shoot.garden.sapcloud.io/ignore'])
+  const ignore = get(metadata, ['annotations', 'shoot.gardener.cloud/ignore'], ignoreDeprecated)
+  return includes(truthyValues, ignore)
 }
 
 export function isStatusProgressing (metadata) {


### PR DESCRIPTION
**What this PR does / why we need it**:
As part of the introduction of the new API group `gardener.cloud`, we also switch labels/annotations belonging to the old API group - ref gardener/gardener#1649.
This PR adapts some labels and annotations usage respecting to the deprecations in gardener/gardener#1833.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Before we consider merge:
- [x] Make sure gardener/gardener#1833 is merged.
- [x] Make sure gardener/gardener#1833 is released.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```action operator
:warning: This Dashboard version is not compatible with Gardener versions prior v1.0.0
```
