### PR TITLE
Do not accept values other than ^(\d+)Gi$

### DIFF
--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -183,8 +183,9 @@ export function displayName (username) {
 
 export function parseSize (value) {
   const sizeRegex = /^(\d+)Gi$/
-  if (sizeRegex.test(value)) {
-    const [, sizeValue] = sizeRegex.exec(value)
+  const result = sizeRegex.exec(value)
+  if (result) {
+    const [, sizeValue] = result
     return sizeValue
   }
   console.error(`Could not parse size ${value} as it does not match regex ^(\\d+)Gi$`)

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -182,7 +182,13 @@ export function displayName (username) {
 }
 
 export function parseSize (value) {
-  return parseInt(replace(value, /(^.+\D)(\d+)(\D.+$)/i, '$2'))
+  const sizeRegex = /^(\d+)Gi$/
+  if (sizeRegex.test(value)) {
+    const [, sizeValue] = sizeRegex.exec(value)
+    return sizeValue
+  }
+  console.error(`Could not parse size ${value} as it does not match regex ^(\\d+)Gi$`)
+  return 0
 }
 
 export function isEmail (value) {


### PR DESCRIPTION
**What this PR does / why we need it**:
We have an issue where we discuss to support other values than Gib when paring values from configuration and shoots. However, Gardener only accepts sizes in the format `^(\d+)Gi$` so I do not see a point in optimizing here. However, we should reject other values (same as gardener does), so that we do not handle values incorrect.

<img width="1307" alt="Screen Shot 2020-03-31 at 17 38 14" src="https://user-images.githubusercontent.com/35373687/78045762-9fa5cd80-7376-11ea-8d35-d5b88540fb59.png">


**Which issue(s) this PR fixes**:
Fixes #493

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user

```
