### PR TITLE
Add user error code for cluster cleanup

### DIFF
--- a/frontend/src/components/ShootStatus.vue
+++ b/frontend/src/components/ShootStatus.vue
@@ -78,6 +78,10 @@ const errorCodes = {
   'ERR_INFRA_DEPENDENCIES': {
     shortDescription: 'Infrastructure Dependencies',
     description: 'Infrastructure operation failed as unmanaged resources exist in your cloud provider account. Please delete all manually created resources related to this Shoot.'
+  },
+  'ERR_CLEANUP_CLUSTER_RESOURCES': {
+    shortDescription: 'Cleanup Cluster',
+    description: 'Cleaning up the cluster failed as some resource are stuck in deletion. Please remove these resources properly or a forceful deletion will happen if this error persists.'
   }
 }
 

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -381,7 +381,8 @@ export function isUserError (errorCodes) {
     'ERR_INFRA_UNAUTHORIZED',
     'ERR_INFRA_INSUFFICIENT_PRIVILEGES',
     'ERR_INFRA_QUOTA_EXCEEDED',
-    'ERR_INFRA_DEPENDENCIES'
+    'ERR_INFRA_DEPENDENCIES',
+    'ERR_CLEANUP_CLUSTER_RESOURCES'
   ]
   return every(errorCodes, errorCode => includes(userErrorCodes, errorCode))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new user error code `ERR_CLEANUP_CLUSTER_RESOURCE`.

See https://github.com/gardener/gardener/pull/2090.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Shoot clusters which are stuck in deletion because resources within the cluster can't be removed properly, will be shown as a user related issue
```
