### PR TITLE
Show last errors header only if there are errors

### DIFF
--- a/frontend/src/components/ShootStatus.vue
+++ b/frontend/src/components/ShootStatus.vue
@@ -41,14 +41,16 @@ limitations under the License.
       </v-tooltip>
     </div>
     <ansi-text v-if="!!popperMessage" :text="popperMessage"></ansi-text>
-    <v-divider class="my-2"></v-divider>
-    <h4 class="error--text text-xs-left">Last Errors</h4>
-    <div v-for="(lastErrorDescription, index) in lastErrorDescriptions" :key="index">
-      <template v-for="errorCodeDescription in lastErrorDescription.errorCodeDescriptions">
-        <h3 class="error--text text-xs-left" :key="errorCodeDescription">{{errorCodeDescription}}</h3>
-      </template>
-      <ansi-text class="error--text" :text="lastErrorDescription.description"></ansi-text>
-    </div>
+    <template v-if="lastErrorDescriptions.length">
+      <v-divider class="my-2"></v-divider>
+      <h4 class="error--text text-xs-left">Last Errors</h4>
+      <div v-for="(lastErrorDescription, index) in lastErrorDescriptions" :key="index">
+        <template v-for="errorCodeDescription in lastErrorDescription.errorCodeDescriptions">
+          <h3 class="error--text text-xs-left" :key="errorCodeDescription">{{errorCodeDescription}}</h3>
+        </template>
+        <ansi-text class="error--text" :text="lastErrorDescription.description"></ansi-text>
+      </div>
+    </template>
   </g-popper>
 </template>
 


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Fixed: `Last Errors` heading in cluster status popup was always visible, also for clusters without errors
```
