### PR TITLE
Introduce seed-info endpoint

### DIFF
--- a/backend/lib/routes/shoots.js
+++ b/backend/lib/routes/shoots.js
@@ -182,6 +182,18 @@ router.route('/:name/info')
     }
   })
 
+router.route('/:name/seed-info')
+  .get(async (req, res, next) => {
+    try {
+      const user = req.user
+      const namespace = req.params.namespace
+      const name = req.params.name
+      res.send(await shoots.seedInfo({ user, namespace, name }))
+    } catch (err) {
+      next(err)
+    }
+  })
+
 if (_.get(config, 'frontend.features.kymaEnabled', false)) {
   router.route('/:name/kyma')
     .get(async (req, res, next) => {

--- a/backend/lib/services/shoots.js
+++ b/backend/lib/services/shoots.js
@@ -297,7 +297,7 @@ exports.info = async function ({ user, namespace, name }) {
   }
 
   const isAdmin = await authorization.isAdmin(user)
-  if (!isAdmin) { // TODO return (user) component secrets also for admin?
+  if (!isAdmin) {
     await assignComponentSecrets(client, data, namespace, name)
   }
 

--- a/backend/test/support/nocks/k8s.js
+++ b/backend/test/support/nocks/k8s.js
@@ -516,16 +516,8 @@ const stub = {
     shootServerUrl,
     shootUser,
     shootPassword,
-    monitoringUser,
-    monitoringPassword,
-    loggingUser,
-    loggingPassword,
-    seedSecretName,
     seedName
   }) {
-    const seedServerURL = 'https://seed.foo.bar:8443'
-    const technicalID = `shoot--${project}--${name}`
-
     const shootResult = getShoot({ name, project, kind, region, seed: seedName })
     shootResult.status.technicalID = `shoot--${project}--${name}`
 
@@ -544,6 +536,41 @@ const stub = {
         allowed: true
       }
     }
+
+    return [nockWithAuthorization(bearer)
+      .get(`/apis/core.gardener.cloud/v1alpha1/namespaces/${namespace}/shoots/${name}`)
+      .reply(200, () => shootResult)
+      .get(`/api/v1/namespaces/${namespace}/secrets/${name}.kubeconfig`)
+      .reply(200, () => kubecfgResult)
+      .post('/apis/authorization.k8s.io/v1/selfsubjectaccessreviews')
+      .reply(200, () => isAdminResult)]
+  },
+  getSeedInfo ({
+    bearer,
+    namespace,
+    name,
+    project,
+    kind,
+    region,
+    monitoringUser,
+    monitoringPassword,
+    loggingUser,
+    loggingPassword,
+    seedSecretName,
+    seedName
+  }) {
+    const seedServerURL = 'https://seed.foo.bar:8443'
+    const technicalID = `shoot--${project}--${name}`
+
+    const shootResult = getShoot({ name, project, kind, region, seed: seedName })
+    shootResult.status.technicalID = `shoot--${project}--${name}`
+
+    const isAdminResult = {
+      status: {
+        allowed: true
+      }
+    }
+
     const seedSecretResult = {
       data: {
         kubeconfig: encodeBase64(getKubeconfig({
@@ -568,8 +595,6 @@ const stub = {
     return [nockWithAuthorization(bearer)
       .get(`/apis/core.gardener.cloud/v1alpha1/namespaces/${namespace}/shoots/${name}`)
       .reply(200, () => shootResult)
-      .get(`/api/v1/namespaces/${namespace}/secrets/${name}.kubeconfig`)
-      .reply(200, () => kubecfgResult)
       .post('/apis/authorization.k8s.io/v1/selfsubjectaccessreviews')
       .reply(200, () => isAdminResult)
       .get(`/api/v1/namespaces/garden/secrets/${seedSecretName}`)

--- a/frontend/src/components/ClusterMetrics.vue
+++ b/frontend/src/components/ClusterMetrics.vue
@@ -16,64 +16,10 @@ limitations under the License.
 
 <template>
   <v-list>
-    <v-list-tile v-if="isAdmin">
-      <v-list-tile-action>
-        <v-icon class="cyan--text text--darken-2">developer_board</v-icon>
-      </v-list-tile-action>
-      <v-list-tile-content>
-        <v-list-tile-sub-title>Grafana</v-list-tile-sub-title>
-        <v-list-tile-title>
-          <v-tooltip v-if="isShootStatusHibernated" top>
-            <span slot="activator">{{grafanaUrlOperators}}</span>
-            Grafana is not running for hibernated clusters
-          </v-tooltip>
-          <a v-else :href="grafanaUrlOperators" target="_blank" class="cyan--text text--darken-2">{{grafanaUrlOperators}}</a>
-        </v-list-tile-title>
-      </v-list-tile-content>
-    </v-list-tile>
-    <v-list-tile v-else>
-      <v-list-tile-action>
-        <v-icon class="cyan--text text--darken-2">developer_board</v-icon>
-      </v-list-tile-action>
-      <v-list-tile-content>
-        <v-list-tile-sub-title>Grafana</v-list-tile-sub-title>
-        <v-list-tile-title>
-          <v-tooltip v-if="isShootStatusHibernated" top>
-            <span slot="activator">{{grafanaUrlUsers}}</span>
-            Grafana is not running for hibernated clusters
-          </v-tooltip>
-          <a v-else :href="grafanaUrlUsers" target="_blank" class="cyan--text text--darken-2">{{grafanaUrlUsers}}</a>
-        </v-list-tile-title>
-      </v-list-tile-content>
-    </v-list-tile>
-    <v-list-tile v-if="isAdmin">
-      <v-list-tile-action>
-      </v-list-tile-action>
-      <v-list-tile-content>
-        <v-list-tile-sub-title>Prometheus</v-list-tile-sub-title>
-        <v-list-tile-title>
-          <v-tooltip v-if="isShootStatusHibernated" top>
-            <span slot="activator">{{prometheusUrl}}</span>
-            Prometheus is not running for hibernated clusters
-          </v-tooltip>
-          <a v-else :href="prometheusUrl" target="_blank" class="cyan--text text--darken-2">{{prometheusUrl}}</a>
-        </v-list-tile-title>
-      </v-list-tile-content>
-    </v-list-tile>
-    <v-list-tile v-if="hasAlertmanager">
-      <v-list-tile-action>
-      </v-list-tile-action>
-      <v-list-tile-content>
-        <v-list-tile-sub-title>Alertmanager</v-list-tile-sub-title>
-        <v-list-tile-title>
-          <v-tooltip v-if="isShootStatusHibernated" top>
-            <span slot="activator">{{alertmanagerUrl}}</span>
-            Alertmanager is not running for hibernated clusters
-          </v-tooltip>
-          <a v-else :href="alertmanagerUrl" target="_blank" class="cyan--text text--darken-2">{{alertmanagerUrl}}</a>
-        </v-list-tile-title>
-      </v-list-tile-content>
-    </v-list-tile>
+    <link-list-tile v-if="isAdmin" icon="developer_board" appTitle="Grafana" :url="grafanaUrlOperators" :urlText="grafanaUrlOperators" :isShootStatusHibernated="isShootStatusHibernated"></link-list-tile>
+    <link-list-tile v-else icon="developer_board" appTitle="Grafana" :url="grafanaUrlUsers" :urlText="grafanaUrlUsers" :isShootStatusHibernated="isShootStatusHibernated"></link-list-tile>
+    <link-list-tile v-if="isAdmin" appTitle="Prometheus" :url="prometheusUrl" :urlText="prometheusUrl" :isShootStatusHibernated="isShootStatusHibernated"></link-list-tile>
+    <link-list-tile v-if="hasAlertmanager" appTitle="Alertmanager" :url="alertmanagerUrl" :urlText="alertmanagerUrl" :isShootStatusHibernated="isShootStatusHibernated"></link-list-tile>
     <v-divider v-show="!!username && !!password" class="my-2" inset></v-divider>
     <username-password :username="username" :password="password"></username-password>
   </v-list>
@@ -82,12 +28,14 @@ limitations under the License.
 <script>
 import get from 'lodash/get'
 import UsernamePassword from '@/components/UsernamePasswordListTile'
+import LinkListTile from '@/components/LinkListTile'
 import { mapGetters } from 'vuex'
 import { shootItem } from '@/mixins/shootItem'
 
 export default {
   components: {
-    UsernamePassword
+    UsernamePassword,
+    LinkListTile
   },
   props: {
     shootItem: {
@@ -113,10 +61,10 @@ export default {
       return get(this.shootItem, 'info.alertmanagerUrl', '')
     },
     username () {
-      return get(this.shootItem, 'info.monitoring_username', '')
+      return this.isAdmin ? get(this.shootItem, 'seedInfo.monitoring_username', '') : get(this.shootItem, 'info.monitoring_username', '')
     },
     password () {
-      return get(this.shootItem, 'info.monitoring_password', '')
+      return this.isAdmin ? get(this.shootItem, 'seedInfo.monitoring_password', '') : get(this.shootItem, 'info.monitoring_password', '')
     },
     hasAlertmanager () {
       const emailReceivers = get(this.shootItem, 'spec.monitoring.alerting.emailReceivers', [])

--- a/frontend/src/components/LinkListTile.vue
+++ b/frontend/src/components/LinkListTile.vue
@@ -1,0 +1,59 @@
+<!--
+Copyright (c) 2019 by SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<template>
+  <v-list-tile>
+    <v-list-tile-action>
+      <v-icon v-if="icon" class="cyan--text text--darken-2">{{icon}}</v-icon>
+    </v-list-tile-action>
+    <v-list-tile-content>
+      <v-list-tile-sub-title>{{appTitle}}</v-list-tile-sub-title>
+      <v-list-tile-title>
+        <v-tooltip v-if="isShootStatusHibernated" top>
+          <span slot="activator">{{urlText}}</span>
+          {{appTitle}} is not running for hibernated clusters
+        </v-tooltip>
+        <a v-else :href="url" target="_blank" class="cyan--text text--darken-2">{{urlText}}</a>
+      </v-list-tile-title>
+    </v-list-tile-content>
+  </v-list-tile>
+</template>
+
+<script>
+
+export default {
+  props: {
+    appTitle: {
+      type: String,
+      required: true
+    },
+    url: {
+      type: String,
+      required: true
+    },
+    urlText: {
+      type: String,
+      required: true
+    },
+    icon: {
+      type: String
+    },
+    isShootStatusHibernated: {
+      type: Boolean
+    }
+  }
+}
+</script>

--- a/frontend/src/components/ShootDetails/ShootAccessCard.vue
+++ b/frontend/src/components/ShootDetails/ShootAccessCard.vue
@@ -38,21 +38,7 @@ limitations under the License.
 
     <v-divider v-if="isTerminalTileVisible && (isDashboardTileVisible || isCredentialsTileVisible || isKubeconfigTileVisible)" class="my-2" inset></v-divider>
 
-    <v-list-tile v-if="isDashboardTileVisible && !hasDashboardTokenAuth">
-      <v-list-tile-action>
-        <v-icon class="cyan--text text--darken-2">developer_board</v-icon>
-      </v-list-tile-action>
-      <v-list-tile-content>
-        <v-list-tile-sub-title>Dashboard</v-list-tile-sub-title>
-        <v-list-tile-title>
-          <v-tooltip v-if="isShootStatusHibernated" top>
-            <span class="grey--text" slot="activator">{{dashboardUrlText}}</span>
-            Dashboard is not running for hibernated clusters
-          </v-tooltip>
-          <a v-else :href="dashboardUrl" target="_blank" class="cyan--text text--darken-2">{{dashboardUrlText}}</a>
-        </v-list-tile-title>
-      </v-list-tile-content>
-    </v-list-tile>
+    <link-list-tile v-if="isDashboardTileVisible && !hasDashboardTokenAuth" icon="developer_board" appTitle="Dashboard" :url="dashboardUrl" :urlText="dashboardUrlText" :isShootStatusHibernated="isShootStatusHibernated"></link-list-tile>
 
     <template v-if="isDashboardTileVisible && hasDashboardTokenAuth">
       <v-list-tile>
@@ -152,6 +138,7 @@ import UsernamePassword from '@/components/UsernamePasswordListTile'
 import CopyBtn from '@/components/CopyBtn'
 import CodeBlock from '@/components/CodeBlock'
 import TerminalListTile from '@/components/TerminalListTile'
+import LinkListTile from '@/components/LinkListTile'
 import get from 'lodash/get'
 import isEmpty from 'lodash/isEmpty'
 import download from 'downloadjs'
@@ -163,7 +150,8 @@ export default {
     UsernamePassword,
     CodeBlock,
     CopyBtn,
-    TerminalListTile
+    TerminalListTile,
+    LinkListTile
   },
   props: {
     shootItem: {

--- a/frontend/src/components/ShootDetails/ShootAddonKymaCard.vue
+++ b/frontend/src/components/ShootDetails/ShootAddonKymaCard.vue
@@ -27,21 +27,7 @@ limitations under the License.
       </v-list-tile-content>
     </v-list-tile>
 
-    <v-list-tile v-if="isConsoleTileVisible">
-      <v-list-tile-action>
-        <v-icon class="cyan--text text--darken-2">developer_board</v-icon>
-      </v-list-tile-action>
-      <v-list-tile-content>
-        <v-list-tile-sub-title>Console</v-list-tile-sub-title>
-        <v-list-tile-title>
-          <v-tooltip v-if="isShootStatusHibernated" top>
-            <span class="grey--text" slot="activator">{{consoleUrl}}</span>
-            Console is not running for hibernated clusters
-          </v-tooltip>
-          <a v-else :href="consoleUrl" target="_blank" class="cyan--text text--darken-2">{{consoleUrl}}</a>
-        </v-list-tile-title>
-      </v-list-tile-content>
-    </v-list-tile>
+    <link-list-tile v-if="isConsoleTileVisible" icon="developer_board" appTitle="Console" :url="consoleUrl" :urlText="consoleUrl" :isShootStatusHibernated="isShootStatusHibernated"></link-list-tile>
 
     <v-divider v-if="isConsoleTileVisible && isCredentialsTileVisible" class="my-2" inset></v-divider>
 
@@ -51,13 +37,15 @@ limitations under the License.
 
 <script>
 import UsernamePassword from '@/components/UsernamePasswordListTile'
+import LinkListTile from '@/components/LinkListTile'
 import { shootItem } from '@/mixins/shootItem'
 import get from 'lodash/get'
 import { shootAddonByName } from '@/utils'
 
 export default {
   components: {
-    UsernamePassword
+    UsernamePassword,
+    LinkListTile
   },
   props: {
     shootItem: {

--- a/frontend/src/components/ShootDetails/ShootLogging.vue
+++ b/frontend/src/components/ShootDetails/ShootLogging.vue
@@ -16,21 +16,7 @@ limitations under the License.
 
 <template>
   <v-list>
-    <v-list-tile v-show="!!kibanaUrl">
-      <v-list-tile-action>
-        <v-icon class="cyan--text text--darken-2">developer_board</v-icon>
-      </v-list-tile-action>
-      <v-list-tile-content>
-        <v-list-tile-sub-title>Kibana</v-list-tile-sub-title>
-        <v-list-tile-title>
-          <v-tooltip v-if="isShootStatusHibernated" top>
-            <span slot="activator">{{kibanaUrl}}</span>
-            Kibana is not running for hibernated clusters
-          </v-tooltip>
-          <a v-else :href="kibanaUrl" target="_blank" class="cyan--text text--darken-2">{{kibanaUrl}}</a>
-        </v-list-tile-title>
-      </v-list-tile-content>
-    </v-list-tile>
+    <link-list-tile v-if="!!kibanaUrl" icon="developer_board" appTitle="Kibana" :url="kibanaUrl" :urlText="kibanaUrl" :isShootStatusHibernated="isShootStatusHibernated"></link-list-tile>
     <v-divider v-show="!!username && !!password" class="my-2" inset></v-divider>
     <username-password :username="username" :password="password"></username-password>
   </v-list>
@@ -38,12 +24,15 @@ limitations under the License.
 
 <script>
 import UsernamePassword from '@/components/UsernamePasswordListTile'
+import LinkListTile from '@/components/LinkListTile'
 import get from 'lodash/get'
+import { mapGetters } from 'vuex'
 import { shootItem } from '@/mixins/shootItem'
 
 export default {
   components: {
-    UsernamePassword
+    UsernamePassword,
+    LinkListTile
   },
   props: {
     shootItem: {
@@ -52,14 +41,17 @@ export default {
   },
   mixins: [shootItem],
   computed: {
+    ...mapGetters([
+      'isAdmin'
+    ]),
     kibanaUrl () {
       return get(this.shootItem, 'info.kibanaUrl', '')
     },
     username () {
-      return get(this.shootItem, 'info.logging_username', '')
+      return this.isAdmin ? get(this.shootItem, 'seedInfo.logging_username', '') : get(this.shootItem, 'info.logging_username', '')
     },
     password () {
-      return get(this.shootItem, 'info.logging_password', '')
+      return this.isAdmin ? get(this.shootItem, 'seedInfo.logging_password', '') : get(this.shootItem, 'info.logging_password', '')
     }
   }
 }

--- a/frontend/src/pages/ShootDetails.vue
+++ b/frontend/src/pages/ShootDetails.vue
@@ -117,11 +117,16 @@ export default {
     info () {
       return get(this, 'value.info', {})
     },
+    seedInfo () {
+      return get(this, 'value.seedInfo', {})
+    },
     shootItem () {
       return get(this, 'value', {})
     },
     isLoggingFeatureGateEnabled () {
-      return !!this.info.logging_username && !!this.info.logging_password
+      const userCredentialsAvailable = !!this.info.logging_username && !!this.info.logging_password
+      const adminCredentialsAvailable = !!this.seedInfo.logging_username && !!this.seedInfo.logging_password
+      return userCredentialsAvailable || adminCredentialsAvailable
     },
     journals () {
       const params = this.$route.params

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -563,6 +563,12 @@ const actions = {
         dispatch('setError', err)
       })
   },
+  getShootSeedInfo ({ dispatch, commit }, { name, namespace }) {
+    return dispatch('shoots/getSeedInfo', { name, namespace })
+      .catch(err => {
+        dispatch('setError', err)
+      })
+  },
   getShootAddonKyma ({ dispatch, commit }, { name, namespace }) {
     return dispatch('shoots/getAddonKyma', { name, namespace })
       .catch(err => {

--- a/frontend/src/utils/Emitter.js
+++ b/frontend/src/utils/Emitter.js
@@ -202,9 +202,12 @@ class ShootSubscription extends AbstractSubscription {
       const { name, namespace } = target
       throttledNsEventEmitter.flush()
       try {
-        await store.dispatch('getShootInfo', { name, namespace })
+        await Promise.all([
+          store.dispatch('getShootInfo', { name, namespace }),
+          store.dispatch('getShootSeedInfo', { name, namespace })
+        ])
       } catch (err) {
-        console.error('SubscribeShootDone Error:', err.message)
+        console.error('SubscribeShootDone error:', err.message)
       }
     })
   }

--- a/frontend/src/utils/Emitter.js
+++ b/frontend/src/utils/Emitter.js
@@ -201,11 +201,14 @@ class ShootSubscription extends AbstractSubscription {
     this.socket.on('shootSubscriptionDone', async ({ kind, target }) => {
       const { name, namespace } = target
       throttledNsEventEmitter.flush()
+      const promises = [
+        store.dispatch('getShootInfo', { name, namespace })
+      ]
+      if (store.getters.isAdmin) {
+        promises.push(store.dispatch('getShootSeedInfo', { name, namespace }))
+      }
       try {
-        await Promise.all([
-          store.dispatch('getShootInfo', { name, namespace }),
-          store.dispatch('getShootSeedInfo', { name, namespace })
-        ])
+        await Promise.all(promises)
       } catch (err) {
         console.error('SubscribeShootDone error:', err.message)
       }

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -93,16 +93,16 @@ export function addShootAnnotation ({ namespace, name, data }) {
   return patchResource(`/api/namespaces/${namespace}/shoots/${name}/metadata/annotations`, data)
 }
 
-export function getShoot ({ namespace, name }) {
-  namespace = encodeURIComponent(namespace)
-  name = encodeURIComponent(name)
-  return getResource(`/api/namespaces/${namespace}/shoots/${name}`)
-}
-
 export function getShootInfo ({ namespace, name }) {
   namespace = encodeURIComponent(namespace)
   name = encodeURIComponent(name)
   return getResource(`/api/namespaces/${namespace}/shoots/${name}/info`)
+}
+
+export function getShootSeedInfo ({ namespace, name }) {
+  namespace = encodeURIComponent(namespace)
+  name = encodeURIComponent(name)
+  return getResource(`/api/namespaces/${namespace}/shoots/${name}/seed-info`)
 }
 
 export function getShootAddonKyma ({ namespace, name }) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces a `shoots/:name/seed-info` endpoint which is used to fetch data from the seed cluster, which was previously done in the `shoots/:name/info` endpoint. See #581 for more details.

**Which issue(s) this PR fixes**:
Fixes #581 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The `kubeconfig` on the cluster details page is shown much faster for clusters of which the seed is isolated / air-gapped
```
