### PR TITLE
[vuetify-2.2] style markdown links

### DIFF
--- a/frontend/src/components/ExternalLink.vue
+++ b/frontend/src/components/ExternalLink.vue
@@ -21,8 +21,7 @@ limitations under the License.
 </template>
 
 <script>
-import split from 'lodash/split'
-import map from 'lodash/map'
+import { textColorFromColor } from '@/utils'
 
 export default {
   name: 'external-link',
@@ -44,8 +43,7 @@ export default {
   },
   computed: {
     textColor () {
-      const iteratee = value => /^(darken|lighten|accent)-\d$/.test(value) ? 'text--' + value : value + '--text'
-      return map(split(this.color, ' '), iteratee)
+      return textColorFromColor(this.color)
     }
   }
 }

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -543,15 +543,33 @@ export function addKymaAddon (options) {
   shootAddonList.push(kymaAddon)
 }
 
-export function compileMarkdown (text) {
+export function textColorFromColor (color) {
+  const iteratee = value => /^(darken|lighten|accent)-\d$/.test(value) ? 'text--' + value : value + '--text'
+  return map(split(color, ' '), iteratee)
+}
+
+export function compileMarkdown (text, linkColor = 'cyan darken-2', transformToExternalLinks = true) {
   if (!text) {
     return undefined
   }
-  return DOMPurify.sanitize(marked(text, {
+  let html = DOMPurify.sanitize(marked(text, {
     gfm: true,
     breaks: true,
     tables: true
   }))
+
+  const linkRegex = /<a (.*?)>(.*?)<\/a>/g
+
+  if (linkColor) {
+    const textColor = join(textColorFromColor(linkColor), ' ')
+    html = html.replace(linkRegex, `<a class="${textColor}" $1>$2</a>`)
+  }
+
+  if (transformToExternalLinks) {
+    html = html.replace(linkRegex, '<a style="text-decoration: none" target="_blank" $1><span style="text-decoration: underline">$2</span> <i class="v-icon mdi mdi-open-in-new" style="font-size: 80%"></i></a>')
+  }
+
+  return html
 }
 
 export function shootAddonByName (name) {

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -565,7 +565,7 @@ export function compileMarkdown (text, linkColor = 'cyan darken-2', transformToE
   if (!text) {
     return undefined
   }
-  let html = DOMPurify.sanitize(marked(text, {
+  const html = DOMPurify.sanitize(marked(text, {
     gfm: true,
     breaks: true,
     tables: true
@@ -574,24 +574,25 @@ export function compileMarkdown (text, linkColor = 'cyan darken-2', transformToE
   const textColorClasses = textColorFromColor(linkColor)
   console.log(textColorClasses)
   const documentFragment = htmlToDocumentFragment(html)
-  if (documentFragment) {
-    const linkElements = documentFragment.querySelectorAll('a')
-    linkElements.forEach(linkElement => {
-      if (textColorClasses.length) {
-        linkElement.classList.add(...textColorClasses)
-      }
-
-      if (transformToExternalLinks) {
-        linkElement.setAttribute('style', 'text-decoration: none')
-        linkElement.setAttribute('target', '_blank')
-        const linkText = linkElement.innerHTML
-        linkElement.innerHTML = `<span style="text-decoration: underline">${linkText}</span> <i class="v-icon mdi mdi-open-in-new" style="font-size: 80%"></i>`
-      }
-    })
+  if (!documentFragment) {
+    return html
   }
 
-  html = documentFragmentToHtml(documentFragment)
-  return html
+  const linkElements = documentFragment.querySelectorAll('a')
+  linkElements.forEach(linkElement => {
+    if (textColorClasses.length) {
+      linkElement.classList.add(...textColorClasses)
+    }
+
+    if (transformToExternalLinks) {
+      linkElement.setAttribute('style', 'text-decoration: none')
+      linkElement.setAttribute('target', '_blank')
+      const linkText = linkElement.innerHTML
+      linkElement.innerHTML = `<span style="text-decoration: underline">${linkText}</span> <i class="v-icon mdi mdi-open-in-new" style="font-size: 80%"></i>`
+    }
+  })
+
+  return documentFragmentToHtml(documentFragment)
 }
 
 export function shootAddonByName (name) {

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -572,7 +572,6 @@ export function compileMarkdown (text, linkColor = 'cyan darken-2', transformToE
   }))
 
   const textColorClasses = textColorFromColor(linkColor)
-  console.log(textColorClasses)
   const documentFragment = htmlToDocumentFragment(html)
   if (!documentFragment) {
     return html


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for styling links in compiled markdown. Currently, all links that are inside markdown (from configuration, journals, etc.) are rendered with default link color and have target _self. With this PR we can modify them to match our style and open in a new tab as we do for other external links.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
NONE
```
