### PR TITLE
Change copy button success behaviour

### DIFF
--- a/frontend/src/components/CopyBtn.vue
+++ b/frontend/src/components/CopyBtn.vue
@@ -29,8 +29,8 @@ limitations under the License.
     </v-snackbar>
     <v-tooltip top>
       <template v-slot:activator="{ on }">
-        <v-btn v-on="on" icon ref="copy">
-          <v-icon :small="true">content_copy</v-icon>
+        <v-btn v-on="on" icon ref="copy" :color="color">
+          <v-icon :small="true">{{icon}}</v-icon>
         </v-btn>
       </template>
       <span>{{tooltipText}}</span>
@@ -46,10 +46,6 @@ export default {
     clipboardText: {
       type: String,
       default: ''
-    },
-    copySuccessText: {
-      type: String,
-      default: 'Copied to clipboard'
     },
     copyFailedText: {
       type: String,
@@ -68,15 +64,16 @@ export default {
     return {
       snackbar: false,
       clipboard: undefined,
-      copyFailed: false
+      copySucceeded: false,
+      timeoutId: undefined
     }
   },
   computed: {
     snackbarText () {
-      return this.copyFailed ? this.copyFailedText : this.copySuccessText
+      return this.copyFailedText
     },
     snackbarColor () {
-      return this.copyFailed ? 'error' : undefined
+      return 'error'
     },
     clipboardOptions () {
       const options = {
@@ -91,6 +88,18 @@ export default {
         vm = vm.$parent
       }
       return options
+    },
+    icon () {
+      if (this.copySucceeded) {
+        return 'mdi-check'
+      }
+      return 'mdi-content-copy'
+    },
+    color () {
+      if (this.copySucceeded) {
+        return 'success'
+      }
+      return undefined
     }
   },
   methods: {
@@ -100,14 +109,17 @@ export default {
       }
       this.clipboard = new Clipboard(this.$refs.copy.$el, this.clipboardOptions)
       this.clipboard.on('success', (event) => {
-        this.snackbar = true
-        this.copyFailed = false
+        this.copySucceeded = true
+        clearTimeout(this.timeoutId)
+        this.timeoutId = setTimeout(() => {
+          this.copySucceeded = false
+        }, 1000);
         this.$emit('copy')
       })
       this.clipboard.on('error', err => {
         console.error('error', err)
-        this.copyFailed = true
         this.snackbar = true
+        this.copySucceeded = false
         this.$emit('copyFailed')
       })
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
Instead of showing the snackbar on successful copy to clipboard, a success icon is shown.

![2020-04-23_13-33-09 (1)](https://user-images.githubusercontent.com/5526658/80094843-3f660e00-8567-11ea-9f93-1c50d71d671f.gif)


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user

```
