### PR TITLE
[hotfix] Fix terminal usage not allowed

### DIFF
--- a/backend/lib/services/terminals/index.js
+++ b/backend/lib/services/terminals/index.js
@@ -547,7 +547,7 @@ function ensureTerminalAllowed ({ method, isAdmin, body }) {
     return
   }
 
-  const { target } = body
+  const { coordinate: { target } } = body
 
   // non-admin users are only allowed to open terminals for shoots
   if (target === TargetEnum.SHOOT) {

--- a/backend/test/services.terminals.spec.js
+++ b/backend/test/services.terminals.spec.js
@@ -356,7 +356,7 @@ describe('services', function () {
         const method = 'foo'
         const target = 'foo'
         try {
-          ensureTerminalAllowed({ method, isAdmin, body: { target } })
+          ensureTerminalAllowed({ method, isAdmin, body: { coordinate: { target } } })
         } catch (err) {
           expect.fail('No exception expected')
         }
@@ -367,7 +367,7 @@ describe('services', function () {
         const method = 'create'
         const target = 'shoot'
         try {
-          ensureTerminalAllowed({ method, isAdmin, body: { target } })
+          ensureTerminalAllowed({ method, isAdmin, body: { coordinate: { target } } })
         } catch (err) {
           expect.fail('No exception expected')
         }
@@ -378,7 +378,7 @@ describe('services', function () {
         const method = 'list'
         const target = 'foo'
         try {
-          ensureTerminalAllowed({ method, isAdmin, body: { target } })
+          ensureTerminalAllowed({ method, isAdmin, body: { coordinate: { target } } })
         } catch (err) {
           expect.fail('No exception expected')
         }
@@ -389,7 +389,7 @@ describe('services', function () {
         const method = 'create'
         const target = 'cp'
         try {
-          ensureTerminalAllowed({ method, isAdmin, body: { target } })
+          ensureTerminalAllowed({ method, isAdmin, body: { coordinate: { target } } })
           expect.fail('Forbidden error expected')
         } catch (err) {
           expect(err).to.be.instanceof(Forbidden)
@@ -401,7 +401,7 @@ describe('services', function () {
         const method = 'create'
         const target = 'garden'
         try {
-          ensureTerminalAllowed({ method, isAdmin, body: { target } })
+          ensureTerminalAllowed({ method, isAdmin, body: { coordinate: { target } } })
           expect.fail('Forbidden error expected')
         } catch (err) {
           expect(err).to.be.instanceof(Forbidden)


### PR DESCRIPTION
**What this PR does / why we need it**:
As regular enduser of the dashboard, when trying to open a terminal session for your cluster you will see the error message `Terminal usage not allowed`, even if you have the privilege to do so.
This is a regression, which this PR fixes.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Fixed: `Terminal usage is not allowed` error when opening a terminal session even if you have the privilege to do so
```
