### PR TITLE
Use spec.monitoring.alerting.emailReceivers for alertmanager tile

### DIFF
--- a/frontend/src/components/ClusterMetrics.vue
+++ b/frontend/src/components/ClusterMetrics.vue
@@ -82,7 +82,6 @@ limitations under the License.
 <script>
 import get from 'lodash/get'
 import UsernamePassword from '@/components/UsernamePasswordListTile'
-import { hasAlertmanager } from '@/utils'
 import { mapGetters } from 'vuex'
 import { shootItem } from '@/mixins/shootItem'
 
@@ -120,7 +119,8 @@ export default {
       return get(this.shootItem, 'info.monitoring_password', '')
     },
     hasAlertmanager () {
-      return hasAlertmanager(get(this.shootItem, 'metadata'))
+      const emailReceivers = get(this.shootItem, 'spec.monitoring.alerting.emailReceivers', [])
+      return emailReceivers.length > 0
     }
   }
 }

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -324,13 +324,6 @@ export function getCreatedBy (metadata) {
   return get(metadata, ['annotations', 'gardener.cloud/created-by']) || get(metadata, ['annotations', 'garden.sapcloud.io/createdBy'])
 }
 
-export function hasAlertmanager (metadata) {
-  if (get(metadata, ['annotations', 'garden.sapcloud.io/operatedBy'])) {
-    return true
-  }
-  return false
-}
-
 export function getProjectName (metadata) {
   const namespace = get(metadata, ['namespace'])
   const projectList = store.getters.projectList


### PR DESCRIPTION
**What this PR does / why we need it**:
With https://github.com/gardener/gardener/pull/1516 the `garden.sapcloud.io/operatedBy` annotation is replaced with `spec.monitoring.alerting.emailReceivers`. Gardener no longer defaults `spec.monitoring.alerting.emailReceivers` to the value of `garden.sapcloud.io/operatedBy`. `garden.sapcloud.io/operatedBy` is currently unused in g/gardener.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Dashboard does now properly uses the `spec.monitoring.alerting.emailReceivers` field to decide whether to show/hide the alertmanager URL
```
