### PR TITLE
Download kubeconfig for garden cluster

### DIFF
--- a/backend/lib/config/test.yaml
+++ b/backend/lib/config/test.yaml
@@ -2,6 +2,7 @@ port: 3030
 logLevel: info
 logFormat: text
 apiServerUrl: https://kubernetes.external.foo.bar
+apiServerCaData: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCkxpNHUKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ==
 gitHub:
   apiUrl: https://api.github.com
   org: gardener
@@ -22,6 +23,9 @@ oidc:
   redirect_uri: http://localhost:8080/auth/callback
   scope: 'openid email profile groups audience:server:client_id:dashboard audience:server:client_id:kube-kubectl'
   clockTolerance: 42
+  public:
+    clientId: kube-kubectl
+    clientSecret: uenbng5TrDKpSK7EJMSe2bKF
 terminal:
   containerImage: dummyImage:1.0.0
   containerImageDescriptions:

--- a/backend/lib/routes/user.js
+++ b/backend/lib/routes/user.js
@@ -24,7 +24,7 @@ const router = module.exports = express.Router({
   mergeParams: true
 })
 
-function getToken({ auth = {} } = {}) {
+function getToken ({ auth = {} } = {}) {
   return auth.bearer
 }
 
@@ -63,7 +63,6 @@ router.route('/token')
 
 router.route('/kubeconfig')
   .get(async (req, res, next) => {
-    const user = req.user || {}
     const {
       apiServerUrl: server,
       apiServerCaData: certificateAuthorityData,

--- a/charts/.gitignore
+++ b/charts/.gitignore
@@ -1,0 +1,6 @@
+.DS_Store
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+yarn.lock

--- a/charts/gardener-dashboard/templates/configmap.yaml
+++ b/charts/gardener-dashboard/templates/configmap.yaml
@@ -177,3 +177,24 @@ data:
         title: {{ .Values.frontendConfig.sla.title }}
         description: {{ .Values.frontendConfig.sla.description }}
 {{- end }}
+{{- if .Values.oidc.kubectl }}
+      kubeconfig:
+        server: {{ required ".Values.apiServerUrl is required" .Values.apiServerUrl }}
+{{- if .Values.apiServerCa }}
+        certificateAuthorityData: {{ b64enc .Values.apiServerCa }}
+{{- else if eq .Values.apiServerSkipTlsVerify true }}
+        insecure-skip-tls-verify: true
+{{- end }}
+        oidc:
+          issuerUrl: {{ required ".Values.oidc.issuerUrl is required" .Values.oidc.issuerUrl }}
+{{- with .Values.oidc.kubelogin }}
+          clientId: {{ .clientId | default "kube-kubectl" }}
+          clientSecret: {{ required ".Values.oidc.kubelogin.clientSecret"  .clientSecret }}
+{{- if .extraScopes }}
+          {{- range .extraScopes }}
+          extraScopes:
+          - {{ . }}
+          {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/gardener-dashboard/templates/configmap.yaml
+++ b/charts/gardener-dashboard/templates/configmap.yaml
@@ -15,6 +15,13 @@ data:
     logLevel: {{ .Values.logLevel }}
     logFormat: text
     apiServerUrl: {{ .Values.apiServerUrl }}
+{{- if .Values.apiServerCaData }}
+    apiServerCaData: {{ .Values.apiServerCaData }}
+{{- else if .Values.apiServerCa }}
+    apiServerCaData: {{ b64enc .Values.apiServerCa }}
+{{- else if eq .Values.apiServerSkipTlsVerify true }}
+    apiServerSkipTlsVerify: true
+{{- end }}
     readinessProbe:
       periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
 {{- if .Values.gitHub }}
@@ -52,6 +59,11 @@ data:
 {{- end }}
 {{- if .Values.oidc.clockTolerance }}
       clockTolerance: {{ .Values.oidc.clockTolerance }}
+{{- end }}
+{{- if .Values.oidc.public }}
+      public:
+        clientId: {{ .Values.oidc.public.clientId | default "kube-kubectl" }}
+        clientSecret: {{ required ".Values.oidc.public.clientSecret" .Values.oidc.public.clientSecret }}
 {{- end }}
 {{- end }}
     {{- if .Values.terminal }}
@@ -176,25 +188,4 @@ data:
       sla:
         title: {{ .Values.frontendConfig.sla.title }}
         description: {{ .Values.frontendConfig.sla.description }}
-{{- end }}
-{{- if .Values.oidc.kubectl }}
-      kubeconfig:
-        server: {{ required ".Values.apiServerUrl is required" .Values.apiServerUrl }}
-{{- if .Values.apiServerCa }}
-        certificateAuthorityData: {{ b64enc .Values.apiServerCa }}
-{{- else if eq .Values.apiServerSkipTlsVerify true }}
-        insecure-skip-tls-verify: true
-{{- end }}
-        oidc:
-          issuerUrl: {{ required ".Values.oidc.issuerUrl is required" .Values.oidc.issuerUrl }}
-{{- with .Values.oidc.kubelogin }}
-          clientId: {{ .clientId | default "kube-kubectl" }}
-          clientSecret: {{ required ".Values.oidc.kubelogin.clientSecret"  .clientSecret }}
-{{- if .extraScopes }}
-          {{- range .extraScopes }}
-          extraScopes:
-          - {{ . }}
-          {{- end }}
-{{- end }}
-{{- end }}
 {{- end }}

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -10,11 +10,14 @@ image:
 
 logLevel: debug
 apiServerUrl: https://api.example.org
-# the certification authority of the kube apiserver or skip tls verify (insecure)
+# the certificateAuthorityData of the kube apiserver
+# apiServerCaData: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCkxpNHUKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ==
+# or the certificateAuthority of the kube apiserver
 # apiServerCa: |
 #   -----BEGIN CERTIFICATE-----
 #   Li4u
 #   -----END CERTIFICATE-----
+# or skip tls verify (insecure)
 # apiServerSkipTlsVerify: true
 containerPort: 8080
 servicePort: 8080
@@ -57,13 +60,11 @@ oidc:
   # redirectUri is the endpoint receiving the OTAC from the OpenID provider after successful login
   redirectUri: https://dashboard.ingress.example.org/auth/callback
   # configuration for kubeconfig download required by kubelogin
-  # kubelogin:
+  # public:
   #  # clientId is the identifier of the public oidc client use by kubelogin
   #  clientId: kube-kubectl
   #  # clientSecret is the public client secret use by kubelogin and all users
   #  clientSecret: ~
-  #  # extraScopes the additional scopes requested
-  #  extraScopes: [ profile, email, groups ]
 
 frontendConfig:
   landingPageUrl: https://github.com/gardener

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -10,6 +10,12 @@ image:
 
 logLevel: debug
 apiServerUrl: https://api.example.org
+# the certification authority of the kube apiserver or skip tls verify (insecure)
+# apiServerCa: |
+#   -----BEGIN CERTIFICATE-----
+#   Li4u
+#   -----END CERTIFICATE-----
+# apiServerSkipTlsVerify: true
 containerPort: 8080
 servicePort: 8080
 resources:
@@ -50,6 +56,14 @@ oidc:
   clientSecret: ~
   # redirectUri is the endpoint receiving the OTAC from the OpenID provider after successful login
   redirectUri: https://dashboard.ingress.example.org/auth/callback
+  # configuration for kubeconfig download required by kubelogin
+  # kubelogin:
+  #  # clientId is the identifier of the public oidc client use by kubelogin
+  #  clientId: kube-kubectl
+  #  # clientSecret is the public client secret use by kubelogin and all users
+  #  clientSecret: ~
+  #  # extraScopes the additional scopes requested
+  #  extraScopes: [ profile, email, groups ]
 
 frontendConfig:
   landingPageUrl: https://github.com/gardener

--- a/charts/package.json
+++ b/charts/package.json
@@ -1,0 +1,83 @@
+{
+  "name": "@gardener-dashboard/charts",
+  "version": "0.0.0",
+  "description": "Gardener Dashboard Charts",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/gardener/dashboard/tree/master/charts"
+  },
+  "contributors": [
+    "Koser, Holger <holger.koser@sap.com>",
+    "Sutter, Peter <peter.sutter@sap.com>",
+    "Gross, Lukas <lukas.gross@sap.com>"
+  ],
+  "private": true,
+  "scripts": {
+    "lint": "eslint --ext .js test",
+    "test": "cross-env NODE_ENV=test mocha"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "chai": "^4.1.2",
+    "cross-env": "^7.0.0",
+    "eslint": "^6.8.0",
+    "eslint-config-standard": "^14.1.0",
+    "eslint-friendly-formatter": "^4.0.1",
+    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-mocha": "^6.2.2",
+    "eslint-plugin-node": "^11.0.0",
+    "eslint-plugin-promise": "^4.0.1",
+    "eslint-plugin-standard": "^4.0.0",
+    "js-yaml": "^3.13.1",
+    "lodash": "^4.17.15",
+    "mocha": "^7"
+  },
+  "eslintConfig": {
+    "root": true,
+    "env": {
+      "node": true,
+      "mocha": true,
+      "es6": true
+    },
+    "extends": "standard",
+    "parserOptions": {
+      "ecmaVersion": 2018
+    },
+    "rules": {
+      "arrow-parens": 0,
+      "generator-star-spacing": 0,
+      "quote-props": [
+        "error",
+        "as-needed"
+      ]
+    },
+    "globals": {
+      "describe": true,
+      "it": true,
+      "before": true,
+      "after": true,
+      "beforeEach": true,
+      "afterEach": true,
+      "expect": true,
+      "helmTemplate": true
+    }
+  },
+  "mocha": {
+    "require": "test/support",
+    "check-leaks": true,
+    "diff": true,
+    "extension": [
+      "js"
+    ],
+    "package": "./package.json",
+    "reporter": "spec",
+    "slow": 75,
+    "timeout": 2000,
+    "ui": "bdd"
+  },
+  "engines": {
+    "node": ">= 12.3.1",
+    "yarn": ">= 1.16.0"
+  }
+}

--- a/charts/test/gardener-dashbaord.spec.js
+++ b/charts/test/gardener-dashbaord.spec.js
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+//
+// Copyright (c) 2019 by SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+const os = require('os')
+const crypto = require('crypto')
+const yaml = require('js-yaml')
+const { merge, chain } = require('lodash')
+
+function writeValues(filename, values = {}) {
+  const ca = '-----BEGIN RSA PRIVATE KEY-----\nLi4u\n-----END RSA PRIVATE KEY-----'
+  const defaultValues = {
+    image: {
+      tag: '1.26.0-dev-4d529c1'
+    },
+    apiServerUrl: 'https://api.garden.example.org',
+    apiServerCa: ca,
+    hosts: [
+      'gardener.ingress.garden.example.org'
+    ],
+    ingress: {
+      annotations: {
+        'nginx.ingress.kubernetes.io/ssl-redirect': 'true',
+        'nginx.ingress.kubernetes.io/use-port-in-redirects': 'true',
+        'kubernetes.io/ingress.class': 'nginx'
+      }
+    },
+    sessionSecret: 'sessionSecret',
+    secret: 'secret',
+    oidc: {
+      issuerUrl: 'https://identity.garden.example.org',
+      clientId: 'dashboard',
+      clientSecret: 'dashboardSecret',
+      ca,
+      public: {
+        clientId: 'kube-kubectl',
+        clientSecret: 'kubeKubectlSecret'
+      }
+    },
+    frontendConfig: {
+      landingPageUrl: 'https://gardener.cloud/',
+      helpMenuItems: [
+        {
+          title: 'Getting Started',
+          icon: 'description',
+          url: 'https://gardener.cloud/about/'
+        },
+        {
+          title: 'slack',
+          icon: 'mdi-slack',
+          url: 'https://kubernetes.slack.com/messages/gardener'
+        },
+        {
+          title: 'Issues',
+          icon: 'mdi-bug',
+          url: 'https://github.com/gardener/dashboard/issues/'
+        }
+      ],
+      externalTools: [
+        {
+          title: 'Applications and Services Hub',
+          icon: 'apps',
+          url: 'https://apps.garden.example.org/foo/bar{?namespace,name}'
+        }
+      ],
+      gitHubRepoUrl: 'https://github.com/gardener/journals'
+    },
+    gitHub: {
+      apiUrl: 'https://github.com/api/v3/',
+      org: 'gardener',
+      repository: 'journals',
+      webhookSecret: 'webhookSecret',
+      authentication: {
+        token: 'webhookAuthenticationToken'
+      }
+    }
+  }
+  values = merge(defaultValues, values)
+  fs.writeFileSync(filename, yaml.safeDump(values))
+  return values
+}
+
+function decodeBase64(data) {
+  return Buffer.from(data, 'base64').toString('utf8')
+}
+
+describe('gardener-dashboard', function () {
+  const template = 'gardener-dashboard'
+  let dirname
+  let filename
+
+  before(function () {
+    dirname = fs.mkdtempSync(path.join(os.tmpdir(), 'helm-'))
+  })
+
+  beforeEach(function () {
+    const randomNumber = crypto.randomBytes(4).readUInt32LE(0)
+    filename = path.join(dirname, `values-${randomNumber}.yaml`)
+  })
+
+  after(function () {
+    fs.rmdirSync(dirname, {
+      maxRetries: 100,
+      recursive: true
+    })
+  })
+
+  afterEach(function () {
+    if (fs.existsSync(filename)) {
+      fs.unlinkSync(filename)
+    }
+  })
+
+  describe('templates', function () {
+    describe('configmap', function () {
+      const name = 'gardener-dashboard-configmap'
+
+      it('should render the template', async function () {
+        const values = writeValues(filename, {})
+        const documents = await helmTemplate(template, filename)
+        const config = chain(documents)
+          .find(['metadata.name', name])
+          .get('data["config.yaml"]')
+          .thru(yaml.safeLoad)
+          .value()
+        const {
+          apiServerUrl,
+          apiServerCaData,
+          oidc
+        } = config
+        expect(apiServerUrl).to.equal(values.apiServerUrl)
+        expect(decodeBase64(apiServerCaData)).to.equal(values.apiServerCa)
+        expect(oidc.issuer).to.equal(values.oidc.issuerUrl)
+        expect(oidc.public.clientId).to.equal(values.oidc.public.clientId)
+        expect(oidc.public.clientSecret).to.equal(values.oidc.public.clientSecret)
+      })
+    })
+  })
+})

--- a/charts/test/support/index.js
+++ b/charts/test/support/index.js
@@ -1,0 +1,45 @@
+//
+// Copyright (c) 2019 by SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+'use strict'
+
+const path = require('path')
+const util = require('util')
+const childProcess = require('child_process')
+const exec = util.promisify(childProcess.exec)
+const yaml = require('js-yaml')
+
+process.env.NODE_ENV = 'test'
+
+/*!
+ * Attach chai to global
+ */
+global.chai = require('chai')
+global.expect = global.chai.expect
+
+async function helmTemplate (template, pathToValues) {
+  const cwd = path.resolve(__dirname, '..', '..', template)
+  const cmd = [
+    '/usr/local/bin/helm',
+    'template',
+    '.',
+    '--values',
+    pathToValues
+  ]
+  const { stdout } = await exec(cmd.join(' '), { cwd })
+  return yaml.safeLoadAll(stdout)
+}
+global.helmTemplate = helmTemplate

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,7 @@
     "test:unit": "vue-cli-service test:unit"
   },
   "dependencies": {
-    "@mdi/font": "^4.4.95",
+    "@mdi/font": "^5.0.45",
     "ansi-html": "^0.0.7",
     "axios": "^0.19.0",
     "clipboard": "^2.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,7 @@
     "test:unit": "vue-cli-service test:unit"
   },
   "dependencies": {
-    "@mdi/font": "^5.0.45",
+    "@mdi/font": "^v4.9.95",
     "ansi-html": "^0.0.7",
     "axios": "^0.19.0",
     "clipboard": "^2.0.1",

--- a/frontend/src/components/AccountAvatar.vue
+++ b/frontend/src/components/AccountAvatar.vue
@@ -19,19 +19,25 @@ limitations under the License.
     <v-avatar :size="size">
       <img :src="avatarUrl"/>
     </v-avatar>
-    <a v-if="mailTo && isEmail" :href="`mailto:${accountName}`" class="pl-2 cyan--text text--darken-2">{{accountName}}</a>
+    <a v-if="mailTo && isEmail" :href="`mailto:${accountName}`" class="pl-2" :class="textColor">{{accountName}}</a>
     <span v-else class="pl-2">{{accountName || '-unknown-'}}</span>
   </div>
 </template>
 
 <script>
 import { gravatarUrlGeneric, isEmail } from '@/utils'
+import split from 'lodash/split'
+import map from 'lodash/map'
 
 export default {
   props: {
     accountName: {
       type: String,
       default: ''
+    },
+    color: {
+      type: String,
+      default: 'cyan darken-2'
     },
     mailTo: {
       type: Boolean,
@@ -43,6 +49,10 @@ export default {
     }
   },
   computed: {
+    textColor () {
+      const iteratee = value => /^(darken|lighten|accent)-\d$/.test(value) ? 'text--' + value : value + '--text'
+      return map(split(this.color, ' '), iteratee)
+    },
     avatarUrl () {
       return gravatarUrlGeneric(this.accountName, this.size * 2)
     },

--- a/frontend/src/components/CodeBlock.vue
+++ b/frontend/src/components/CodeBlock.vue
@@ -35,15 +35,22 @@ import CopyBtn from '@/components/CopyBtn'
 import trim from 'lodash/trim'
 import split from 'lodash/split'
 import replace from 'lodash/replace'
-import highlight from 'highlight.js/lib/highlight.js'
-import highlightJSON from 'highlight.js/lib/languages/json'
-import highlightYAML from 'highlight.js/lib/languages/yaml'
-import highlightJavascript from 'highlight.js/lib/languages/javascript'
-import highlightBash from 'highlight.js/lib/languages/bash'
-highlight.registerLanguage('json', highlightJSON)
-highlight.registerLanguage('yaml', highlightYAML)
-highlight.registerLanguage('javascript', highlightJavascript)
-highlight.registerLanguage('bash', highlightBash)
+import hljs from 'highlight.js/lib/highlight.js'
+
+import bash from 'highlight.js/lib/languages/bash'
+import shell from 'highlight.js/lib/languages/shell'
+import json from 'highlight.js/lib/languages/json'
+import javascript from 'highlight.js/lib/languages/javascript'
+import yaml from 'highlight.js/lib/languages/yaml'
+
+import 'highlight.js/styles/docco.css'
+
+hljs.registerLanguage('bash', bash)
+hljs.registerLanguage('shell', shell)
+hljs.registerLanguage('json', json)
+hljs.registerLanguage('javascript', javascript)
+hljs.registerLanguage('yaml', yaml)
+
 export default {
   components: {
     CopyBtn
@@ -88,7 +95,7 @@ export default {
         })
         block.textContent = trim(lines.join('\n'))
       }
-      highlight.highlightBlock(block)
+      hljs.highlightBlock(block)
       this.$emit('highlightBlock')
     },
     onCopy () {
@@ -116,8 +123,8 @@ export default {
     overflow: hidden;
     position: relative;
     border-radius: 2px;
-    background-color: $grey.lighten-3;
-    color: $grey.lighten-3;
+    background-color: $grey.lighten-5;
+    color: $grey.lighten-5;
     font-family: "Operator Mono", "Fira Code", Menlo, Hack, "Roboto Mono", "Liberation Mono", Monaco, monospace;
     font-size: 14px;
     line-height: 1.4em;
@@ -158,9 +165,12 @@ export default {
       margin: 0;
       white-space: pre;
     }
-    code {
+    code.hljs {
       padding: 0;
-      background: none;
+      white-space: pre !important;
+      color: initial;
+      background-color: initial;
+      font-weight: normal;
       box-shadow: none;
       -webkit-box-shadow: none;
       &:before {

--- a/frontend/src/components/ExternalLink.vue
+++ b/frontend/src/components/ExternalLink.vue
@@ -1,0 +1,61 @@
+<!--
+Copyright (c) 2019 by SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<template>
+  <a :href="url" target="_blank" :class="textColor">
+    <span :style="{ fontSize: size + 'px' }"><slot></slot></span><v-icon :size="size" :color="color">mdi-open-in-new</v-icon>
+  </a>
+</template>
+
+<script>
+import split from 'lodash/split'
+import map from 'lodash/map'
+
+export default {
+  name: 'external-link',
+  props: {
+    url: {
+      type: String
+    },
+    text: {
+      type: String
+    },
+    size: {
+      type: Number,
+      default: 14
+    },
+    color: {
+      type: String,
+      default: 'cyan darken-2'
+    }
+  },
+  computed: {
+    textColor () {
+      const iteratee = value => /^(darken|lighten|accent)-\d$/.test(value) ? 'text--' + value : value + '--text'
+      return map(split(this.color, ' '), iteratee)
+    }
+  }
+}
+</script>
+
+<style scoped>
+  a {
+    text-decoration: none;
+  }
+  a > span {
+    text-decoration-line: underline;
+  }
+</style>

--- a/frontend/src/pages/Account.vue
+++ b/frontend/src/pages/Account.vue
@@ -17,97 +17,169 @@ limitations under the License.
 <template>
   <v-container grid-list-lg fluid>
     <v-layout row wrap>
-      <v-flex md6 xs12>
+      <v-flex xs12 sm6 class="pr-3">
         <v-card>
-          <v-toolbar card class="teal darken-1" dark>
-            <v-icon class="white--text pr-2">{{icon}}</v-icon>
-            <v-toolbar-title>User Details</v-toolbar-title>
-            <v-spacer></v-spacer>
-            <copy-btn
-              :clipboard-text="idToken"
-              tooltip-text="Copy ID Token to clipboard"
-              copy-success-text="Copied ID Token to clipboard!">
-            </copy-btn>
+          <v-toolbar card dark dense class="teal darken-2">
+            <v-toolbar-title>Details</v-toolbar-title>
           </v-toolbar>
-          <v-card-text>
-            <v-layout row wrap>
-              <v-flex xs12>
-                <label class="caption grey--text text--darken-2">Name</label>
-                <p class="pt-2">
+          <v-list two-line class="no-height">
+            <v-list-tile>
+              <v-list-tile-avatar>
+                <v-icon color="teal darken-2">{{icon}}</v-icon>
+              </v-list-tile-avatar>
+              <v-list-tile-content>
+                <v-list-tile-title class="label pb-2">User</v-list-tile-title>
+                <v-list-tile-sub-title class="content pb-2">
                   <account-avatar :account-name="username" mailTo :size="32"/>
-                </p>
-              </v-flex>
-              <v-flex v-if="!!fullDisplayName" md6 xs12>
-                <label class="caption grey--text text--darken-2">Display Name</label>
-                <p class="subheading">{{fullDisplayName}}</p>
-              </v-flex>
-              <v-flex xs12>
-                <label class="caption grey--text text--darken-2">Groups</label>
-                <p>
-                  <v-chip v-for="(group, index) in groups" :key="index" label small outline disabled color="black">{{group}}</v-chip>
-                </p>
-              </v-flex>
-              <v-flex xs12>
-                <label class="caption grey--text text--darken-2">Session Expiration</label>
-                <p class="subheading">{{expiresAt}}</p>
-              </v-flex>
-            </v-layout>
-          </v-card-text>
+                </v-list-tile-sub-title>
+              </v-list-tile-content>
+            </v-list-tile>
+            <v-list-tile v-if="!!fullDisplayName">
+              <v-list-tile-avatar>
+                &nbsp;
+              </v-list-tile-avatar>
+              <v-list-tile-content>
+                <v-list-tile-title class="label">Name</v-list-tile-title>
+                <v-list-tile-sub-title class="content pb-2">
+                  {{fullDisplayName}}
+                </v-list-tile-sub-title>
+              </v-list-tile-content>
+            </v-list-tile>
+            <v-list-tile>
+              <v-list-tile-avatar>
+                &nbsp;
+              </v-list-tile-avatar>
+              <v-list-tile-content>
+                <v-list-tile-title class="label">Groups</v-list-tile-title>
+                <v-list-tile-sub-title class="content">
+                  <span style="margin-left: -4px">
+                    <v-chip v-for="(group, index) in groups" :key="index" label small outline disabled color="black">{{group}}</v-chip>
+                  </span>
+                </v-list-tile-sub-title>
+              </v-list-tile-content>
+            </v-list-tile>
+            <v-divider inset class="my-2"/>
+            <v-list-tile>
+              <v-list-tile-avatar>
+                <v-icon color="teal darken-2">timelapse</v-icon>
+              </v-list-tile-avatar>
+              <v-list-tile-content>
+                <v-list-tile-title class="label">Session</v-list-tile-title>
+                <v-list-tile-sub-title class="content">
+                   Expires {{expiresAt}}
+                </v-list-tile-sub-title>
+              </v-list-tile-content>
+            </v-list-tile>
+          </v-list>
         </v-card>
       </v-flex>
       <v-flex md6 xs12>
-        <v-card >
-          <v-toolbar card class="teal darken-1" dark>
-            <v-icon class="white--text pr-2">insert_drive_file</v-icon>
-            <v-toolbar-title>Kubeconfig</v-toolbar-title>
+        <v-card>
+          <v-toolbar card dark dense class="teal darken-2">
+            <v-toolbar-title>Access</v-toolbar-title>
           </v-toolbar>
-          <v-card-text>
-            <v-layout row wrap>
-              <v-flex xs12>
-                 The downloaded kubeconfig will use <a href="https://github.com/int128/kubelogin"><tt>kubelogin</tt></a>, also known as <tt>kubectl oidc-login</tt>.
-                 for login into the garden cluster. Below you can configure some of command line arguments of <tt>kubelogin</tt>.
-              </v-flex>
-              <v-flex xs12 d-flex>
-                <v-select
-                  color="teal darken-1"
-                  v-model="projectName"
-                  :items="projectNames"
-                  label="Project"
-                  hint="The namespace of the project will be the namespace of the <tt>current-context</tt>"
-                  persistent-hint
-                ></v-select>
-              </v-flex>
-              <v-flex xs12 d-flex>
-                <v-select
-                  color="teal darken-1"
-                  v-model="grantType"
-                  :items="grantTypes"
-                  label="Grant Type"
-                  hint="The authorization grant type to use"
-                  persistent-hint
-                ></v-select>
-              </v-flex>
-              <v-flex xs12 d-flex>
-                <v-switch
-                  color="teal darken-1"
-                  v-model="skipOpenBrowser"
-                  label="Skip Open Browser"
-                  hint="If true, it does not open the browser on authentication"
-                  persistent-hint
-                ></v-switch>
-              </v-flex>
-            </v-layout>
-          </v-card-text>
-          <v-card-actions class="grey lighten-4 mt-2">
-            <div class="ma-1">
-              <v-tooltip top>
-                <v-btn flat color="grey darken-4" slot="activator" @click="onDownload">
-                  Download
-                </v-btn>
-                <span>Download Kubeconfig</span>
-              </v-tooltip>
-            </div>
-          </v-card-actions>
+          <v-list>
+            <v-list-tile>
+              <v-list-tile-avatar>
+                <v-icon color="teal darken-2">mdi-key </v-icon>
+              </v-list-tile-avatar>
+              <v-list-tile-content>
+                <v-list-tile-title class="label">Token</v-list-tile-title>
+                <v-list-tile-sub-title class="content">Personal bearer token for API authentication</v-list-tile-sub-title>
+              </v-list-tile-content>
+              <v-list-tile-action>
+                <copy-btn :clipboard-text="idToken"></copy-btn>
+              </v-list-tile-action>
+            </v-list-tile>
+            <v-divider inset class="my-2"/>
+            <v-list-tile>
+              <v-list-tile-avatar>
+                <v-icon color="teal darken-2">insert_drive_file</v-icon>
+              </v-list-tile-avatar>
+              <v-list-tile-content>
+                <v-list-tile-title>Kubeconfig</v-list-tile-title>
+              </v-list-tile-content>
+              <v-list-tile-action>
+                <v-tooltip top>
+                  <v-btn slot="activator" icon @click.native.stop="onDownload">
+                    <v-icon>mdi-download</v-icon>
+                  </v-btn>
+                  <span>Download Kubeconfig</span>
+                </v-tooltip>
+              </v-list-tile-action>
+              <v-list-tile-action>
+                <v-tooltip top>
+                  <v-btn slot="activator" icon @click.native.stop="expansionPanel = !expansionPanel">
+                    <v-icon>{{ expansionPanel ? 'expand_less' : 'expand_more' }}</v-icon>
+                  </v-btn>
+                  <span>{{ expansionPanel ? 'Collapse advanced options' : 'Show advanced options' }}</span>
+                </v-tooltip>
+              </v-list-tile-action>
+            </v-list-tile>
+            <v-expand-transition>
+              <v-card v-if="expansionPanel" flat class="mx-2 pb-2">
+                <v-card-text class="pt-1">
+                  <div>
+                    This <tt>kubeconfig</tt> has a user that initiates
+                    <a href="https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens" target="_blank">
+                      <tt>OIDC</tt>
+                    </a>
+                    authentication via <tt>kubelogin</tt>.
+                    If not already done, please setup
+                    <a link href="https://github.com/int128/kubelogin#setup" target="_blank">
+                      <tt>kubelogin</tt>
+                    </a>
+                    according to their instructions.
+                    For more information about <tt>kubelogin</tt> please read the documentation on their website.
+                    <br>
+                    Below you can configure and preview some the <tt>kubeconfig</tt> file before download.
+                  </div>
+                  <v-tabs slider-color="grey lighten-5" color="teal darken-2" dark class="mt-2 elevation-1">
+                    <v-tab>Configure</v-tab>
+                    <v-tab>Preview</v-tab>
+                    <v-spacer/>
+                    <copy-btn :clipboard-text="kubeconfig"></copy-btn>
+                    <v-tab-item class="pa-3">
+                      <v-layout row wrap>
+                        <v-flex xs12>
+                          <v-select
+                            color="teal darken-1"
+                            v-model="projectName"
+                            :items="projectNames"
+                            label="Project"
+                            hint="The namespace of the selected project will be the default namespace in the kubeconfig"
+                            persistent-hint
+                          ></v-select>
+                        </v-flex>
+                        <v-flex xs12>
+                          <v-select
+                            color="teal darken-1"
+                            v-model="grantType"
+                            :items="grantTypes"
+                            label="Grant Type"
+                            hint="The authorization grant type to use"
+                            persistent-hint
+                          ></v-select>
+                        </v-flex>
+                        <v-flex xs12>
+                          <v-switch
+                            color="teal darken-1"
+                            v-model="skipOpenBrowser"
+                            label="Skip Open Browser"
+                            hint="If true, it does not open the browser on authentication"
+                            persistent-hint
+                          ></v-switch>
+                        </v-flex>
+                      </v-layout>
+                    </v-tab-item>
+                    <v-tab-item>
+                      <code-block lang="yaml" :content="kubeconfig" :show-copy-button="false"></code-block>
+                    </v-tab-item>
+                  </v-tabs>
+                </v-card-text>
+              </v-card>
+            </v-expand-transition>
+          </v-list>
         </v-card>
       </v-flex>
     </v-layout>
@@ -116,6 +188,7 @@ limitations under the License.
 
 <script>
 import CopyBtn from '@/components/CopyBtn'
+import CodeBlock from '@/components/CodeBlock'
 import download from 'downloadjs'
 import AccountAvatar from '@/components/AccountAvatar'
 import { getToken } from '@/utils/api'
@@ -123,6 +196,7 @@ import { mapState, mapGetters } from 'vuex'
 import moment from 'moment-timezone'
 import map from 'lodash/map'
 import find from 'lodash/find'
+import get from 'lodash/get'
 
 // js-yaml
 import jsyaml from 'js-yaml'
@@ -136,11 +210,13 @@ function safeDump (value) {
 export default {
   components: {
     CopyBtn,
+    CodeBlock,
     AccountAvatar
   },
   name: 'profile',
   data () {
     return {
+      expansionPanel: false,
       projectName: undefined,
       skipOpenBrowser: false,
       grantType: 'auto',
@@ -154,9 +230,7 @@ export default {
   async mounted () {
     try {
       const project = find(this.projectList, ['metadata.namespace', this.namespace])
-      if (project) {
-        this.projectName = project.metadata.name
-      }
+      this.projectName = get(project, 'metadata.name', '')
       const { data } = await getToken()
       this.idToken = data.token
     } catch (err) {
@@ -176,6 +250,15 @@ export default {
       'isAdmin',
       'canCreateProject'
     ]),
+    expansionPanelIndex () {
+      switch (this.expansionPanel) {
+        case 'kubeconfig':
+        case 'settings':
+          return 0
+        default:
+          return null
+      }
+    },
     icon () {
       return this.isAdmin ? 'supervisor_account' : 'mdi-account'
     },
@@ -189,12 +272,20 @@ export default {
       return moment.duration(this.user.exp - Math.floor(Date.now() / 1000), 'seconds').humanize(true)
     },
     projectNames () {
-      return map(this.projectList, 'metadata.name')
+      const names = map(this.projectList, 'metadata.name')
+      names.unshift('')
+      return names
+    },
+    kubeconfigFilename () {
+      if (this.projectName) {
+        return `kubeconfig-garden-${this.projectName}.yaml`
+      }
+      return 'kubeconfig-garden.yaml'
     },
     kubeconfig () {
       const project = find(this.projectList, ['metadata.name', this.projectName])
-      const name = 'garden-' + project.metadata.name
-      const namespace = project.metadata.namespace
+      const name = 'garden-' + get(project, 'metadata.name', 'none')
+      const namespace = get(project, 'metadata.namespace')
       const {
         server,
         certificateAuthorityData,
@@ -237,7 +328,7 @@ export default {
           args
         }
       }
-      return {
+      return safeDump({
         kind: 'Config',
         apiVersion: 'v1',
         clusters: [{
@@ -254,15 +345,34 @@ export default {
           user
         }],
         preferences: {}
-      }
+      })
     }
   },
   methods: {
     onDownload () {
-      const filename = `kubeconfig-garden-${this.projectName}.yaml`
-      const data = safeDump(this.kubeconfig)
-      download(data, filename, 'text/yaml')
+      let filename = 'kubeconfig-garden'
+      if (this.projectName) {
+        filename += '-' + this.projectName
+      }
+      filename += '.yaml'
+      download(this.kubeconfig, filename, 'text/yaml')
     }
   }
 }
 </script>
+
+<style lang="stylus" scoped>
+  .no-height >>> [role=listitem] > :first-child {
+    height: unset;
+    min-height: 48px;
+  }
+  .label {
+    font-size: 14px !important;
+    color: rgba(0,0,0,0.54) !important;
+  }
+  .content {
+    font-size: 16px !important;
+    font-weight: 400 !important;
+    color: inherit !important;
+  }
+</style>

--- a/frontend/src/pages/Account.vue
+++ b/frontend/src/pages/Account.vue
@@ -30,7 +30,7 @@ limitations under the License.
               <v-list-tile-content>
                 <v-list-tile-title class="label pb-2">User</v-list-tile-title>
                 <v-list-tile-sub-title class="content pb-2">
-                  <account-avatar :account-name="username" mailTo :size="32"/>
+                  <account-avatar :account-name="username" mailTo color="teal darken-2" :size="32"/>
                 </v-list-tile-sub-title>
               </v-list-tile-content>
             </v-list-tile>
@@ -84,8 +84,8 @@ limitations under the License.
                 <v-icon color="teal darken-2">mdi-key </v-icon>
               </v-list-tile-avatar>
               <v-list-tile-content>
-                <v-list-tile-title class="label">Token</v-list-tile-title>
-                <v-list-tile-sub-title class="content">Personal bearer token for API authentication</v-list-tile-sub-title>
+                <v-list-tile-title>Token</v-list-tile-title>
+                <v-list-tile-sub-title>Personal bearer token for API authentication</v-list-tile-sub-title>
               </v-list-tile-content>
               <v-list-tile-action>
                 <copy-btn :clipboard-text="idToken"></copy-btn>
@@ -117,24 +117,24 @@ limitations under the License.
               </v-list-tile-action>
             </v-list-tile>
             <v-expand-transition>
-              <v-card v-if="expansionPanel" flat class="mx-2 pb-2">
-                <v-card-text class="pt-1">
-                  <div>
-                    This <tt>kubeconfig</tt> has a user that initiates
-                    <a href="https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens" target="_blank">
-                      <tt>OIDC</tt>
+              <v-card v-if="expansionPanel" flat class="mx-2">
+                <v-card-text class="pt-0">
+                  <div class="grey--text text--darken-2">
+                    The downloaded <tt>kubeconfig</tt> will initiate
+                    <a href="https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens" target="_blank" class="teal--text text--darken-2">
+                      OIDC
                     </a>
                     authentication via <tt>kubelogin</tt>.
-                    If not already done, please setup
-                    <a link href="https://github.com/int128/kubelogin#setup" target="_blank">
-                      <tt>kubelogin</tt>
-                    </a>
-                    according to their instructions.
-                    For more information about <tt>kubelogin</tt> please read the documentation on their website.
-                    <br>
+                    If not already done, please install <tt>kubelogin</tt>
+                    according to the
+                    <a link href="https://github.com/int128/kubelogin#setup" target="_blank" class="teal--text text--darken-2">
+                      setup instructions
+                    </a>.
+                    For more information about please refer to the <tt>kubelogin</tt> documentation.
+                    <br/>
                     Below you can configure and preview some the <tt>kubeconfig</tt> file before download.
                   </div>
-                  <v-tabs slider-color="grey lighten-5" color="teal darken-2" dark class="mt-2 elevation-1">
+                  <v-tabs slider-color="grey lighten-5" color="grey lighten-3" class="mt-2 elevation-1">
                     <v-tab>Configure</v-tab>
                     <v-tab>Preview</v-tab>
                     <v-spacer/>

--- a/frontend/src/pages/Account.vue
+++ b/frontend/src/pages/Account.vue
@@ -138,7 +138,7 @@ limitations under the License.
                     <br>
                     Below you can configure and preview the <tt>kubeconfig</tt> file before download.
                   </div>
-                  <v-tabs slider-color="grey lighten-5" color="grey lighten-3" class="mt-2 elevation-1">
+                  <v-tabs slider-color="grey lighten-1" color="grey lighten-3" class="mt-2 elevation-1">
                     <v-tab>Configure</v-tab>
                     <v-tab>Preview</v-tab>
                     <v-tab-item class="pa-3">
@@ -194,7 +194,7 @@ import CodeBlock from '@/components/CodeBlock'
 import ExternalLink from '@/components/ExternalLink'
 import download from 'downloadjs'
 import AccountAvatar from '@/components/AccountAvatar'
-import { getToken } from '@/utils/api'
+import { getToken, getKubeconfigData } from '@/utils/api'
 import { mapState, mapGetters } from 'vuex'
 import moment from 'moment-timezone'
 import map from 'lodash/map'
@@ -222,6 +222,7 @@ export default {
     return {
       expansionPanel: false,
       projectName: undefined,
+      kubeconfigData: undefined,
       skipOpenBrowser: false,
       grantType: 'auto',
       grantTypes: [ 'auto', 'authcode', 'authcode-keyboard' ],
@@ -235,8 +236,15 @@ export default {
     try {
       const project = find(this.projectList, ['metadata.namespace', this.namespace])
       this.projectName = get(project, 'metadata.name', '')
-      const { data } = await getToken()
+      const [
+        { data },
+        { data: kubeconfigData }
+      ] = await Promise.all([
+        getToken(),
+        getKubeconfigData()
+      ])
       this.idToken = data.token
+      this.kubeconfigData = kubeconfigData
     } catch (err) {
       console.error(err.message)
     }
@@ -295,8 +303,8 @@ export default {
           clientId,
           clientSecret,
           extraScopes = []
-        }
-      } = this.cfg.kubeconfig
+        } = {}
+      } = this.kubeconfigData || {}
       const cluster = {
         'certificate-authority-data': certificateAuthorityData,
         server

--- a/frontend/src/pages/Account.vue
+++ b/frontend/src/pages/Account.vue
@@ -17,7 +17,7 @@ limitations under the License.
 <template>
   <v-container grid-list-lg fluid>
     <v-layout row wrap>
-      <v-flex xs12 sm6 class="pr-3">
+      <v-flex xs12 md6>
         <v-card>
           <v-toolbar card dark dense class="teal darken-2">
             <v-toolbar-title>Details</v-toolbar-title>
@@ -73,7 +73,7 @@ limitations under the License.
           </v-list>
         </v-card>
       </v-flex>
-      <v-flex md6 xs12>
+      <v-flex xs12 md6>
         <v-card>
           <v-toolbar card dark dense class="teal darken-2">
             <v-toolbar-title>Access</v-toolbar-title>
@@ -98,47 +98,49 @@ limitations under the License.
               </v-list-tile-avatar>
               <v-list-tile-content>
                 <v-list-tile-title>Kubeconfig</v-list-tile-title>
+                <v-list-tile-sub-title>Personalized command line interface access</v-list-tile-sub-title>
               </v-list-tile-content>
               <v-list-tile-action>
                 <v-tooltip top>
                   <v-btn slot="activator" icon @click.native.stop="onDownload">
                     <v-icon>mdi-download</v-icon>
                   </v-btn>
-                  <span>Download Kubeconfig</span>
+                  <span>Download kubeconfig</span>
                 </v-tooltip>
+              </v-list-tile-action>
+              <v-list-tile-action>
+                <copy-btn :clipboard-text="kubeconfig" tooltipText="Copy kubeconfig to clipboard"></copy-btn>
               </v-list-tile-action>
               <v-list-tile-action>
                 <v-tooltip top>
                   <v-btn slot="activator" icon @click.native.stop="expansionPanel = !expansionPanel">
-                    <v-icon>{{ expansionPanel ? 'expand_less' : 'expand_more' }}</v-icon>
+                    <v-icon>{{expansionPanelIcon}}</v-icon>
                   </v-btn>
-                  <span>{{ expansionPanel ? 'Collapse advanced options' : 'Show advanced options' }}</span>
+                  <span>{{expansionPanelTooltip}}</span>
                 </v-tooltip>
               </v-list-tile-action>
             </v-list-tile>
             <v-expand-transition>
-              <v-card v-if="expansionPanel" flat class="mx-2">
+              <v-card v-if="expansionPanel" flat class="mx-2 mt-2">
                 <v-card-text class="pt-0">
                   <div class="grey--text text--darken-2">
                     The downloaded <tt>kubeconfig</tt> will initiate
-                    <a href="https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens" target="_blank" class="teal--text text--darken-2">
+                    <external-link url="https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens" color="teal darken-2">
                       OIDC
-                    </a>
+                    </external-link>
                     authentication via <tt>kubelogin</tt>.
                     If not already done, please install <tt>kubelogin</tt>
                     according to the
-                    <a link href="https://github.com/int128/kubelogin#setup" target="_blank" class="teal--text text--darken-2">
+                    <external-link url="https://github.com/int128/kubelogin#setup" color="teal darken-2">
                       setup instructions
-                    </a>.
-                    For more information about please refer to the <tt>kubelogin</tt> documentation.
-                    <br/>
-                    Below you can configure and preview some the <tt>kubeconfig</tt> file before download.
+                    </external-link>.
+                    For more information please refer to the <tt>kubelogin</tt> documentation.
+                    <br>
+                    Below you can configure and preview the <tt>kubeconfig</tt> file before download.
                   </div>
                   <v-tabs slider-color="grey lighten-5" color="grey lighten-3" class="mt-2 elevation-1">
                     <v-tab>Configure</v-tab>
                     <v-tab>Preview</v-tab>
-                    <v-spacer/>
-                    <copy-btn :clipboard-text="kubeconfig"></copy-btn>
                     <v-tab-item class="pa-3">
                       <v-layout row wrap>
                         <v-flex xs12>
@@ -189,6 +191,7 @@ limitations under the License.
 <script>
 import CopyBtn from '@/components/CopyBtn'
 import CodeBlock from '@/components/CodeBlock'
+import ExternalLink from '@/components/ExternalLink'
 import download from 'downloadjs'
 import AccountAvatar from '@/components/AccountAvatar'
 import { getToken } from '@/utils/api'
@@ -211,6 +214,7 @@ export default {
   components: {
     CopyBtn,
     CodeBlock,
+    ExternalLink,
     AccountAvatar
   },
   name: 'profile',
@@ -250,14 +254,11 @@ export default {
       'isAdmin',
       'canCreateProject'
     ]),
-    expansionPanelIndex () {
-      switch (this.expansionPanel) {
-        case 'kubeconfig':
-        case 'settings':
-          return 0
-        default:
-          return null
-      }
+    expansionPanelIcon () {
+      return this.expansionPanel ? 'expand_less' : 'expand_more'
+    },
+    expansionPanelTooltip () {
+      return this.expansionPanel ? 'Hide advanced options' : 'Show advanced options'
     },
     icon () {
       return this.isAdmin ? 'supervisor_account' : 'mdi-account'
@@ -272,7 +273,7 @@ export default {
       return moment.duration(this.user.exp - Math.floor(Date.now() / 1000), 'seconds').humanize(true)
     },
     projectNames () {
-      const names = map(this.projectList, 'metadata.name')
+      const names = map(this.projectList, 'metadata.name').sort()
       names.unshift('')
       return names
     },

--- a/frontend/src/pages/Account.vue
+++ b/frontend/src/pages/Account.vue
@@ -91,96 +91,98 @@ limitations under the License.
                 <copy-btn :clipboard-text="idToken"></copy-btn>
               </v-list-tile-action>
             </v-list-tile>
-            <v-divider inset class="my-2"/>
-            <v-list-tile>
-              <v-list-tile-avatar>
-                <v-icon color="teal darken-2">insert_drive_file</v-icon>
-              </v-list-tile-avatar>
-              <v-list-tile-content>
-                <v-list-tile-title>Kubeconfig</v-list-tile-title>
-                <v-list-tile-sub-title>Personalized command line interface access</v-list-tile-sub-title>
-              </v-list-tile-content>
-              <v-list-tile-action>
-                <v-tooltip top>
-                  <v-btn slot="activator" icon @click.native.stop="onDownload">
-                    <v-icon>mdi-download</v-icon>
-                  </v-btn>
-                  <span>Download kubeconfig</span>
-                </v-tooltip>
-              </v-list-tile-action>
-              <v-list-tile-action>
-                <copy-btn :clipboard-text="kubeconfig" tooltipText="Copy kubeconfig to clipboard"></copy-btn>
-              </v-list-tile-action>
-              <v-list-tile-action>
-                <v-tooltip top>
-                  <v-btn slot="activator" icon @click.native.stop="expansionPanel = !expansionPanel">
-                    <v-icon>{{expansionPanelIcon}}</v-icon>
-                  </v-btn>
-                  <span>{{expansionPanelTooltip}}</span>
-                </v-tooltip>
-              </v-list-tile-action>
-            </v-list-tile>
-            <v-expand-transition>
-              <v-card v-if="expansionPanel" flat class="mx-2 mt-2">
-                <v-card-text class="pt-0">
-                  <div class="grey--text text--darken-2">
-                    The downloaded <tt>kubeconfig</tt> will initiate
-                    <external-link url="https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens" color="teal darken-2">
-                      OIDC
-                    </external-link>
-                    authentication via <tt>kubelogin</tt>.
-                    If not already done, please install <tt>kubelogin</tt>
-                    according to the
-                    <external-link url="https://github.com/int128/kubelogin#setup" color="teal darken-2">
-                      setup instructions
-                    </external-link>.
-                    For more information please refer to the <tt>kubelogin</tt> documentation.
-                    <br>
-                    Below you can configure and preview the <tt>kubeconfig</tt> file before download.
-                  </div>
-                  <v-tabs slider-color="grey lighten-1" color="grey lighten-3" class="mt-2 elevation-1">
-                    <v-tab>Configure</v-tab>
-                    <v-tab>Preview</v-tab>
-                    <v-tab-item class="pa-3">
-                      <v-layout row wrap>
-                        <v-flex xs12>
-                          <v-select
-                            color="teal darken-1"
-                            v-model="projectName"
-                            :items="projectNames"
-                            label="Project"
-                            hint="The namespace of the selected project will be the default namespace in the kubeconfig"
-                            persistent-hint
-                          ></v-select>
-                        </v-flex>
-                        <v-flex xs12>
-                          <v-select
-                            color="teal darken-1"
-                            v-model="grantType"
-                            :items="grantTypes"
-                            label="Grant Type"
-                            hint="The authorization grant type to use"
-                            persistent-hint
-                          ></v-select>
-                        </v-flex>
-                        <v-flex xs12>
-                          <v-switch
-                            color="teal darken-1"
-                            v-model="skipOpenBrowser"
-                            label="Skip Open Browser"
-                            hint="If true, it does not open the browser on authentication"
-                            persistent-hint
-                          ></v-switch>
-                        </v-flex>
-                      </v-layout>
-                    </v-tab-item>
-                    <v-tab-item>
-                      <code-block lang="yaml" :content="kubeconfig" :show-copy-button="false"></code-block>
-                    </v-tab-item>
-                  </v-tabs>
-                </v-card-text>
-              </v-card>
-            </v-expand-transition>
+            <template v-if="isKubeconfigEnabled">
+              <v-divider inset class="my-2"/>
+              <v-list-tile>
+                <v-list-tile-avatar>
+                  <v-icon color="teal darken-2">insert_drive_file</v-icon>
+                </v-list-tile-avatar>
+                <v-list-tile-content>
+                  <v-list-tile-title>Kubeconfig</v-list-tile-title>
+                  <v-list-tile-sub-title>Personalized command line interface access</v-list-tile-sub-title>
+                </v-list-tile-content>
+                <v-list-tile-action>
+                  <v-tooltip top>
+                    <v-btn slot="activator" icon @click.native.stop="onDownload">
+                      <v-icon>mdi-download</v-icon>
+                    </v-btn>
+                    <span>Download kubeconfig</span>
+                  </v-tooltip>
+                </v-list-tile-action>
+                <v-list-tile-action>
+                  <copy-btn :clipboard-text="kubeconfig" tooltipText="Copy kubeconfig to clipboard"></copy-btn>
+                </v-list-tile-action>
+                <v-list-tile-action>
+                  <v-tooltip top>
+                    <v-btn slot="activator" icon @click.native.stop="expansionPanel = !expansionPanel">
+                      <v-icon>{{expansionPanelIcon}}</v-icon>
+                    </v-btn>
+                    <span>{{expansionPanelTooltip}}</span>
+                  </v-tooltip>
+                </v-list-tile-action>
+              </v-list-tile>
+              <v-expand-transition>
+                <v-card v-if="expansionPanel" flat class="mx-2 mt-2">
+                  <v-card-text class="pt-0">
+                    <div class="grey--text text--darken-2">
+                      The downloaded <tt>kubeconfig</tt> will initiate
+                      <external-link url="https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens" color="teal darken-2">
+                        OIDC
+                      </external-link>
+                      authentication via <tt>kubelogin</tt>.
+                      If not already done, please install <tt>kubelogin</tt>
+                      according to the
+                      <external-link url="https://github.com/int128/kubelogin#setup" color="teal darken-2">
+                        setup instructions
+                      </external-link>.
+                      For more information please refer to the <tt>kubelogin</tt> documentation.
+                      <br>
+                      Below you can configure and preview the <tt>kubeconfig</tt> file before download.
+                    </div>
+                    <v-tabs slider-color="grey lighten-1" color="grey lighten-3" class="mt-2 elevation-1">
+                      <v-tab>Configure</v-tab>
+                      <v-tab>Preview</v-tab>
+                      <v-tab-item class="pa-3">
+                        <v-layout row wrap>
+                          <v-flex xs12>
+                            <v-select
+                              color="teal darken-1"
+                              v-model="projectName"
+                              :items="projectNames"
+                              label="Project"
+                              hint="The namespace of the selected project will be the default namespace in the kubeconfig"
+                              persistent-hint
+                            ></v-select>
+                          </v-flex>
+                          <v-flex xs12>
+                            <v-select
+                              color="teal darken-1"
+                              v-model="grantType"
+                              :items="grantTypes"
+                              label="Grant Type"
+                              hint="The authorization grant type to use"
+                              persistent-hint
+                            ></v-select>
+                          </v-flex>
+                          <v-flex xs12>
+                            <v-switch
+                              color="teal darken-1"
+                              v-model="skipOpenBrowser"
+                              label="Skip Open Browser"
+                              hint="If true, it does not open the browser on authentication"
+                              persistent-hint
+                            ></v-switch>
+                          </v-flex>
+                        </v-layout>
+                      </v-tab-item>
+                      <v-tab-item>
+                        <code-block lang="yaml" :content="kubeconfig" :show-copy-button="false"></code-block>
+                      </v-tab-item>
+                    </v-tabs>
+                  </v-card-text>
+                </v-card>
+              </v-expand-transition>
+            </template>
           </v-list>
         </v-card>
       </v-flex>
@@ -194,7 +196,7 @@ import CodeBlock from '@/components/CodeBlock'
 import ExternalLink from '@/components/ExternalLink'
 import download from 'downloadjs'
 import AccountAvatar from '@/components/AccountAvatar'
-import { getToken, getKubeconfigData } from '@/utils/api'
+import { getToken } from '@/utils/api'
 import { mapState, mapGetters } from 'vuex'
 import moment from 'moment-timezone'
 import map from 'lodash/map'
@@ -236,15 +238,8 @@ export default {
     try {
       const project = find(this.projectList, ['metadata.namespace', this.namespace])
       this.projectName = get(project, 'metadata.name', '')
-      const [
-        { data },
-        { data: kubeconfigData }
-      ] = await Promise.all([
-        getToken(),
-        getKubeconfigData()
-      ])
+      const { data } = await getToken()
       this.idToken = data.token
-      this.kubeconfigData = kubeconfigData
     } catch (err) {
       console.error(err.message)
     }
@@ -253,14 +248,16 @@ export default {
     ...mapState([
       'user',
       'namespace',
-      'cfg'
+      'cfg',
+      'kubeconfigData'
     ]),
     ...mapGetters([
       'username',
       'projectList',
       'fullDisplayName',
       'isAdmin',
-      'canCreateProject'
+      'canCreateProject',
+      'isKubeconfigEnabled'
     ]),
     expansionPanelIcon () {
       return this.expansionPanel ? 'expand_less' : 'expand_more'
@@ -298,6 +295,7 @@ export default {
       const {
         server,
         certificateAuthorityData,
+        insecureSkipTlsVerify,
         oidc: {
           issuerUrl,
           clientId,
@@ -306,8 +304,12 @@ export default {
         } = {}
       } = this.kubeconfigData || {}
       const cluster = {
-        'certificate-authority-data': certificateAuthorityData,
         server
+      }
+      if (certificateAuthorityData) {
+        cluster['certificate-authority-data'] = certificateAuthorityData
+      } else if (insecureSkipTlsVerify) {
+        cluster['insecure-skip-tls-verify'] = true
       }
       const context = {
         cluster: name,
@@ -359,12 +361,7 @@ export default {
   },
   methods: {
     onDownload () {
-      let filename = 'kubeconfig-garden'
-      if (this.projectName) {
-        filename += '-' + this.projectName
-      }
-      filename += '.yaml'
-      download(this.kubeconfig, filename, 'text/yaml')
+      download(this.kubeconfig, this.kubeconfigFilename, 'text/yaml')
     }
   }
 }

--- a/frontend/src/pages/Account.vue
+++ b/frontend/src/pages/Account.vue
@@ -15,52 +15,123 @@ limitations under the License.
  -->
 
 <template>
-  <v-container fluid>
-    <v-card class="mt-2">
-      <v-toolbar card class="teal darken-1" dark>
-        <v-icon class="white--text pr-2">{{icon}}</v-icon>
-        <v-toolbar-title>User Details</v-toolbar-title>
-        <v-spacer></v-spacer>
-        <copy-btn
-          :clipboard-text="idToken"
-          tooltip-text="Copy ID Token to clipboard"
-          copy-success-text="Copied ID Token to clipboard!">
-        </copy-btn>
-      </v-toolbar>
-      <v-card-text>
-        <v-layout row wrap>
-          <v-flex md6 xs12>
-            <label class="caption grey--text text--darken-2">Name</label>
-            <p class="pt-2">
-              <account-avatar :account-name="username" mailTo :size="32"/>
-            </p>
-          </v-flex>
-          <v-flex v-if="!!fullDisplayName" md6 xs12>
-            <label class="caption grey--text text--darken-2">Display Name</label>
-            <p class="subheading">{{fullDisplayName}}</p>
-          </v-flex>
-          <v-flex md6 xs12>
-            <label class="caption grey--text text--darken-2">Groups</label>
-            <p>
-              <v-chip v-for="(group, index) in groups" :key="index" label small outline disabled color="black">{{group}}</v-chip>
-            </p>
-          </v-flex>
-          <v-flex md6 xs12>
-            <label class="caption grey--text text--darken-2">Session Expiration</label>
-            <p class="subheading">{{expiresAt}}</p>
-          </v-flex>
-        </v-layout>
-      </v-card-text>
-    </v-card>
+  <v-container grid-list-lg fluid>
+    <v-layout row wrap>
+      <v-flex md6 xs12>
+        <v-card>
+          <v-toolbar card class="teal darken-1" dark>
+            <v-icon class="white--text pr-2">{{icon}}</v-icon>
+            <v-toolbar-title>User Details</v-toolbar-title>
+            <v-spacer></v-spacer>
+            <copy-btn
+              :clipboard-text="idToken"
+              tooltip-text="Copy ID Token to clipboard"
+              copy-success-text="Copied ID Token to clipboard!">
+            </copy-btn>
+          </v-toolbar>
+          <v-card-text>
+            <v-layout row wrap>
+              <v-flex xs12>
+                <label class="caption grey--text text--darken-2">Name</label>
+                <p class="pt-2">
+                  <account-avatar :account-name="username" mailTo :size="32"/>
+                </p>
+              </v-flex>
+              <v-flex v-if="!!fullDisplayName" md6 xs12>
+                <label class="caption grey--text text--darken-2">Display Name</label>
+                <p class="subheading">{{fullDisplayName}}</p>
+              </v-flex>
+              <v-flex xs12>
+                <label class="caption grey--text text--darken-2">Groups</label>
+                <p>
+                  <v-chip v-for="(group, index) in groups" :key="index" label small outline disabled color="black">{{group}}</v-chip>
+                </p>
+              </v-flex>
+              <v-flex xs12>
+                <label class="caption grey--text text--darken-2">Session Expiration</label>
+                <p class="subheading">{{expiresAt}}</p>
+              </v-flex>
+            </v-layout>
+          </v-card-text>
+        </v-card>
+      </v-flex>
+      <v-flex md6 xs12>
+        <v-card >
+          <v-toolbar card class="teal darken-1" dark>
+            <v-icon class="white--text pr-2">insert_drive_file</v-icon>
+            <v-toolbar-title>Kubeconfig</v-toolbar-title>
+          </v-toolbar>
+          <v-card-text>
+            <v-layout row wrap>
+              <v-flex xs12>
+                 The downloaded kubeconfig will use <a href="https://github.com/int128/kubelogin"><tt>kubelogin</tt></a>, also known as <tt>kubectl oidc-login</tt>.
+                 for login into the garden cluster. Below you can configure some of command line arguments of <tt>kubelogin</tt>.
+              </v-flex>
+              <v-flex xs12 d-flex>
+                <v-select
+                  color="teal darken-1"
+                  v-model="projectName"
+                  :items="projectNames"
+                  label="Project"
+                  hint="The namespace of the project will be the namespace of the <tt>current-context</tt>"
+                  persistent-hint
+                ></v-select>
+              </v-flex>
+              <v-flex xs12 d-flex>
+                <v-select
+                  color="teal darken-1"
+                  v-model="grantType"
+                  :items="grantTypes"
+                  label="Grant Type"
+                  hint="The authorization grant type to use"
+                  persistent-hint
+                ></v-select>
+              </v-flex>
+              <v-flex xs12 d-flex>
+                <v-switch
+                  color="teal darken-1"
+                  v-model="skipOpenBrowser"
+                  label="Skip Open Browser"
+                  hint="If true, it does not open the browser on authentication"
+                  persistent-hint
+                ></v-switch>
+              </v-flex>
+            </v-layout>
+          </v-card-text>
+          <v-card-actions class="grey lighten-4 mt-2">
+            <div class="ma-1">
+              <v-tooltip top>
+                <v-btn flat color="grey darken-4" slot="activator" @click="onDownload">
+                  Download
+                </v-btn>
+                <span>Download Kubeconfig</span>
+              </v-tooltip>
+            </div>
+          </v-card-actions>
+        </v-card>
+      </v-flex>
+    </v-layout>
   </v-container>
 </template>
 
 <script>
 import CopyBtn from '@/components/CopyBtn'
+import download from 'downloadjs'
 import AccountAvatar from '@/components/AccountAvatar'
 import { getToken } from '@/utils/api'
 import { mapState, mapGetters } from 'vuex'
 import moment from 'moment-timezone'
+import map from 'lodash/map'
+import find from 'lodash/find'
+
+// js-yaml
+import jsyaml from 'js-yaml'
+
+function safeDump (value) {
+  return jsyaml.safeDump(value, {
+    skipInvalid: true
+  })
+}
 
 export default {
   components: {
@@ -70,6 +141,10 @@ export default {
   name: 'profile',
   data () {
     return {
+      projectName: undefined,
+      skipOpenBrowser: false,
+      grantType: 'auto',
+      grantTypes: [ 'auto', 'authcode', 'authcode-keyboard' ],
       idToken: undefined,
       showToken: false,
       floatingButton: false,
@@ -78,6 +153,10 @@ export default {
   },
   async mounted () {
     try {
+      const project = find(this.projectList, ['metadata.namespace', this.namespace])
+      if (project) {
+        this.projectName = project.metadata.name
+      }
       const { data } = await getToken()
       this.idToken = data.token
     } catch (err) {
@@ -86,10 +165,13 @@ export default {
   },
   computed: {
     ...mapState([
-      'user'
+      'user',
+      'namespace',
+      'cfg'
     ]),
     ...mapGetters([
       'username',
+      'projectList',
       'fullDisplayName',
       'isAdmin',
       'canCreateProject'
@@ -105,6 +187,81 @@ export default {
     },
     expiresAt () {
       return moment.duration(this.user.exp - Math.floor(Date.now() / 1000), 'seconds').humanize(true)
+    },
+    projectNames () {
+      return map(this.projectList, 'metadata.name')
+    },
+    kubeconfig () {
+      const project = find(this.projectList, ['metadata.name', this.projectName])
+      const name = 'garden-' + project.metadata.name
+      const namespace = project.metadata.namespace
+      const {
+        server,
+        certificateAuthorityData,
+        oidc: {
+          issuerUrl,
+          clientId,
+          clientSecret,
+          extraScopes = []
+        }
+      } = this.cfg.kubeconfig
+      const cluster = {
+        'certificate-authority-data': certificateAuthorityData,
+        server
+      }
+      const context = {
+        cluster: name,
+        user: 'oidc-login'
+      }
+      if (namespace) {
+        context.namespace = namespace
+      }
+      const args = [
+        'oidc-login',
+        'get-token',
+        '--oidc-issuer-url=' + issuerUrl,
+        '--oidc-client-id=' + clientId,
+        '--oidc-client-secret=' + clientSecret
+      ]
+      for (const scope of extraScopes) {
+        args.push('--oidc-extra-scope=' + scope)
+      }
+      args.push('--grant-type=' + this.grantType)
+      if (this.skipOpenBrowser) {
+        args.push('--skip-open-browser')
+      }
+      const user = {
+        exec: {
+          apiVersion: 'client.authentication.k8s.io/v1beta1',
+          command: 'kubectl',
+          args
+        }
+      }
+      return {
+        kind: 'Config',
+        apiVersion: 'v1',
+        clusters: [{
+          name,
+          cluster
+        }],
+        contexts: [{
+          context,
+          name
+        }],
+        'current-context': name,
+        users: [{
+          name: 'oidc-login',
+          user
+        }],
+        preferences: {}
+      }
+    }
+  },
+  methods: {
+    onDownload () {
+      const filename = `kubeconfig-garden-${this.projectName}.yaml`
+      const data = safeDump(this.kubeconfig)
+      download(data, filename, 'text/yaml')
     }
   }
 }

--- a/frontend/src/pages/Administration.vue
+++ b/frontend/src/pages/Administration.vue
@@ -41,6 +41,7 @@ limitations under the License.
             <label class="caption grey--text text--darken-2">Technical Contact</label>
             <p class="subheading"><account-avatar :account-name="technicalContact" :mail-to="true"></account-avatar></p>
           </v-flex>
+
         </v-layout>
         <v-layout row wrap>
           <v-flex lg4 xs12>
@@ -75,6 +76,14 @@ limitations under the License.
           <v-flex xs12 v-if="slaDescriptionCompiledMarkdown">
             <label class="caption grey--text text--darken-2">{{slaTitle}}</label>
             <p class="subheading" v-html="slaDescriptionCompiledMarkdown" />
+          </v-flex>
+          <v-flex xs12>
+            <label class="caption grey--text text--darken-2">Command Line Interface Access</label>
+            <p class="subheading">
+              Go to
+              <router-link :to="{ name: 'Account', query: { namespace: this.namespace } }">My Account</router-link>
+              to download the <tt>kubeconfig</tt> for this project.
+            </p>
           </v-flex>
         </v-layout>
         <update-dialog v-model="edit" :project="project" mode="update"></update-dialog>
@@ -132,7 +141,8 @@ export default {
   },
   computed: {
     ...mapState([
-      'cfg'
+      'cfg',
+      'namespace'
     ]),
     ...mapGetters([
       'shootList',

--- a/frontend/src/pages/Administration.vue
+++ b/frontend/src/pages/Administration.vue
@@ -77,7 +77,7 @@ limitations under the License.
             <label class="caption grey--text text--darken-2">{{slaTitle}}</label>
             <p class="subheading" v-html="slaDescriptionCompiledMarkdown" />
           </v-flex>
-          <v-flex xs12>
+          <v-flex xs12 v-if="isKubeconfigEnabled">
             <label class="caption grey--text text--darken-2">Command Line Interface Access</label>
             <p class="subheading">
               Go to
@@ -150,7 +150,8 @@ export default {
       'canPatchProject',
       'canDeleteProject',
       'projectFromProjectList',
-      'costObjectSettings'
+      'costObjectSettings',
+      'isKubeconfigEnabled'
     ]),
     project () {
       return this.projectFromProjectList

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -509,6 +509,7 @@ export default function createRouter ({ store, userManager }) {
       await Promise.all([
         ensureCloudProfilesLoaded(),
         ensureProjectsLoaded(),
+        store.dispatch('fetchKubeconfigData'),
         store.dispatch('unsubscribeComments')
       ])
       const params = to.params || {}

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -20,7 +20,7 @@ import createLogger from 'vuex/dist/logger'
 
 import EmitterWrapper from '@/utils/Emitter'
 import { gravatarUrlGeneric, displayName, fullDisplayName, getDateFormatted, addKymaAddon, canI } from '@/utils'
-import { getSubjectRules } from '@/utils/api'
+import { getSubjectRules, getKubeconfigData } from '@/utils/api'
 import reduce from 'lodash/reduce'
 import map from 'lodash/map'
 import flatMap from 'lodash/flatMap'
@@ -67,6 +67,7 @@ if (debug) {
 // initial state
 const state = {
   cfg: null,
+  kubeconfigData: null,
   ready: false,
   namespace: null,
   subjectRules: { // selfSubjectRules for state.namespace
@@ -630,6 +631,9 @@ const getters = {
   },
   splitpaneResize (state) {
     return state.splitpaneResize
+  },
+  isKubeconfigEnabled (state) {
+    return !!(get(state, 'kubeconfigData.oidc.clientId') && get(state, 'kubeconfigData.oidc.clientSecret'))
   }
 }
 
@@ -868,6 +872,12 @@ const actions = {
     }
     return state.subjectRules
   },
+  async fetchKubeconfigData ({ commit }) {
+    if (!store.state.kubeconfigData) {
+      const { data } = await getKubeconfigData()
+      commit('SET_KUBECONFIG_DATA', data)
+    }
+  },
   setOnlyShootsWithIssues ({ commit }, value) {
     commit('SET_ONLYSHOOTSWITHISSUES', value)
     return state.onlyShootsWithIssues
@@ -947,6 +957,9 @@ const mutations = {
   },
   SET_SUBJECT_RULES (state, value) {
     state.subjectRules = value
+  },
+  SET_KUBECONFIG_DATA (state, value) {
+    state.kubeconfigData = value
   },
   SET_ONLYSHOOTSWITHISSUES (state, value) {
     state.onlyShootsWithIssues = value

--- a/frontend/src/stylus/main.styl
+++ b/frontend/src/stylus/main.styl
@@ -42,37 +42,6 @@ $swift-ease-in-out-duration = .5s !default
 $swift-ease-in-out-timing-function = cubic-bezier(.35, 0, .25, 1) !default
 $swift-ease-in-out = all $swift-ease-in-out-duration $swift-ease-in-out-timing-function !default
 
-.code-block {
-  .hljs-keyword,
-  .hljs-selector-tag,
-  .hljs-selector-class,
-  .hljs-subst {
-    font-weight: 500;
-  }
-  .hljs-keyword {
-    color: $pink.darken-1;
-  }
-  .hljs-string {
-    color: $teal.darken-2;
-  }
-  .hljs-comment {
-    color: $grey.darken-2;
-    font-style: italic;
-  }
-  .hljs-built_in,
-  .hljs-attr,
-  .hljs-attribute {
-    color: $blue.darken-2;
-  }
-  .hljs-selector-tag,
-  .hljs-selector-class,
-  .hljs-tag,
-  .hljs-name,
-  .hljs-number {
-    color: $purple.darken-1;
-  }
-}
-
 .mr-extra {
   margin-right: 96px
 }

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -234,6 +234,10 @@ export function getToken () {
   return getResource('/api/user/token')
 }
 
+export function getKubeconfigData () {
+  return getResource('/api/user/kubeconfig')
+}
+
 /* Info */
 export function getInfo () {
   return getResource(`/api/info`)

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -131,10 +131,10 @@
     cssnano-preset-default "^4.0.0"
     postcss "^7.0.0"
 
-"@mdi/font@^5.0.45":
-  version "5.0.45"
-  resolved "https://registry.yarnpkg.com/@mdi/font/-/font-5.0.45.tgz#8eda40c41dc7ee9e7a51dbe9191c5c38b8482422"
-  integrity sha512-3sOO/UMyQqrmizW5zjvhKJP4FZFO7LblRw4G0alDxK1ekUwNxNXI7hYv8ACAv8H44riBuqlVJ7u39XDqv/Xwuw==
+"@mdi/font@^v4.9.95":
+  version "4.9.95"
+  resolved "https://registry.yarnpkg.com/@mdi/font/-/font-4.9.95.tgz#00ed2ffe289c9230f146e74559c07542d3f4475a"
+  integrity sha512-m2sbAs+SMwRnWpkMriBxEulwuhmqRyh6X+hdOZlqSxYZUM2C2TaDnQ4gcilzdoAgru2XYnWViZ/xPuSDGgRXVw==
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -131,10 +131,10 @@
     cssnano-preset-default "^4.0.0"
     postcss "^7.0.0"
 
-"@mdi/font@^4.4.95":
-  version "4.4.95"
-  resolved "https://registry.yarnpkg.com/@mdi/font/-/font-4.4.95.tgz#4a00f46a500120714ded1524f376f7882346d3fd"
-  integrity sha512-9BSvtpDF83dQ06VmwCeXTebzZZisIf4u6d62uC53oD6bzBUEMqiQrbW+oxyFrBYn3VxttRt/MKuL/wKUV9HWmA==
+"@mdi/font@^5.0.45":
+  version "5.0.45"
+  resolved "https://registry.yarnpkg.com/@mdi/font/-/font-5.0.45.tgz#8eda40c41dc7ee9e7a51dbe9191c5c38b8482422"
+  integrity sha512-3sOO/UMyQqrmizW5zjvhKJP4FZFO7LblRw4G0alDxK1ekUwNxNXI7hYv8ACAv8H44riBuqlVJ7u39XDqv/Xwuw==
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow users to download a kubeconfig file for accessing the garden cluster. The kubeconfig file will oidc-login kubectl plugin for cluster authentication.

**New configuration properties example [`values.yaml`]**
```yaml
...
apiServerUrl: https://api.garden.example.org  # required - URL of kube-apiserver 
apiServerCaData: LS0tLS1CRUdJTiBDR...         # optional - caData of kube-apiserver 
...
oidc:
  issuer: https://identity.garden.example.org # required - URL of OIDC provider
  ...
  public:
    clientId: kube-kubectl              # optional - Id of the public OIDC client. Defaults to `kube-kubectl`. 
    clientSecret: <publicClientSecret>  # required - Secret of the public OIDC client  
...
```
**Advanced options collapsed**
<img width="1406" alt="Advanced options collapsed" src="https://user-images.githubusercontent.com/1574023/78662695-2b68ae00-78d1-11ea-9b40-2c5dd6cbc198.png">

**Advanced options expaned**
<div>
<img width="557" alt="Screen Shot 2020-04-07 at 13 09 34" src="https://user-images.githubusercontent.com/1574023/78662730-3ae7f700-78d1-11ea-947c-b384d1044590.png">

**Which issue(s) this PR fixes**:
Fixes #417

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Users are able to download a `kubeconfig` file for accessing the garden cluster with `kubectl`
```
