### PR TITLE
Terminals: Use non-deprecated fields

### DIFF
--- a/backend/test/acceptance/api.terminals.spec.js
+++ b/backend/test/acceptance/api.terminals.spec.js
@@ -51,7 +51,7 @@ module.exports = function info ({ agent, sandbox, k8s, auth }) {
         namespace,
         name,
         annotations: {
-          'garden.sapcloud.io/createdBy': username
+          'gardener.cloud/created-by': username
         }
       },
       spec: {

--- a/backend/test/support/nocks/k8s.js
+++ b/backend/test/support/nocks/k8s.js
@@ -975,7 +975,7 @@ const stub = {
           .map(value => value.split('='))
           .fromPairs()
           .value()
-        return labels['garden.sapcloud.io/createdBy'] === hash(username)
+        return labels['dashboard.gardener.cloud/created-by-hash'] === hash(username)
       })
       .reply(200, { items: [] })
       .post(`/apis/dashboard.gardener.cloud/v1alpha1/namespaces/${namespace}/terminals`, body => {
@@ -999,7 +999,7 @@ const stub = {
         namespace,
         name,
         annotations: {
-          'garden.sapcloud.io/createdBy': username
+          'gardener.cloud/created-by': username
         }
       },
       spec: {
@@ -1061,7 +1061,7 @@ const stub = {
           .map(value => value.split('='))
           .fromPairs()
           .value()
-        return labels['garden.sapcloud.io/createdBy'] === hash(username)
+        return labels['dashboard.gardener.cloud/created-by-hash'] === hash(username)
       })
       .reply(200, { items: [terminal] })
       .patch(`/apis/dashboard.gardener.cloud/v1alpha1/namespaces/${namespace}/terminals/${name}`, body => {
@@ -1100,7 +1100,7 @@ const stub = {
         namespace,
         name,
         annotations: {
-          'garden.sapcloud.io/createdBy': username
+          'gardener.cloud/created-by': username
         }
       }
     }
@@ -1126,7 +1126,7 @@ const stub = {
         namespace,
         name,
         annotations: {
-          'garden.sapcloud.io/createdBy': username
+          'gardener.cloud/created-by': username
         }
       }
     }
@@ -1144,7 +1144,7 @@ const stub = {
         namespace: 'foo',
         annotations: {
           'dashboard.gardener.cloud/identifier': '1',
-          'garden.sapcloud.io/createdBy': username
+          'gardener.cloud/created-by': username
         }
       },
       spec: {},
@@ -1156,7 +1156,7 @@ const stub = {
         namespace: 'foo',
         annotations: {
           'dashboard.gardener.cloud/identifier': '2',
-          'garden.sapcloud.io/createdBy': username
+          'gardener.cloud/created-by': username
         }
       },
       spec: {},
@@ -1173,7 +1173,7 @@ const stub = {
           .map(value => value.split('='))
           .fromPairs()
           .value()
-        return labels['garden.sapcloud.io/createdBy'] === hash(username)
+        return labels['dashboard.gardener.cloud/created-by-hash'] === hash(username)
       })
       .reply(200, { items: [terminal1, terminal2] })
     return scope


### PR DESCRIPTION
**What this PR does / why we need it**:
The following applies only for `Terminal` resources:

We should not use anymore the annotation `garden.sapcloud.io/createdBy`. This field was deprecated with `terminal-controller-manager` `v0.8.0`. It will be removed with the upcoming version `v0.9.0`. 
Instead, `gardener.cloud/created-by` annotation should be used

In addition:
- using `dashboard.gardener.cloud/created-by-hash` label instead of `garden.sapcloud.io/createdBy`
- using `dashboard.gardener.cloud/identifier-hash` label instead of `dashboard.gardener.cloud/identifier`

Also unused labels are removed:
- `dashboard.gardener.cloud/hostCluster`
- `dashboard.gardener.cloud/targetCluster`
- `garden.sapcloud.io/name`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Corresponding commit on `terminal-controller-manager`: https://github.com/gardener/terminal-controller-manager/commit/ab92b4fb3a05f56b3fcab25d8f627d3cad38c332

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```action operator
This dashboard version requires `terminal-controller-manager` `v0.8.0` or higher, in case the terminal feature is enabled.
```
