### PR TITLE
[hotfix] Support Kubernetes Dashboard v2 URLS

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -321,6 +321,10 @@ Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)\
 Copyright (c) 2013 Julian Gruber <julian@juliangruber.com>\
 [MIT License](https://github.com/juliangruber/reconnect-core#license)
 
+- [semver](https://github.com/npm/node-semver)\
+Copyright (c) Isaac Z. Schlueter and Contributors\
+[ISC License](https://github.com/npm/node-semver/blob/master/LICENSE)
+
 - [socket.io](https://github.com/socketio/socket.io)\
 Copyright (c) 2014-2017 Automattic <dev@cloudup.com>\
 [MIT License](https://github.com/socketio/socket.io/blob/master/LICENSE)

--- a/backend/lib/config/test.yaml
+++ b/backend/lib/config/test.yaml
@@ -36,8 +36,6 @@ terminal:
 frontend:
   features:
     terminalEnabled: true
-  dashboardUrl:
-    pathname: /api/v1/namespaces/kube-system/services/kubernetes-dashboard/proxy/
   landingPageUrl: https://gardener.cloud/
   helpMenuItems:
   - title: Getting Started

--- a/backend/lib/services/shoots.js
+++ b/backend/lib/services/shoots.js
@@ -230,7 +230,7 @@ exports.remove = async function ({ user, namespace, name }) {
   return client['core.gardener.cloud'].shoots.delete(namespace, name)
 }
 
-function getDashboarUrlPath(kubernetesVersion) {
+function getDashboardUrlPath (kubernetesVersion) {
   if (!kubernetesVersion) {
     return undefined
   }
@@ -238,9 +238,8 @@ function getDashboarUrlPath(kubernetesVersion) {
     return '/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/'
   }
   return '/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/'
-
 }
-exports.getDashboarUrlPath = getDashboarUrlPath
+exports.getDashboardUrlPath = getDashboardUrlPath
 
 exports.info = async function ({ user, namespace, name }) {
   const client = user.client
@@ -294,7 +293,7 @@ exports.info = async function ({ user, namespace, name }) {
       .commit()
 
     data.serverUrl = kubeconfig.fromKubeconfig(data.kubeconfig).url
-    data.dashboardUrlPath = getDashboarUrlPath(shoot.spec.kubernetes.version)
+    data.dashboardUrlPath = getDashboardUrlPath(shoot.spec.kubernetes.version)
   }
 
   const isAdmin = await authorization.isAdmin(user)

--- a/backend/package.json
+++ b/backend/package.json
@@ -49,6 +49,7 @@
     "p-retry": "^4.2.0",
     "p-timeout": "^3.2.0",
     "reconnect-core": "^1.3.0",
+    "semver": "^7.1.2",
     "socket.io": "^2.3.0",
     "uuid": "^3.3.2",
     "ws": "^7.0.1",

--- a/backend/test/acceptance/api.shoots.spec.js
+++ b/backend/test/acceptance/api.shoots.spec.js
@@ -119,6 +119,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
     const loggingPassword = 'loggingBarPwd'
     const seedClusterName = `${region}.${kind}.example.org`
     const shootServerUrl = 'https://seed.foo.bar:443'
+    const dashboardUrlPath = '/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/'
     const seedShootIngressDomain = `${project}--${name}.ingress.${seedClusterName}`
     const cleanKubeconfigSpy = sandbox.spy(kubeconfig, 'cleanKubeconfig')
 
@@ -139,6 +140,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
     expect(res.body.logging_username).to.eql(loggingUser)
     expect(res.body.logging_password).to.eql(loggingPassword)
     expect(res.body.serverUrl).to.eql(shootServerUrl)
+    expect(res.body.dashboardUrlPath).to.eql(dashboardUrlPath)
     expect(res.body.seedShootIngressDomain).to.eql(seedShootIngressDomain)
   })
 

--- a/backend/test/services.shoots.spec.js
+++ b/backend/test/services.shoots.spec.js
@@ -17,28 +17,28 @@
 'use strict'
 
 const {
-  getDashboarUrlPath
+  getDashboardUrlPath
 } = require('../lib/services/shoots')
 
 describe('services', function () {
   /* eslint no-unused-expressions: 0 */
   describe('shoots', function () {
-    describe('#dashboarUrlPath', function () {
+    describe('#getDashboardUrlPath', function () {
       it('should return dashboard URL path for kubernetes version < 1.16.0', async function () {
-        expect(getDashboarUrlPath('1.14.0')).to.be.equals('/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/')
-        expect(getDashboarUrlPath('1.15.1')).to.be.equals('/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/')
-        expect(getDashboarUrlPath('1.15.9')).to.be.equals('/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/')
+        expect(getDashboardUrlPath('1.14.0')).to.be.equals('/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/')
+        expect(getDashboardUrlPath('1.15.1')).to.be.equals('/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/')
+        expect(getDashboardUrlPath('1.15.9')).to.be.equals('/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/')
       })
 
       it('should return dashboard URL path for kubernetes version >= 1.16.0', async function () {
-        expect(getDashboarUrlPath('1.16.0')).to.be.equals('/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/')
-        expect(getDashboarUrlPath('1.16.1')).to.be.equals('/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/')
-        expect(getDashboarUrlPath('1.17.0')).to.be.equals('/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/')
-        expect(getDashboarUrlPath('v1.17.0')).to.be.equals('/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/')
+        expect(getDashboardUrlPath('1.16.0')).to.be.equals('/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/')
+        expect(getDashboardUrlPath('1.16.1')).to.be.equals('/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/')
+        expect(getDashboardUrlPath('1.17.0')).to.be.equals('/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/')
+        expect(getDashboardUrlPath('v1.17.0')).to.be.equals('/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/')
       })
 
       it('should return no dashboard URL path', async function () {
-        expect(getDashboarUrlPath(undefined)).to.be.undefined
+        expect(getDashboardUrlPath(undefined)).to.be.undefined
       })
     })
   })

--- a/backend/test/services.shoots.spec.js
+++ b/backend/test/services.shoots.spec.js
@@ -1,0 +1,45 @@
+//
+// Copyright (c) 2019 by SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+'use strict'
+
+const {
+  getDashboarUrlPath
+} = require('../lib/services/shoots')
+
+describe('services', function () {
+  /* eslint no-unused-expressions: 0 */
+  describe('shoots', function () {
+    describe('#dashboarUrlPath', function () {
+      it('should return dashboard URL path for kubernetes version < 1.16.0', async function () {
+        expect(getDashboarUrlPath('1.14.0')).to.be.equals('/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/')
+        expect(getDashboarUrlPath('1.15.1')).to.be.equals('/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/')
+        expect(getDashboarUrlPath('1.15.9')).to.be.equals('/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/')
+      })
+
+      it('should return dashboard URL path for kubernetes version >= 1.16.0', async function () {
+        expect(getDashboarUrlPath('1.16.0')).to.be.equals('/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/')
+        expect(getDashboarUrlPath('1.16.1')).to.be.equals('/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/')
+        expect(getDashboarUrlPath('1.17.0')).to.be.equals('/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/')
+        expect(getDashboarUrlPath('v1.17.0')).to.be.equals('/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/')
+      })
+
+      it('should return no dashboard URL path', async function () {
+        expect(getDashboarUrlPath(undefined)).to.be.undefined
+      })
+    })
+  })
+})

--- a/backend/test/support/nocks/k8s.js
+++ b/backend/test/support/nocks/k8s.js
@@ -381,7 +381,8 @@ function getShoot ({
   region = 'foo-west',
   bindingName = 'foo-secret',
   seed = 'infra1-seed',
-  hibernation = { enabled: false }
+  hibernation = { enabled: false },
+  kubernetesVersion = '1.16.0'
 }) {
   const shoot = {
     metadata: {
@@ -399,7 +400,10 @@ function getShoot ({
       provider: {
         type: kind
       },
-      seedName: seed
+      seedName: seed,
+      kubernetes: {
+        version: kubernetesVersion
+      }
     },
     status: {}
   }

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -4542,6 +4542,11 @@ semver@^6.0.0, semver@^6.1.0, semver@^6.1.2, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
+semver@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.1.2.tgz#847bae5bce68c5d08889824f02667199b70e3d87"
+  integrity sha512-BJs9T/H8sEVHbeigqzIEo57Iu/3DG6c4QoqTfbQB3BPA4zgzAomh/Fk9E7QtjWQ8mx2dgA9YCfSF4y9k9bHNpQ==
+
 send@0.17.1:
   version "0.17.1"
   resolved "https://registry.yarnpkg.com/send/-/send-0.17.1.tgz#c1d8b059f7900f7466dd4938bdc44e11ddb376c8"

--- a/charts/gardener-dashboard/templates/configmap.yaml
+++ b/charts/gardener-dashboard/templates/configmap.yaml
@@ -127,8 +127,6 @@ data:
         url: {{ .url }}
       {{- end }}
 {{- end }}
-      dashboardUrl:
-        pathname: /api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy
 {{- if .Values.frontendConfig.gitHubRepoUrl }}
       gitHubRepoUrl: {{ .Values.frontendConfig.gitHubRepoUrl }}
 {{- end }}

--- a/frontend/src/components/ShootDetails/ShootAccessCard.vue
+++ b/frontend/src/components/ShootDetails/ShootAccessCard.vue
@@ -188,11 +188,15 @@ export default {
       if (!this.hasDashboardEnabled) {
         return ''
       }
-      if (this.hasDashboardTokenAuth) {
-        const pathname = get(this.cfg, 'dashboardUrl.pathname', '')
-        return `http://localhost:8001${pathname}`
+      if (!this.hasDashboardTokenAuth) {
+        return this.shootInfo.dashboardUrl || ''
       }
-      return this.shootInfo.dashboardUrl || ''
+
+      if (!this.shootInfo.dashboardUrlPath) {
+        return ''
+      }
+      const pathname = this.shootInfo.dashboardUrlPath
+      return `http://localhost:8001${pathname}`
     },
     dashboardUrlText () {
       if (this.hasDashboardTokenAuth) {

--- a/frontend/src/store/modules/shoots.js
+++ b/frontend/src/store/modules/shoots.js
@@ -157,7 +157,7 @@ const actions = {
         if (info.serverUrl) {
           const [, scheme, host] = uriPattern.exec(info.serverUrl)
           const authority = `//${replace(host, /^\/\//, '')}`
-          const pathname = get(rootState.cfg, 'dashboardUrl.pathname')
+          const pathname = info.dashboardUrlPath
           info.dashboardUrl = [scheme, authority, pathname].join('')
           info.dashboardUrlText = [scheme, host].join('')
         }


### PR DESCRIPTION
**What this PR does / why we need it**:
* For < 1.16 clusters the dashboard URL is http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/
* For >= 1.16 clusters the dashboard URL is http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/

**Which issue(s) this PR fixes**:
Fixes #555

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Fixed kubernetes dashboard link for kubernetes clusters >= `1.16`
```
