### PR TITLE
[master] Fix missing namespace

### DIFF
--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -212,7 +212,7 @@ export function getPrivileges () {
   return getResource('/api/user/privileges')
 }
 
-export function getSubjectRules ({ namespace }) {
+export function getSubjectRules ({ namespace = 'default' }) {
   return callResourceMethod('/api/user/subjectrules/', {
     namespace
   })


### PR DESCRIPTION
(cherry picked from commit e0755b735d24499fc01c47e72e25be1befed0c09)

**What this PR does / why we need it**:
When a user is not a member of any project, the dashboard will shown an empty page. In the javascript console of the browser you can see the following errors:
```
POST http://localhost:8080/api/user/subjectrules/ 400 (Bad Request)
Router error: Request failed with status code 400
```

This is because a namespace is required for `SelfsubjectRulesReview`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user

```
