### PR TITLE
Always v-slot instead slot and slot-scope

### DIFF
--- a/frontend/src/components/DeleteCluster.vue
+++ b/frontend/src/components/DeleteCluster.vue
@@ -28,7 +28,7 @@ limitations under the License.
     :smallIcon="small"
     maxWidth="600"
   >
-    <template slot="actionComponent">
+    <template v-slot:actionComponent>
       <v-list>
         <v-list-item-content>
           <v-list-item-subtitle>

--- a/frontend/src/components/GPopper.vue
+++ b/frontend/src/components/GPopper.vue
@@ -49,7 +49,7 @@ limitations under the License.
       </v-card>
       <lazy-component @show="emitRendered()"></lazy-component>
     </div>
-    <template slot="reference">
+    <template v-slot:reference>
       <slot name="popperRef"></slot>
     </template>
   </popper>

--- a/frontend/src/components/GTerminal.vue
+++ b/frontend/src/components/GTerminal.vue
@@ -33,9 +33,11 @@ limitations under the License.
         :boundariesSelector="`#boundary_${uuid}`"
       >
         {{snackbarDetailsText}}
-        <v-btn slot="popperRef" text small class="cyan--text text--darken-2">
-          Details
-        </v-btn>
+        <template v-slot:popperRef>
+          <v-btn text small color="cyan darken-2">
+            Details
+          </v-btn>
+        </template>
       </g-popper>
       <v-btn text color="cyan darken-2" @click="retry()">
         Retry
@@ -59,7 +61,7 @@ limitations under the License.
     <draggable-component :uuid="uuid">
       <template v-slot:handle>
         <v-system-bar dark class="systemBarTop" :class="backgroundClass" @click.native="focus">
-          <v-btn :disabled="!isTerminalSessionCreated" icon small class="text-none grey--text text--lighten-1 systemBarButton ml-1 mr-1 g-ignore-drag" @click="deleteTerminal">
+          <v-btn :disabled="!isTerminalSessionCreated" icon small color="grey lighten-1" class="text-none systemBarButton ml-1 mr-1 g-ignore-drag" @click="deleteTerminal">
             <v-icon class="mr-0" small>mdi-close</v-icon>
           </v-btn>
           <v-spacer></v-spacer>
@@ -77,9 +79,11 @@ limitations under the License.
                 :boundariesSelector="`#boundary_${uuid}`"
               >
                 <span v-html="compiledImageHelpText"></span>
-                <v-btn v-on="tooltip" slot="popperRef" v-if="terminalSession.imageHelpText" icon small class="text-none grey--text text--lighten-1 systemBarButton ml-1 mr-1 g-ignore-drag">
-                  <v-icon class="mr-0" small>mdi-help-circle-outline</v-icon>
-                </v-btn>
+                <template v-slot:popperRef>
+                  <v-btn v-on="tooltip" v-if="terminalSession.imageHelpText" icon small color="grey lighten-1" class="text-none systemBarButton ml-1 mr-1 g-ignore-drag">
+                    <v-icon class="mr-0" small>mdi-help-circle-outline</v-icon>
+                  </v-btn>
+                </template>
               </g-popper>
             </template>
             Help
@@ -91,7 +95,7 @@ limitations under the License.
             min-width="400px"
           >
             <template v-slot:activator="{ on: menu }">
-              <v-btn v-on="menu" icon small class="text-none grey--text text--lighten-1 systemBarButton ml-1 mr-1 g-ignore-drag">
+              <v-btn v-on="menu" icon small color="grey lighten-1" class="text-none systemBarButton ml-1 mr-1 g-ignore-drag">
                 <v-icon class="mr-0" small>mdi-menu</v-icon>
               </v-btn>
             </template>
@@ -139,7 +143,7 @@ limitations under the License.
             <template v-slot:activator="{ on: menu }">
               <v-tooltip v-on="menu" :disabled="connectionMenu" top style="min-width: 110px">
                 <template v-slot:activator="{ on: tooltip }">
-                  <v-btn v-on="tooltip" small text class="text-none grey--text text--lighten-1 systemBarButton">
+                  <v-btn v-on="tooltip" small text color="grey lighten-1" class="text-none systemBarButton">
                     <icon-base width="18" height="18" viewBox="-2 -2 30 30" iconColor="#bdbdbd" class="mr-2">
                       <connected v-if="terminalSession.connectionState === TerminalSession.CONNECTED"></connected>
                       <disconnected v-else></disconnected>
@@ -165,7 +169,7 @@ limitations under the License.
 
           <v-tooltip v-if="imageShortText" top>
             <template v-slot:activator="{ on: tooltip }">
-              <v-btn v-on="tooltip" text @click="configure('imageBtn')" :loading="loading.imageBtn" class="text-none grey--text text--lighten-1 systemBarButton">
+              <v-btn v-on="tooltip" text @click="configure('imageBtn')" :loading="loading.imageBtn" color="grey lighten-1" class="text-none systemBarButton">
                 <v-icon class="mr-2">mdi-layers-triple-outline</v-icon>
                 <span>{{imageShortText}}</span>
               </v-btn>
@@ -175,7 +179,7 @@ limitations under the License.
 
           <v-tooltip v-if="privilegedMode !== undefined && target === 'shoot'" top>
             <template v-slot:activator="{ on: tooltip }">
-              <v-btn v-on="tooltip" small text @click="configure('secContextBtn')" :loading="loading.secContextBtn" class="text-none grey--text text--lighten-1 systemBarButton">
+              <v-btn v-on="tooltip" small text @click="configure('secContextBtn')" :loading="loading.secContextBtn" color="grey lighten-1" class="text-none systemBarButton">
                 <v-icon class="mr-2">mdi-shield-account</v-icon>
                 <span>{{privilegedModeText}}</span>
               </v-btn>
@@ -187,7 +191,7 @@ limitations under the License.
 
           <v-tooltip v-if="terminalSession.node && target === 'shoot'" top>
             <template v-slot:activator="{ on: tooltip }">
-              <v-btn v-on="tooltip" small text @click="configure('nodeBtn')" :loading="loading.nodeBtn" class="text-none grey--text text--lighten-1 systemBarButton">
+              <v-btn v-on="tooltip" small text @click="configure('nodeBtn')" :loading="loading.nodeBtn" color="grey lighten-1" class="text-none systemBarButton">
                 <v-icon :size="14" class="mr-2">mdi-server</v-icon>
                 <span>{{terminalSession.node}}</span>
               </v-btn>

--- a/frontend/src/components/NewShoot/NewShootInfrastructureDetails.vue
+++ b/frontend/src/components/NewShoot/NewShootInfrastructureDetails.vue
@@ -44,21 +44,21 @@ limitations under the License.
           persistent-hint
           :hint="secretHint"
           >
-          <template slot="item" slot-scope="data">
-            <template v-if="isAddNewSecret(data.item)">
+          <template v-slot:item="{ item }">
+            <template v-if="isAddNewSecret(item)">
               <v-icon>mdi-plus</v-icon>
-              <span class="pl-2">{{get(data.item, 'title')}}</span>
+              <span class="pl-2">{{get(item, 'title')}}</span>
             </template>
             <template v-else>
-              <span>{{get(data.item, 'metadata.name')}}</span>
-              <v-icon v-if="!isOwnSecretBinding(data.item)">mdi-share</v-icon>
+              <span>{{get(item, 'metadata.name')}}</span>
+              <v-icon v-if="!isOwnSecretBinding(item)">mdi-share</v-icon>
             </template>
           </template>
-          <template slot="selection" slot-scope="data">
+          <template v-slot:selection="{ item }">
             <span>
-              {{get(data.item, 'metadata.name')}}
+              {{get(item, 'metadata.name')}}
             </span>
-            <v-icon v-if="!isOwnSecretBinding(data.item)">mdi-share</v-icon>
+            <v-icon v-if="!isOwnSecretBinding(item)">mdi-share</v-icon>
           </template>
         </v-select>
       </v-col>

--- a/frontend/src/components/PurposeConfiguration.vue
+++ b/frontend/src/components/PurposeConfiguration.vue
@@ -22,7 +22,7 @@ limitations under the License.
     ref="actionDialog"
     maxWidth="400"
     caption="Configure Purpose">
-    <template slot="actionComponent">
+    <template v-slot:actionComponent>
       <purpose
         ref="purpose"
         :secret="secret"

--- a/frontend/src/components/ReconcileStart.vue
+++ b/frontend/src/components/ReconcileStart.vue
@@ -24,7 +24,7 @@ limitations under the License.
     icon="mdi-refresh"
     maxWidth="600"
     confirmButtonText="Trigger now">
-    <template slot="actionComponent">
+    <template v-slot:actionComponent>
       <v-row >
         <v-col>
           <div class="subtitle-1 pt-4">Do you want to trigger a reconcile of your cluster outside of the regular reconciliation schedule?<br />

--- a/frontend/src/components/RotateKubeconfigStart.vue
+++ b/frontend/src/components/RotateKubeconfigStart.vue
@@ -25,7 +25,7 @@ limitations under the License.
     maxWidth="600"
     :confirmRequired="true"
     confirmButtonText="Rotate">
-    <template slot="actionComponent">
+    <template v-slot:actionComponent>
       <v-row >
         <v-col>
           <div class="py-4">Do you want to start rotation of kubeconfig credentials?

--- a/frontend/src/components/Secret.vue
+++ b/frontend/src/components/Secret.vue
@@ -46,7 +46,7 @@ limitations under the License.
         @delete="onDelete"
       >
         <!-- forward slot -->
-        <template slot="rowSubTitle">
+        <template v-slot:rowSubTitle>
           <slot name="rowSubTitle" :secret="row"></slot>
         </template>
       </secret-row>

--- a/frontend/src/components/ShootAddons/AddonConfiguration.vue
+++ b/frontend/src/components/ShootAddons/AddonConfiguration.vue
@@ -23,7 +23,7 @@ limitations under the License.
     maxWidth="900"
     max-height="60vh"
     >
-    <template slot="actionComponent">
+    <template v-slot:actionComponent>
       <manage-shoot-addons
         ref="addons"
         :isCreateMode="false"

--- a/frontend/src/components/ShootHibernation/ChangeHibernation.vue
+++ b/frontend/src/components/ShootHibernation/ChangeHibernation.vue
@@ -25,7 +25,7 @@ limitations under the License.
     :confirmRequired="confirmRequired"
     :disabled="!isHibernationPossible"
     maxWidth="600">
-    <template slot="actionComponent">
+    <template v-slot:actionComponent>
       <template v-if="!isShootSettingHibernated">
         This will scale the worker nodes of your cluster down to zero.<br /><br />
         Type <b>{{shootName}}</b> below and confirm to hibernate your cluster.<br /><br />

--- a/frontend/src/components/ShootHibernation/HibernationConfiguration.vue
+++ b/frontend/src/components/ShootHibernation/HibernationConfiguration.vue
@@ -21,7 +21,7 @@ limitations under the License.
     @dialogOpened="onConfigurationDialogOpened"
     ref="actionDialog"
     caption="Configure Hibernation Schedule">
-    <template slot="actionComponent">
+    <template v-slot:actionComponent>
       <manage-hibernation-schedule
         ref="hibernationSchedule"
         :isHibernationPossible="isHibernationPossible"

--- a/frontend/src/components/ShootHibernation/HibernationScheduleWarning.vue
+++ b/frontend/src/components/ShootHibernation/HibernationScheduleWarning.vue
@@ -28,14 +28,16 @@ limitations under the License.
         a hibernation schedule or explicitly deactivate scheduled hibernation for this cluster.
       </template>
     </div>
-    <div slot="popperRef">
-      <v-tooltip top>
-        <template v-slot:activator="{ on: tooltip }">
-          <v-icon v-on="tooltip" color="cyan darken-2" class="cursor-pointer">mdi-calendar-alert</v-icon>
-        </template>
-        <span>No Hibernation Schedule</span>
-      </v-tooltip>
-    </div>
+    <template v-slot:popperRef>
+      <div>
+        <v-tooltip top>
+          <template v-slot:activator="{ on: tooltip }">
+            <v-icon v-on="tooltip" color="cyan darken-2" class="cursor-pointer">mdi-calendar-alert</v-icon>
+          </template>
+          <span>No Hibernation Schedule</span>
+        </v-tooltip>
+      </div>
+    </template>
   </g-popper>
 
 </template>

--- a/frontend/src/components/ShootListRow.vue
+++ b/frontend/src/components/ShootListRow.vue
@@ -54,10 +54,10 @@ limitations under the License.
       <shoot-seed-name :shootItem="shootItem" />
     </td>
     <td class="nowrap" v-if="this.headerVisible['technicalId']">
-      <v-row class="fill-height flex-nowrap" align="center" justify="start" slot="activator">
+      <div class="d-flex align-center justify-start flex-nowrap fill-height">
         <span>{{shootTechnicalId}}</span>
         <copy-btn :clipboard-text="shootTechnicalId"></copy-btn>
-      </v-row>
+      </div>
     </td>
     <td class="nowrap" v-if="this.headerVisible['createdBy']">
       <account-avatar :account-name="shootCreatedBy"></account-avatar>

--- a/frontend/src/components/ShootMaintenance/MaintenanceConfiguration.vue
+++ b/frontend/src/components/ShootMaintenance/MaintenanceConfiguration.vue
@@ -21,7 +21,7 @@ limitations under the License.
     @dialogOpened="onConfigurationDialogOpened"
     ref="actionDialog"
     caption="Configure Maintenance">
-    <template slot="actionComponent">
+    <template v-slot:actionComponent>
       <maintenance-time
         ref="maintenanceTime"
         :time-window-begin="data.timeWindowBegin"

--- a/frontend/src/components/ShootMaintenance/MaintenanceStart.vue
+++ b/frontend/src/components/ShootMaintenance/MaintenanceStart.vue
@@ -24,7 +24,7 @@ limitations under the License.
     icon="mdi-refresh"
     maxWidth="850"
     confirmButtonText="Trigger now">
-    <template slot="actionComponent">
+    <template v-slot:actionComponent>
       <v-row >
         <v-col>
           <div class="subtitle-1 pt-4">Do you want to start the maintenance of your cluster outside of the configured maintenance time window?</div>

--- a/frontend/src/components/ShootStatus.vue
+++ b/frontend/src/components/ShootStatus.vue
@@ -16,32 +16,34 @@ limitations under the License.
 
 <template>
   <g-popper :title="statusTitle" :time="{ dateTime: operation.lastUpdateTime }" :toolbarColor="color" :popperKey="popperKeyWithType" :placement="popperPlacement">
-    <div slot="popperRef" class="shoot-status-div">
-      <v-tooltip top>
-        <template v-slot:activator="{ on }">
-          <div v-on="on">
-            <v-progress-circular v-if="showProgress" class="vertical-align-middle cursor-pointer" :size="27" :width="3" :value="operation.progress" :color="color" :rotate="-90">
-              <v-icon v-if="isStatusHibernated" class="vertical-align-middle progress-icon" :color="color">mdi-sleep</v-icon>
-              <v-icon v-else-if="isUserError" class="vertical-align-middle progress-icon-user-error" color="error">mdi-account-alert</v-icon>
-              <v-icon v-else-if="shootDeleted" class="vertical-align-middle progress-icon" :color="color">mdi-delete</v-icon>
-              <v-icon v-else-if="isTypeCreate" class="vertical-align-middle progress-icon" :color="color">mdi-plus</v-icon>
-              <v-icon v-else-if="isTypeReconcile && !isError" class="vertical-align-middle progress-icon-check" :color="color">mdi-check</v-icon>
-              <span v-else-if="isError" class="vertical-align-middle error-exclamation-mark">!</span>
-              <template v-else>{{operation.progress}}</template>
-            </v-progress-circular>
-            <v-icon v-else-if="isStatusHibernated" class="vertical-align-middle cursor-pointer status-icon" :color="color">mdi-sleep</v-icon>
-            <v-icon v-else-if="reconciliationDeactivated" class="vertical-align-middle cursor-pointer status-icon" :color="color">mdi-block-helper</v-icon>
-            <v-icon v-else-if="isAborted && shootDeleted" class="vertical-align-middle cursor-pointer status-icon" :color="color">mdi-delete</v-icon>
-            <v-icon v-else-if="isAborted && isTypeCreate" class="vertical-align-middle cursor-pointer status-icon" :color="color">mdi-plus</v-icon>
-            <v-icon v-else-if="isUserError" class="vertical-align-middle cursor-pointer status-icon" :color="color">mdi-account-alert</v-icon>
-            <v-icon v-else-if="isError" class="vertical-align-middle cursor-pointer status-icon" :color="color">mdi-alert-outline</v-icon>
-            <v-progress-circular v-else-if="isPending" class="vertical-align-middle cursor-pointer" :size="27" :width="3" indeterminate :color="color"></v-progress-circular>
-            <v-icon v-else class="vertical-align-middle cursor-pointer status-icon-check" color="success">mdi-check-circle-outline</v-icon>
-          </div>
-        </template>
-        <div>{{ tooltipText }}</div>
-      </v-tooltip>
-    </div>
+    <template v-slot:popperRef>
+      <div class="shoot-status-div">
+        <v-tooltip top>
+          <template v-slot:activator="{ on }">
+            <div v-on="on">
+              <v-progress-circular v-if="showProgress" class="vertical-align-middle cursor-pointer" :size="27" :width="3" :value="operation.progress" :color="color" :rotate="-90">
+                <v-icon v-if="isStatusHibernated" class="vertical-align-middle progress-icon" :color="color">mdi-sleep</v-icon>
+                <v-icon v-else-if="isUserError" class="vertical-align-middle progress-icon-user-error" color="error">mdi-account-alert</v-icon>
+                <v-icon v-else-if="shootDeleted" class="vertical-align-middle progress-icon" :color="color">mdi-delete</v-icon>
+                <v-icon v-else-if="isTypeCreate" class="vertical-align-middle progress-icon" :color="color">mdi-plus</v-icon>
+                <v-icon v-else-if="isTypeReconcile && !isError" class="vertical-align-middle progress-icon-check" :color="color">mdi-check</v-icon>
+                <span v-else-if="isError" class="vertical-align-middle error-exclamation-mark">!</span>
+                <template v-else>{{operation.progress}}</template>
+              </v-progress-circular>
+              <v-icon v-else-if="isStatusHibernated" class="vertical-align-middle cursor-pointer status-icon" :color="color">mdi-sleep</v-icon>
+              <v-icon v-else-if="reconciliationDeactivated" class="vertical-align-middle cursor-pointer status-icon" :color="color">mdi-block-helper</v-icon>
+              <v-icon v-else-if="isAborted && shootDeleted" class="vertical-align-middle cursor-pointer status-icon" :color="color">mdi-delete</v-icon>
+              <v-icon v-else-if="isAborted && isTypeCreate" class="vertical-align-middle cursor-pointer status-icon" :color="color">mdi-plus</v-icon>
+              <v-icon v-else-if="isUserError" class="vertical-align-middle cursor-pointer status-icon" :color="color">mdi-account-alert</v-icon>
+              <v-icon v-else-if="isError" class="vertical-align-middle cursor-pointer status-icon" :color="color">mdi-alert-outline</v-icon>
+              <v-progress-circular v-else-if="isPending" class="vertical-align-middle cursor-pointer" :size="27" :width="3" indeterminate :color="color"></v-progress-circular>
+              <v-icon v-else class="vertical-align-middle cursor-pointer status-icon-check" color="success">mdi-check-circle-outline</v-icon>
+            </div>
+          </template>
+          <div>{{ tooltipText }}</div>
+        </v-tooltip>
+      </div>
+    </template>
     <ansi-text v-if="!!popperMessage" :text="popperMessage"></ansi-text>
     <template v-if="lastErrorDescriptions.length">
       <v-divider class="my-2"></v-divider>

--- a/frontend/src/components/ShootVersion/ShootVersion.vue
+++ b/frontend/src/components/ShootVersion/ShootVersion.vue
@@ -58,9 +58,9 @@ limitations under the License.
       defaultColor="orange"
       ref="gDialog"
       >
-      <template slot="caption">Update Cluster</template>
-      <template slot="affectedObjectName">{{shootName}}</template>
-      <template slot="message">
+      <template v-slot:caption>Update Cluster</template>
+      <template v-slot:affectedObjectName>{{shootName}}</template>
+      <template v-slot:message>
         <shoot-version-update
           :availableK8sUpdates="availableK8sUpdates"
           :currentk8sVersion="shootK8sVersion"

--- a/frontend/src/components/ShootWorkers/ManageWorkers.vue
+++ b/frontend/src/components/ShootWorkers/ManageWorkers.vue
@@ -27,15 +27,16 @@ limitations under the License.
         :zonedCluster="zonedCluster"
         :updateOSMaintenance="updateOSMaintenance"
         @valid="onWorkerValid">
-        <v-btn v-show="index>0 || internalWorkers.length>1"
-          small
-          slot="action"
-          outlined
-          icon
-          color="grey"
-          @click.native.stop="onRemoveWorker(index)">
-          <v-icon>mdi-close</v-icon>
-        </v-btn>
+        <template v-slot:action>
+          <v-btn v-show="index>0 || internalWorkers.length>1"
+            small
+            outlined
+            icon
+            color="grey"
+            @click.native.stop="onRemoveWorker(index)">
+            <v-icon>mdi-close</v-icon>
+          </v-btn>
+        </template>
       </worker-input-generic>
     </v-row>
     <v-row key="addWorker" class="list-item pt-2">

--- a/frontend/src/components/ShootWorkers/WorkerConfiguration.vue
+++ b/frontend/src/components/ShootWorkers/WorkerConfiguration.vue
@@ -22,7 +22,7 @@ limitations under the License.
     ref="actionDialog"
     maxWidth="760"
     caption="Configure Workers">
-    <template slot="actionComponent">
+    <template v-slot:actionComponent>
       <manage-workers
       ref="manageWorkers"
       @valid="onWorkersValid"

--- a/frontend/src/components/ShootWorkers/WorkerGroup.vue
+++ b/frontend/src/components/ShootWorkers/WorkerGroup.vue
@@ -27,18 +27,17 @@ limitations under the License.
       :key="index"
       align="center"
     >
-      <span class="ma-1">
-        <span class="font-weight-bold">{{line.title}}:</span> {{line.value}} {{line.description}}
-      </span>
+      <span class="ma-1 font-weight-bold">{{line.title}}:</span> {{line.value}} {{line.description}}
     </v-row>
-    <v-chip
-      slot="popperRef"
-      small
-      class="cursor-pointer my-0 ml-0"
-      outlined
-      color="cyan darken-2">
-      {{workerGroup.name}}
-    </v-chip>
+    <template v-slot:popperRef>
+      <v-chip
+        small
+        class="cursor-pointer my-0 ml-0"
+        outlined
+        color="cyan darken-2">
+        {{workerGroup.name}}
+      </v-chip>
+    </template>
   </g-popper>
 </template>
 

--- a/frontend/src/components/StatusTag.vue
+++ b/frontend/src/components/StatusTag.vue
@@ -25,26 +25,28 @@ limitations under the License.
       :popperKey="popperKeyWithType"
       :placement="popperPlacement"
       :disabled="!tag.message">
-      <div slot="popperRef">
-        <v-tooltip top max-width="400px" :disabled="tooltipDisabled">
-          <template v-slot:activator="{ on }">
-            <v-chip
-              v-on="on"
-              class="status-tag"
-              :class="{ 'cursor-pointer': tag.message }"
-              outlined
-              :text-color="color"
-              small
-              :color="color">
-              {{chipText}}
-            </v-chip>
-          </template>
-          <span class="font-weight-bold">{{chipTooltip.title}}</span>
-          <div v-if="chipTooltip.description">
-            {{chipTooltip.description}}
-          </div>
-        </v-tooltip>
-      </div>
+      <template v-slot:popperRef>
+        <div>
+          <v-tooltip top max-width="400px" :disabled="tooltipDisabled">
+            <template v-slot:activator="{ on }">
+              <v-chip
+                v-on="on"
+                class="status-tag"
+                :class="{ 'cursor-pointer': tag.message }"
+                outlined
+                :text-color="color"
+                small
+                :color="color">
+                {{chipText}}
+              </v-chip>
+            </template>
+            <span class="font-weight-bold">{{chipTooltip.title}}</span>
+            <div v-if="chipTooltip.description">
+              {{chipTooltip.description}}
+            </div>
+          </v-tooltip>
+        </div>
+      </template>
       <ansi-text :text="tag.message"></ansi-text>
     </g-popper>
     <time-string

--- a/frontend/src/components/dialogs/ConfirmDialog.vue
+++ b/frontend/src/components/dialogs/ConfirmDialog.vue
@@ -22,8 +22,8 @@ limitations under the License.
     :max-width="maxWidth"
     :defaultColor="dialogColor"
     >
-    <template slot="caption">{{captionText}}</template>
-    <template slot="message">
+    <template v-slot:caption>{{captionText}}</template>
+    <template v-slot:message>
       <div v-html="messageHtml"></div>
     </template>
   </g-dialog>

--- a/frontend/src/components/dialogs/SecretDialogAlicloud.vue
+++ b/frontend/src/components/dialogs/SecretDialogAlicloud.vue
@@ -28,7 +28,7 @@ limitations under the License.
     replaceTitle="Replace Alibaba Cloud Secret"
     @input="onInput">
 
-    <template slot="data-slot">
+    <template v-slot:data-slot>
       <div>
         <v-text-field
           color="grey darken-4"

--- a/frontend/src/components/dialogs/SecretDialogAlicloudHelp.vue
+++ b/frontend/src/components/dialogs/SecretDialogAlicloudHelp.vue
@@ -20,27 +20,30 @@ limitations under the License.
     color="grey darken-4"
     backgroundSrc="/static/background_alicloud.svg"
     :value="value"
-    @input="onInput">
-    <div slot="help-content" class="help-content">
-      <p>
-        Before you can provision and access a Kubernetes cluster on Alibaba Cloud, you need to add account credentials. To manage
-        credentials for Alibaba Cloud Resource Access Management (RAM), use the
-        <a href="https://ram.console.aliyun.com/overview" target="_blank" class="grey--text  text--darken-2">RAM Console <v-icon style="font-size:80%">mdi-open-in-new</v-icon></a>.
-        The Gardener needs the credentials to provision and operate the Alibaba Cloud infrastructure for your Kubernetes cluster.
-      </p>
-      <p>
-        Gardener uses encrypted system disk when creating Shoot, please enable ECS disk encryption on Alibaba Cloud Console
-        (<a class="grey--text text--darken-2" href="https://www.alibabacloud.com/help/doc-detail/59643.htm" target="_blank">official
-        documentation <v-icon style="font-size:80%">mdi-open-in-new</v-icon></a>).
-      </p>
-      <p>
-        Copy the Alibaba Cloud RAM policy document below and attach it to the RAM user
-        (<a class="grey--text text--darken-2" href="https://www.alibabacloud.com/help/product/28625.htm?spm=a3c0i.100866.1204872.1.79461e4eLtFABp" target="_blank">official
-        documentation <v-icon style="font-size:80%">mdi-open-in-new</v-icon></a>). Alternatively, you can assign following permissions to the RAM
-        user: AliyunECSFullAccess, AliyunSLBFullAccess, AliyunVPCFullAccess, AliyunEIPFullAccess, AliyunNATGatewayFullAccess.
-      </p>
-      <code-block height="250px" lang="json" :content="JSON.stringify(template, undefined, 2)"></code-block>
-    </div>
+    @input="onInput"
+  >
+    <template v-slot:help-content>
+      <div class="help-content">
+        <p>
+          Before you can provision and access a Kubernetes cluster on Alibaba Cloud, you need to add account credentials. To manage
+          credentials for Alibaba Cloud Resource Access Management (RAM), use the
+          <a href="https://ram.console.aliyun.com/overview" target="_blank" class="grey--text  text--darken-2">RAM Console <v-icon style="font-size:80%">mdi-open-in-new</v-icon></a>.
+          The Gardener needs the credentials to provision and operate the Alibaba Cloud infrastructure for your Kubernetes cluster.
+        </p>
+        <p>
+          Gardener uses encrypted system disk when creating Shoot, please enable ECS disk encryption on Alibaba Cloud Console
+          (<a class="grey--text text--darken-2" href="https://www.alibabacloud.com/help/doc-detail/59643.htm" target="_blank">official
+          documentation <v-icon style="font-size:80%">mdi-open-in-new</v-icon></a>).
+        </p>
+        <p>
+          Copy the Alibaba Cloud RAM policy document below and attach it to the RAM user
+          (<a class="grey--text text--darken-2" href="https://www.alibabacloud.com/help/product/28625.htm?spm=a3c0i.100866.1204872.1.79461e4eLtFABp" target="_blank">official
+          documentation <v-icon style="font-size:80%">mdi-open-in-new</v-icon></a>). Alternatively, you can assign following permissions to the RAM
+          user: AliyunECSFullAccess, AliyunSLBFullAccess, AliyunVPCFullAccess, AliyunEIPFullAccess, AliyunNATGatewayFullAccess.
+        </p>
+        <code-block height="250px" lang="json" :content="JSON.stringify(template, undefined, 2)"></code-block>
+      </div>
+    </template>
   </secret-dialog-help>
 </template>
 

--- a/frontend/src/components/dialogs/SecretDialogAws.vue
+++ b/frontend/src/components/dialogs/SecretDialogAws.vue
@@ -28,7 +28,7 @@ limitations under the License.
     replaceTitle="Replace AWS Secret"
     @input="onInput">
 
-    <template slot="data-slot">
+    <template v-slot:data-slot>
       <div>
         <v-text-field
           color="orange darken-1"

--- a/frontend/src/components/dialogs/SecretDialogAwsHelp.vue
+++ b/frontend/src/components/dialogs/SecretDialogAwsHelp.vue
@@ -20,21 +20,24 @@ limitations under the License.
     color="orange darken-1"
     backgroundSrc="/static/background_aws.svg"
     :value="value"
-    @input="onInput">
-    <div slot="help-content" class="help-content">
-      <p>
-        Before you can provision and access a Kubernetes cluster, you need to add account credentials. To manage
-        credentials for AWS Identity and Access Management (IAM), use the
-        <a href="https://console.aws.amazon.com/iam/home" target="_blank" class="orange--text  text--darken-2">IAM Console <v-icon style="font-size:80%">mdi-open-in-new</v-icon></a>.
-        The Gardener needs the credentials to provision and operate the AWS infrastructure for your Kubernetes cluster.
-      </p>
-      <p>
-        Copy the AWS IAM policy document below and attach it to the IAM user
-        (<a class="orange--text text--darken-1" href="http://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_manage.html" target="_blank">official
-        documentation <v-icon style="font-size:80%">mdi-open-in-new</v-icon></a>).
-      </p>
-      <code-block height="250px" lang="json" :content="JSON.stringify(template, undefined, 2)"></code-block>
-    </div>
+    @input="onInput"
+  >
+    <template v-slot:help-content>
+      <div class="help-content">
+        <p>
+          Before you can provision and access a Kubernetes cluster, you need to add account credentials. To manage
+          credentials for AWS Identity and Access Management (IAM), use the
+          <a href="https://console.aws.amazon.com/iam/home" target="_blank" class="orange--text  text--darken-2">IAM Console <v-icon style="font-size:80%">mdi-open-in-new</v-icon></a>.
+          The Gardener needs the credentials to provision and operate the AWS infrastructure for your Kubernetes cluster.
+        </p>
+        <p>
+          Copy the AWS IAM policy document below and attach it to the IAM user
+          (<a class="orange--text text--darken-1" href="http://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_manage.html" target="_blank">official
+          documentation <v-icon style="font-size:80%">mdi-open-in-new</v-icon></a>).
+        </p>
+        <code-block height="250px" lang="json" :content="JSON.stringify(template, undefined, 2)"></code-block>
+      </div>
+    </template>
   </secret-dialog-help>
 </template>
 

--- a/frontend/src/components/dialogs/SecretDialogAzure.vue
+++ b/frontend/src/components/dialogs/SecretDialogAzure.vue
@@ -28,7 +28,7 @@ limitations under the License.
     replaceTitle="Replace Azure Secret"
     @input="onInput">
 
-    <template slot="data-slot">
+    <template v-slot:data-slot>
       <div>
         <v-text-field
           color="blue darken-1"

--- a/frontend/src/components/dialogs/SecretDialogAzureHelp.vue
+++ b/frontend/src/components/dialogs/SecretDialogAzureHelp.vue
@@ -20,23 +20,26 @@ limitations under the License.
     color="blue darken-1"
     backgroundSrc="/static/background_azure.svg"
     :value="value"
-    @input="onInput">
-    <div slot="help-content" class="help-content">
-      <p>
-        Before you can provision and access a Kubernetes cluster on Azure, you need to add account credentials.
-        The Gardener needs the credentials to provision and operate the Azure infrastructure for your Kubernetes cluster.
-      </p>
-      <p>
-        Ensure that the account has the <b>contributor</b> role.
-      </p>
-      <p>
-        Read the
-        <a href="https://docs.microsoft.com/azure/active-directory/role-based-access-control-configure"
-         target="_blank"
-         class="blue--text text--darken-1">
-         IAM Console help section<v-icon style="font-size:80%">mdi-open-in-new</v-icon></a> on how to manage your credentials and subscriptions.
-      </p>
-    </div>
+    @input="onInput"
+  >
+    <template v-slot:help-content>
+      <div class="help-content">
+        <p>
+          Before you can provision and access a Kubernetes cluster on Azure, you need to add account credentials.
+          The Gardener needs the credentials to provision and operate the Azure infrastructure for your Kubernetes cluster.
+        </p>
+        <p>
+          Ensure that the account has the <b>contributor</b> role.
+        </p>
+        <p>
+          Read the
+          <a href="https://docs.microsoft.com/azure/active-directory/role-based-access-control-configure"
+          target="_blank"
+          class="blue--text text--darken-1">
+          IAM Console help section<v-icon style="font-size:80%">mdi-open-in-new</v-icon></a> on how to manage your credentials and subscriptions.
+        </p>
+      </div>
+    </template>
   </secret-dialog-help>
 </template>
 

--- a/frontend/src/components/dialogs/SecretDialogDelete.vue
+++ b/frontend/src/components/dialogs/SecretDialogDelete.vue
@@ -36,10 +36,12 @@ limitations under the License.
 
       <v-card-text>
         <v-container fluid>
-          <div slot="message">
-            Are you sure to delete the secret <span class="font-weight-bold">{{name}}</span>? <br /><span class="red--text font-weight-bold">The operation
-            can not be undone.</span>
-          </div>
+          <template v-slot:message>
+            <div>
+              Are you sure to delete the secret <span class="font-weight-bold">{{name}}</span>?<br/>
+              <span class="red--text font-weight-bold">The operation can not be undone.</span>
+            </div>
+          </template>
         </v-container>
         <g-alert color="error" :message.sync="errorMessage" :detailedMessage.sync="detailedErrorMessage"></g-alert>
       </v-card-text>

--- a/frontend/src/components/dialogs/SecretDialogGcp.vue
+++ b/frontend/src/components/dialogs/SecretDialogGcp.vue
@@ -28,7 +28,7 @@ limitations under the License.
     replaceTitle="Replace Google Secret"
     @input="onInput">
 
-    <template slot="data-slot">
+    <template v-slot:data-slot>
       <div>
         <v-textarea
           ref="serviceAccountKey"

--- a/frontend/src/components/dialogs/SecretDialogGcpHelp.vue
+++ b/frontend/src/components/dialogs/SecretDialogGcpHelp.vue
@@ -14,45 +14,48 @@ See the License for the specific language governing permissions and
 limitations under the License.
  -->
 
- <template>
-   <secret-dialog-help
-     title="About GCP Service Accounts"
-     color="green"
-     backgroundSrc="/static/background_gcp.svg"
-     :value="value"
-     @input="onInput">
-     <div slot="help-content" class="help-content">
-      <p>
-        A service account is a special account that can be used by services and applications running on your Google
-        Compute Engine instance to interact with other Google Cloud Platform APIs. Applications can use service
-        account credentials to authorize themselves to a set of APIs and perform actions within the permissions
-        granted to the service account and virtual machine instance.
-      </p>
+<template>
+  <secret-dialog-help
+    title="About GCP Service Accounts"
+    color="green"
+    backgroundSrc="/static/background_gcp.svg"
+    :value="value"
+    @input="onInput"
+  >
+    <template v-slot:help-content>
+      <div class="help-content">
+        <p>
+          A service account is a special account that can be used by services and applications running on your Google
+          Compute Engine instance to interact with other Google Cloud Platform APIs. Applications can use service
+          account credentials to authorize themselves to a set of APIs and perform actions within the permissions
+          granted to the service account and virtual machine instance.
+        </p>
 
-      <p>
-        Ensure that the service account has at least the roles below.
-        <ul>
-          <li>Service Account Admin</li>
-          <li>Service Account Token Creator</li>
-          <li>Service Account User</li>
-          <li>Compute Admin</li>
-        </ul>
+        <p>
+          Ensure that the service account has at least the roles below.
+          <ul>
+            <li>Service Account Admin</li>
+            <li>Service Account Token Creator</li>
+            <li>Service Account User</li>
+            <li>Compute Admin</li>
+          </ul>
 
-      </p>
+        </p>
 
-      <p>
-        The Service Account has to be enabled for the Google Identity and Access Management API.
-      </p>
+        <p>
+          The Service Account has to be enabled for the Google Identity and Access Management API.
+        </p>
 
-      <p>
-        Read the
-        <a href="https://cloud.google.com/compute/docs/access/service-accounts"
-           target="_blank"
-           class="green--text">
-          Service Account Documentation<v-icon style="font-size: 80%">mdi-open-in-new</v-icon></a> on how to apply for credentials
-        to service accounts.
-      </p>
-    </div>
+        <p>
+          Read the
+          <a href="https://cloud.google.com/compute/docs/access/service-accounts"
+              target="_blank"
+              class="green--text">
+            Service Account Documentation<v-icon style="font-size: 80%">mdi-open-in-new</v-icon></a> on how to apply for credentials
+          to service accounts.
+        </p>
+      </div>
+    </template>
   </secret-dialog-help>
 </template>
 

--- a/frontend/src/components/dialogs/SecretDialogMetal.vue
+++ b/frontend/src/components/dialogs/SecretDialogMetal.vue
@@ -28,7 +28,7 @@ limitations under the License.
     replaceTitle="Replace Metal Secret"
     @input="onInput">
 
-    <template slot="data-slot">
+    <template v-slot:data-slot>
       <div>
         <v-text-field
           color="blue"

--- a/frontend/src/components/dialogs/SecretDialogMetalHelp.vue
+++ b/frontend/src/components/dialogs/SecretDialogMetalHelp.vue
@@ -20,13 +20,16 @@ limitations under the License.
     color="blue"
     backgroundSrc="/static/background_metal.svg"
     :value="value"
-    @input="onInput">
-    <div slot="help-content" class="help-content">
-     <p>
-       Before you can provision and access a Kubernetes cluster on Metal Stack, you need to provide HMAC credentials and the endpoint of your Metal API.
-       The Gardener needs the credentials to provision and operate the Metal Stack infrastructure for your Kubernetes cluster.
-     </p>
-   </div>
+    @input="onInput"
+  >
+    <template v-slot:help-content>
+      <div class="help-content">
+        <p>
+          Before you can provision and access a Kubernetes cluster on Metal Stack, you need to provide HMAC credentials and the endpoint of your Metal API.
+          The Gardener needs the credentials to provision and operate the Metal Stack infrastructure for your Kubernetes cluster.
+        </p>
+      </div>
+    </template>
   </secret-dialog-help>
 </template>
 

--- a/frontend/src/components/dialogs/SecretDialogOpenstack.vue
+++ b/frontend/src/components/dialogs/SecretDialogOpenstack.vue
@@ -28,7 +28,7 @@ limitations under the License.
     replaceTitle="Replace OpenStack Secret"
     @input="onInput">
 
-    <template slot="data-slot">
+    <template v-slot:data-slot>
       <div>
         <v-text-field
           color="black"

--- a/frontend/src/components/dialogs/SecretDialogOpenstackHelp.vue
+++ b/frontend/src/components/dialogs/SecretDialogOpenstackHelp.vue
@@ -14,29 +14,32 @@ See the License for the specific language governing permissions and
 limitations under the License.
  -->
 
- <template>
-   <secret-dialog-help
-     title="About OpenStack Secrets"
-     color="black"
-     backgroundSrc="/static/background_openstack.svg"
-     :value="value"
-     @input="onInput">
-     <div slot="help-content" class="help-content">
-      <p>
-        Before you can provision and access a Kubernetes cluster on OpenStack, you need to add account credentials.
-        The Gardener needs the credentials to provision and operate the OpenStack infrastructure for your Kubernetes cluster.
-      </p>
-      <p>
-        Ensure that the user has privileges to <b>create, modify and delete VMs</b>.
-      </p>
-      <p>
-        Read the
-        <a href="https://docs.openstack.org/horizon/latest/admin/admin-manage-roles.html"
-           target="_blank"
-           class="black--text">
-          OpenStack help section<v-icon style="font-size: 80%">mdi-open-in-new</v-icon></a> on how to create and manage roles.
-      </p>
-    </div>
+<template>
+  <secret-dialog-help
+    title="About OpenStack Secrets"
+    color="black"
+    backgroundSrc="/static/background_openstack.svg"
+    :value="value"
+    @input="onInput"
+  >
+    <template v-slot:help-content>
+      <div class="help-content">
+        <p>
+          Before you can provision and access a Kubernetes cluster on OpenStack, you need to add account credentials.
+          The Gardener needs the credentials to provision and operate the OpenStack infrastructure for your Kubernetes cluster.
+        </p>
+        <p>
+          Ensure that the user has privileges to <b>create, modify and delete VMs</b>.
+        </p>
+        <p>
+          Read the
+          <a href="https://docs.openstack.org/horizon/latest/admin/admin-manage-roles.html"
+            target="_blank"
+            class="black--text">
+            OpenStack help section<v-icon style="font-size: 80%">mdi-open-in-new</v-icon></a> on how to create and manage roles.
+        </p>
+      </div>
+    </template>
   </secret-dialog-help>
 </template>
 

--- a/frontend/src/components/dialogs/SecretDialogVSphere.vue
+++ b/frontend/src/components/dialogs/SecretDialogVSphere.vue
@@ -28,7 +28,7 @@ limitations under the License.
     replaceTitle="Replace VMware vSphere Secret"
     @input="onInput">
 
-    <template slot="data-slot">
+    <template v-slot:data-slot>
       <div>
         <v-text-field
         color="indigo darken-4"

--- a/frontend/src/components/dialogs/SecretDialogVSphereHelp.vue
+++ b/frontend/src/components/dialogs/SecretDialogVSphereHelp.vue
@@ -14,34 +14,37 @@ See the License for the specific language governing permissions and
 limitations under the License.
  -->
 
- <template>
-   <secret-dialog-help
-     title="About VMware vSphere Secrets"
-     color="indigo darken-4"
-     backgroundSrc="/static/background_vsphere.svg"
-     :value="value"
-     @input="onInput">
-     <div slot="help-content" class="help-content">
-      <p>
-        Before you can provision and access a Kubernetes cluster on VMware vSphere, you need to add vSphere and NSX-T account credentials.
-        The Gardener needs these credentials to provision and operate the VMware vSphere infrastructure for your Kubernetes cluster.
-      </p>
-      <p>
-        Ensure that these accounts have privileges to <b>create, modify and delete VMs and Networking resources</b>.
-      </p>
-      <p>
-        Please read the
-        <a href="https://docs.vmware.com/de/VMware-vSphere/index.html"
-           target="_blank"
-           class="indigo--text text--darken-4">
-          VMware vSphere Documentation</a>
-          and the
-        <a href="https://docs.vmware.com/en/VMware-NSX-T-Data-Center/index.html"
-          target="_blank"
-          class="indigo--text text--darken-4">
-         VMware NSX-T Data Center Documentation</a>.
-      </p>
-    </div>
+<template>
+  <secret-dialog-help
+    title="About VMware vSphere Secrets"
+    color="indigo darken-4"
+    backgroundSrc="/static/background_vsphere.svg"
+    :value="value"
+    @input="onInput"
+  >
+    <template v-slot:help-content>
+      <div class="help-content">
+        <p>
+          Before you can provision and access a Kubernetes cluster on VMware vSphere, you need to add vSphere and NSX-T account credentials.
+          The Gardener needs these credentials to provision and operate the VMware vSphere infrastructure for your Kubernetes cluster.
+        </p>
+        <p>
+          Ensure that these accounts have privileges to <b>create, modify and delete VMs and Networking resources</b>.
+        </p>
+        <p>
+          Please read the
+          <a href="https://docs.vmware.com/de/VMware-vSphere/index.html"
+            target="_blank"
+            class="indigo--text text--darken-4">
+            VMware vSphere Documentation</a>
+            and the
+          <a href="https://docs.vmware.com/en/VMware-NSX-T-Data-Center/index.html"
+            target="_blank"
+            class="indigo--text text--darken-4">
+          VMware NSX-T Data Center Documentation</a>.
+        </p>
+      </div>
+    </template>
   </secret-dialog-help>
 </template>
 

--- a/frontend/src/components/dialogs/TargetSelectionDialog.vue
+++ b/frontend/src/components/dialogs/TargetSelectionDialog.vue
@@ -23,8 +23,8 @@ limitations under the License.
     defaultColor="cyan-darken-2"
     ref="gDialog"
     >
-    <template slot="caption">Select Target</template>
-    <template slot="message">
+    <template v-slot:caption>Select Target</template>
+    <template v-slot:message>
       <v-radio-group
         v-model="selectedTarget"
         label="Terminal Target"

--- a/frontend/src/components/dialogs/TerminalSettingsDialog.vue
+++ b/frontend/src/components/dialogs/TerminalSettingsDialog.vue
@@ -25,8 +25,8 @@ limitations under the License.
     defaultColor="cyan-darken-2"
     ref="gDialog"
     >
-    <template slot="caption">Change Terminal Settings</template>
-    <template slot="message">
+    <template v-slot:caption>Change Terminal Settings</template>
+    <template v-slot:message>
       <v-text-field
         color="cyan darken-2"
         v-model="selectedContainerImage"
@@ -80,17 +80,17 @@ limitations under the License.
           :class="{ 'ml-4': isAdmin }"
           class="ml-2"
         >
-          <template slot="item" slot-scope="data">
+          <template v-slot:item="{ item }">
             <v-list-item-content>
-              <v-list-item-title>{{data.item.data.kubernetesHostname}}</v-list-item-title>
+              <v-list-item-title>{{item.data.kubernetesHostname}}</v-list-item-title>
               <v-list-item-subtitle>
-                <span>Ready: {{data.item.data.readyStatus}} | Version: {{data.item.data.version}} | Created: <time-string :date-time="data.item.metadata.creationTimestamp" :pointInTime="-1"></time-string></span>
+                <span>Ready: {{item.data.readyStatus}} | Version: {{item.data.version}} | Created: <time-string :date-time="item.metadata.creationTimestamp" :pointInTime="-1"></time-string></span>
               </v-list-item-subtitle>
             </v-list-item-content>
           </template>
-          <template slot="selection" slot-scope="data">
+          <template v-slot:selection="{ item }">
             <span :class="nodeTextColor" class="ml-2">
-            {{data.item.data.kubernetesHostname}} [{{data.item.data.version}}]
+            {{item.data.kubernetesHostname}} [{{item.data.version}}]
             </span>
           </template>
         </v-select>

--- a/frontend/src/views/Administration.vue
+++ b/frontend/src/views/Administration.vue
@@ -105,10 +105,10 @@ limitations under the License.
       :errorMessage.sync="errorMessage"
       :detailedErrorMessage.sync="detailedErrorMessage"
       ref="gDialog">
-      <template slot="caption">
+      <template v-slot:caption>
         Confirm Delete
       </template>
-      <template slot="message">
+      <template v-slot:message>
         Are you sure to delete the project <b>{{projectName}}</b>?
         <br />
         <i class="red--text">The operation can not be undone.</i>

--- a/frontend/src/views/Secrets.vue
+++ b/frontend/src/views/Secrets.vue
@@ -74,8 +74,8 @@ limitations under the License.
     @update="onUpdate"
     @delete="onDelete"
     >
-      <template v-if="isOwnSecretBinding(props.secret)" slot="rowSubTitle" slot-scope="props">
-        {{props.secret.data.domainName}} / {{props.secret.data.tenantName}}
+      <template v-if="isOwnSecretBinding(secret)" v-slot:rowSubTitle="{ secret }">
+        {{secret.data.domainName}} / {{secret.data.tenantName}}
       </template>
     </secret>
 
@@ -123,7 +123,7 @@ limitations under the License.
     @update="onUpdate"
     @delete="onDelete"
     >
-      <template v-if="isOwnSecretBinding(secret)" slot="rowSubTitle" slot-scope="{ secret }">
+      <template v-if="isOwnSecretBinding(secret)" v-slot:rowSubTitle="{ secret }">
         <v-tooltip top>
           <template v-slot:activator="{ on }">
             <span v-on="on">{{secret.data.vsphereUsername}}</span>


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR replaces all occurences of `slot` and  `slot-scope` properties with the new syntax `v-slot`.

**Which issue(s) this PR fixes**:
Fixes #630

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
NONE
```
