### PR TITLE
Add more user error codes

### DIFF
--- a/frontend/src/components/ShootStatus.vue
+++ b/frontend/src/components/ShootStatus.vue
@@ -86,6 +86,14 @@ const errorCodes = {
   ERR_CLEANUP_CLUSTER_RESOURCES: {
     shortDescription: 'Cleanup Cluster',
     description: 'Cleaning up the cluster failed as some resource are stuck in deletion. Please remove these resources properly or a forceful deletion will happen if this error persists.'
+  },
+  ERR_INFRA_RESOURCES_DEPLETED: {
+    shortDescription: 'Infrastructure Resources Depleted',
+    description: 'The underlying infrastructure provider proclaimed that it does not have enough resources to fulfill your request at this point in time. You might want to wait or change your shoot configuration.'
+  },
+  ERR_CONFIGURATION_PROBLEM: {
+    shortDescription: 'Configuration Problem',
+    description: 'There is a configuration problem that is most likely caused by your Shoot specification. Please double-check the error message and resolve the problem.'
   }
 }
 

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -388,7 +388,9 @@ export function isUserError (errorCodes) {
     'ERR_INFRA_INSUFFICIENT_PRIVILEGES',
     'ERR_INFRA_QUOTA_EXCEEDED',
     'ERR_INFRA_DEPENDENCIES',
-    'ERR_CLEANUP_CLUSTER_RESOURCES'
+    'ERR_CLEANUP_CLUSTER_RESOURCES',
+    'ERR_INFRA_RESOURCES_DEPLETED',
+    'ERR_CONFIGURATION_PROBLEM'
   ]
   return every(errorCodes, errorCode => includes(userErrorCodes, errorCode))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new user error codes `ERR_INFRA_RESOURCES_DEPLETED` and `ERR_CONFIGURATION_PROBLEM`.

See https://github.com/gardener/gardener/pull/2237.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Shoot clusters with configuration problems or error indicating resource depletion of the underlying infrastructure provider will now be shown as user related issues.
```