### PR TITLE
Use gardener logo for gardenlinux os image

### DIFF
--- a/frontend/src/components/VendorIcon.vue
+++ b/frontend/src/components/VendorIcon.vue
@@ -84,6 +84,8 @@ export default {
           return require('@/assets/metal.svg')
         case 'metal-white':
           return require('@/assets/metal-white.svg')
+        case 'gardenlinux':
+          return require('@/assets/logo.svg')
       }
       return undefined
     },

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -124,6 +124,8 @@ const vendorNameFromImageName = imageName => {
     return 'coreos'
   } else if (lowerCaseName.includes('ubuntu')) {
     return 'ubuntu'
+  } else if (lowerCaseName.includes('gardenlinux')) {
+    return 'gardenlinux'
   } else if (lowerCaseName.includes('suse') && lowerCaseName.includes('jeos')) {
     return 'suse-jeos'
   } else if (lowerCaseName.includes('suse') && lowerCaseName.includes('chost')) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Use gardener logo for gardenlinux os image for now
<img width="636" alt="Screenshot 2020-04-17 at 21 20 09" src="https://user-images.githubusercontent.com/5526658/79606395-d3f8e800-80f1-11ea-8399-e28ea8e77f4a.png">


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user

```
