### PR TITLE
Show pods, nodes and services CIDR

### DIFF
--- a/frontend/src/components/ShootDetails/ShootInfrastructureCard.vue
+++ b/frontend/src/components/ShootDetails/ShootInfrastructureCard.vue
@@ -81,11 +81,31 @@ limitations under the License.
 
       <v-divider class="my-2" inset></v-divider>
       <v-card-title class="listItem">
-        <v-icon class="cyan--text text--darken-2 avatar">settings_ethernet</v-icon>
-        <v-flex class="pa-0">
-          <span class="grey--text">CIDR</span><br>
-          <span class="subheading">{{shootCidr}}</span>
-        </v-flex>
+        <v-layout class="py-2">
+          <v-flex shrink justify-center class="pr-0 pt-3">
+            <v-icon class="cyan--text text--darken-2 avatar">settings_ethernet</v-icon>
+          </v-flex>
+          <v-flex class="pa-0">
+            <v-layout row>
+              <v-flex>
+                <span class="grey--text">Pods CIDR</span><br>
+                <span class="subheading">{{podsCidr}}</span>
+              </v-flex>
+            </v-layout>
+            <v-layout row>
+              <v-flex>
+                <span class="grey--text">Nodes CIDR</span><br>
+                <span class="subheading">{{nodesCidr}}</span>
+              </v-flex>
+            </v-layout>
+            <v-layout row>
+              <v-flex>
+                <span class="grey--text">Services CIDR</span><br>
+                <span class="subheading">{{servicesCidr}}</span>
+              </v-flex>
+            </v-layout>
+          </v-flex>
+        </v-layout>
       </v-card-title>
 
       <template v-if="!!shootIngressDomainText">

--- a/frontend/src/mixins/shootItem.js
+++ b/frontend/src/mixins/shootItem.js
@@ -106,8 +106,14 @@ export const shootItem = {
     shootZones () {
       return uniq(flatMap(get(this.shootSpec, 'provider.workers'), 'zones'))
     },
-    shootCidr () {
-      return get(this.shootSpec, 'provider.infrastructureConfig.networks.vpc.cidr')
+    podsCidr () {
+      return get(this.shootSpec, 'networking.pods')
+    },
+    nodesCidr () {
+      return get(this.shootSpec, 'networking.nodes')
+    },
+    servicesCidr () {
+      return get(this.shootSpec, 'networking.services')
     },
     shootDomain () {
       return get(this.shootSpec, 'dns.domain')


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the pods, nodes and services CIDR to the cluster details page.
<img width="1341" alt="Screenshot 2020-02-06 at 15 47 38" src="https://user-images.githubusercontent.com/5526658/73947619-0c14cb00-48f8-11ea-8d7f-a1ddb0a7fbc5.png">


**Which issue(s) this PR fixes**:
Fixes #577 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Added Pods, nodes and services CIDR to cluster details page
```
