### PR TITLE
Add gardenctl commands

### DIFF
--- a/backend/lib/config/gardener.js
+++ b/backend/lib/config/gardener.js
@@ -25,7 +25,7 @@ const { join: joinPath } = require('path')
 
 const environmentVariableDefinitions = {
   SESSION_SECRET: 'sessionSecret', // pragma: whitelist secret
-  APISERVER_URL: 'apiServerUrl',
+  API_SERVER_URL: 'apiServerUrl',
   OIDC_ISSUER: 'oidc.issuer',
   OIDC_CLIENT_ID: 'oidc.client_id',
   OIDC_CLIENT_SECRET: 'oidc.client_secret', // pragma: whitelist secret

--- a/backend/lib/config/gardener.js
+++ b/backend/lib/config/gardener.js
@@ -25,6 +25,7 @@ const { join: joinPath } = require('path')
 
 const environmentVariableDefinitions = {
   SESSION_SECRET: 'sessionSecret', // pragma: whitelist secret
+  APISERVER_URL: 'apiServerUrl',
   OIDC_ISSUER: 'oidc.issuer',
   OIDC_CLIENT_ID: 'oidc.client_id',
   OIDC_CLIENT_SECRET: 'oidc.client_secret', // pragma: whitelist secret
@@ -97,15 +98,12 @@ module.exports = {
         if (this.existsSync(filename)) {
           _.merge(config, yaml.safeLoad(this.readFileSync(filename, 'utf8')))
         }
-        _.set(config, 'frontend.primaryLoginType', config.oidc ? 'oidc' : 'token')
       } catch (err) { /* ignore */ }
     }
     this.assignEnvironmentVariables(config, env)
-    if (!config.gitHub && _.has(config, 'frontend.gitHubRepoUrl')) {
-      _.unset(config, 'frontend.gitHubRepoUrl')
-    }
     const requiredConfigurationProperties = [
       'sessionSecret',
+      'apiServerUrl',
       'oidc.issuer',
       'oidc.client_id',
       'oidc.client_secret',
@@ -114,6 +112,13 @@ module.exports = {
     _.forEach(requiredConfigurationProperties, path => {
       assert.ok(_.get(config, path), `Configuration value '${path}' is required`)
     })
+
+    _.set(config, 'frontend.primaryLoginType', config.oidc ? 'oidc' : 'token')
+    _.set(config, 'frontend.apiServerUrl', config.apiServerUrl)
+    if (!config.gitHub && _.has(config, 'frontend.gitHubRepoUrl')) {
+      _.unset(config, 'frontend.gitHubRepoUrl')
+    }
+
     return config
   },
   existsSync,

--- a/backend/lib/middleware.js
+++ b/backend/lib/middleware.js
@@ -19,10 +19,7 @@
 const _ = require('lodash')
 const config = require('./config')
 const logger = require('./logger')
-const {
-  isHttpError,
-  dashboardClient // privileged client for the garden cluster
-} = require('./kubernetes-client')
+const { isHttpError } = require('./kubernetes-client')
 const { NotFound, InternalServerError } = require('./errors')
 
 function frontendConfig (req, res, next) {

--- a/backend/lib/middleware.js
+++ b/backend/lib/middleware.js
@@ -19,11 +19,16 @@
 const _ = require('lodash')
 const config = require('./config')
 const logger = require('./logger')
-const { isHttpError } = require('./kubernetes-client')
+const {
+  isHttpError,
+  dashboardClient // privileged client for the garden cluster
+} = require('./kubernetes-client')
 const { NotFound, InternalServerError } = require('./errors')
 
 function frontendConfig (req, res, next) {
-  const frontendConfig = {}
+  const frontendConfig = {
+    apiServerUrl: _.get(config, 'apiServerUrl', dashboardClient.cluster.server.toString())
+  }
   res.json(Object.assign(frontendConfig, config.frontend))
 }
 

--- a/backend/lib/middleware.js
+++ b/backend/lib/middleware.js
@@ -26,9 +26,7 @@ const {
 const { NotFound, InternalServerError } = require('./errors')
 
 function frontendConfig (req, res, next) {
-  const frontendConfig = {
-    apiServerUrl: _.get(config, 'apiServerUrl', dashboardClient.cluster.server.toString())
-  }
+  const frontendConfig = {}
   res.json(Object.assign(frontendConfig, config.frontend))
 }
 

--- a/backend/lib/services/members.js
+++ b/backend/lib/services/members.js
@@ -176,7 +176,7 @@ exports.get = async function ({ user, namespace, name }) {
   const [, serviceAccountNamespace, serviceAccountName] = /^system:serviceaccount:([^:]+):([^:]+)$/.exec(name) || []
   if (serviceAccountNamespace === namespace) {
     const serviceaccount = await client.core.serviceaccounts.get(namespace, serviceAccountName)
-    const server = _.get(config, 'apiServerUrl', client.cluster.server.toString())
+    const server = config.apiServerUrl
     const secretName = _.first(serviceaccount.secrets).name
     const secret = await client.core.secrets.get(namespace, secretName)
     const token = decodeBase64(secret.data.token)

--- a/backend/test/config.spec.js
+++ b/backend/test/config.spec.js
@@ -63,7 +63,7 @@ describe('config', function () {
     describe('#loadConfig', function () {
       const sandbox = sinon.createSandbox()
       const requiredEnvironmentVariables = {
-        APISERVER_URL: 'apiServerUrl',
+        API_SERVER_URL: 'apiServerUrl',
         SESSION_SECRET: 'secret', // pragma: whitelist secret
         OIDC_ISSUER: 'issuer',
         OIDC_CLIENT_ID: 'client_id',

--- a/backend/test/config.spec.js
+++ b/backend/test/config.spec.js
@@ -63,6 +63,7 @@ describe('config', function () {
     describe('#loadConfig', function () {
       const sandbox = sinon.createSandbox()
       const requiredEnvironmentVariables = {
+        APISERVER_URL: 'apiServerUrl',
         SESSION_SECRET: 'secret', // pragma: whitelist secret
         OIDC_ISSUER: 'issuer',
         OIDC_CLIENT_ID: 'client_id',

--- a/frontend/src/components/ShootDetails/GardenctlCard.vue
+++ b/frontend/src/components/ShootDetails/GardenctlCard.vue
@@ -1,0 +1,135 @@
+<!--
+Copyright (c) 2019 by SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<template>
+  <v-card v-if="isAdmin">
+    <v-card-title class="subheading white--text cyan darken-2 cardTitle">
+      Gardenctl
+    </v-card-title>
+    <div class="list">
+      <v-card-title class="listItem" >
+        <v-layout class="py-2">
+          <v-flex shrink justify-center class="pr-0 pt-3">
+            <v-icon class="cyan--text text--darken-2 avatar">mdi-console-line</v-icon>
+          </v-flex>
+          <v-flex class="pa-0">
+            <v-layout row v-for="command in commands" :key="command.title">
+              <v-flex>
+                <span class="grey--text">{{command.title}}</span><br>
+                <code>{{command.value}}</code>
+              </v-flex>
+              <copy-btn :clipboard-text="command.value"></copy-btn>
+            </v-layout>
+          </v-flex>
+        </v-layout>
+      </v-card-title>
+    </div>
+  </v-card>
+</template>
+
+<script>
+import CopyBtn from '@/components/CopyBtn'
+import { shootItem } from '@/mixins/shootItem'
+import { mapState, mapGetters } from 'vuex'
+import get from 'lodash/get'
+
+export default {
+  components: {
+    CopyBtn
+  },
+  props: {
+    shootItem: {
+      type: Object
+    }
+  },
+  mixins: [shootItem],
+  computed: {
+    ...mapState([
+      'cfg'
+    ]),
+    ...mapGetters([
+      'projectFromProjectList',
+      'isAdmin'
+    ]),
+    projectName () {
+      const project = this.projectFromProjectList
+      return get(project, 'metadata.name')
+    },
+    commands () {
+      return [
+        {
+          title: 'Target Seed',
+          value: this.targetSeedCommand
+        },
+        {
+          title: 'Target Shoot',
+          value: this.targetShootCommand
+        }
+      ]
+    },
+    targetSeedCommand () {
+      const args = []
+      if (this.cfg.apiServerUrl) {
+        args.push(`--server ${this.cfg.apiServerUrl}`)
+      }
+      if (this.shootSeedName) {
+        args.push(`--seed ${this.shootSeedName}`)
+      }
+      if (this.shootTechnicalId) {
+        args.push(`--namespace ${this.shootTechnicalId}`)
+      }
+
+      return `gardenctl target ${args.join(' ')}`
+    },
+    targetShootCommand () {
+      const args = []
+      if (this.cfg.apiServerUrl) {
+        args.push(`--server ${this.cfg.apiServerUrl}`)
+      }
+      if (this.projectName) {
+        args.push(`--project ${this.projectName}`)
+      }
+      if (this.shootName) {
+        args.push(`--shoot ${this.shootName}`)
+      }
+
+      return `gardenctl target ${args.join(' ')}`
+    }
+  }
+}
+</script>
+
+<style lang="styl" scoped>
+
+  .cardTitle {
+    line-height: 10px;
+  }
+
+  .listItem {
+    padding-top: 0px;
+    padding-bottom: 0px;
+  }
+
+  .list {
+    padding-top: 8px;
+    padding-bottom: 8px;
+  }
+
+  .avatar {
+    padding-right: 33px;
+  }
+
+</style>

--- a/frontend/src/components/ShootDetails/GardenctlCard.vue
+++ b/frontend/src/components/ShootDetails/GardenctlCard.vue
@@ -132,4 +132,9 @@ export default {
     padding-right: 33px;
   }
 
+  >>> code {
+    box-shadow: none;
+    -webkit-box-shadow: none;
+  }
+
 </style>

--- a/frontend/src/pages/ShootDetails.vue
+++ b/frontend/src/pages/ShootDetails.vue
@@ -24,6 +24,8 @@ limitations under the License.
 
         <shoot-external-tools-card :shootItem="shootItem" class="mt-3"></shoot-external-tools-card>
 
+        <gardenctl-card :shootItem="shootItem" class="mt-3"></gardenctl-card>
+
         <shoot-lifecycle-card ref="shootLifecycle" :shootItem="shootItem" class="mt-3"></shoot-lifecycle-card>
       </v-flex>
 
@@ -72,6 +74,7 @@ import ShootDetailsCard from '@/components/ShootDetails/ShootDetailsCard'
 import ShootInfrastructureCard from '@/components/ShootDetails/ShootInfrastructureCard'
 import ShootLifecycleCard from '@/components/ShootDetails/ShootLifecycleCard'
 import ShootExternalToolsCard from '@/components/ShootDetails/ShootExternalToolsCard'
+import GardenctlCard from '@/components/ShootDetails/GardenctlCard'
 import get from 'lodash/get'
 import has from 'lodash/has'
 import { shootAddonByName } from '@/utils'
@@ -90,7 +93,8 @@ export default {
     ShootJournalsCard,
     ShootMonitoringCard,
     ShootLogging,
-    ShootExternalToolsCard
+    ShootExternalToolsCard,
+    GardenctlCard
   },
   mixins: [shootItem],
   computed: {


### PR DESCRIPTION
**What this PR does / why we need it**:
With the new [`gardenctl target server`](https://github.com/gardener/gardenctl/pull/180) command we have the ability to target the garden without knowing how the operator named the garden locally.

On the cluster details page, an operator can now copy gardenctl commands to
- target the shoot
- target the seed (and corresponding seed-shoot namespace)

<img width="1361" alt="Screenshot 2020-04-03 at 17 08 36" src="https://user-images.githubusercontent.com/5526658/78375896-c90c6680-75cd-11ea-9615-7ac86b6a6d74.png">


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```action operator
Please make sure you have updated `gardenctl` to `v0.17.0` or higher
```
```improvement operator
On the cluster details page you can now copy `gardenctl` commands to quickly target the shoot or seed.
```
