### PR TITLE
Check whether gardenlet respects the ignore annotation

### DIFF
--- a/charts/gardener-dashboard/templates/configmap.yaml
+++ b/charts/gardener-dashboard/templates/configmap.yaml
@@ -153,6 +153,9 @@ data:
 {{- if .Values.frontendConfig.seedCandidateDeterminationStrategy }}
       seedCandidateDeterminationStrategy: {{ .Values.frontendConfig.seedCandidateDeterminationStrategy }}
 {{- end }}
+{{- if .Values.frontendConfig.gardenletRespectsSyncPeriodOverwrite }}
+      gardenletRespectsSyncPeriodOverwrite: {{ .Values.frontendConfig.gardenletRespectsSyncPeriodOverwrite }}
+{{- end }}
 {{- if .Values.frontendConfig.alert }}
       alert:
         type: {{ .Values.frontendConfig.alert.type }}

--- a/charts/gardener-dashboard/templates/configmap.yaml
+++ b/charts/gardener-dashboard/templates/configmap.yaml
@@ -153,8 +153,11 @@ data:
 {{- if .Values.frontendConfig.seedCandidateDeterminationStrategy }}
       seedCandidateDeterminationStrategy: {{ .Values.frontendConfig.seedCandidateDeterminationStrategy }}
 {{- end }}
-{{- if .Values.frontendConfig.gardenletRespectsSyncPeriodOverwrite }}
-      gardenletRespectsSyncPeriodOverwrite: {{ .Values.frontendConfig.gardenletRespectsSyncPeriodOverwrite }}
+{{- if .Values.frontendConfig.gardenlet }}
+{{- if .Values.frontendConfig.gardenlet.respectsSyncPeriodOverwrite }}
+      gardenlet:
+        respectsSyncPeriodOverwrite: {{ .Values.frontendConfig.gardenlet.respectsSyncPeriodOverwrite }}
+{{- end }}
 {{- end }}
 {{- if .Values.frontendConfig.alert }}
       alert:

--- a/charts/gardener-dashboard/templates/configmap.yaml
+++ b/charts/gardener-dashboard/templates/configmap.yaml
@@ -154,9 +154,9 @@ data:
       seedCandidateDeterminationStrategy: {{ .Values.frontendConfig.seedCandidateDeterminationStrategy }}
 {{- end }}
 {{- if .Values.frontendConfig.gardenlet }}
-{{- if .Values.frontendConfig.gardenlet.respectsSyncPeriodOverwrite }}
+{{- if .Values.frontendConfig.gardenlet.respectSyncPeriodOverwrite }}
       gardenlet:
-        respectsSyncPeriodOverwrite: {{ .Values.frontendConfig.gardenlet.respectsSyncPeriodOverwrite }}
+        respectSyncPeriodOverwrite: {{ .Values.frontendConfig.gardenlet.respectSyncPeriodOverwrite }}
 {{- end }}
 {{- end }}
 {{- if .Values.frontendConfig.alert }}

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -69,6 +69,7 @@ frontendConfig:
       end: 00 08 * * 1,2,3,4,5
     production: ~
   seedCandidateDeterminationStrategy: SameRegion
+  gardenletRespectsSyncPeriodOverwrite: true # this flag should be in sync with gardenlet-configuration controllers.shoot.respectSyncPeriodOverwrite https://github.com/gardener/gardener/blob/045b03f02d7bf47a9ef39e2981ce92b86e444bda/pkg/gardenlet/apis/config/v1alpha1/types.go#L223-L226
   features:
     terminalEnabled: false
     kymaEnabled: false

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -70,7 +70,7 @@ frontendConfig:
     production: ~
   seedCandidateDeterminationStrategy: SameRegion
   gardenlet:
-    respectsSyncPeriodOverwrite: true # this flag should be in sync with gardenlet-configuration controllers.shoot.respectSyncPeriodOverwrite https://github.com/gardener/gardener/blob/045b03f02d7bf47a9ef39e2981ce92b86e444bda/pkg/gardenlet/apis/config/v1alpha1/types.go#L223-L226
+    respectSyncPeriodOverwrite: true # this flag should be in sync with gardenlet-configuration controllers.shoot.respectSyncPeriodOverwrite https://github.com/gardener/gardener/blob/045b03f02d7bf47a9ef39e2981ce92b86e444bda/pkg/gardenlet/apis/config/v1alpha1/types.go#L223-L226
   features:
     terminalEnabled: false
     kymaEnabled: false

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -69,7 +69,8 @@ frontendConfig:
       end: 00 08 * * 1,2,3,4,5
     production: ~
   seedCandidateDeterminationStrategy: SameRegion
-  gardenletRespectsSyncPeriodOverwrite: true # this flag should be in sync with gardenlet-configuration controllers.shoot.respectSyncPeriodOverwrite https://github.com/gardener/gardener/blob/045b03f02d7bf47a9ef39e2981ce92b86e444bda/pkg/gardenlet/apis/config/v1alpha1/types.go#L223-L226
+  gardenlet:
+    respectsSyncPeriodOverwrite: true # this flag should be in sync with gardenlet-configuration controllers.shoot.respectSyncPeriodOverwrite https://github.com/gardener/gardener/blob/045b03f02d7bf47a9ef39e2981ce92b86e444bda/pkg/gardenlet/apis/config/v1alpha1/types.go#L223-L226
   features:
     terminalEnabled: false
     kymaEnabled: false

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -366,6 +366,10 @@ export function shootHasIssue (shoot) {
 }
 
 export function isReconciliationDeactivated (metadata) {
+  const gardenletRespectsSyncPeriodOverwrite = get(store.state, 'cfg.gardenletRespectsSyncPeriodOverwrite')
+  if (!gardenletRespectsSyncPeriodOverwrite) {
+    return false
+  }
   const truthyValues = ['1', 't', 'T', 'true', 'TRUE', 'True']
   const ignoreDeprecated = get(metadata, ['annotations', 'shoot.garden.sapcloud.io/ignore'])
   const ignore = get(metadata, ['annotations', 'shoot.gardener.cloud/ignore'], ignoreDeprecated)

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -366,8 +366,8 @@ export function shootHasIssue (shoot) {
 }
 
 export function isReconciliationDeactivated (metadata) {
-  const respectsSyncPeriodOverwrite = get(store.state, 'cfg.gardenlet.respectsSyncPeriodOverwrite')
-  if (!respectsSyncPeriodOverwrite) {
+  const respectSyncPeriodOverwrite = get(store.state, 'cfg.gardenlet.respectSyncPeriodOverwrite')
+  if (!respectSyncPeriodOverwrite) {
     return false
   }
   const truthyValues = ['1', 't', 'T', 'true', 'TRUE', 'True']

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -366,8 +366,8 @@ export function shootHasIssue (shoot) {
 }
 
 export function isReconciliationDeactivated (metadata) {
-  const gardenletRespectsSyncPeriodOverwrite = get(store.state, 'cfg.gardenletRespectsSyncPeriodOverwrite')
-  if (!gardenletRespectsSyncPeriodOverwrite) {
+  const respectsSyncPeriodOverwrite = get(store.state, 'cfg.gardenlet.respectsSyncPeriodOverwrite')
+  if (!respectsSyncPeriodOverwrite) {
     return false
   }
   const truthyValues = ['1', 't', 'T', 'true', 'TRUE', 'True']


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the configuration flag if gardenlet respects the ignore annotation. This flag should be in sync with `GardenletConfiguration` `controllers.shoot.respectSyncPeriodOverwrite` https://github.com/gardener/gardener/blob/045b03f02d7bf47a9ef39e2981ce92b86e444bda/pkg/gardenlet/apis/config/v1alpha1/types.go#L223-L226

example `values.yaml`:
```yaml
frontendConfig:
  ...
  gardenlet:
    respectSyncPeriodOverwrite: true
```

**Which issue(s) this PR fixes**:
Fixes #386

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```action operator
In case the flag `controllers.shoot.respectSyncPeriodOverwrite` is disabled on the `GardenletConfiguration`, set the dashboard flag `frontendConfig.gardenlet.respectSyncPeriodOverwrite` also to false
```
