### PR TITLE
Allow to create multiple journals per cluster

### DIFF
--- a/frontend/src/components/ShootDetails/ShootJournalsCard.vue
+++ b/frontend/src/components/ShootDetails/ShootJournalsCard.vue
@@ -32,6 +32,12 @@ limitations under the License.
         <v-spacer></v-spacer>
       </v-card-actions>
     </v-card>
+    <v-layout v-if="journals.length && !!gitHubRepoUrl" align-center justify-center row>
+      <v-btn flat class="action-button cyan--text text--darken-2 mt-3" :href="createJournalLink" target="_blank" title="Create Journal">
+        Create Journal
+        <v-icon color="cyan darken-2" class="link-icon pl-2">mdi-open-in-new</v-icon>
+      </v-btn>
+    </v-layout>
   </div>
 
 </template>

--- a/frontend/src/components/ShootJournals/JournalComment.vue
+++ b/frontend/src/components/ShootJournals/JournalComment.vue
@@ -16,7 +16,7 @@ limitations under the License.
 
 <template>
   <v-layout>
-    <v-flex xs1>
+    <v-flex style="max-width: 60px;">
       <v-avatar size="40px">
         <img :src="avatarUrl" :title="login"/>
       </v-avatar>


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR you can now create multiple journals for different issues per shoot cluster. The `Create Journal` button is always visible (journal feature must be configured).
<img width="1154" alt="Screenshot 2020-03-10 at 11 14 43" src="https://user-images.githubusercontent.com/5526658/76307601-6d4e0680-62c9-11ea-9874-21769f0ec1b9.png">

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
You can now create multiple journals per shoot
```
