### PR TITLE
Terminal: reload not working in edge case

### DIFF
--- a/backend/test/support/nocks/k8s.js
+++ b/backend/test/support/nocks/k8s.js
@@ -952,6 +952,8 @@ const stub = {
       })
       .reply(200, { items: [] })
       .post(`/apis/dashboard.gardener.cloud/v1alpha1/namespaces/${namespace}/terminals`, body => {
+        expect(body.metadata.annotations).to.have.property('dashboard.gardener.cloud/preferredHost')
+
         const { metadata, spec: { host } } = body
         const suffix = '0815'
         _.merge(terminal, body)
@@ -966,13 +968,14 @@ const stub = {
       .reply(200, () => terminal)
     return scope
   },
-  reuseTerminal ({ bearer, username, namespace, name, target, shootName, seedName, hostNamespace, containerImage }) {
+  reuseTerminal ({ bearer, username, namespace, name, target, shootName, seedName, hostNamespace, containerImage, preferredHost = 'seed' }) {
     let terminal = {
       metadata: {
         namespace,
         name,
         annotations: {
-          'gardener.cloud/created-by': username
+          'gardener.cloud/created-by': username,
+          'dashboard.gardener.cloud/preferredHost': preferredHost
         }
       },
       spec: {

--- a/frontend/src/components/GTerminal.vue
+++ b/frontend/src/components/GTerminal.vue
@@ -141,9 +141,9 @@ limitations under the License.
             dark
           >
             <template v-slot:activator="{ on: menu }">
-              <v-tooltip v-on="menu" :disabled="connectionMenu" top style="min-width: 110px">
+              <v-tooltip :disabled="connectionMenu" top style="min-width: 110px">
                 <template v-slot:activator="{ on: tooltip }">
-                  <v-btn v-on="tooltip" small text color="grey lighten-1" class="text-none systemBarButton">
+                  <v-btn v-on="{ ...tooltip, ...menu }" small text color="grey lighten-1" class="text-none systemBarButton">
                     <icon-base width="18" height="18" viewBox="-2 -2 30 30" iconColor="#bdbdbd" class="mr-2">
                       <connected v-if="terminalSession.connectionState === TerminalSession.CONNECTED"></connected>
                       <disconnected v-else></disconnected>


### PR DESCRIPTION
**What this PR does / why we need it**:
The connection to the terminal pod fails when pressing the reload button in the browser for a privileged terminal or (as admin) when using the cluster as host cluster.
This is because the wrong kube-apiserver was selected (the seed instead of the shoot kube-apiserver).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user

```
