### PR TITLE
Fix unknown vendor icon

### DIFF
--- a/frontend/src/components/VendorIcon.vue
+++ b/frontend/src/components/VendorIcon.vue
@@ -17,11 +17,13 @@ limitations under the License.
 <template>
   <span>
     <img v-if="iconSrc" :src="iconSrc" :width="getWidth" :height="getHeight" :class="contentClass" style="vertical-align:middle">
-    <v-icon v-else :class="contentClass" style="font-size:1.5em">{{value}}</v-icon>
+    <v-icon v-else-if="isMdiIcon" :class="contentClass" style="font-size:1.5em">{{value}}</v-icon>
+    <v-icon v-else :class="contentClass" class="cyan--text text--darken-2" style="font-size:1.5em">mdi-blur-radial</v-icon>
   </span>
 </template>
 
 <script>
+import startsWith from 'lodash/startsWith'
 
 export default {
   props: {
@@ -87,6 +89,9 @@ export default {
         return 20
       }
       return this.width
+    },
+    isMdiIcon () {
+      return startsWith(this.value, 'mdi-')
     }
   }
 }

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -117,13 +117,6 @@ const vendorNameFromImageName = imageName => {
   return undefined
 }
 
-const iconForVendor = vendorName => {
-  if (!vendorName) {
-    return 'mdi-blur-radial'
-  }
-  return vendorName
-}
-
 const vendorNeedsLicense = vendorName => {
   return vendorName === 'suse-jeos'
 }
@@ -241,7 +234,7 @@ const getters = {
             expirationDate,
             expirationDateString: getDateFormatted(expirationDate),
             vendorName,
-            icon: iconForVendor(vendorName),
+            icon: vendorName,
             needsLicense: vendorNeedsLicense(vendorName)
           }
         })

--- a/frontend/tests/unit/store.index.spec.js
+++ b/frontend/tests/unit/store.index.spec.js
@@ -87,7 +87,6 @@ describe('Store', function () {
     expect(suseImage).to.equal(dashboardMachineImages[1]) // check sorting
 
     const fooImage = find(dashboardMachineImages, { name: 'foo', version: '1.2.3' })
-    expect(fooImage.icon).to.equal('mdi-blur-radial')
     expect(fooImage.needsLicense).to.equal(false)
   })
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Old behaviour:
<img width="331" alt="Screenshot 2020-02-26 at 17 27 21" src="https://user-images.githubusercontent.com/5526658/75365283-46e99d80-58bd-11ea-8d45-2ae26b19d797.png">

New behaviour:
<img width="311" alt="Screenshot 2020-02-26 at 17 23 23" src="https://user-images.githubusercontent.com/5526658/75364900-b743ef00-58bc-11ea-97c2-7e9a1b4f990c.png">
A placeholder icon is shown for infrastructures that are unknown for the dashboard.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
A placeholder icon is shown for infrastructures that are unknown for the dashboard
```
