### PR TITLE
Rename suse-jeos to suse-chost

### DIFF
--- a/frontend/src/components/VendorIcon.vue
+++ b/frontend/src/components/VendorIcon.vue
@@ -76,6 +76,8 @@ export default {
           return require('@/assets/coreos.svg')
         case 'suse-jeos':
           return require('@/assets/suse.svg')
+        case 'suse-chost':
+          return require('@/assets/suse.svg')
         case 'ubuntu':
           return require('@/assets/ubuntu.svg')
         case 'metal':

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -126,12 +126,14 @@ const vendorNameFromImageName = imageName => {
     return 'ubuntu'
   } else if (lowerCaseName.includes('suse') && lowerCaseName.includes('jeos')) {
     return 'suse-jeos'
+  } else if (lowerCaseName.includes('suse') && lowerCaseName.includes('chost')) {
+    return 'suse-chost'
   }
   return undefined
 }
 
 const vendorNeedsLicense = vendorName => {
-  return vendorName === 'suse-jeos'
+  return vendorName === 'suse-jeos' || vendorName === 'suse-chost'
 }
 
 const matchesPropertyOrEmpty = (path, srcValue) => {

--- a/frontend/tests/unit/store.index.spec.js
+++ b/frontend/tests/unit/store.index.spec.js
@@ -30,7 +30,7 @@ describe('Store', function () {
         ]
       },
       {
-        'name': 'suse-jeos',
+        'name': 'suse-chost',
         'versions': [
           {
             'version': '15.1.20190927'
@@ -72,17 +72,17 @@ describe('Store', function () {
     const dashboardMachineImages = getters.machineImagesByCloudProfileName({}, storeGetters)('foo')
     expect(dashboardMachineImages).to.have.length(4)
 
-    const expiredImage = find(dashboardMachineImages, { name: 'suse-jeos', version: '15.1.20191127' })
+    const expiredImage = find(dashboardMachineImages, { name: 'suse-chost', version: '15.1.20191127' })
     expect(expiredImage).to.equal(undefined)
 
     const invalidImage = find(dashboardMachineImages, { name: 'foo', version: '1.02.3' })
     expect(invalidImage).to.equal(undefined)
 
-    const suseImage = find(dashboardMachineImages, { name: 'suse-jeos', version: '15.1.20191027' })
+    const suseImage = find(dashboardMachineImages, { name: 'suse-chost', version: '15.1.20191027' })
     expect(suseImage.expirationDate).to.equal('2119-04-05T01:02:03Z')
     expect(suseImage.expirationDateString).to.not.equal(undefined)
-    expect(suseImage.vendorName).to.equal('suse-jeos')
-    expect(suseImage.icon).to.equal('suse-jeos')
+    expect(suseImage.vendorName).to.equal('suse-chost')
+    expect(suseImage.icon).to.equal('suse-chost')
     expect(suseImage.needsLicense).to.equal(true)
     expect(suseImage).to.equal(dashboardMachineImages[1]) // check sorting
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add support for `suse-chost` which is the replacement of `suse-jeos`.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
A support for `suse-chost` as alternative name of `suse-jeos` has been added.
```
