### PR TITLE
Evaluate HibernationPossible constraint

### DIFF
--- a/frontend/src/components/ShootHibernation/ChangeHibernation.vue
+++ b/frontend/src/components/ShootHibernation/ChangeHibernation.vue
@@ -23,6 +23,7 @@ limitations under the License.
     :icon="icon"
     :confirmButtonText="confirmText"
     :confirmRequired="confirmRequired"
+    :disabled="!isHibernationPossible"
     maxWidth="600">
     <template slot="actionComponent">
       <template v-if="!isShootSettingHibernated">
@@ -77,6 +78,9 @@ export default {
       }
     },
     caption () {
+      if (!this.isHibernationPossible) {
+        return this.hibernationPossibleMessage
+      }
       if (!this.isShootSettingHibernated) {
         return 'Hibernate Cluster'
       } else {

--- a/frontend/src/components/ShootHibernation/HibernationConfiguration.vue
+++ b/frontend/src/components/ShootHibernation/HibernationConfiguration.vue
@@ -24,6 +24,8 @@ limitations under the License.
     <template slot="actionComponent">
       <manage-hibernation-schedule
         ref="hibernationSchedule"
+        :isHibernationPossible="isHibernationPossible"
+        :hibernationPossibleMessage="hibernationPossibleMessage"
         @valid="onHibernationScheduleValid"
       ></manage-hibernation-schedule>
     </template>

--- a/frontend/src/components/ShootHibernation/ManageHibernationSchedule.vue
+++ b/frontend/src/components/ShootHibernation/ManageHibernationSchedule.vue
@@ -68,10 +68,12 @@ limitations under the License.
       </v-alert>
     </v-layout>
     <v-layout row v-if="!isHibernationPossible" class="pt-2">
-      <v-alert :value="true" type="warning" outline>
-        <div class="font-weight-bold">Your hibernation schedule may not have any effect:</div>
-        <div>{{hibernationPossibleMessage}}</div>
-      </v-alert>
+      <v-flex>
+        <v-alert :value="true" type="warning" outline>
+          <div class="font-weight-bold">Your hibernation schedule may not have any effect:</div>
+          <div>{{hibernationPossibleMessage}}</div>
+        </v-alert>
+      </v-flex>
     </v-layout>
   </div>
 </template>

--- a/frontend/src/components/ShootHibernation/ManageHibernationSchedule.vue
+++ b/frontend/src/components/ShootHibernation/ManageHibernationSchedule.vue
@@ -67,6 +67,12 @@ limitations under the License.
         You probably configured crontab lines for your hibernation schedule manually. Please edit your schedules directly in the cluster specification. You can also delete it there and come back to this screen to configure your schedule via the Dashboard UI.
       </v-alert>
     </v-layout>
+    <v-layout row v-if="!isHibernationPossible" class="pt-2">
+      <v-alert :value="true" type="warning" outline>
+        <div class="font-weight-bold">Your hibernation schedule may not have any effect:</div>
+        <div>{{hibernationPossibleMessage}}</div>
+      </v-alert>
+    </v-layout>
   </div>
 </template>
 
@@ -91,6 +97,13 @@ export default {
   props: {
     userInterActionBus: {
       type: Object
+    },
+    isHibernationPossible: {
+      type: Boolean,
+      default: true
+    },
+    hibernationPossibleMessage: {
+      type: String
     }
   },
   data () {

--- a/frontend/src/dialogs/ActionIconDialog.vue
+++ b/frontend/src/dialogs/ActionIconDialog.vue
@@ -16,8 +16,8 @@ limitations under the License.
 
 <template>
   <div>
-    <v-tooltip top>
-      <v-btn slot="activator" :small="smallIcon" icon @click="showDialog" :class="iconClass" :loading="loading" :disabled="isShootMarkedForDeletion || isShootActionsDisabledForPurpose">
+    <v-tooltip top max-width="600px">
+      <v-btn slot="activator" :small="smallIcon" icon @click="showDialog" :class="iconClass" :loading="loading" :disabled="isShootMarkedForDeletion || isShootActionsDisabledForPurpose || disabled">
         <v-icon :medium="!smallIcon">{{icon}}</v-icon>
       </v-btn>
       {{shootActionToolTip(caption)}}
@@ -103,6 +103,10 @@ export default {
     dialogColor: {
       type: String,
       default: 'orange'
+    },
+    disabled: {
+      type: Boolean,
+      default: false
     }
   },
   mixins: [shootItem],

--- a/frontend/src/mixins/shootItem.js
+++ b/frontend/src/mixins/shootItem.js
@@ -18,6 +18,7 @@ import get from 'lodash/get'
 import uniq from 'lodash/uniq'
 import flatMap from 'lodash/flatMap'
 import cloneDeep from 'lodash/cloneDeep'
+import find from 'lodash/find'
 
 import {
   getDateFormatted,
@@ -175,6 +176,17 @@ export const shootItem = {
     },
     isControlPlaneMigrating () {
       return this.shootStatusSeedName && this.shootSeedName && this.shootStatusSeedName !== this.shootSeedName
+    },
+    hibernationPossibleConstraint () {
+      const constraints = get(this.shootItem, 'status.constraints')
+      return find(constraints, ['type', 'HibernationPossible'])
+    },
+    isHibernationPossible () {
+      const status = get(this.hibernationPossibleConstraint, 'status', 'True')
+      return status !== 'False'
+    },
+    hibernationPossibleMessage () {
+      return get(this.hibernationPossibleConstraint, 'message', 'Hibernation currently not possible')
     }
   },
   methods: {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR disables the hibernation button when the hibernation is not possible.
It also gives a warning on the hibernation schedule dialog informing the user in case the schedule can't be carried out as planned.

<img width="932" alt="Screenshot 2020-03-11 at 12 46 08" src="https://user-images.githubusercontent.com/5526658/76414533-cbe1b600-6397-11ea-8fe9-86a13c118597.png">

The tooltip on the disabled button shows the message of the `HibernationPossible` constraint:
<img width="692" alt="Screenshot 2020-03-11 at 12 46 20" src="https://user-images.githubusercontent.com/5526658/76414540-cedca680-6397-11ea-9efd-6e1044fd4e6d.png">


**Which issue(s) this PR fixes**:
Fixes #612 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
The hibernation button will be disabled if `gardener` detects that the cluster cannot be hibernated because of problematic admission webhook configurations on the shoot cluster
```
