### PR TITLE
Fix FP and LB Name not reset when region is changed

### DIFF
--- a/frontend/src/components/NewShoot/NewShootInfrastructureDetails.vue
+++ b/frontend/src/components/NewShoot/NewShootInfrastructureDetails.vue
@@ -545,6 +545,9 @@ export default {
     onInputRegion () {
       this.partitionID = head(this.partitionIDs)
       this.onInputPartitionID()
+      this.floatingPoolName = head(this.allFloatingPoolNames)
+      this.loadBalancerProviderName = head(this.allLoadBalancerProviderNames)
+      this.onInputLoadBalancerProviderName()
       this.$v.region.$touch()
       this.userInterActionBus.emit('updateRegion', this.region)
       this.validateInput()


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Fix: OpenStack Floating Pool and Load Balancer name not reset when region changed on create cluster page
```
