### PR TITLE
Bug/uncaught undefined

### DIFF
--- a/frontend/src/dialogs/ProjectDialog.vue
+++ b/frontend/src/dialogs/ProjectDialog.vue
@@ -315,7 +315,6 @@ export default {
           const project = await this.save()
           this.loading = false
           this.hide()
-          this.$emit('submit', project)
           if (this.isCreateMode) {
             this.$router.push({
               name: 'Secrets',

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -33,7 +33,7 @@ limitations under the License.
           <span>You are not authorized to create projects</span>
         </v-tooltip>
       </v-card-text>
-      <project-create-dialog @submit="onProjectCreated" v-model="projectDialog">
+      <project-create-dialog v-model="projectDialog">
       </project-create-dialog>
     </v-card>
   </v-container>
@@ -75,18 +75,6 @@ export default {
   mounted () {
     if (this.$route.path === '/namespace/+') {
       this.projectDialog = true
-    }
-  },
-  methods: {
-    onProjectCreated ({ metadata } = {}) {
-      const name = 'ShootList'
-      let namespace = metadata.namespace
-      if (!namespace) {
-        namespace = this.namespaces[0]
-      }
-      if (namespace) {
-        this.$router.push({ name, params: { namespace } })
-      }
     }
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the error in the browser console that appears when creating your first project.
This happened because both in 
- `ProjectDialog.vue` https://github.com/gardener/dashboard/blob/85d37eb731bc40670f6bfe21cb34b16c673ade46/frontend/src/dialogs/ProjectDialog.vue#L318-L324 and 
- `Home.vue` https://github.com/gardener/dashboard/blob/85d37eb731bc40670f6bfe21cb34b16c673ade46/frontend/src/pages/Home.vue#L81-L90
 a navigation was initiated.

**Which issue(s) this PR fixes**:
Fixes #623 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user

```
