### PR TITLE
Make webhook secret optional

### DIFF
--- a/charts/gardener-dashboard/templates/secret-github.yaml
+++ b/charts/gardener-dashboard/templates/secret-github.yaml
@@ -13,5 +13,7 @@ type: Opaque
 data:
   authentication.username: {{ required ".Values.gitHub.authentication.username is required" (b64enc .Values.gitHub.authentication.username) }}
   authentication.token: {{ required ".Values.gitHub.authentication.token is required" (b64enc .Values.gitHub.authentication.token) }}
-  webhookSecret: {{ required ".Values.gitHub.webhookSecret is required" (b64enc .Values.gitHub.webhookSecret) }}
+  {{- if .Values.gitHub.webhookSecret }}
+  webhookSecret: {{ b64enc .Values.gitHub.webhookSecret }}
+  {{- end }}
 {{- end }}

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -101,7 +101,7 @@ gitHub:
   apiUrl: https://api.foo-github.com
   org: dummyorg
   repository: dummyrepo
-  webhookSecret: foobar
+  webhookSecret: foobar # optional if pollIntervalSeconds is defined
   authentication:
     username: dashboard
     token: dummytoken


### PR DESCRIPTION
**What this PR does / why we need it**:
With the introduction of #607, the webhook secret is now optional when configuring `github. pollIntervalSeconds`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user

```
