### PR TITLE
Update the Shoot status label

### DIFF
--- a/backend/lib/services/shoots.js
+++ b/backend/lib/services/shoots.js
@@ -33,7 +33,7 @@ exports.list = async function ({ user, namespace, shootsWithIssuesOnly = false }
   const client = user.client
   const query = {}
   if (shootsWithIssuesOnly) {
-    query.labelSelector = 'shoot.garden.sapcloud.io/status!=healthy'
+    query.labelSelector = 'shoot.gardener.cloud/status!=healthy'
   }
   if (!namespace) {
     return client['core.gardener.cloud'].shoots.listAllNamespaces(query)

--- a/backend/lib/utils/index.js
+++ b/backend/lib/utils/index.js
@@ -50,7 +50,7 @@ function getSeedNameFromShoot ({ spec = {} }) {
 }
 
 function shootHasIssue (shoot) {
-  return _.get(shoot, ['metadata', 'labels', 'shoot.garden.sapcloud.io/status'], 'healthy') !== 'healthy'
+  return _.get(shoot, ['metadata', 'labels', 'shoot.gardener.cloud/status'], 'healthy') !== 'healthy'
 }
 
 function joinMemberRoleAndRoles (role, roles) {

--- a/backend/test/utils.spec.js
+++ b/backend/test/utils.spec.js
@@ -51,14 +51,14 @@ describe('utils', function () {
       const shoot = {
         metadata: {
           labels: {
-            'shoot.garden.sapcloud.io/status': undefined
+            'shoot.gardener.cloud/status': undefined
           }
         }
       }
       expect(shootHasIssue(shoot)).to.be.false
-      shoot.metadata.labels['shoot.garden.sapcloud.io/status'] = 'healthy'
+      shoot.metadata.labels['shoot.gardener.cloud/status'] = 'healthy'
       expect(shootHasIssue(shoot)).to.be.false
-      shoot.metadata.labels['shoot.garden.sapcloud.io/status'] = 'unhealthy'
+      shoot.metadata.labels['shoot.gardener.cloud/status'] = 'unhealthy'
       expect(shootHasIssue(shoot)).to.be.true
     })
 

--- a/backend/test/watches.spec.js
+++ b/backend/test/watches.spec.js
@@ -138,13 +138,13 @@ describe('watches', function () {
     const foobarUnhealthy = _
       .chain(foobar)
       .cloneDeep()
-      .set('metadata.labels["shoot.garden.sapcloud.io/status"]', 'unhealthy')
+      .set('metadata.labels["shoot.gardener.cloud/status"]', 'unhealthy')
       .value()
 
     const foobazUnhealthy = _
       .chain(foobaz)
       .cloneDeep()
-      .set('metadata.labels["shoot.garden.sapcloud.io/status"]', 'unhealthy')
+      .set('metadata.labels["shoot.gardener.cloud/status"]', 'unhealthy')
       .value()
 
     let shootsWithIssues

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -394,7 +394,7 @@ export function isUserError (errorCodes) {
   return every(errorCodes, errorCode => includes(userErrorCodes, errorCode))
 }
 export function shootHasIssue (shoot) {
-  return get(shoot, ['metadata', 'labels', 'shoot.garden.sapcloud.io/status'], 'healthy') !== 'healthy'
+  return get(shoot, ['metadata', 'labels', 'shoot.gardener.cloud/status'], 'healthy') !== 'healthy'
 }
 
 export function isReconciliationDeactivated (metadata) {
@@ -405,7 +405,7 @@ export function isReconciliationDeactivated (metadata) {
 }
 
 export function isStatusProgressing (metadata) {
-  return get(metadata, ['labels', 'shoot.garden.sapcloud.io/status']) === 'progressing'
+  return get(metadata, ['labels', 'shoot.gardener.cloud/status']) === 'progressing'
 }
 
 export function isSelfTerminationWarning (expirationTimestamp) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Update the Shoot status label to be the non-deprecated one. Since gardener/gardener@v1.0.0 (ref https://github.com/gardener/gardener/pull/1833/) both labels are maintained but `shoot.garden.sapcloud.io/status` will be removed soon.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
NONE
```
