### PR TITLE
Adapt to Gardener API changes

### DIFF
--- a/backend/lib/kubernetes-client/groups.js
+++ b/backend/lib/kubernetes-client/groups.js
@@ -55,7 +55,7 @@ class Extensions extends V1Beta1(NamedGroup(Resource)) {
   }
 }
 
-class GardenerCore extends V1Alpha1(NamedGroup(Resource)) {
+class GardenerCore extends V1Beta1(NamedGroup(Resource)) {
   static get group () {
     return 'core.gardener.cloud'
   }

--- a/backend/lib/routes/info.js
+++ b/backend/lib/routes/info.js
@@ -42,7 +42,7 @@ async function fetchGardenerVersion () {
         service,
         caBundle
       }
-    } = await dashboardClient['apiregistration.k8s.io'].apiservices.get('v1alpha1.core.gardener.cloud')
+    } = await dashboardClient['apiregistration.k8s.io'].apiservices.get('v1beta1.core.gardener.cloud')
     const uri = `https://${service.name}.${service.namespace}/version`
     const version = await got(uri, {
       ca: decodeBase64(caBundle),

--- a/backend/lib/routes/shoots.js
+++ b/backend/lib/routes/shoots.js
@@ -195,3 +195,16 @@ if (_.get(config, 'frontend.features.kymaEnabled', false)) {
       }
     })
 }
+
+router.route('/:name/spec/purpose')
+  .put(async (req, res, next) => {
+    try {
+      const user = req.user
+      const namespace = req.params.namespace
+      const name = req.params.name
+      const body = req.body
+      res.send(await shoots.replacePurpose({ user, namespace, name, body }))
+    } catch (err) {
+      next(err)
+    }
+  })

--- a/backend/lib/services/shoots.js
+++ b/backend/lib/services/shoots.js
@@ -81,6 +81,7 @@ exports.replace = async function ({ user, namespace, name, body }) {
   Object.assign(metadata, { labels, annotations })
   // compose new body
   body = { kind, apiVersion, metadata, spec, status }
+  body = { kind, apiVersion, metadata, spec, status }
   // replace
   return client['core.gardener.cloud'].shoots.update(namespace, name, body)
 }
@@ -117,6 +118,17 @@ exports.replaceHibernationSchedules = async function ({ user, namespace, name, b
       hibernation: {
         schedules
       }
+    }
+  }
+  return client['core.gardener.cloud'].shoots.mergePatch(namespace, name, payload)
+}
+
+exports.replacePurpose = async function ({ user, namespace, name, body }) {
+  const client = user.client
+  const purpose = body.purpose
+  const payload = {
+    spec: {
+      purpose
     }
   }
   return client['core.gardener.cloud'].shoots.mergePatch(namespace, name, payload)

--- a/backend/lib/services/shoots.js
+++ b/backend/lib/services/shoots.js
@@ -81,7 +81,6 @@ exports.replace = async function ({ user, namespace, name, body }) {
   Object.assign(metadata, { labels, annotations })
   // compose new body
   body = { kind, apiVersion, metadata, spec, status }
-  body = { kind, apiVersion, metadata, spec, status }
   // replace
   return client['core.gardener.cloud'].shoots.update(namespace, name, body)
 }

--- a/backend/test/acceptance/api.shoots.spec.js
+++ b/backend/test/acceptance/api.shoots.spec.js
@@ -76,6 +76,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
 
     expect(res).to.have.status(200)
     expect(res).to.be.json
+    expect(res.body.metadata).to.eql({ name, namespace, resourceVersion, annotations })
     expect(res.body.spec).to.eql(spec)
   })
 
@@ -147,7 +148,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
     const bearer = await user.bearer
     const metadata = {
       annotations: {
-        'garden.sapcloud.io/created-by': 'baz@example.org'
+        'gardener.cloud/created-by': 'baz@example.org'
       },
       labels: {
         foo: 'bar'
@@ -169,7 +170,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
     const actLabels = body.metadata.labels
     const expLabels = metadata.labels
     expect(actLabels).to.eql(expLabels)
-    const actCreatedBy = body.metadata.annotations['garden.sapcloud.io/created-by']
+    const actCreatedBy = body.metadata.annotations['gardener.cloud/created-by']
     const expCreatedBy = 'baz@example.org'
     expect(actCreatedBy).to.equal(expCreatedBy)
   })

--- a/backend/test/support/nocks/k8s.js
+++ b/backend/test/support/nocks/k8s.js
@@ -537,7 +537,7 @@ const stub = {
     }
 
     return [nockWithAuthorization(bearer)
-      .get(`/apis/core.gardener.cloud/v1alpha1/namespaces/${namespace}/shoots/${name}`)
+      .get(`/apis/core.gardener.cloud/v1beta1/namespaces/${namespace}/shoots/${name}`)
       .reply(200, () => shootResult)
       .get(`/api/v1/namespaces/${namespace}/secrets/${name}.kubeconfig`)
       .reply(200, () => kubecfgResult)

--- a/backend/test/support/nocks/k8s.js
+++ b/backend/test/support/nocks/k8s.js
@@ -388,9 +388,7 @@ function getShoot ({
     metadata: {
       name,
       namespace,
-      annotations: {
-        'garden.sapcloud.io/purpose': purpose
-      }
+      annotations: {}
     },
     spec: {
       secretBindingName: bindingName,
@@ -403,7 +401,8 @@ function getShoot ({
       seedName: seed,
       kubernetes: {
         version: kubernetesVersion
-      }
+      },
+      purpose
     },
     status: {}
   }
@@ -652,6 +651,16 @@ const stub = {
     return nockWithAuthorization(bearer)
       .patch(`/apis/core.gardener.cloud/v1beta1/namespaces/${namespace}/shoots/${name}`, body => {
         shoot.spec.hibernation.enabled = body.spec.hibernation.enabled
+        return true
+      })
+      .reply(200, () => shoot)
+  },
+  replacePurpose ({ bearer, namespace, name, project }) {
+    const shoot = getShoot({ name, project })
+
+    return nockWithAuthorization(bearer)
+      .patch(`/apis/core.gardener.cloud/v1beta1/namespaces/${namespace}/shoots/${name}`, body => {
+        shoot.spec.purpose = body.spec.purpose
         return true
       })
       .reply(200, () => shoot)

--- a/backend/test/support/nocks/k8s.js
+++ b/backend/test/support/nocks/k8s.js
@@ -466,14 +466,14 @@ const stub = {
     }
 
     return nockWithAuthorization(bearer)
-      .get(`/apis/core.gardener.cloud/v1alpha1/namespaces/${namespace}/shoots`)
+      .get(`/apis/core.gardener.cloud/v1beta1/namespaces/${namespace}/shoots`)
       .reply(200, shoots)
   },
   getShoot ({ bearer, namespace, name, ...rest }) {
     const shoot = getShoot({ namespace, name, ...rest })
 
     return nockWithAuthorization(bearer)
-      .get(`/apis/core.gardener.cloud/v1alpha1/namespaces/${namespace}/shoots/${name}`)
+      .get(`/apis/core.gardener.cloud/v1beta1/namespaces/${namespace}/shoots/${name}`)
       .reply(200, shoot)
   },
   createShoot ({ bearer, namespace, spec, resourceVersion = 42 }) {
@@ -484,7 +484,7 @@ const stub = {
     const result = { metadata, spec }
 
     return nockWithAuthorization(bearer)
-      .post(`/apis/core.gardener.cloud/v1alpha1/namespaces/${namespace}/shoots`, body => {
+      .post(`/apis/core.gardener.cloud/v1beta1/namespaces/${namespace}/shoots`, body => {
         _.assign(metadata, body.metadata)
         return true
       })
@@ -498,12 +498,12 @@ const stub = {
     const result = { metadata }
 
     return nockWithAuthorization(bearer)
-      .patch(`/apis/core.gardener.cloud/v1alpha1/namespaces/${namespace}/shoots/${name}`, body => {
+      .patch(`/apis/core.gardener.cloud/v1beta1/namespaces/${namespace}/shoots/${name}`, body => {
         _.assign(metadata, body.metadata)
         return true
       })
       .reply(200)
-      .delete(`/apis/core.gardener.cloud/v1alpha1/namespaces/${namespace}/shoots/${name}`)
+      .delete(`/apis/core.gardener.cloud/v1beta1/namespaces/${namespace}/shoots/${name}`)
       .reply(200, () => result)
   },
   getShootInfo ({
@@ -566,7 +566,7 @@ const stub = {
     }
 
     return [nockWithAuthorization(bearer)
-      .get(`/apis/core.gardener.cloud/v1alpha1/namespaces/${namespace}/shoots/${name}`)
+      .get(`/apis/core.gardener.cloud/v1beta1/namespaces/${namespace}/shoots/${name}`)
       .reply(200, () => shootResult)
       .get(`/api/v1/namespaces/${namespace}/secrets/${name}.kubeconfig`)
       .reply(200, () => kubecfgResult)
@@ -583,9 +583,9 @@ const stub = {
   replaceShoot ({ bearer, namespace, name, project, createdBy }) {
     const shoot = getShoot({ name, project, createdBy })
     return nockWithAuthorization(bearer)
-      .get(`/apis/core.gardener.cloud/v1alpha1/namespaces/${namespace}/shoots/${name}`)
+      .get(`/apis/core.gardener.cloud/v1beta1/namespaces/${namespace}/shoots/${name}`)
       .reply(200, () => shoot)
-      .put(`/apis/core.gardener.cloud/v1alpha1/namespaces/${namespace}/shoots/${name}`, body => {
+      .put(`/apis/core.gardener.cloud/v1beta1/namespaces/${namespace}/shoots/${name}`, body => {
         _.assign(shoot, body)
         return true
       })
@@ -595,7 +595,7 @@ const stub = {
     const shoot = getShoot({ name, project, createdBy })
 
     return nockWithAuthorization(bearer)
-      .patch(`/apis/core.gardener.cloud/v1alpha1/namespaces/${namespace}/shoots/${name}`, body => {
+      .patch(`/apis/core.gardener.cloud/v1beta1/namespaces/${namespace}/shoots/${name}`, body => {
         const payload = _.head(body)
         if (payload.op === 'replace' && payload.path === '/spec/kubernetes/version') {
           shoot.spec.kubernetes = _.assign({}, shoot.spec.kubernetes, payload.value)
@@ -607,7 +607,7 @@ const stub = {
   replaceWorkers ({ bearer, namespace, name, project, workers }) {
     const shoot = getShoot({ name, project })
     return nockWithAuthorization(bearer)
-      .patch(`/apis/core.gardener.cloud/v1alpha1/namespaces/${namespace}/shoots/${name}`, body => {
+      .patch(`/apis/core.gardener.cloud/v1beta1/namespaces/${namespace}/shoots/${name}`, body => {
         const payload = _.head(body)
         if (payload.op === 'replace' && payload.path === '/spec/provider/workers') {
           shoot.spec.provider.workers = workers
@@ -620,7 +620,7 @@ const stub = {
     const shoot = getShoot({ name, project, createdBy })
 
     return nockWithAuthorization(bearer)
-      .patch(`/apis/core.gardener.cloud/v1alpha1/namespaces/${namespace}/shoots/${name}`, body => {
+      .patch(`/apis/core.gardener.cloud/v1beta1/namespaces/${namespace}/shoots/${name}`, body => {
         shoot.metadata.annotations = Object.assign({}, shoot.metadata.annotations, body.metadata.annotations)
         return true
       })
@@ -630,7 +630,7 @@ const stub = {
     const shoot = getShoot({ name, project })
 
     return nockWithAuthorization(bearer)
-      .patch(`/apis/core.gardener.cloud/v1alpha1/namespaces/${namespace}/shoots/${name}`, body => {
+      .patch(`/apis/core.gardener.cloud/v1beta1/namespaces/${namespace}/shoots/${name}`, body => {
         shoot.spec.maintenance = body.spec.maintenance
         return true
       })
@@ -640,7 +640,7 @@ const stub = {
     const shoot = getShoot({ name, project })
 
     return nockWithAuthorization(bearer)
-      .patch(`/apis/core.gardener.cloud/v1alpha1/namespaces/${namespace}/shoots/${name}`, body => {
+      .patch(`/apis/core.gardener.cloud/v1beta1/namespaces/${namespace}/shoots/${name}`, body => {
         shoot.spec.hibernation.schedules = body.spec.hibernation.schedules
         return true
       })
@@ -650,7 +650,7 @@ const stub = {
     const shoot = getShoot({ name, project })
 
     return nockWithAuthorization(bearer)
-      .patch(`/apis/core.gardener.cloud/v1alpha1/namespaces/${namespace}/shoots/${name}`, body => {
+      .patch(`/apis/core.gardener.cloud/v1beta1/namespaces/${namespace}/shoots/${name}`, body => {
         shoot.spec.hibernation.enabled = body.spec.hibernation.enabled
         return true
       })
@@ -664,7 +664,7 @@ const stub = {
       ? _.filter(infrastructureSecretList, ['metadata.namespace', namespace])
       : []
     return nockWithAuthorization(bearer)
-      .get(`/apis/core.gardener.cloud/v1alpha1/namespaces/${namespace}/secretbindings`)
+      .get(`/apis/core.gardener.cloud/v1beta1/namespaces/${namespace}/secretbindings`)
       .reply(200, {
         items: secretBindings
       })
@@ -691,7 +691,7 @@ const stub = {
         return true
       })
       .reply(200, () => resultSecret)
-      .post(`/apis/core.gardener.cloud/v1alpha1/namespaces/${namespace}/secretbindings`, body => {
+      .post(`/apis/core.gardener.cloud/v1beta1/namespaces/${namespace}/secretbindings`, body => {
         expect(body).to.not.have.nested.property('metadata.resourceVersion')
         _.assign(resultSecretBinding.metadata, body.metadata)
         _.assign(resultSecretBinding.secretRef, body.secretRef)
@@ -714,7 +714,7 @@ const stub = {
     })
 
     return nockWithAuthorization(bearer)
-      .get(`/apis/core.gardener.cloud/v1alpha1/namespaces/${bindingNamespace}/secretbindings/${bindingName}`)
+      .get(`/apis/core.gardener.cloud/v1beta1/namespaces/${bindingNamespace}/secretbindings/${bindingName}`)
       .reply(200, () => resultSecretBinding)
       .patch(`/api/v1/namespaces/${namespace}/secrets/${name}`, body => {
         expect(body).to.not.have.nested.property('metadata.resourceVersion')
@@ -737,7 +737,7 @@ const stub = {
     })
 
     return nockWithAuthorization(bearer)
-      .get(`/apis/core.gardener.cloud/v1alpha1/namespaces/${bindingNamespace}/secretbindings/${bindingName}`)
+      .get(`/apis/core.gardener.cloud/v1beta1/namespaces/${bindingNamespace}/secretbindings/${bindingName}`)
       .reply(200, () => resultSecretBinding)
   },
   deleteInfrastructureSecret ({ bearer, namespace, project, name, bindingName, bindingNamespace, cloudProfileName, resourceVersion = 42 }) {
@@ -754,13 +754,13 @@ const stub = {
     })
 
     return nockWithAuthorization(bearer)
-      .get(`/apis/core.gardener.cloud/v1alpha1/namespaces/${bindingNamespace}/secretbindings/${bindingName}`)
+      .get(`/apis/core.gardener.cloud/v1beta1/namespaces/${bindingNamespace}/secretbindings/${bindingName}`)
       .reply(200, () => resultSecretBinding)
-      .get(`/apis/core.gardener.cloud/v1alpha1/namespaces/${bindingNamespace}/shoots`)
+      .get(`/apis/core.gardener.cloud/v1beta1/namespaces/${bindingNamespace}/shoots`)
       .reply(200, {
         items: [shoot]
       })
-      .delete(`/apis/core.gardener.cloud/v1alpha1/namespaces/${bindingNamespace}/secretbindings/${bindingName}`)
+      .delete(`/apis/core.gardener.cloud/v1beta1/namespaces/${bindingNamespace}/secretbindings/${bindingName}`)
       .reply(200)
       .delete(`/api/v1/namespaces/${bindingNamespace}/secrets/${name}`)
       .reply(200)
@@ -778,7 +778,7 @@ const stub = {
     })
 
     return nockWithAuthorization(bearer)
-      .get(`/apis/core.gardener.cloud/v1alpha1/namespaces/${bindingNamespace}/secretbindings/${bindingName}`)
+      .get(`/apis/core.gardener.cloud/v1beta1/namespaces/${bindingNamespace}/secretbindings/${bindingName}`)
       .reply(200, () => resultSecretBinding)
   },
   deleteInfrastructureSecretReferencedByShoot ({ bearer, namespace, project, name, bindingName, bindingNamespace, cloudProfileName, resourceVersion = 42 }) {
@@ -796,9 +796,9 @@ const stub = {
     })
 
     return nockWithAuthorization(bearer)
-      .get(`/apis/core.gardener.cloud/v1alpha1/namespaces/${bindingNamespace}/secretbindings/${bindingName}`)
+      .get(`/apis/core.gardener.cloud/v1beta1/namespaces/${bindingNamespace}/secretbindings/${bindingName}`)
       .reply(200, () => resultSecretBinding)
-      .get(`/apis/core.gardener.cloud/v1alpha1/namespaces/${bindingNamespace}/shoots`)
+      .get(`/apis/core.gardener.cloud/v1beta1/namespaces/${bindingNamespace}/shoots`)
       .reply(200, {
         items: [shoot, referencingShoot]
       })
@@ -809,7 +809,7 @@ const stub = {
     return [
       scope,
       nockWithAuthorization(auth.bearer)
-        .get('/apis/core.gardener.cloud/v1alpha1/projects')
+        .get('/apis/core.gardener.cloud/v1beta1/projects')
         .reply(200, {
           items: projectList
         })
@@ -857,18 +857,18 @@ const stub = {
     canGetSecretsInAllNamespaces(scope)
     if (target === 'garden') {
       scope
-        .get(`/apis/core.gardener.cloud/v1alpha1/namespaces/garden/shoots/${seedName}`)
+        .get(`/apis/core.gardener.cloud/v1beta1/namespaces/garden/shoots/${seedName}`)
         .reply(404)
     } else {
       const shootResource = _.find(shootList, ['metadata.name', shootName])
       seedName = getSeedNameFromShoot(shootResource)
       scope
-        .get(`/apis/core.gardener.cloud/v1alpha1/namespaces/${namespace}/shoots/${shootName}`)
+        .get(`/apis/core.gardener.cloud/v1beta1/namespaces/${namespace}/shoots/${shootName}`)
         .reply(200, shootResource)
     }
     if (target === 'cp') {
       scope
-        .get(`/apis/core.gardener.cloud/v1alpha1/namespaces/garden/shoots/${seedName}`)
+        .get(`/apis/core.gardener.cloud/v1beta1/namespaces/garden/shoots/${seedName}`)
         .reply(200, {
           metadata: {
             name: seedName,
@@ -999,7 +999,7 @@ const stub = {
       nockWithAuthorization(bearer)
         .get(`/api/v1/namespaces/${namespace}`)
         .reply(200, () => getProjectNamespace(namespace))
-        .get(`/apis/core.gardener.cloud/v1alpha1/projects/${name}`)
+        .get(`/apis/core.gardener.cloud/v1beta1/projects/${name}`)
         .reply(statusCode, () => result)
     ]
   },
@@ -1015,7 +1015,7 @@ const stub = {
     }
 
     return nockWithAuthorization(bearer)
-      .post('/apis/core.gardener.cloud/v1alpha1/projects', body => {
+      .post('/apis/core.gardener.cloud/v1beta1/projects', body => {
         const namespace = `garden-${body.metadata.name}`
         _
           .chain(result)
@@ -1034,9 +1034,9 @@ const stub = {
       nockWithAuthorization(bearer)
         .get(`/api/v1/namespaces/${namespace}`)
         .reply(200, () => getProjectNamespace(namespace))
-        .get(`/apis/core.gardener.cloud/v1alpha1/projects/${name}`)
+        .get(`/apis/core.gardener.cloud/v1beta1/projects/${name}`)
         .reply(200, () => project)
-        .patch(`/apis/core.gardener.cloud/v1alpha1/projects/${name}`, body => {
+        .patch(`/apis/core.gardener.cloud/v1beta1/projects/${name}`, body => {
           _.merge(newProject, body)
           return true
         })
@@ -1051,17 +1051,17 @@ const stub = {
       nockWithAuthorization(bearer)
         .get(`/api/v1/namespaces/${namespace}`)
         .reply(200, () => getProjectNamespace(namespace))
-        .get(`/apis/core.gardener.cloud/v1alpha1/namespaces/${namespace}/shoots`)
+        .get(`/apis/core.gardener.cloud/v1beta1/namespaces/${namespace}/shoots`)
         .reply(200, {
           items: []
         })
-        .get(`/apis/core.gardener.cloud/v1alpha1/projects/${name}`)
+        .get(`/apis/core.gardener.cloud/v1beta1/projects/${name}`)
         .reply(200, () => project)
-        .patch(`/apis/core.gardener.cloud/v1alpha1/projects/${name}`, body => {
+        .patch(`/apis/core.gardener.cloud/v1beta1/projects/${name}`, body => {
           return _.get(body, confirmationPath) === 'true'
         })
         .reply(200, () => _.set(project, confirmationPath, 'true'))
-        .delete(`/apis/core.gardener.cloud/v1alpha1/projects/${name}`)
+        .delete(`/apis/core.gardener.cloud/v1beta1/projects/${name}`)
         .reply(200, () => project)
     ]
   },
@@ -1069,7 +1069,7 @@ const stub = {
     const project = readProject(namespace)
     if (project) {
       const scope = nockWithAuthorization(bearer)
-        .get(`/apis/core.gardener.cloud/v1alpha1/projects/${project.metadata.name}`)
+        .get(`/apis/core.gardener.cloud/v1beta1/projects/${project.metadata.name}`)
         .reply(200, () => project)
       getServiceAccountsForNamespace(scope, namespace)
 
@@ -1093,11 +1093,11 @@ const stub = {
     const name = project.metadata.name
 
     const scope = nockWithAuthorization(bearer)
-      .get(`/apis/core.gardener.cloud/v1alpha1/projects/${name}`)
+      .get(`/apis/core.gardener.cloud/v1beta1/projects/${name}`)
       .reply(200, () => project)
     if (!_.find(project.spec.members, ['name', username])) {
       scope
-        .patch(`/apis/core.gardener.cloud/v1alpha1/projects/${name}`, body => {
+        .patch(`/apis/core.gardener.cloud/v1beta1/projects/${name}`, body => {
           if (!_.find(body.spec.members, ['name', username])) {
             return false
           }
@@ -1120,11 +1120,11 @@ const stub = {
     const name = project.metadata.name
 
     const scope = nockWithAuthorization(bearer)
-      .get(`/apis/core.gardener.cloud/v1alpha1/projects/${name}`)
+      .get(`/apis/core.gardener.cloud/v1beta1/projects/${name}`)
       .reply(200, () => project)
     if (_.find(project.spec.members, ['name', username])) {
       scope
-        .patch(`/apis/core.gardener.cloud/v1alpha1/projects/${name}`, body => {
+        .patch(`/apis/core.gardener.cloud/v1beta1/projects/${name}`, body => {
           if (_.find(body.spec.members, ['name', username])) {
             return false
           }
@@ -1146,7 +1146,7 @@ const stub = {
     const name = project.metadata.name
     const isMember = _.findIndex(project.spec.members, ['name', username]) !== -1
     const scope = nockWithAuthorization(bearer)
-      .get(`/apis/core.gardener.cloud/v1alpha1/projects/${name}`)
+      .get(`/apis/core.gardener.cloud/v1beta1/projects/${name}`)
       .reply(200, () => project)
     const scopes = [
       nockWithAuthorization(bearer)
@@ -1183,7 +1183,7 @@ const stub = {
     const statusCode = !version ? 404 : 200
     return [
       nockWithAuthorization(auth.bearer)
-        .get('/apis/apiregistration.k8s.io/v1/apiservices/v1alpha1.core.gardener.cloud')
+        .get('/apis/apiregistration.k8s.io/v1/apiservices/v1beta1.core.gardener.cloud')
         .reply(200, body),
       nock(serviceUrl)
         .get('/version')

--- a/frontend/src/components/NewShoot/NewShootDetails.vue
+++ b/frontend/src/components/NewShoot/NewShootDetails.vue
@@ -56,16 +56,12 @@ limitations under the License.
         </select-hint-colorizer>
       </v-flex>
       <v-flex class="regularInput">
-        <v-select
-          color="cyan darken-2"
-          label="Purpose"
-          :items="purposes"
-          v-model="purpose"
-          hint="Indicate the importance of the cluster"
-          persistent-hint
-          @input="onInputPurpose"
-          @blur="$v.purpose.$touch()"
-          ></v-select>
+        <purpose
+          ref="purpose"
+          :secret="secret"
+          @updatePurpose="onUpdatePurpose"
+          @valid="onPurposeValid">
+        </purpose>
       </v-flex>
     </v-layout>
 </v-container>
@@ -74,8 +70,9 @@ limitations under the License.
 <script>
 
 import SelectHintColorizer from '@/components/SelectHintColorizer'
+import Purpose from '@/components/Purpose'
 import { mapGetters, mapState } from 'vuex'
-import { getValidationErrors, purposesForSecret } from '@/utils'
+import { getValidationErrors } from '@/utils'
 import { required, maxLength } from 'vuelidate/lib/validators'
 import { resourceName, noStartEndHyphen, noConsecutiveHyphen } from '@/utils/validators'
 import head from 'lodash/head'
@@ -94,9 +91,6 @@ const validationErrors = {
   },
   kubernetesVersion: {
     required: 'Kubernetes version is required'
-  },
-  purpose: {
-    required: ' Purpose is required'
   }
 }
 
@@ -113,16 +107,14 @@ const validations = {
   },
   kubernetesVersion: {
     required
-  },
-  purpose: {
-    required
   }
 }
 
 export default {
   name: 'new-shoot-details',
   components: {
-    SelectHintColorizer
+    SelectHintColorizer,
+    Purpose
   },
   props: {
     userInterActionBus: {
@@ -137,6 +129,7 @@ export default {
       kubernetesVersion: undefined,
       purpose: undefined,
       valid: false,
+      purposeValid: false,
       cloudProfileName: undefined,
       secret: undefined,
       updateK8sMaintenance: undefined
@@ -151,9 +144,6 @@ export default {
       'sortedKubernetesVersions',
       'shootByNamespaceAndName'
     ]),
-    purposes () {
-      return purposesForSecret(this.secret)
-    },
     sortedKubernetesVersionsList () {
       return this.sortedKubernetesVersions(this.cloudProfileName)
     },
@@ -181,21 +171,20 @@ export default {
       this.$v.kubernetesVersion.$touch()
       this.validateInput()
     },
-    onInputPurpose () {
-      this.$v.name.$touch()
+    onUpdatePurpose (purpose) {
+      this.purpose = purpose
       this.userInterActionBus.emit('updatePurpose', this.purpose)
       this.validateInput()
     },
+    onPurposeValid (value) {
+      this.purposeValid = value
+    },
     validateInput () {
-      const valid = !this.$v.$invalid
+      const valid = !this.$v.$invalid && this.purposeValid
       if (this.valid !== valid) {
         this.valid = valid
         this.$emit('valid', valid)
       }
-    },
-    setDefaultPurpose () {
-      this.purpose = head(this.purposes)
-      this.onInputPurpose()
     },
     setDefaultKubernetesVersion () {
       this.kubernetesVersion = get(head(this.sortedKubernetesVersionsList), 'version')
@@ -213,8 +202,9 @@ export default {
       this.cloudProfileName = cloudProfileName
       this.secret = secret
       this.kubernetesVersion = kubernetesVersion
-      this.purpose = purpose
       this.updateK8sMaintenance = updateK8sMaintenance
+
+      this.$refs.purpose.setPurpose(purpose)
 
       this.validateInput()
     }
@@ -222,7 +212,7 @@ export default {
   mounted () {
     this.userInterActionBus.on('updateSecret', secret => {
       this.secret = secret
-      this.setDefaultPurpose()
+      this.$refs.purpose.setDefaultPurpose()
     })
     this.userInterActionBus.on('updateCloudProfileName', cloudProfileName => {
       this.cloudProfileName = cloudProfileName

--- a/frontend/src/components/NewShoot/NewShootInfrastructureDetails.vue
+++ b/frontend/src/components/NewShoot/NewShootInfrastructureDetails.vue
@@ -30,6 +30,7 @@ limitations under the License.
       </v-flex>
       <v-flex class="regularInput">
         <v-select
+          ref="secret"
           color="cyan darken-2"
           label="Secret"
           :items="secretItems"
@@ -377,15 +378,14 @@ export default {
     onInputSecret () {
       if (this.isAddNewSecret(this.secret)) {
         this.onAddSecret()
-        this.secret = head(this.infrastructureSecretsByProfileName)
       } else {
         this.$v.secret.$touch()
-        this.userInterActionBus.emit('updateSecret', this.secret)
         this.validateInput()
+        this.userInterActionBus.emit('updateSecret', this.secret)
       }
     },
     onInputRegion () {
-      this.$v.secret.$touch()
+      this.$v.region.$touch()
       this.userInterActionBus.emit('updateRegion', this.region)
       this.validateInput()
     },
@@ -447,6 +447,12 @@ export default {
       return (item && item.value === 'ADD_NEW_SECRET') || item === 'ADD_NEW_SECRET'
     },
     onAddSecret () {
+      this.secret = undefined
+      this.$nextTick(() => {
+        // need to set in next ui loop as it would not render correctly otherwise
+        this.secret = head(this.infrastructureSecretsByProfileName)
+        this.onInputSecret()
+      })
       this.secretItemsBeforeAdd = cloneDeep(this.secretItems)
       this.addSecretDialogState[this.infrastructureKind].visible = true
     },
@@ -454,6 +460,7 @@ export default {
       const newSecret = head(differenceWith(this.secretItems, this.secretItemsBeforeAdd, isEqual))
       if (newSecret) {
         this.secret = newSecret
+        this.onInputSecret()
       }
     }
   },

--- a/frontend/src/components/Purpose.vue
+++ b/frontend/src/components/Purpose.vue
@@ -1,0 +1,122 @@
+<!--
+Copyright (c) 2019 by SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<template>
+  <div>
+    <v-select
+      hint="Indicate the importance of the cluster"
+      color="cyan darken-2"
+      label="Purpose"
+      :items="purposes"
+      item-text="purpose"
+      item-value="purpose"
+      v-model="internalPurpose"
+      persistent-hint
+      :error-messages="getErrorMessages('internalPurpose')"
+      @input="onInputPurpose"
+      @blur="$v.internalPurpose.$touch()">
+      <template v-slot:item="{ item }">
+        <v-list-tile-content>
+          <v-list-tile-title>{{item.purpose}}</v-list-tile-title>
+          <v-list-tile-sub-title>
+            {{item.description}}
+          </v-list-tile-sub-title>
+        </v-list-tile-content>
+      </template>
+    </v-select>
+  </div>
+</template>
+
+<script>
+import { required } from 'vuelidate/lib/validators'
+import { getValidationErrors, purposesForSecret } from '@/utils'
+import map from 'lodash/map'
+import head from 'lodash/head'
+
+const validationErrors = {
+  internalPurpose: {
+    required: 'Purpose is required.'
+  }
+}
+
+export default {
+  name: 'Purpose',
+  props: {
+    secret: {
+      type: Object
+    }
+  },
+  data () {
+    return {
+      validationErrors,
+      valid: undefined,
+      internalPurpose: undefined
+    }
+  },
+  validations () {
+    return this.validators
+  },
+  computed: {
+    validators () {
+      return {
+        internalPurpose: {
+          required
+        }
+      }
+    },
+    purposes () {
+      const purposes = purposesForSecret(this.secret)
+      return map(purposes, purpose => ({
+        purpose,
+        description: this.descriptionForPurpose(purpose)
+      }))
+    }
+  },
+  methods: {
+    getErrorMessages (field) {
+      return getValidationErrors(this, field)
+    },
+    onInputPurpose () {
+      this.$v.internalPurpose.$touch()
+      this.$emit('updatePurpose', this.internalPurpose)
+      this.validateInput()
+    },
+    validateInput () {
+      const valid = !this.$v.$invalid
+      if (this.valid !== valid) {
+        this.valid = valid
+        this.$emit('valid', valid)
+      }
+    },
+    descriptionForPurpose (purpose) {
+      switch (purpose) {
+        case 'testing':
+          return 'Testing clusters do not get a monitoring or a logging stack as part of their control planes'
+        default:
+          return ''
+      }
+    },
+    setDefaultPurpose () {
+      this.internalPurpose = head(this.purposes).purpose
+      this.onInputPurpose()
+    },
+    setPurpose (purpose) {
+      this.internalPurpose = purpose
+      this.onInputPurpose()
+    }
+  }
+}
+</script>

--- a/frontend/src/components/PurposeConfiguration.vue
+++ b/frontend/src/components/PurposeConfiguration.vue
@@ -37,7 +37,7 @@ limitations under the License.
 
 <script>
 import ActionIconDialog from '@/dialogs/ActionIconDialog'
-import { addShootAnnotation } from '@/utils/api'
+import { updateShootPurpose } from '@/utils/api'
 import { purposesForSecret } from '@/utils'
 import { shootItem } from '@/mixins/shootItem'
 import { errorDetailsFromError } from '@/utils/error'
@@ -76,13 +76,12 @@ export default {
     },
     async updateConfiguration () {
       try {
-        const purposeAnnotation = {
-          'garden.sapcloud.io/purpose': this.purpose
-        }
-        await addShootAnnotation({
+        await updateShootPurpose({
           namespace: this.shootNamespace,
           name: this.shootName,
-          data: purposeAnnotation
+          data: {
+            purpose: this.purpose
+          }
         })
       } catch (err) {
         const errorMessage = 'Could not update purpose'

--- a/frontend/src/components/PurposeConfiguration.vue
+++ b/frontend/src/components/PurposeConfiguration.vue
@@ -23,29 +23,30 @@ limitations under the License.
     maxWidth="400"
     caption="Configure Purpose">
     <template slot="actionComponent">
-      <v-select
-        color="cyan darken-2"
-        label="Purpose"
-        :items="purposes"
-        v-model="purpose"
-        hint="Indicate the importance of the cluster"
-        persistent-hint
-        ></v-select>
+      <purpose
+        ref="purpose"
+        :secret="secret"
+        @updatePurpose="onUpdatePurpose"
+        @valid="onPurposeValid">
+      </purpose>
     </template>
   </action-icon-dialog>
 </template>
 
 <script>
 import ActionIconDialog from '@/dialogs/ActionIconDialog'
+import Purpose from '@/components/Purpose'
 import { updateShootPurpose } from '@/utils/api'
-import { purposesForSecret } from '@/utils'
 import { shootItem } from '@/mixins/shootItem'
 import { errorDetailsFromError } from '@/utils/error'
+import { mapGetters } from 'vuex'
+import find from 'lodash/find'
 
 export default {
   name: 'purpose-configuration',
   components: {
-    ActionIconDialog
+    ActionIconDialog,
+    Purpose
   },
   props: {
     shootItem: {
@@ -55,18 +56,33 @@ export default {
   mixins: [shootItem],
   data () {
     return {
-      purpose: null
+      purpose: undefined,
+      purposeValid: false
     }
   },
   computed: {
+    ...mapGetters([
+      'infrastructureSecretsByCloudProfileName'
+    ]),
     valid () {
-      return !!this.purpose
+      return this.purposeValid
     },
-    purposes () {
-      return purposesForSecret(this.shootSecretBindingName)
+    secret () {
+      const secrets = this.infrastructureSecretsByCloudProfileName(this.shootCloudProfileName)
+      const secret = find(secrets, ['metadata.bindingName', this.shootSecretBindingName])
+      if (!secret) {
+        console.error('Secret must not be undefined')
+      }
+      return secret
     }
   },
   methods: {
+    onPurposeValid (value) {
+      this.purposeValid = value
+    },
+    onUpdatePurpose (purpose) {
+      this.purpose = purpose
+    },
     async onConfigurationDialogOpened () {
       this.reset()
       const confirmed = await this.$refs.actionDialog.waitForDialogClosed()
@@ -93,6 +109,7 @@ export default {
     },
     reset () {
       this.purpose = this.shootPurpose
+      this.$refs.purpose.setPurpose(this.purpose)
     }
   }
 }

--- a/frontend/src/components/ShootDetails/ShootAccessCard.vue
+++ b/frontend/src/components/ShootDetails/ShootAccessCard.vue
@@ -211,10 +211,10 @@ export default {
       return this.shootInfo.cluster_password || ''
     },
     hasDashboardEnabled () {
-      return get(this.shootItem, 'spec.addons.kubernetes-dashboard.enabled', false) === true
+      return get(this.shootItem, 'spec.addons.kubernetesDashboard.enabled', false) === true
     },
     hasDashboardTokenAuth () {
-      return get(this.shootItem, 'spec.addons.kubernetes-dashboard.authenticationMode', 'basic') === 'token'
+      return get(this.shootItem, 'spec.addons.kubernetesDashboard.authenticationMode', 'basic') === 'token'
     },
 
     kubeconfig () {

--- a/frontend/src/components/ShootDetails/ShootInfrastructureCard.vue
+++ b/frontend/src/components/ShootDetails/ShootInfrastructureCard.vue
@@ -155,7 +155,7 @@ export default {
       return includes(this.namespaces, 'garden')
     },
     shootIngressDomainText () {
-      const nginxIngressEnabled = get(this.shootItem, 'spec.addons.nginx-ingress.enabled', false)
+      const nginxIngressEnabled = get(this.shootItem, 'spec.addons.nginxIngress.enabled', false)
       if (!this.shootDomain || !nginxIngressEnabled) {
         return undefined
       }

--- a/frontend/src/components/ShootDetails/ShootJournalsCard.vue
+++ b/frontend/src/components/ShootDetails/ShootJournalsCard.vue
@@ -39,6 +39,9 @@ limitations under the License.
 <script>
 import get from 'lodash/get'
 import forEach from 'lodash/forEach'
+import join from 'lodash/join'
+import map from 'lodash/map'
+import compact from 'lodash/compact'
 import { mapState } from 'vuex'
 import Journal from '@/components/ShootJournals/Journal'
 import { canLinkToSeed } from '@/utils'
@@ -86,7 +89,9 @@ export default {
 
       const createdAt = `**Created At:** ${this.shootCreatedAt}`
       const lastOperation = `**Last Op:** ${get(this.shootLastOperation, 'description', '')}`
-      const lastError = `**Last Error:** ${get(this.shootLastError, 'description', '-')}`
+      let shootLastErrorDescriptions = compact(map(this.shootLastErrors, 'description'))
+      shootLastErrorDescriptions = join(shootLastErrorDescriptions, '\n')
+      const lastError = `**Last Errors:** ${shootLastErrorDescriptions || '-'}`
 
       const journalTitle = encodeURIComponent(`[${this.shootNamespace}/${this.shootName}]`)
       const body = encodeURIComponent(`

--- a/frontend/src/components/ShootDetails/ShootLogging.vue
+++ b/frontend/src/components/ShootDetails/ShootLogging.vue
@@ -16,9 +16,21 @@ limitations under the License.
 
 <template>
   <v-list>
-    <link-list-tile v-if="!!kibanaUrl" icon="developer_board" appTitle="Kibana" :url="kibanaUrl" :urlText="kibanaUrl" :isShootStatusHibernated="isShootStatusHibernated"></link-list-tile>
-    <v-divider v-show="!!username && !!password" class="my-2" inset></v-divider>
-    <username-password :username="username" :password="password"></username-password>
+    <v-list-tile v-if="isTestingCluster">
+      <v-list-tile-action>
+        <v-icon class="cyan--text text--darken-2">mdi-alert-circle-outline</v-icon>
+      </v-list-tile-action>
+      <v-list-tile-content>
+        <v-list-tile-title>
+          Logging Stack not available for clusters with purpose testing
+        </v-list-tile-title>
+      </v-list-tile-content>
+    </v-list-tile>
+    <template v-else>
+      <link-list-tile v-if="!!kibanaUrl" icon="developer_board" appTitle="Kibana" :url="kibanaUrl" :urlText="kibanaUrl" :isShootStatusHibernated="isShootStatusHibernated"></link-list-tile>
+      <v-divider v-show="!!username && !!password" class="my-2" inset></v-divider>
+      <username-password :username="username" :password="password"></username-password>
+    </template>
   </v-list>
 </template>
 

--- a/frontend/src/components/ShootDetails/ShootMonitoringCard.vue
+++ b/frontend/src/components/ShootDetails/ShootMonitoringCard.vue
@@ -40,6 +40,7 @@ limitations under the License.
             {{shootStatusTitle}}
         </div>
       </v-card-title>
+
       <v-divider class="my-2" inset></v-divider>
       <v-card-title class="listItem">
         <v-icon class="cyan--text text--darken-2 avatar">mdi-speedometer</v-icon>
@@ -49,10 +50,13 @@ limitations under the License.
           <status-tags v-else :conditions="shootConditions" popperPlacement="bottom"></status-tags>
         </div>
       </v-card-title>
-      <template v-if="seedShootIngressDomain">
-        <v-divider class="my-2" inset></v-divider>
-        <cluster-metrics :shootItem="shootItem"></cluster-metrics>
-      </template>
+
+      <v-divider class="my-2" inset></v-divider>
+      <v-card-title class="listItem" v-if="!!metricsNotAvailableText">
+        <v-icon class="cyan--text text--darken-2 avatar">mdi-alert-circle-outline</v-icon>
+        <span class="subheading">{{metricsNotAvailableText}}</span>
+      </v-card-title>
+      <cluster-metrics :shootItem="shootItem" v-else></cluster-metrics>
     </div>
   </v-card>
 </template>
@@ -86,6 +90,15 @@ export default {
   computed: {
     isLastOperationTypeDelete () {
       return isTypeDelete(this.shootLastOperation)
+    },
+    metricsNotAvailableText () {
+      if (this.isTestingCluster) {
+        return 'Cluster Metrics not available for clusters with purpose testing'
+      }
+      if (!this.seedShootIngressDomain) {
+        return 'Cluster Metrics not available'
+      }
+      return undefined
     }
   },
   methods: {

--- a/frontend/src/components/ShootDetails/ShootMonitoringCard.vue
+++ b/frontend/src/components/ShootDetails/ShootMonitoringCard.vue
@@ -27,7 +27,7 @@ limitations under the License.
           <shoot-status
             class="shootStatus"
             :operation="shootLastOperation"
-            :lastError="shootLastError"
+            :lastErrors="shootLastErrors"
             :popperKey="`${shootNamespace}/${shootName}_lastOp`"
             :isStatusHibernated="isShootStatusHibernated"
             :isHibernationProgressing="isShootStatusHibernationProgressing"

--- a/frontend/src/components/ShootListRow.vue
+++ b/frontend/src/components/ShootListRow.vue
@@ -75,7 +75,7 @@ limitations under the License.
       <div>
         <shoot-status
          :operation="shootLastOperation"
-         :lastError="shootLastError"
+         :lastErrors="shootLastErrors"
          :popperKey="`${shootNamespace}/${shootName}`"
          :isStatusHibernated="isShootStatusHibernated"
          :isHibernationProgressing="isShootStatusHibernationProgressing"

--- a/frontend/src/components/ShootMaintenance/MaintenanceComponents.vue
+++ b/frontend/src/components/ShootMaintenance/MaintenanceComponents.vue
@@ -70,8 +70,7 @@ export default {
   name: 'maintenance-components',
   props: {
     userInterActionBus: {
-      type: Object,
-      required: true
+      type: Object
     },
     title: {
       type: String,

--- a/frontend/src/components/ShootMaintenance/MaintenanceConfiguration.vue
+++ b/frontend/src/components/ShootMaintenance/MaintenanceConfiguration.vue
@@ -105,7 +105,7 @@ export default {
 
       this.$refs.maintenanceTime.reset()
 
-      this.$refs.maintenanceComponents.setComponentUpdates({ k8sUpdates: this.data.updateOSVersion, osUpdates: this.data.updateKubernetesVersion })
+      this.$refs.maintenanceComponents.setComponentUpdates({ k8sUpdates: this.data.updateKubernetesVersion, osUpdates: this.data.updateOSVersion })
     },
     onMaintenanceTimeValid (value) {
       this.maintenanceTimeValid = value

--- a/frontend/src/components/ShootMaintenance/MaintenanceStart.vue
+++ b/frontend/src/components/ShootMaintenance/MaintenanceStart.vue
@@ -107,7 +107,7 @@ export default {
       }
     },
     reset () {
-      this.$refs.maintenanceComponents.setComponentUpdates({ k8sUpdates: this.updateOSVersion, osUpdates: this.updateKubernetesVersion })
+      this.$refs.maintenanceComponents.setComponentUpdates({ k8sUpdates: this.updateKubernetesVersion, osUpdates: this.updateOSVersion })
     }
   },
   watch: {

--- a/frontend/src/components/ShootStatus.vue
+++ b/frontend/src/components/ShootStatus.vue
@@ -43,7 +43,7 @@ limitations under the License.
     <ansi-text v-if="!!popperMessage" :text="popperMessage"></ansi-text>
     <v-divider class="my-2"></v-divider>
     <h4 class="error--text text-xs-left">Last Errors</h4>
-    <div v-for="lastErrorDescription in lastErrorDescriptions" v-bind:key="lastErrorDescription.description">
+    <div v-for="(lastErrorDescription, index) in lastErrorDescriptions" :key="index">
       <template v-for="errorCodeDescription in lastErrorDescription.errorCodeDescriptions">
         <h3 class="error--text text-xs-left" :key="errorCodeDescription">{{errorCodeDescription}}</h3>
       </template>
@@ -140,12 +140,10 @@ export default {
       return isUserError(this.allErrorCodes)
     },
     lastErrorDescriptions () {
-      return map(this.lastErrors, lastError => {
-        return {
-          description: lastError.description,
-          errorCodeDescriptions: map(lastError.codes, code => get(errorCodes, `${code}.description`, code))
-        }
-      })
+      return map(this.lastErrors, lastError => ({
+        description: lastError.description,
+        errorCodeDescriptions: map(lastError.codes, code => get(errorCodes, `${code}.description`, code))
+      }))
     },
     allErrorCodes () {
       return allErrorCodesFromLastErrors(this.lastErrors)

--- a/frontend/src/components/ShootStatus.vue
+++ b/frontend/src/components/ShootStatus.vue
@@ -211,8 +211,8 @@ export default {
       }
     }
   },
-  watch: {
-    statusTitle (statusTitle) {
+  methods: {
+    emitExtendedTitle (statusTitle) {
       // similar to tooltipText, except the progress is missing
       let extendedTitle = statusTitle
       if (this.isUserError) {
@@ -220,6 +220,14 @@ export default {
       }
 
       this.$emit('titleChange', extendedTitle)
+    }
+  },
+  mounted () {
+    this.emitExtendedTitle(this.statusTitle)
+  },
+  watch: {
+    statusTitle (statusTitle) {
+      this.emitExtendedTitle(statusTitle)
     }
   }
 }

--- a/frontend/src/mixins/shootItem.js
+++ b/frontend/src/mixins/shootItem.js
@@ -76,6 +76,9 @@ export const shootItem = {
     shootPurpose () {
       return get(this.shootSpec, 'purpose')
     },
+    isTestingCluster () {
+      return this.shootPurpose === 'testing'
+    },
     shootExpirationTimestamp () {
       return this.shootAnnotations['shoot.gardener.cloud/expiration-timestamp'] || this.shootAnnotations['shoot.garden.sapcloud.io/expirationTimestamp']
     },

--- a/frontend/src/mixins/shootItem.js
+++ b/frontend/src/mixins/shootItem.js
@@ -57,7 +57,7 @@ export const shootItem = {
       return this.shootAnnotations['shoot.garden.sapcloud.io/operation']
     },
     shootPurpose () {
-      return this.shootAnnotations['garden.sapcloud.io/purpose']
+      return get(this.shootSpec, 'purpose')
     },
     shootExpirationTimestamp () {
       return this.shootAnnotations['shoot.garden.sapcloud.io/expirationTimestamp']

--- a/frontend/src/mixins/shootItem.js
+++ b/frontend/src/mixins/shootItem.js
@@ -129,8 +129,8 @@ export const shootItem = {
     shootLastOperation () {
       return get(this.shootItem, 'status.lastOperation', {})
     },
-    shootLastError () {
-      return get(this.shootItem, 'status.lastError', {})
+    shootLastErrors () {
+      return get(this.shootItem, 'status.lastErrors', [])
     },
     shootConditions () {
       return get(this.shootItem, 'status.conditions', [])

--- a/frontend/src/pages/NewShoot.vue
+++ b/frontend/src/pages/NewShoot.vue
@@ -247,7 +247,7 @@ export default {
       const { name, kubernetesVersion, purpose } = this.$refs.clusterDetails.getDetailsData()
       set(shootResource, 'metadata.name', name)
       set(shootResource, 'spec.kubernetes.version', kubernetesVersion)
-      set(shootResource, 'metadata.annotations["garden.sapcloud.io/purpose"]', purpose)
+      set(shootResource, 'spec.purpose', purpose)
 
       const workers = this.$refs.manageWorkers.getWorkers()
       set(shootResource, 'spec.provider.workers', workers)
@@ -340,7 +340,7 @@ export default {
 
       const name = get(shootResource, 'metadata.name')
       const kubernetesVersion = get(shootResource, 'spec.kubernetes.version')
-      const purpose = get(shootResource, 'metadata.annotations["garden.sapcloud.io/purpose"]')
+      const purpose = get(shootResource, 'spec.purpose')
       this.purpose = purpose
       this.$refs.clusterDetails.setDetailsData({ name, kubernetesVersion, purpose, secret, cloudProfileName, updateK8sMaintenance: k8sUpdates })
 

--- a/frontend/src/pages/NewShoot.vue
+++ b/frontend/src/pages/NewShoot.vue
@@ -157,12 +157,12 @@ export default {
   data () {
     return {
       userInterActionBus: new EventEmitter(),
-      infrastructureValid: undefined,
-      infrastructureDetailsValid: undefined,
-      detailsValid: undefined,
-      workersValid: undefined,
-      maintenanceTimeValid: undefined,
-      hibernationScheduleValid: undefined,
+      infrastructureValid: false,
+      infrastructureDetailsValid: false,
+      detailsValid: false,
+      workersValid: false,
+      maintenanceTimeValid: false,
+      hibernationScheduleValid: false,
       errorMessage: undefined,
       detailedErrorMessage: undefined,
       isShootCreated: false

--- a/frontend/src/pages/ShootDetails.vue
+++ b/frontend/src/pages/ShootDetails.vue
@@ -42,9 +42,9 @@ limitations under the License.
           <shoot-access-card :shootItem="shootItem"></shoot-access-card>
         </v-card>
 
-        <shoot-monitoring-card v-show="shootPurpose !== 'testing'" :shootItem="shootItem" class="mt-3"></shoot-monitoring-card>
+        <shoot-monitoring-card :shootItem="shootItem" class="mt-3"></shoot-monitoring-card>
 
-        <v-card v-show="isLoggingFeatureGateEnabled && shootPurpose !== 'testing'">
+        <v-card v-show="isLoggingFeatureGateEnabled">
           <v-card-title class="subheading white--text cyan darken-2 mt-3">
             Logging
           </v-card-title>

--- a/frontend/src/pages/ShootDetails.vue
+++ b/frontend/src/pages/ShootDetails.vue
@@ -42,9 +42,9 @@ limitations under the License.
           <shoot-access-card :shootItem="shootItem"></shoot-access-card>
         </v-card>
 
-        <shoot-monitoring-card :shootItem="shootItem" class="mt-3"></shoot-monitoring-card>
+        <shoot-monitoring-card v-show="shootPurpose !== 'testing'" :shootItem="shootItem" class="mt-3"></shoot-monitoring-card>
 
-        <v-card v-show="isLoggingFeatureGateEnabled">
+        <v-card v-show="isLoggingFeatureGateEnabled && shootPurpose !== 'testing'">
           <v-card-title class="subheading white--text cyan darken-2 mt-3">
             Logging
           </v-card-title>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -601,6 +601,13 @@ export default function createRouter ({ store, userManager }) {
             return store.dispatch('subscribeShoots', { name: params.name, namespace })
               .then(() => undefined)
           case 'ShootItem':
+            return Promise
+              .all([
+                store.dispatch('fetchInfrastructureSecrets'), // Required for purpose configuration
+                store.dispatch('subscribeShoot', { name: params.name, namespace }),
+                store.dispatch('subscribeComments', { name: params.name, namespace })
+              ])
+              .then(() => undefined)
           case 'ShootItemHibernationSettings':
             return Promise
               .all([

--- a/frontend/src/store/modules/shoots.js
+++ b/frontend/src/store/modules/shoots.js
@@ -287,7 +287,7 @@ const actions = {
     set(shootResource, 'metadata.name', name)
 
     const purpose = head(purposesForSecret(secret))
-    set(shootResource, 'metadata.annotations["garden.sapcloud.io/purpose"]', purpose)
+    set(shootResource, 'spec.purpose', purpose)
 
     const kubernetesVersion = head(rootGetters.sortedKubernetesVersions(cloudProfileName))
     set(shootResource, 'spec.kubernetes.version', kubernetesVersion.version)
@@ -363,7 +363,7 @@ const getRawVal = (item, column) => {
   const spec = item.spec
   switch (column) {
     case 'purpose':
-      return get(metadata, ['annotations', 'garden.sapcloud.io/purpose'])
+      return get(spec, 'purpose')
     case 'lastOperation':
       return get(item, 'status.lastOperation')
     case 'createdAt':

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -147,6 +147,12 @@ export function updateShootAddons ({ namespace, name, data }) {
   return updateResource(`/api/namespaces/${namespace}/shoots/${name}/spec/addons`, data)
 }
 
+export function updateShootPurpose ({ namespace, name, data }) {
+  namespace = encodeURIComponent(namespace)
+  name = encodeURIComponent(name)
+  return updateResource(`/api/namespaces/${namespace}/shoots/${name}/spec/purpose`, data)
+}
+
 /* Cloud Profiles */
 
 export function getCloudprofiles () {

--- a/frontend/src/utils/createShoot.js
+++ b/frontend/src/utils/createShoot.js
@@ -70,7 +70,7 @@ export function getProviderTemplate (infrastructureKind) {
           apiVersion: 'gcp.provider.extensions.gardener.cloud/v1alpha1',
           kind: 'InfrastructureConfig',
           networks: {
-            worker: workerCIDR
+            workers: workerCIDR
           }
         },
         controlPlaneConfig: {
@@ -85,7 +85,7 @@ export function getProviderTemplate (infrastructureKind) {
           apiVersion: 'openstack.provider.extensions.gardener.cloud/v1alpha1',
           kind: 'InfrastructureConfig',
           networks: {
-            worker: workerCIDR
+            workers: workerCIDR
           }
         },
         controlPlaneConfig: {
@@ -158,7 +158,7 @@ export function getDefaultZonesNetworkConfiguration (zones, infrastructureKind, 
       return map(zones, (zone, index) => {
         return {
           name: zone,
-          worker: zoneNetworksAli[index]
+          workers: zoneNetworksAli[index]
         }
       })
     default:

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -43,6 +43,8 @@ import join from 'lodash/join'
 import last from 'lodash/last'
 import sample from 'lodash/sample'
 import compact from 'lodash/compact'
+import uniq from 'lodash/uniq'
+import flatMap from 'lodash/flatMap'
 import store from '../store'
 const uuidv4 = require('uuid/v4')
 
@@ -473,7 +475,7 @@ export function selfTerminationDaysForSecret (secret) {
   }
 
   const quotas = get(secret, 'quotas')
-  let terminationDays = clusterLifetimeDays(quotas, { spec: { scope: { apiVersion: 'core.gardener.cloud/v1alpha1', kind: 'Project' } } })
+  let terminationDays = clusterLifetimeDays(quotas, { spec: { scope: { apiVersion: 'core.gardener.cloud/v1beta1', kind: 'Project' } } })
   if (!terminationDays) {
     terminationDays = clusterLifetimeDays(quotas, { spec: { scope: { apiVersion: 'v1', kind: 'Secret' } } })
   }
@@ -487,14 +489,14 @@ export function purposesForSecret (secret) {
 
 export const shootAddonList = [
   {
-    name: 'kubernetes-dashboard',
+    name: 'kubernetesDashboard',
     title: 'Dashboard',
     description: 'General-purpose web UI for Kubernetes clusters. Several high-profile attacks have shown weaknesses, so installation is not recommend, especially not for production clusters.',
     visible: true,
     enabled: false
   },
   {
-    name: 'nginx-ingress',
+    name: 'nginxIngress',
     title: 'Nginx Ingress',
     description: 'Default ingress-controller. Alternatively you may install any other ingress-controller of your liking. If you select this option, please note that Gardener will include it in its reconciliation and you can’t override it’s configuration.',
     visible: true,
@@ -597,4 +599,8 @@ export function generateWorker (availableZones, cloudProfileName, region) {
   }
 
   return worker
+}
+
+export function allErrorCodesFromLastErrors (lastErrors) {
+  return uniq(compact(flatMap(lastErrors, 'codes')))
 }

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -479,7 +479,7 @@ export function selfTerminationDaysForSecret (secret) {
 }
 
 export function purposesForSecret (secret) {
-  return selfTerminationDaysForSecret(secret) ? ['evaluation'] : ['evaluation', 'development', 'production', 'testing']
+  return selfTerminationDaysForSecret(secret) ? ['evaluation'] : ['evaluation', 'development', 'testing', 'production']
 }
 
 export const shootAddonList = [

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -448,8 +448,8 @@ export function purposeRequiresHibernationSchedule (purpose) {
 }
 
 export function isShootHasNoHibernationScheduleWarning (shoot) {
+  const purpose = get(shoot, 'spec.purpose')
   const annotations = get(shoot, 'metadata.annotations', {})
-  const purpose = annotations['garden.sapcloud.io/purpose']
   if (purposeRequiresHibernationSchedule(purpose)) {
     const hasNoScheduleFlag = !!annotations['dashboard.garden.sapcloud.io/no-hibernation-schedule']
     if (!hasNoScheduleFlag && isEmpty(get(shoot, 'spec.hibernation.schedules'))) {
@@ -484,7 +484,7 @@ export function selfTerminationDaysForSecret (secret) {
 }
 
 export function purposesForSecret (secret) {
-  return selfTerminationDaysForSecret(secret) ? ['evaluation'] : ['evaluation', 'development', 'production']
+  return selfTerminationDaysForSecret(secret) ? ['evaluation'] : ['evaluation', 'development', 'production', 'testing']
 }
 
 export const shootAddonList = [

--- a/frontend/tests/unit/NewShootDetails.spec.js
+++ b/frontend/tests/unit/NewShootDetails.spec.js
@@ -15,7 +15,7 @@
 //
 
 import { expect } from 'chai'
-import { shallowMount } from '@vue/test-utils'
+import { mount } from '@vue/test-utils'
 import NewShootDetails from '@/components/NewShoot/NewShootDetails.vue'
 import Vue from 'vue'
 import Vuetify from 'vuetify'
@@ -44,7 +44,7 @@ function createNewShootDetailsComponent (kubernetesVersion) {
   const propsData = {
     userInterActionBus: new EventEmitter()
   }
-  const wrapper = shallowMount(NewShootDetails, {
+  const wrapper = mount(NewShootDetails, {
     propsData,
     computed: {
       sortedKubernetesVersionsList: () => sampleVersions

--- a/frontend/tests/unit/store.shoots.spec.js
+++ b/frontend/tests/unit/store.shoots.spec.js
@@ -108,9 +108,11 @@ describe('Store.Shoots', function () {
             progress: 100,
             state: 'Succeeded'
           },
-          lastError: {
-            description: 'foo'
-          },
+          lastErrors: [
+            {
+              description: 'foo'
+            }
+          ],
           conditions: [
             {
               status: 'False',

--- a/frontend/tests/unit/store.shoots.spec.js
+++ b/frontend/tests/unit/store.shoots.spec.js
@@ -26,10 +26,7 @@ describe('Store.Shoots', function () {
       shoot2_foo: {
         metadata: {
           name: 'shoot2',
-          namespace: 'foo',
-          annotations: {
-            'garden.sapcloud.io/purpose': 'development'
-          }
+          namespace: 'foo'
         },
         spec: {
           creationTimestamp: '2020-01-01T20:00:00Z',
@@ -39,7 +36,8 @@ describe('Store.Shoots', function () {
           region: 'region1',
           provider: {
             type: 'infra1'
-          }
+          },
+          purpose: 'development'
         },
         status: {
           lastOperation: {
@@ -57,10 +55,7 @@ describe('Store.Shoots', function () {
       shoot1_foo: {
         metadata: {
           name: 'shoot1',
-          namespace: 'foo',
-          annotations: {
-            'garden.sapcloud.io/purpose': 'production'
-          }
+          namespace: 'foo'
         },
         spec: {
           creationTimestamp: '2020-02-01T20:00:00Z',
@@ -70,7 +65,8 @@ describe('Store.Shoots', function () {
           region: 'region1',
           provider: {
             type: 'infra2'
-          }
+          },
+          purpose: 'production'
         },
         status: {
           lastOperation: {
@@ -88,10 +84,7 @@ describe('Store.Shoots', function () {
       shoot3_foo: {
         metadata: {
           name: 'shoot3',
-          namespace: 'foo',
-          annotations: {
-            'garden.sapcloud.io/purpose': 'development'
-          }
+          namespace: 'foo'
         },
         spec: {
           creationTimestamp: '2020-01-01T20:00:00Z',
@@ -101,7 +94,8 @@ describe('Store.Shoots', function () {
           region: 'region2',
           provider: {
             type: 'infra1'
-          }
+          },
+          purpose: 'development'
         },
         status: {
           lastOperation: {
@@ -154,7 +148,7 @@ describe('Store.Shoots', function () {
     expect(sortedShoots[2].metadata.name).to.equal('shoot1')
   })
 
-  it('should sort shoots by purpose', function () {
+  it('should sort shoots by creationTimestamp', function () {
     store.dispatch('setShootListSortParams', { sortBy: 'creationTimestamp', descending: false })
 
     const sortedShoots = store.getters.shootList


### PR DESCRIPTION
**What this PR does / why we need it**:
- Updated to gardener.cloud/v1beta1 API
- Updated to new fields in infra specs
- Use spec.purpose field

**Which issue(s) this PR fixes**:
Fixes #536

**Special notes for your reviewer**:
<img width="607" alt="Screen Shot 2020-02-18 at 12 05 25" src="https://user-images.githubusercontent.com/35373687/74730916-50cd2a00-5247-11ea-8c80-e7a8d303e38d.png">

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Adapted to `gardener.cloud/v1beta1` API
```
```improvement user
Support for the new `testing` purpose. Shoots with this purpose won't get a logging or monitoring stack as part of their control planes
```
