### PR TITLE
Require costObject on project

### DIFF
--- a/backend/lib/services/infrastructureSecrets.js
+++ b/backend/lib/services/infrastructureSecrets.js
@@ -16,7 +16,7 @@
 
 const _ = require('lodash')
 const logger = require('../logger')
-const { Resources } = require('../kubernetes-client')
+const { dashboardClient, Resources, isHttpError } = require('../kubernetes-client')
 const { UnprocessableEntity, PreconditionFailed, MethodNotAllowed } = require('../errors')
 const { format: fmt } = require('util')
 const { decodeBase64, encodeBase64 } = require('../utils')
@@ -25,8 +25,9 @@ const cloudprofiles = require('./cloudprofiles')
 const shoots = require('./shoots')
 const { getQuotas } = require('../cache')
 
-function fromResource ({ secretBinding, cloudProviderKind, secret, quotas = [] }) {
+function fromResource ({ secretBinding, cloudProviderKind, secret, project, quotas = [] }) {
   const cloudProfileName = secretBinding.metadata.labels['cloudprofile.garden.sapcloud.io/name']
+  const costObject = _.get(project, 'metadata.annotations["billing.gardener.cloud/costObject"]')
 
   const infrastructureSecret = {}
   infrastructureSecret.metadata = _
@@ -36,7 +37,9 @@ function fromResource ({ secretBinding, cloudProviderKind, secret, quotas = [] }
       cloudProviderKind,
       cloudProfileName,
       bindingNamespace: _.get(secretBinding, 'metadata.namespace'),
-      bindingName: _.get(secretBinding, 'metadata.name')
+      bindingName: _.get(secretBinding, 'metadata.name'),
+      hasCostObject: !_.isEmpty(costObject),
+      projectName: _.get(project, 'metadata.name')
     })
     .value()
 
@@ -129,7 +132,7 @@ function resolveQuotas (secretBinding) {
   }
 }
 
-async function getInfrastructureSecrets ({ secretBindings, cloudProfileList, secretList }) {
+async function getInfrastructureSecrets ({ secretBindings, cloudProfileList, secretList, projectMap, namespace }) {
   return _
     .chain(secretBindings)
     .map(secretBinding => {
@@ -138,6 +141,11 @@ async function getInfrastructureSecrets ({ secretBindings, cloudProfileList, sec
         const cloudProfile = _.find(cloudProfileList, ['metadata.name', cloudProfileName])
         const cloudProviderKind = _.get(cloudProfile, 'metadata.cloudProviderKind')
         const secretName = _.get(secretBinding, 'secretRef.name')
+        const secretNamespace = _.get(secretBinding, 'secretRef.namespace', namespace)
+        const project = projectMap[secretNamespace]
+        if (!project) {
+          throw new Error(fmt('Could not determine project for namespace %s', secretNamespace))
+        }
         if (!cloudProviderKind) {
           throw new Error(fmt('Could not determine cloud provider kind for cloud profile name %s. Skipping infrastructure secret with name %s', cloudProfileName, secretName))
         }
@@ -149,6 +157,7 @@ async function getInfrastructureSecrets ({ secretBindings, cloudProfileList, sec
           secretBinding,
           cloudProviderKind,
           secret,
+          project,
           quotas: resolveQuotas(secretBinding)
         })
       } catch (err) {
@@ -177,10 +186,35 @@ exports.list = async function ({ user, namespace }) {
       client.core.secrets.list(namespace),
       client['core.gardener.cloud'].secretbindings.list(namespace)
     ])
+
+    const getProjectPromises = _
+      .chain(secretBindings)
+      .map('secretRef.namespace')
+      .uniq()
+      .map(ns => {
+        if (!_.isEmpty(ns)) {
+          return ns
+        }
+        return namespace
+      })
+      /* reading projects with dashboard client as the referenced secret can be from a different project to which the user has no access.
+      we need to fetch the project name and hasCostObject info and pass it to the user (which is not a sensitive information, thus we can use the dashboard client) */
+      .map(ns => dashboardClient.getProjectByNamespace(ns).catch(err => {
+        if (isHttpError(err, 404)) {
+          return
+        }
+        throw err
+      }))
+      .value()
+
+    const projects = await Promise.all(getProjectPromises)
+    const projectMap = _.keyBy(projects, 'spec.namespace')
+
     return getInfrastructureSecrets({
       secretBindings,
       cloudProfileList,
-      secretList
+      secretList,
+      projectMap
     })
   } catch (err) {
     logger.error(err)
@@ -196,10 +230,17 @@ exports.create = async function ({ user, namespace, body }) {
   const secretBinding = await client['core.gardener.cloud'].secretbindings.create(namespace, toSecretBindingResource(body))
 
   const cloudProfileName = _.get(body, 'metadata.cloudProfileName')
-  const cloudProviderKind = await getCloudProviderKind(cloudProfileName)
+  const [
+    cloudProviderKind,
+    project
+  ] = await Promise.all([
+    getCloudProviderKind(cloudProfileName),
+    client.getProjectByNamespace(namespace)
+  ])
   return fromResource({
     secretBinding,
     secret,
+    project,
     cloudProviderKind,
     quotas: resolveQuotas(secretBinding)
   })
@@ -225,11 +266,18 @@ exports.patch = async function ({ user, namespace, bindingName, body }) {
   const secret = await client.core.secrets.mergePatch(namespace, secretName, toSecretResource(body))
 
   const cloudProfileName = _.get(body, 'metadata.cloudProfileName')
-  const cloudProviderKind = await getCloudProviderKind(cloudProfileName)
+  const [
+    cloudProviderKind,
+    project
+  ] = await Promise.all([
+    getCloudProviderKind(cloudProfileName),
+    client.getProjectByNamespace(namespace)
+  ])
 
   return fromResource({
     secretBinding,
     secret,
+    project,
     cloudProviderKind,
     quotas: resolveQuotas(secretBinding)
   })

--- a/backend/test/acceptance/api.infrastructureSecrets.spec.js
+++ b/backend/test/acceptance/api.infrastructureSecrets.spec.js
@@ -23,6 +23,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
   /* eslint no-unused-expressions: 0 */
   const name = 'bar'
   const project = 'foo'
+  const hasCostObject = true
   const namespace = `garden-${project}`
   const bindingName = `${name}-sb`
   const cloudProfileName = 'infra1-profileName'
@@ -49,6 +50,8 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
     expect(res).to.be.json
     expect(res.body).to.have.length(3)
     _.forEach(res.body, secret => {
+      expect(secret.metadata).to.have.property('hasCostObject')
+      expect(secret.metadata).to.have.property('projectName')
       expect(secret.quotas).to.have.length(2)
     })
   })
@@ -79,7 +82,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
 
     expect(res).to.have.status(200)
     expect(res).to.be.json
-    expect(res.body.metadata).to.eql({ name, namespace, resourceVersion, bindingName, bindingNamespace: namespace, cloudProfileName, cloudProviderKind })
+    expect(res.body.metadata).to.eql({ name, namespace, resourceVersion, bindingName, bindingNamespace: namespace, cloudProfileName, cloudProviderKind, hasCostObject, projectName: project })
     expect(res.body.data).to.have.own.property('key')
     expect(res.body.data).to.have.own.property('secret')
   })
@@ -96,7 +99,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
 
     expect(res).to.have.status(200)
     expect(res).to.be.json
-    expect(res.body.metadata).to.eql({ name, namespace, bindingName, cloudProfileName, bindingNamespace: namespace, cloudProviderKind, resourceVersion })
+    expect(res.body.metadata).to.eql({ name, namespace, bindingName, cloudProfileName, bindingNamespace: namespace, cloudProviderKind, resourceVersion, hasCostObject, projectName: project })
     expect(res.body.data).to.have.own.property('key')
     expect(res.body.data).to.have.own.property('secret')
   })

--- a/backend/test/acceptance/api.projects.spec.js
+++ b/backend/test/acceptance/api.projects.spec.js
@@ -25,6 +25,9 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
   /* eslint no-unused-expressions: 0 */
   const name = 'foo'
   const namespace = `garden-${name}`
+  const annotations = {
+    'billing.gardener.cloud/costObject': '9999999999'
+  }
   const metadata = { name }
   const username = `${name}@example.org`
   const id = username
@@ -57,7 +60,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
 
     expect(res).to.have.status(200)
     expect(res).to.be.json
-    expect(res.body).to.have.length(3)
+    expect(res.body).to.have.length(4)
   })
 
   it('should return the foo project', async function () {
@@ -70,7 +73,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
 
     expect(res).to.have.status(200)
     expect(res).to.be.json
-    expect(res.body.metadata).to.eql({ name, namespace, resourceVersion, role })
+    expect(res.body.metadata).to.eql({ name, namespace, annotations, resourceVersion, role })
   })
 
   it('should reject request with authorization error', async function () {
@@ -101,7 +104,8 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
       owner,
       description,
       purpose,
-      phase: 'Initial'
+      phase: 'Initial',
+      costObject: '9999999999'
     })
     // project with initializer
     const newProject = _.cloneDeep(project)
@@ -129,7 +133,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
     expect(watchStub).to.have.been.calledOnce
     expect(res).to.have.status(200)
     expect(res).to.be.json
-    expect(res.body.metadata).to.eql({ name, namespace, resourceVersion, role })
+    expect(res.body.metadata).to.eql({ name, namespace, annotations, resourceVersion, role })
     expect(res.body.data).to.eql({ createdBy, owner, description, purpose })
   })
 
@@ -192,7 +196,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
 
     expect(res).to.have.status(200)
     expect(res).to.be.json
-    expect(res.body.metadata).to.eql({ name, namespace, resourceVersion, role })
+    expect(res.body.metadata).to.eql({ name, namespace, annotations, resourceVersion, role })
     expect(res.body.data).to.eql({ createdBy, owner, description, purpose })
   })
 

--- a/frontend/src/dialogs/ProjectDialog.vue
+++ b/frontend/src/dialogs/ProjectDialog.vue
@@ -87,10 +87,6 @@ limitations under the License.
                   ref="description"
                   label="Description"
                   v-model="description"
-                  :error-messages="getFieldValidationErrors('description')"
-                  @input="$v.description.$touch()"
-                  @blur="$v.description.$touch()"
-                  counter="50"
                   ></v-text-field>
               </v-flex>
             </v-layout>
@@ -267,9 +263,6 @@ export default {
             }
             return RegExp(this.costObjectRegex).test(value || '') // undefined cannot be evaluated, use empty string as default
           }
-        },
-        description: {
-          maxLength: maxLength(50)
         }
       }
       if (this.isCreateMode) {
@@ -286,9 +279,6 @@ export default {
     },
     validationErrors () {
       return {
-        description: {
-          maxLength: 'Description exceeds the maximum length'
-        },
         projectName: {
           required: 'Name is required',
           maxLength: 'Name exceeds the maximum length',

--- a/frontend/src/utils/validators.js
+++ b/frontend/src/utils/validators.js
@@ -17,6 +17,7 @@
 import { withParams, regex, ref } from 'vuelidate/lib/validators/common'
 import { minValue } from 'vuelidate/lib/validators'
 import includes from 'lodash/includes'
+import get from 'lodash/get'
 import { parseSize } from '@/utils'
 
 const base64Pattern = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/
@@ -53,6 +54,15 @@ const unique = key => withParams({ type: 'unique', key },
 const uniqueWorkerName = withParams({ type: 'uniqueWorkerName' },
   function unique (value) {
     return this.workers.filter(item => item.name === value).length === 1
+  }
+)
+
+const requiresCostObjectIfEnabled = withParams({ type: 'requiresCostObjectIfEnabled' },
+  function (infrastructureSecret) {
+    if (!this.costObjectSettingEnabled) {
+      return true
+    }
+    return get(infrastructureSecret, 'metadata.hasCostObject', false)
   }
 )
 
@@ -99,5 +109,6 @@ export {
   includesIfAvailable,
   minVolumeSize,
   uniqueWorkerName,
-  numberOrPercentage
+  numberOrPercentage,
+  requiresCostObjectIfEnabled
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
If `costObject` is configured in `values.yaml`, the project (in which the infrastructure secret resides) must have a cost object set in order to be able to create a cluster.

<img width="1428" alt="Screenshot 2020-03-05 at 17 53 41" src="https://user-images.githubusercontent.com/5526658/76004754-4dee5c80-5f0a-11ea-862b-852788ebaaa3.png">

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
If the `costObject` feature is enabled by the gardener administrator, projects must have a cost object set in order to be able to create a cluster
```
