### PR TITLE
Optimized Create Cluster / Cluster Editor Dialogs Buttons 

### DIFF
--- a/frontend/src/pages/NewShoot.vue
+++ b/frontend/src/pages/NewShoot.vue
@@ -420,9 +420,10 @@ export default {
     },
     confirmNavigation () {
       return this.$refs.confirmDialog.waitForConfirmation({
-        confirmButtonText: 'Leave',
-        captionText: 'Leave Create Cluster Page?',
-        messageHtml: 'Your cluster has not been created.<br/>Do you want to cancel cluster creation and discard your changes?'
+        confirmButtonText: 'Yes',
+        cancelButtonText: 'No',
+        captionText: 'Cancel Cluster Creation?',
+        messageHtml: 'Your cluster has not been created.<br/>Do you want to cancel cluster creation and discard your draft?'
       })
     },
     confirmNavigateToYamlIfInvalid () {

--- a/frontend/src/pages/ShootDetailsEditor.vue
+++ b/frontend/src/pages/ShootDetailsEditor.vue
@@ -125,7 +125,8 @@ export default {
     },
     confirmEditorNavigation () {
       return this.$refs.confirmDialog.waitForConfirmation({
-        confirmButtonText: 'Leave',
+        confirmButtonText: 'Yes',
+        cancelButtonText: 'No',
         captionText: 'Leave Editor?',
         messageHtml: 'Your changes have not been saved.<br/>Are you sure you want to leave the editor?'
       })


### PR DESCRIPTION
**What this PR does / why we need it**:
The labeling of the create cluster / cluster editor warning dialogs was a bit confusing. So we optimized it to make it more clear.

<img width="400" alt="Screen Shot 2020-04-03 at 20 49 41" src="https://user-images.githubusercontent.com/35373687/78401981-21f1f400-75fa-11ea-888e-20012d6a7213.png">

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user

```
