### PR TITLE
Access Restrictions

### DIFF
--- a/charts/gardener-dashboard/templates/configmap.yaml
+++ b/charts/gardener-dashboard/templates/configmap.yaml
@@ -203,8 +203,8 @@ data:
             description: {{ .display.description }}{{- end }}
           input:
             title: {{ .input.title }}{{- if .input.description }}
-            description: {{ .input.description }}{{- end }}
-            inverted: {{ .input.inverted | default false }}
+            description: {{ .input.description }}{{- end }}{{- if .input.inverted }}
+            inverted: {{ .input.inverted }}{{- end }}
           {{- if .options }}
           options:
           {{- range .options }}
@@ -215,8 +215,8 @@ data:
               description: {{ .display.description }}{{- end }}
             input:
               title: {{ .input.title }}{{- if .input.description }}
-              description: {{ .input.description }}{{- end }}
-              inverted: {{ .input.inverted | default false }}
+              description: {{ .input.description }}{{- end }}{{- if .input.inverted }}
+              inverted: {{ .input.inverted }}{{- end }}
           {{- end }}
           {{- end }}
         {{- end }}

--- a/charts/gardener-dashboard/templates/configmap.yaml
+++ b/charts/gardener-dashboard/templates/configmap.yaml
@@ -189,21 +189,13 @@ data:
         title: {{ .Values.frontendConfig.sla.title }}
         description: {{ .Values.frontendConfig.sla.description }}
 {{- end }}
-{{- if .Values.frontendConfig.accessRestrictions }}
-      accessRestrictions:
-      {{- range .Values.frontendConfig.accessRestrictions }}
-      - key: {{ .key }}
-        display:
-          visibleIf: {{ .display.visibleIf }}{{- if .display.title }}
-          title: {{ .display.title }}{{- end }}{{- if .display.description }}
-          description: {{ .display.description }}{{- end }}
-        input:
-          title: {{ .input.title }}{{- if .input.description }}
-          description: {{ .input.description }}{{- end }}
-          inverted: {{ .input.inverted | default false }}
-        {{- if .options }}
-        options:
-        {{- range .options }}
+{{- if .Values.frontendConfig.accessRestriction }}
+      accessRestriction:
+        {{- if  .Values.frontendConfig.accessRestriction.noItemsText }}
+        noItemsText: {{  .Values.frontendConfig.accessRestriction.noItemsText }}
+        {{- end }}
+        items:
+        {{- range .Values.frontendConfig.accessRestriction.items }}
         - key: {{ .key }}
           display:
             visibleIf: {{ .display.visibleIf }}{{- if .display.title }}
@@ -213,7 +205,19 @@ data:
             title: {{ .input.title }}{{- if .input.description }}
             description: {{ .input.description }}{{- end }}
             inverted: {{ .input.inverted | default false }}
+          {{- if .options }}
+          options:
+          {{- range .options }}
+          - key: {{ .key }}
+            display:
+              visibleIf: {{ .display.visibleIf }}{{- if .display.title }}
+              title: {{ .display.title }}{{- end }}{{- if .display.description }}
+              description: {{ .display.description }}{{- end }}
+            input:
+              title: {{ .input.title }}{{- if .input.description }}
+              description: {{ .input.description }}{{- end }}
+              inverted: {{ .input.inverted | default false }}
+          {{- end }}
+          {{- end }}
         {{- end }}
-        {{- end }}
-      {{- end }}
 {{- end }}

--- a/charts/gardener-dashboard/templates/configmap.yaml
+++ b/charts/gardener-dashboard/templates/configmap.yaml
@@ -201,7 +201,6 @@ data:
           title: {{ .input.title }}{{- if .input.description }}
           description: {{ .input.description }}{{- end }}
           inverted: {{ .input.inverted | default false }}
-          isSelectedByDefault: {{ .input.isSelectedByDefault }}
         {{- if .options }}
         options:
         {{- range .options }}
@@ -214,7 +213,6 @@ data:
             title: {{ .input.title }}{{- if .input.description }}
             description: {{ .input.description }}{{- end }}
             inverted: {{ .input.inverted | default false }}
-            isSelectedByDefault: {{ .input.isSelectedByDefault }}
         {{- end }}
         {{- end }}
       {{- end }}

--- a/charts/gardener-dashboard/templates/configmap.yaml
+++ b/charts/gardener-dashboard/templates/configmap.yaml
@@ -189,3 +189,33 @@ data:
         title: {{ .Values.frontendConfig.sla.title }}
         description: {{ .Values.frontendConfig.sla.description }}
 {{- end }}
+{{- if .Values.frontendConfig.accessRestrictions }}
+      accessRestrictions:
+      {{- range .Values.frontendConfig.accessRestrictions }}
+      - key: {{ .key }}
+        display:
+          visibleIf: {{ .display.visibleIf }}{{- if .display.title }}
+          title: {{ .display.title }}{{- end }}{{- if .display.description }}
+          description: {{ .display.description }}{{- end }}
+        input:
+          title: {{ .input.title }}{{- if .input.description }}
+          description: {{ .input.description }}{{- end }}
+          inverted: {{ .input.inverted | default false }}
+          isSelectedByDefault: {{ .input.isSelectedByDefault }}
+        {{- if .options }}
+        options:
+        {{- range .options }}
+        - key: {{ .key }}
+          display:
+            visibleIf: {{ .display.visibleIf }}{{- if .display.title }}
+            title: {{ .display.title }}{{- end }}{{- if .display.description }}
+            description: {{ .display.description }}{{- end }}
+          input:
+            title: {{ .input.title }}{{- if .input.description }}
+            description: {{ .input.description }}{{- end }}
+            inverted: {{ .input.inverted | default false }}
+            isSelectedByDefault: {{ .input.isSelectedByDefault }}
+        {{- end }}
+        {{- end }}
+      {{- end }}
+{{- end }}

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -112,6 +112,41 @@ frontendConfig:
   #   title: SLAs
   #   description: https://foo.example.com/gardener-sla
 
+  # # accessRestrictions is used to define the access restricion text, keys and value mappings
+  # accessRestrictions:
+  # - key: seed.gardener.cloud/eu-access
+  #   display:
+  #     visibleIf: true
+  #     # title: foo # optional title, if not defined key will be used
+  #     # description: bar # optional description displayed in a tooltip
+  #   input:
+  #     title: EU Access
+  #     description: |
+  #       This service is offered to you with our regular SLAs and 24x7 support for the control plane of the cluster. 24x7 support for cluster add-ons and nodes is only available if you meet the following conditions:
+  #     # inverted: false
+  #     isSelectedByDefault: false
+  #   options:
+  #   - key: support.gardener.cloud/eu-access-for-cluster-addons
+  #     display:
+  #       visibleIf: false
+  #       # title: bar # optional title, if not defined key will be used
+  #       # description: baz # optional description displayed in a tooltip
+  #     input:
+  #       title: No personal data is used as name or in the content of Gardener or Kubernetes resources (e.g. Gardener project name or Kubernetes namespace, configMap or secret in Gardener or Kubernetes)
+  #       description: |
+  #         If you can't comply, only third-level/dev support at usual 8x5 working hours in EEA will be available to you for all cluster add-ons such as DNS and certificates, Calico overlay network and network policies, kube-proxy and services, and everything else that would require direct inspection of your cluster through its API server
+  #       inverted: true
+  #       isSelectedByDefault: false
+  #   - key: support.gardener.cloud/eu-access-for-cluster-nodes
+  #     display:
+  #       visibleIf: false
+  #     input:
+  #       title: No personal data is stored in any Kubernetes volume except for container file system, emptyDirs, and persistentVolumes (in particular, not on hostPath volumes)
+  #       description: |
+  #         If you can't comply, only third-level/dev support at usual 8x5 working hours in EEA will be available to you for all node-related components such as Docker and Kubelet, the operating system, and everything else that would require direct inspection of your nodes through a privileged pod or SSH
+  #       inverted: true
+  #       isSelectedByDefault: false
+
 gitHub:
   apiUrl: https://api.foo-github.com
   org: dummyorg

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -124,7 +124,6 @@ frontendConfig:
   #     description: |
   #       This service is offered to you with our regular SLAs and 24x7 support for the control plane of the cluster. 24x7 support for cluster add-ons and nodes is only available if you meet the following conditions:
   #     # inverted: false
-  #     isSelectedByDefault: false
   #   options:
   #   - key: support.gardener.cloud/eu-access-for-cluster-addons
   #     display:
@@ -136,7 +135,6 @@ frontendConfig:
   #       description: |
   #         If you can't comply, only third-level/dev support at usual 8x5 working hours in EEA will be available to you for all cluster add-ons such as DNS and certificates, Calico overlay network and network policies, kube-proxy and services, and everything else that would require direct inspection of your cluster through its API server
   #       inverted: true
-  #       isSelectedByDefault: false
   #   - key: support.gardener.cloud/eu-access-for-cluster-nodes
   #     display:
   #       visibleIf: false
@@ -145,7 +143,6 @@ frontendConfig:
   #       description: |
   #         If you can't comply, only third-level/dev support at usual 8x5 working hours in EEA will be available to you for all node-related components such as Docker and Kubelet, the operating system, and everything else that would require direct inspection of your nodes through a privileged pod or SSH
   #       inverted: true
-  #       isSelectedByDefault: false
 
 gitHub:
   apiUrl: https://api.foo-github.com

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -112,37 +112,39 @@ frontendConfig:
   #   title: SLAs
   #   description: https://foo.example.com/gardener-sla
 
-  # # accessRestrictions is used to define the access restricion text, keys and value mappings
-  # accessRestrictions:
-  # - key: seed.gardener.cloud/eu-access
-  #   display:
-  #     visibleIf: true
-  #     # title: foo # optional title, if not defined key will be used
-  #     # description: bar # optional description displayed in a tooltip
-  #   input:
-  #     title: EU Access
-  #     description: |
-  #       This service is offered to you with our regular SLAs and 24x7 support for the control plane of the cluster. 24x7 support for cluster add-ons and nodes is only available if you meet the following conditions:
-  #     # inverted: false
-  #   options:
-  #   - key: support.gardener.cloud/eu-access-for-cluster-addons
+  # # accessRestriction is used to define the access restricion text, keys and value mappings
+  # accessRestriction:
+  #   noItemsText: No access restriction options available for region {region} and cloud profile {cloudProfile}
+  #   items:
+  #   - key: seed.gardener.cloud/eu-access
   #     display:
-  #       visibleIf: false
-  #       # title: bar # optional title, if not defined key will be used
-  #       # description: baz # optional description displayed in a tooltip
+  #       visibleIf: true
+  #       # title: foo # optional title, if not defined key will be used
+  #       # description: bar # optional description displayed in a tooltip
   #     input:
-  #       title: No personal data is used as name or in the content of Gardener or Kubernetes resources (e.g. Gardener project name or Kubernetes namespace, configMap or secret in Gardener or Kubernetes)
+  #       title: EU Access
   #       description: |
-  #         If you can't comply, only third-level/dev support at usual 8x5 working hours in EEA will be available to you for all cluster add-ons such as DNS and certificates, Calico overlay network and network policies, kube-proxy and services, and everything else that would require direct inspection of your cluster through its API server
-  #       inverted: true
-  #   - key: support.gardener.cloud/eu-access-for-cluster-nodes
-  #     display:
-  #       visibleIf: false
-  #     input:
-  #       title: No personal data is stored in any Kubernetes volume except for container file system, emptyDirs, and persistentVolumes (in particular, not on hostPath volumes)
-  #       description: |
-  #         If you can't comply, only third-level/dev support at usual 8x5 working hours in EEA will be available to you for all node-related components such as Docker and Kubelet, the operating system, and everything else that would require direct inspection of your nodes through a privileged pod or SSH
-  #       inverted: true
+  #         This service is offered to you with our regular SLAs and 24x7 support for the control plane of the cluster. 24x7 support for cluster add-ons and nodes is only available if you meet the following conditions:
+  #       # inverted: false
+  #     options:
+  #     - key: support.gardener.cloud/eu-access-for-cluster-addons
+  #       display:
+  #         visibleIf: false
+  #         # title: bar # optional title, if not defined key will be used
+  #         # description: baz # optional description displayed in a tooltip
+  #       input:
+  #         title: No personal data is used as name or in the content of Gardener or Kubernetes resources (e.g. Gardener project name or Kubernetes namespace, configMap or secret in Gardener or Kubernetes)
+  #         description: |
+  #           If you can't comply, only third-level/dev support at usual 8x5 working hours in EEA will be available to you for all cluster add-ons such as DNS and certificates, Calico overlay network and network policies, kube-proxy and services, and everything else that would require direct inspection of your cluster through its API server
+  #         inverted: true
+  #     - key: support.gardener.cloud/eu-access-for-cluster-nodes
+  #       display:
+  #         visibleIf: false
+  #       input:
+  #         title: No personal data is stored in any Kubernetes volume except for container file system, emptyDirs, and persistentVolumes (in particular, not on hostPath volumes)
+  #         description: |
+  #           If you can't comply, only third-level/dev support at usual 8x5 working hours in EEA will be available to you for all node-related components such as Docker and Kubelet, the operating system, and everything else that would require direct inspection of your nodes through a privileged pod or SSH
+  #         inverted: true
 
 gitHub:
   apiUrl: https://api.foo-github.com

--- a/charts/test/gardener-dashbaord.spec.js
+++ b/charts/test/gardener-dashbaord.spec.js
@@ -177,6 +177,156 @@ describe('gardener-dashboard', function () {
         expect(oidc.issuer).to.equal(values.oidc.issuerUrl)
         expect(oidc.public).to.be.undefined
       })
+
+      describe('access restrictions', function () {
+        it('should render the template without options', async function () {
+          const values = writeValues(filename, {
+            frontendConfig: {
+                accessRestriction: {
+                  noItemsText: 'no items text',
+                  items: [
+                    {
+                      key: 'foo',
+                      display: {
+                        visibleIf: true 
+                      },
+                      input: {
+                        title: 'Foo'
+                      }
+                    }
+                  ]
+                }
+              }
+            })
+          const documents = await helmTemplate(template, filename)
+          const config = chain(documents)
+            .find(['metadata.name', name])
+            .get('data["config.yaml"]')
+            .thru(yaml.safeLoad)
+            .value()
+          const {
+            frontend: {
+              accessRestriction: {
+                noItemsText,
+                items
+              }
+            }
+          } = config
+          expect(noItemsText).to.equal('no items text')
+          expect(items.length).to.equal(1)
+          expect(items[0]).to.eql({
+            key: 'foo',
+            display: {
+              visibleIf: true 
+            },
+            input: {
+              title: 'Foo'
+            }
+          })
+        })
+
+        it('should render the template with options', async function () {
+          const values = writeValues(filename, {
+            frontendConfig: {
+                accessRestriction: {
+                  items: [
+                    {
+                      key: 'foo',
+                      display: {
+                        visibleIf: true,
+                        title: 'display Foo',
+                        description: 'display Foo description',
+                      },
+                      input: {
+                        title: 'input Foo',
+                        description: 'input Foo description',
+                        inverted: true
+                      },
+                      options: [
+                        {
+                          key: 'foo-option-1',
+                          display: {
+                            visibleIf: false,
+                            title: 'display Foo Option 1',
+                            description: 'display Foo  Option 1 description',
+                          },
+                          input: {
+                            title: 'input Foo Option 1',
+                            description: 'input Foo  Option 1 description',
+                            inverted: false
+                          }
+                        },
+                        {
+                          key: 'foo-option-2',
+                          display: {
+                            visibleIf: true,
+                          },
+                          input: {
+                            title: 'input Foo Option 2',
+                            description: 'input Foo  Option 2 description',
+                            inverted: true
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            })
+          const documents = await helmTemplate(template, filename)
+          const config = chain(documents)
+            .find(['metadata.name', name])
+            .get('data["config.yaml"]')
+            .thru(yaml.safeLoad)
+            .value()
+          const {
+            frontend: {
+              accessRestriction: {
+                items
+              }
+            }
+          } = config
+          expect(items.length).to.equal(1)
+          expect(items[0]).to.eql({
+            key: 'foo',
+            display: {
+              visibleIf: true,
+              title: 'display Foo',
+              description: 'display Foo description',
+            },
+            input: {
+              title: 'input Foo',
+              description: 'input Foo description',
+              inverted: true
+            },
+            options: [
+              {
+                key: 'foo-option-1',
+                display: {
+                  visibleIf: false,
+                  title: 'display Foo Option 1',
+                  description: 'display Foo  Option 1 description',
+                },
+                input: {
+                  title: 'input Foo Option 1',
+                  description: 'input Foo  Option 1 description',
+                }
+              },
+              {
+                key: 'foo-option-2',
+                display: {
+                  visibleIf: true,
+                },
+                input: {
+                  title: 'input Foo Option 2',
+                  description: 'input Foo  Option 2 description',
+                  inverted: true
+                }
+              }
+            ]
+          })
+        })
+      })
     })
   })
 })

--- a/frontend/src/components/ShootAccessRestrictions/AccessRestrictionChips.vue
+++ b/frontend/src/components/ShootAccessRestrictions/AccessRestrictionChips.vue
@@ -1,0 +1,69 @@
+<!--
+Copyright (c) 2020 by SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<template>
+  <div>
+    <v-row v-for="{ key, title, description, options } in selectedAccessRestrictions" :key="key" class="mx-0 mb-1">
+      <v-tooltip
+        top
+        :disabled="!description"
+      >
+        <template v-slot:activator="{ on }">
+          <v-chip
+            v-on="on"
+            small
+            outlined
+            color="cyan darken-2"
+            class="mr-2 mb-1"
+          >{{title}}</v-chip>
+        </template>
+        {{description}}
+      </v-tooltip>
+      <v-tooltip
+        v-for="{ key: optionsKey, title, description } in options"
+        :key="`${key}_${optionsKey}`"
+        top
+        :disabled="!description"
+      >
+        <template v-slot:activator="{ on }">
+          <v-chip
+            v-on="on"
+            small
+            outlined
+            color="cyan darken-2"
+            class="mr-2"
+          >{{title}}</v-chip>
+        </template>
+        {{description}}
+      </v-tooltip>
+    </v-row>
+  </div>
+</template>
+
+<script>
+
+export default {
+  props: {
+    selectedAccessRestrictions: {
+      type: Object
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+
+</style>

--- a/frontend/src/components/ShootAccessRestrictions/AccessRestrictions.vue
+++ b/frontend/src/components/ShootAccessRestrictions/AccessRestrictions.vue
@@ -16,7 +16,7 @@ limitations under the License.
 
 <template>
   <div v-if="definitions">
-    <v-row v-for="(definition, index)  in definitions" :key="definition.key">
+    <v-row v-for="(definition, index) in definitions" :key="definition.key">
       <v-list :class="{ 'grey lighten-5': index % 2 }">
         <v-list-item v-if="definition">
           <v-list-item-action class="action-select">

--- a/frontend/src/components/ShootAccessRestrictions/AccessRestrictions.vue
+++ b/frontend/src/components/ShootAccessRestrictions/AccessRestrictions.vue
@@ -1,0 +1,173 @@
+<!--
+Copyright (c) 2019 by SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<template>
+  <div v-if="definitions">
+    <v-row v-for="(definition, index)  in definitions" :key="definition.key">
+      <v-list :class="{ 'grey lighten-5': index % 2 }">
+        <v-list-item v-if="definition">
+          <v-list-item-action class="action-select">
+            <v-switch
+              v-model="accessRestrictions[definition.key].value"
+              color="cyan darken-2"
+              inset
+            ></v-switch>
+          </v-list-item-action>
+          <v-list-item-content>
+            <v-list-item-title class="wrap-text" v-html="compileMarkdown(definition.input.title)"></v-list-item-title>
+            <v-list-item-subtitle v-if="definition.input.description" class="wrap-text" v-html="compileMarkdown(definition.input.description)"></v-list-item-subtitle>
+          </v-list-item-content>
+        </v-list-item>
+        <template v-if="definition">
+          <v-list-item v-for="optionValue in definition.options" :key="optionValue.key">
+            <v-list-item-action class="action-select">
+              <v-checkbox
+                v-model="accessRestrictions[definition.key].options[optionValue.key].value"
+                :disabled="!enabled(definition)"
+                color="cyan darken-2"
+              ></v-checkbox>
+            </v-list-item-action>
+            <v-list-item-content>
+              <v-list-item-title class="wrap-text" :class="textClass(definition)" v-html="compileMarkdown(optionValue.input.title)"></v-list-item-title>
+              <v-list-item-subtitle v-if="optionValue.input.description" class="wrap-text pt-n3" :class="textClass(definition)" v-html="compileMarkdown(optionValue.input.description)"></v-list-item-subtitle>
+            </v-list-item-content>
+          </v-list-item>
+        </template>
+      </v-list>
+    </v-row>
+  </div>
+  <div v-else class="pt-4">
+    No access restriction options available for region {{region}}
+  </div>
+</template>
+
+<script>
+import cloneDeep from 'lodash/cloneDeep'
+import isEmpty from 'lodash/isEmpty'
+import get from 'lodash/get'
+import set from 'lodash/set'
+import unset from 'lodash/unset'
+import { compileMarkdown } from '@/utils'
+import { mapState, mapGetters } from 'vuex'
+
+export default {
+  props: {
+    userInterActionBus: {
+      type: Object
+    }
+  },
+  data () {
+    return {
+      accessRestrictions: undefined,
+      cloudProfileName: undefined,
+      region: undefined,
+      shootResource: undefined
+    }
+  },
+  computed: {
+    ...mapState([
+      'cfg'
+    ]),
+    ...mapGetters([
+      'accessRestrictionDefinitionsByCloudProfileNameAndRegion',
+      'accessRestrictionsForShootByCloudProfileNameAndRegion',
+      'labelsByCloudProfileNameAndRegion'
+    ]),
+    definitions () {
+      return this.accessRestrictionDefinitionsByCloudProfileNameAndRegion({ cloudProfileName: this.cloudProfileName, region: this.region })
+    }
+  },
+  methods: {
+    compileMarkdown (value) {
+      return compileMarkdown(value)
+    },
+    setAccessRestrictions ({ shootResource, cloudProfileName, region }) {
+      this.shootResource = shootResource
+      this.cloudProfileName = cloudProfileName
+      this.region = region
+
+      const accessRestrictions = this.accessRestrictionsForShootByCloudProfileNameAndRegion({ shootResource, cloudProfileName, region })
+      this.accessRestrictions = cloneDeep(accessRestrictions)
+    },
+    enabled (definition) {
+      const inverted = definition.input.inverted
+      const value = this.accessRestrictions[definition.key].value
+      return inverted ? !value : value
+    },
+    textClass (definition) {
+      const enabled = this.enabled(definition)
+      return enabled ? 'text--secondary' : 'text--disabled'
+    },
+    applyTo (shootResource) {
+      const definitions = this.definitions || []
+      const accessRestrictions = this.accessRestrictions || {}
+      for (const { key, input, options: optionDefinitions } of definitions) {
+        const { value, options } = accessRestrictions[key]
+        const { inverted = false } = input
+        const accessRestrictionEnabled = inverted ? !value : value
+        if (accessRestrictionEnabled) {
+          set(shootResource, ['spec', 'seedSelector', 'matchLabels', key], 'true')
+        } else {
+          unset(shootResource, ['spec', 'seedSelector', 'matchLabels', key])
+        }
+
+        for (const { key, input } of optionDefinitions) {
+          const { value } = options[key]
+          const { inverted = false } = input
+          const optionEnabled = inverted ? !value : value
+          if (accessRestrictionEnabled) {
+            set(shootResource, ['metadata', 'annotations', key], `${optionEnabled}`)
+          } else {
+            unset(shootResource, ['metadata', 'annotations', key])
+          }
+        }
+      }
+
+      if (isEmpty(get(shootResource, 'spec.seedSelector.matchLabels'))) {
+        unset(shootResource, 'spec.seedSelector.matchLabels')
+      }
+      if (isEmpty(get(shootResource, 'spec.seedSelector'))) {
+        unset(shootResource, 'spec.seedSelector')
+      }
+
+      return shootResource
+    }
+  },
+  mounted () {
+    if (this.userInterActionBus) {
+      this.userInterActionBus.on('updateCloudProfileName', cloudProfileName => {
+        this.setAccessRestrictions({ shootResource: this.shootResource, cloudProfileName, region: this.region })
+      })
+      this.userInterActionBus.on('updateRegion', region => {
+        this.setAccessRestrictions({ shootResource: this.shootResource, cloudProfileName: this.cloudProfileName, region })
+      })
+    }
+  }
+}
+
+</script>
+
+<style lang="scss" scoped>
+  .wrap-text {
+    white-space: normal;
+  }
+
+  .action-select {
+    align-self: flex-start;
+    min-width: 48px;
+  }
+
+</style>

--- a/frontend/src/components/ShootAccessRestrictions/AccessRestrictions.vue
+++ b/frontend/src/components/ShootAccessRestrictions/AccessRestrictions.vue
@@ -50,7 +50,7 @@ limitations under the License.
     </v-row>
   </div>
   <div v-else class="pt-4">
-    No access restriction options available for region {{region}}
+    {{noItemsText}}
   </div>
 </template>
 
@@ -82,12 +82,16 @@ export default {
       'cfg'
     ]),
     ...mapGetters([
+      'accessRestrictionNoItemsTextForCloudProfileNameAndRegion',
       'accessRestrictionDefinitionsByCloudProfileNameAndRegion',
       'accessRestrictionsForShootByCloudProfileNameAndRegion',
       'labelsByCloudProfileNameAndRegion'
     ]),
     definitions () {
       return this.accessRestrictionDefinitionsByCloudProfileNameAndRegion({ cloudProfileName: this.cloudProfileName, region: this.region })
+    },
+    noItemsText () {
+      return this.accessRestrictionNoItemsTextForCloudProfileNameAndRegion({ cloudProfileName: this.cloudProfileName, region: this.region })
     }
   },
   methods: {

--- a/frontend/src/components/ShootAccessRestrictions/AccessRestrictions.vue
+++ b/frontend/src/components/ShootAccessRestrictions/AccessRestrictions.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2019 by SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+Copyright (c) 2020 by SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/frontend/src/components/ShootAccessRestrictions/AccessRestrictionsConfiguration.vue
+++ b/frontend/src/components/ShootAccessRestrictions/AccessRestrictionsConfiguration.vue
@@ -1,0 +1,98 @@
+<!--
+Copyright (c) 2019 by SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<template>
+  <action-icon-dialog
+    :shootItem="shootItem"
+    :disabled="disabled"
+    :tooltip="tooltip"
+    @dialogOpened="onConfigurationDialogOpened"
+    ref="actionDialog"
+    maxWidth="760"
+    caption="Configure Access Restrictions">
+    <template v-slot:actionComponent>
+      <access-restrictions
+        ref="accessRestrictions"
+      >
+      </access-restrictions>
+    </template>
+  </action-icon-dialog>
+</template>
+
+<script>
+import ActionIconDialog from '@/components/dialogs/ActionIconDialog'
+import AccessRestrictions from '@/components/ShootAccessRestrictions/AccessRestrictions'
+import isEmpty from 'lodash/isEmpty'
+import cloneDeep from 'lodash/cloneDeep'
+import { replaceShoot } from '@/utils/api'
+import { shootItem } from '@/mixins/shootItem'
+import { mapGetters } from 'vuex'
+import { errorDetailsFromError } from '@/utils/error'
+
+export default {
+  name: 'access-restriction-configuration',
+  components: {
+    ActionIconDialog,
+    AccessRestrictions
+  },
+  props: {
+    shootItem: {
+      type: Object
+    }
+  },
+  mixins: [shootItem],
+  computed: {
+    ...mapGetters([
+      'accessRestrictionDefinitionsByCloudProfileNameAndRegion'
+    ]),
+    disabled () {
+      const accessRestrictionDefinitions = this.accessRestrictionDefinitionsByCloudProfileNameAndRegion({ cloudProfileName: this.shootCloudProfileName, region: this.shootRegion })
+      return isEmpty(accessRestrictionDefinitions)
+    },
+    tooltip () {
+      if (!this.disabled) {
+        return undefined
+      }
+      return `No access restriction options available for region ${this.shootRegion}`
+    }
+  },
+  methods: {
+    async onConfigurationDialogOpened () {
+      this.reset()
+      const confirmed = await this.$refs.actionDialog.waitForDialogClosed()
+      if (confirmed) {
+        this.updateConfiguration()
+      }
+    },
+    async updateConfiguration () {
+      try {
+        const shootResource = cloneDeep(this.shootItem)
+        this.$refs.accessRestrictions.applyTo(shootResource)
+        await replaceShoot({ namespace: this.shootNamespace, name: this.shootName, data: shootResource })
+      } catch (err) {
+        const errorMessage = 'Could not save access restriction configuration'
+        const errorDetails = errorDetailsFromError(err)
+        const detailedErrorMessage = errorDetails.detailedMessage
+        this.$refs.actionDialog.setError({ errorMessage, detailedErrorMessage })
+        console.error(this.errorMessage, errorDetails.errorCode, errorDetails.detailedMessage, err)
+      }
+    },
+    reset () {
+      this.$refs.accessRestrictions.setAccessRestrictions({ shootResource: this.shootItem, cloudProfileName: this.shootCloudProfileName, region: this.shootRegion })
+    }
+  }
+}
+</script>

--- a/frontend/src/components/ShootAccessRestrictions/AccessRestrictionsConfiguration.vue
+++ b/frontend/src/components/ShootAccessRestrictions/AccessRestrictionsConfiguration.vue
@@ -56,17 +56,21 @@ export default {
   mixins: [shootItem],
   computed: {
     ...mapGetters([
+      'accessRestrictionNoItemsTextForCloudProfileNameAndRegion',
       'accessRestrictionDefinitionsByCloudProfileNameAndRegion'
     ]),
     disabled () {
       const accessRestrictionDefinitions = this.accessRestrictionDefinitionsByCloudProfileNameAndRegion({ cloudProfileName: this.shootCloudProfileName, region: this.shootRegion })
       return isEmpty(accessRestrictionDefinitions)
     },
+    noItemsText () {
+      return this.accessRestrictionNoItemsTextForCloudProfileNameAndRegion({ cloudProfileName: this.shootCloudProfileName, region: this.shootRegion })
+    },
     tooltip () {
       if (!this.disabled) {
         return undefined
       }
-      return `No access restriction options available for region ${this.shootRegion}`
+      return this.noItemsText
     }
   },
   methods: {

--- a/frontend/src/components/ShootAccessRestrictions/AccessRestrictionsConfiguration.vue
+++ b/frontend/src/components/ShootAccessRestrictions/AccessRestrictionsConfiguration.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2019 by SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+Copyright (c) 2020 by SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/frontend/src/components/ShootDetails/ShootDetailsCard.vue
+++ b/frontend/src/components/ShootDetails/ShootDetailsCard.vue
@@ -152,7 +152,7 @@ limitations under the License.
           </v-list-item-content>
         </v-list-item>
       </template>
-      <template v-if="cfg.accessRestrictions">
+      <template v-if="cfg.accessRestriction">
         <v-divider inset></v-divider>
         <v-list-item>
           <v-list-item-icon>

--- a/frontend/src/components/ShootDetails/ShootDetailsCard.vue
+++ b/frontend/src/components/ShootDetails/ShootDetailsCard.vue
@@ -152,6 +152,60 @@ limitations under the License.
           </v-list-item-content>
         </v-list-item>
       </template>
+      <template v-if="cfg.accessRestrictions">
+        <v-divider inset></v-divider>
+        <v-list-item>
+          <v-list-item-icon>
+            <v-icon color="cyan darken-2">mdi-earth</v-icon>
+          </v-list-item-icon>
+          <v-list-item-content>
+            <v-list-item-subtitle>Access Restrictions</v-list-item-subtitle>
+            <v-list-item-title v-if="selectedAccessRestrictions.length" class="d-flex align-center pt-1 flex-wrap">
+              <v-row v-for="{ key, title, description, options } in selectedAccessRestrictions" :key="key" class="mx-0 mb-1">
+                <v-tooltip
+                  top
+                  :disabled="!description"
+                >
+                  <template v-slot:activator="{ on }">
+                    <v-chip
+                      v-on="on"
+                      small
+                      outlined
+                      color="cyan darken-2"
+                      class="mr-2 mb-1"
+                    >{{title}}</v-chip>
+                  </template>
+                  {{description}}
+                </v-tooltip>
+                <v-tooltip
+                  v-for="{ key: optionsKey, title, description } in options"
+                  :key="`${key}_${optionsKey}`"
+                  top
+                  :disabled="!description"
+                >
+                  <template v-slot:activator="{ on }">
+                    <v-chip
+                      v-on="on"
+                      small
+                      outlined
+                      color="cyan darken-2"
+                      class="mr-2"
+                    >{{title}}</v-chip>
+                  </template>
+                  {{description}}
+                </v-tooltip>
+              </v-row>
+            </v-list-item-title>
+            <v-list-item-title v-else class="d-flex align-center pt-1">
+              No access restrictions configured
+            </v-list-item-title>
+          </v-list-item-content>
+          <v-list-item-action>
+            <access-restrictions-configuration
+              :shootItem="shootItem"></access-restrictions-configuration>
+          </v-list-item-action>
+        </v-list-item>
+      </template>
       <v-divider inset></v-divider>
       <v-list-item>
         <v-list-item-icon>
@@ -188,12 +242,14 @@ import AccountAvatar from '@/components/AccountAvatar'
 import TimeString from '@/components/TimeString'
 import WorkerGroup from '@/components/ShootWorkers/WorkerGroup'
 import WorkerConfiguration from '@/components/ShootWorkers/WorkerConfiguration'
+import AccessRestrictionsConfiguration from '@/components/ShootAccessRestrictions/AccessRestrictionsConfiguration'
 import PurposeConfiguration from '@/components/PurposeConfiguration'
 import ShootVersion from '@/components/ShootVersion/ShootVersion'
 import AddonConfiguration from '@/components/ShootAddons/AddonConfiguration'
 import CopyBtn from '@/components/CopyBtn'
 import filter from 'lodash/filter'
 import map from 'lodash/map'
+import compact from 'lodash/compact'
 import {
   isSelfTerminationWarning,
   isValidTerminationDate,
@@ -204,12 +260,63 @@ import {
 import { shootItem } from '@/mixins/shootItem'
 import { mapState, mapGetters } from 'vuex'
 
+function optionMap (optionDefinition, option) {
+  const {
+    key,
+    display: {
+      visibleIf = false,
+      title = key,
+      description
+    }
+  } = optionDefinition
+  const { value } = option
+
+  const optionVisible = visibleIf === value
+  if (!optionVisible) {
+    return undefined // skip
+  }
+
+  return {
+    key,
+    title,
+    description
+  }
+}
+
+function accessRestrictionMap (definition, accessRestriction) {
+  const {
+    key,
+    display: {
+      visibleIf = false,
+      title = key,
+      description
+    },
+    options: optionDefinitions
+  } = definition
+  const { value, options } = accessRestriction
+
+  const accessRestrictionVisible = visibleIf === value
+  if (!accessRestrictionVisible) {
+    return undefined // skip
+  }
+
+  const optionsList = compact(map(optionDefinitions, optionDefinition => optionMap(optionDefinition, options[optionDefinition.key])))
+
+  return {
+    key,
+    title,
+    description,
+    options: optionsList
+  }
+}
+
 export default {
   components: {
     AccountAvatar,
     TimeString,
     WorkerGroup,
     WorkerConfiguration,
+    AccessRestrictionsConfiguration,
     PurposeConfiguration,
     AddonConfiguration,
     ShootVersion,
@@ -226,7 +333,9 @@ export default {
       'cfg'
     ]),
     ...mapGetters([
-      'canGetSecrets'
+      'canGetSecrets',
+      'accessRestrictionsForShootByCloudProfileNameAndRegion',
+      'accessRestrictionDefinitionsByCloudProfileNameAndRegion'
     ]),
     expirationTimestamp () {
       return this.shootAnnotations['shoot.gardener.cloud/expiration-timestamp'] || this.shootAnnotations['shoot.garden.sapcloud.io/expirationTimestamp']
@@ -243,6 +352,15 @@ export default {
     },
     isValidTerminationDate () {
       return isValidTerminationDate(this.expirationTimestamp)
+    },
+    accessRestrictionDefinitions () {
+      return this.accessRestrictionDefinitionsByCloudProfileNameAndRegion({ cloudProfileName: this.shootCloudProfileName, region: this.shootRegion })
+    },
+    accessRestrictions () {
+      return this.accessRestrictionsForShootByCloudProfileNameAndRegion({ shootResource: this.shootItem, cloudProfileName: this.shootCloudProfileName, region: this.shootRegion })
+    },
+    selectedAccessRestrictions () {
+      return compact(map(this.accessRestrictionDefinitions, definition => accessRestrictionMap(definition, this.accessRestrictions[definition.key])))
     },
     addon () {
       return (name) => {

--- a/frontend/src/components/ShootListRow.vue
+++ b/frontend/src/components/ShootListRow.vue
@@ -87,6 +87,9 @@ limitations under the License.
     <td class="nowrap text-center" v-if="this.headerVisible['readiness']">
       <status-tags :conditions="shootConditions"></status-tags>
     </td>
+    <td v-if="this.headerVisible['accessRestrictions']">
+      <access-restriction-chips :selectedAccessRestrictions="shootSelectedAccessRestrictions"></access-restriction-chips>
+    </td>
     <td class="nowrap" v-if="this.headerVisible['journal']">
       <v-tooltip top>
         <template v-slot:activator="{ on }">
@@ -127,6 +130,7 @@ limitations under the License.
 
 <script>
 import { mapGetters } from 'vuex'
+import AccessRestrictionChips from '@/components/ShootAccessRestrictions/AccessRestrictionChips'
 import AccountAvatar from '@/components/AccountAvatar'
 import Vendor from '@/components/Vendor'
 import ShootStatus from '@/components/ShootStatus'
@@ -152,6 +156,7 @@ import { shootItem } from '@/mixins/shootItem'
 
 export default {
   components: {
+    AccessRestrictionChips,
     StatusTags,
     PurposeTag,
     ShootStatus,

--- a/frontend/src/components/dialogs/ActionIconDialog.vue
+++ b/frontend/src/components/dialogs/ActionIconDialog.vue
@@ -31,7 +31,8 @@ limitations under the License.
           </v-btn>
         </div>
       </template>
-      {{shootActionToolTip(caption)}}
+      <template v-if="tooltip">{{tooltip}}</template>
+      <template v-else>{{shootActionToolTip(caption)}}</template>
     </v-tooltip>
     <g-dialog
       :confirmButtonText="confirmButtonText"
@@ -77,6 +78,9 @@ export default {
       default: 'mdi-settings-outline'
     },
     caption: {
+      type: String
+    },
+    tooltip: {
       type: String
     },
     confirmButtonText: {

--- a/frontend/src/mixins/shootItem.js
+++ b/frontend/src/mixins/shootItem.js
@@ -19,6 +19,7 @@ import uniq from 'lodash/uniq'
 import flatMap from 'lodash/flatMap'
 import cloneDeep from 'lodash/cloneDeep'
 import find from 'lodash/find'
+import { mapGetters } from 'vuex'
 
 import {
   getDateFormatted,
@@ -31,6 +32,9 @@ import {
 
 export const shootItem = {
   computed: {
+    ...mapGetters([
+      'selectedAccessRestrictionsForShootByCloudProfileNameAndRegion'
+    ]),
     shootMetadata () {
       return get(this.shootItem, 'metadata', {})
     },
@@ -177,6 +181,9 @@ export const shootItem = {
     },
     shootStatusSeedName () {
       return get(this.shootItem, 'status.seed')
+    },
+    shootSelectedAccessRestrictions () {
+      return this.selectedAccessRestrictionsForShootByCloudProfileNameAndRegion({ shootResource: this.shootItem, cloudProfileName: this.shootCloudProfileName, region: this.shootRegion })
     },
     isControlPlaneMigrating () {
       return this.shootStatusSeedName && this.shootSeedName && this.shootStatusSeedName !== this.shootSeedName

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -174,10 +174,8 @@ function mapOption (optionValue, shootResource) {
     return
   }
 
-  const isSelectedByDefault = get(optionValue, 'isSelectedByDefault', false)
   const inputInverted = get(optionValue, 'input.inverted', false)
-  const defaultValue = inputInverted ? !isSelectedByDefault : isSelectedByDefault
-  const rawValue = get(shootResource, ['metadata', 'annotations', key], `${defaultValue}`) === 'true'
+  const rawValue = get(shootResource, ['metadata', 'annotations', key]) === 'true'
   const value = inputInverted ? !rawValue : rawValue
 
   const option = {
@@ -186,19 +184,17 @@ function mapOption (optionValue, shootResource) {
   return [key, option]
 }
 
-function mapAccessRestriction (accessRestrictionValue, shootResource) {
-  const key = get(accessRestrictionValue, 'key')
+function mapAccessRestriction (accessRestrictionDefinition, shootResource) {
+  const key = get(accessRestrictionDefinition, 'key')
   if (!key) {
     return
   }
 
-  const isSelectedByDefault = get(accessRestrictionValue, 'isSelectedByDefault', false)
-  const inputInverted = get(accessRestrictionValue, 'input.inverted', false)
-  const defaultValue = inputInverted ? !isSelectedByDefault : isSelectedByDefault
-  const rawValue = get(shootResource, ['spec', 'seedSelector', 'matchLabels', key], `${defaultValue}`) === 'true'
+  const inputInverted = get(accessRestrictionDefinition, 'input.inverted', false)
+  const rawValue = get(shootResource, ['spec', 'seedSelector', 'matchLabels', key]) === 'true'
   const value = inputInverted ? !rawValue : rawValue
 
-  let optionsPair = map(get(accessRestrictionValue, 'options'), option => mapOption(option, shootResource))
+  let optionsPair = map(get(accessRestrictionDefinition, 'options'), option => mapOption(option, shootResource))
   optionsPair = compact(optionsPair)
   const options = fromPairs(optionsPair)
 
@@ -1170,5 +1166,6 @@ export {
   getters,
   mutations,
   modules,
-  plugins
+  plugins,
+  mapAccessRestriction
 }

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -43,6 +43,7 @@ import sortBy from 'lodash/sortBy'
 import lowerCase from 'lodash/lowerCase'
 import cloneDeep from 'lodash/cloneDeep'
 import max from 'lodash/max'
+import template from 'lodash/template'
 import toPairs from 'lodash/toPairs'
 import fromPairs from 'lodash/fromPairs'
 import isEqual from 'lodash/isEqual'
@@ -331,6 +332,17 @@ const getters = {
       return []
     }
   },
+  accessRestrictionNoItemsTextForCloudProfileNameAndRegion (state, getters) {
+    return ({ cloudProfileName: cloudProfile, region }) => {
+      const noItemsText = get(state, 'cfg.accessRestriction.noItemsText', 'No access restriction options available for region ${region}') // eslint-disable-line no-template-curly-in-string
+
+      const compiled = template(noItemsText)
+      return compiled({
+        region,
+        cloudProfile
+      })
+    }
+  },
   accessRestrictionDefinitionsByCloudProfileNameAndRegion (state, getters) {
     return ({ cloudProfileName, region }) => {
       if (!cloudProfileName) {
@@ -345,7 +357,8 @@ const getters = {
         return undefined
       }
 
-      return filter(state.cfg.accessRestrictions, ({ key }) => {
+      const items = get(state, 'cfg.accessRestriction.items')
+      return filter(items, ({ key }) => {
         if (!key) {
           return false
         }

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -175,8 +175,10 @@ function mapOption (optionValue, shootResource) {
     return
   }
 
+  const isSelectedByDefault = false
   const inputInverted = get(optionValue, 'input.inverted', false)
-  const rawValue = get(shootResource, ['metadata', 'annotations', key]) === 'true'
+  const defaultValue = inputInverted ? !isSelectedByDefault : isSelectedByDefault
+  const rawValue = get(shootResource, ['metadata', 'annotations', key], `${defaultValue}`) === 'true'
   const value = inputInverted ? !rawValue : rawValue
 
   const option = {
@@ -191,8 +193,10 @@ function mapAccessRestriction (accessRestrictionDefinition, shootResource) {
     return
   }
 
+  const isSelectedByDefault = false
   const inputInverted = get(accessRestrictionDefinition, 'input.inverted', false)
-  const rawValue = get(shootResource, ['spec', 'seedSelector', 'matchLabels', key]) === 'true'
+  const defaultValue = inputInverted ? !isSelectedByDefault : isSelectedByDefault
+  const rawValue = get(shootResource, ['spec', 'seedSelector', 'matchLabels', key], `${defaultValue}`) === 'true'
   const value = inputInverted ? !rawValue : rawValue
 
   let optionsPair = map(get(accessRestrictionDefinition, 'options'), option => mapOption(option, shootResource))

--- a/frontend/src/views/NewShoot.vue
+++ b/frontend/src/views/NewShoot.vue
@@ -53,16 +53,27 @@ limitations under the License.
             ></new-shoot-infrastructure-details>
         </v-card-text>
       </v-card>
+      <v-card flat class="mt-4" v-if="cfg.accessRestrictions">
+        <v-card-title class="subtitle-1 white--text cyan darken-2 cardTitle">
+         Access Restrictions
+        </v-card-title>
+        <v-card-text>
+          <access-restrictions
+            ref="accessRestrictions"
+            :userInterActionBus="userInterActionBus"
+          ></access-restrictions>
+        </v-card-text>
+      </v-card>
       <v-card flat class="mt-4">
         <v-card-title class="subtitle-1 white--text cyan darken-2 cardTitle">
           Worker
         </v-card-title>
         <v-card-text>
           <manage-workers
-          ref="manageWorkers"
-          :userInterActionBus="userInterActionBus"
-          @valid="onWorkersValid"
-         ></manage-workers>
+            ref="manageWorkers"
+            :userInterActionBus="userInterActionBus"
+            @valid="onWorkersValid"
+          ></manage-workers>
        </v-card-text>
       </v-card>
       <v-card flat class="mt-4">
@@ -118,6 +129,7 @@ limitations under the License.
 
 import NewShootSelectInfrastructure from '@/components/NewShoot/NewShootSelectInfrastructure'
 import NewShootInfrastructureDetails from '@/components/NewShoot/NewShootInfrastructureDetails'
+import AccessRestrictions from '@/components/ShootAccessRestrictions/AccessRestrictions'
 import NewShootDetails from '@/components/NewShoot/NewShootDetails'
 import ManageShootAddons from '@/components/ShootAddons/ManageAddons'
 import MaintenanceComponents from '@/components/ShootMaintenance/MaintenanceComponents'
@@ -144,6 +156,7 @@ export default {
   components: {
     NewShootSelectInfrastructure,
     NewShootInfrastructureDetails,
+    AccessRestrictions,
     NewShootDetails,
     ManageShootAddons,
     MaintenanceComponents,
@@ -169,7 +182,8 @@ export default {
   },
   computed: {
     ...mapState([
-      'namespace'
+      'namespace',
+      'cfg'
     ]),
     ...mapGetters([
       'newShootResource',
@@ -261,6 +275,10 @@ export default {
       }
       if (!isEmpty(firewallNetworks)) {
         set(shootResource, 'spec.provider.infrastructureConfig.firewall.networks', firewallNetworks)
+      }
+
+      if (this.$refs.accessRestrictions) {
+        this.$refs.accessRestrictions.applyTo(shootResource)
       }
 
       const { name, kubernetesVersion, purpose } = this.$refs.clusterDetails.getDetailsData()
@@ -362,6 +380,10 @@ export default {
         firewallSize,
         firewallNetworks
       })
+
+      if (this.$refs.accessRestrictions) {
+        this.$refs.accessRestrictions.setAccessRestrictions({ shootResource, cloudProfileName, region })
+      }
 
       const utcBegin = get(shootResource, 'spec.maintenance.timeWindow.begin')
       const k8sUpdates = get(shootResource, 'spec.maintenance.autoUpdate.kubernetesVersion', true)

--- a/frontend/src/views/NewShoot.vue
+++ b/frontend/src/views/NewShoot.vue
@@ -53,7 +53,7 @@ limitations under the License.
             ></new-shoot-infrastructure-details>
         </v-card-text>
       </v-card>
-      <v-card flat class="mt-4" v-if="cfg.accessRestrictions">
+      <v-card flat class="mt-4" v-if="cfg.accessRestriction">
         <v-card-title class="subtitle-1 white--text cyan darken-2 cardTitle">
          Access Restrictions
         </v-card-title>

--- a/frontend/src/views/ShootList.vue
+++ b/frontend/src/views/ShootList.vue
@@ -202,6 +202,7 @@ export default {
         { text: 'STATUS', value: 'lastOperation', align: 'left', checked: false, defaultChecked: true, hidden: false },
         { text: 'VERSION', value: 'k8sVersion', align: 'center', checked: false, defaultChecked: true, hidden: false },
         { text: 'READINESS', value: 'readiness', sortable: true, align: 'center', checked: false, defaultChecked: true, hidden: false },
+        { text: 'ACCESS RESTRICTIONS', value: 'accessRestrictions', sortable: false, align: 'left', checked: false, defaultChecked: false, hidden: false, adminOnly: false },
         { text: 'JOURNAL', value: 'journal', sortable: false, align: 'left', checked: false, defaultChecked: false, hidden: false, adminOnly: true },
         { text: 'JOURNAL LABELS', value: 'journalLabels', sortable: false, align: 'left', checked: false, defaultChecked: true, hidden: false, adminOnly: true },
         { text: 'ACTIONS', value: 'actions', sortable: false, align: 'right', checked: false, defaultChecked: true, hidden: false }
@@ -302,6 +303,10 @@ export default {
           case 'project':
             header.hidden = !!this.projectScope
             break
+          case 'accessRestrictions': {
+            header.hidden = !this.cfg.accessRestriction
+            break
+          }
           default:
             if (get(header, 'adminOnly', false)) {
               header.hidden = !this.isAdmin

--- a/frontend/tests/unit/store.shoots.spec.js
+++ b/frontend/tests/unit/store.shoots.spec.js
@@ -229,6 +229,18 @@ describe('Store.AccessRestrictions', function () {
           input: {
             inverted: true
           }
+        },
+        {
+          key: 'foo-option-3',
+          input: {
+            inverted: true
+          }
+        },
+        {
+          key: 'foo-option-4',
+          input: {
+            inverted: true
+          }
         }
       ]
     }
@@ -236,7 +248,9 @@ describe('Store.AccessRestrictions', function () {
     shootResource = {
       metadata: {
         annotations: {
-          'foo-option-1': 'false'
+          'foo-option-1': 'false',
+          'foo-option-2': 'false',
+          'foo-option-3': 'true'
         }
       },
       spec: {
@@ -261,6 +275,12 @@ describe('Store.AccessRestrictions', function () {
           },
           'foo-option-2': {
             value: true // value inverted as defined in definition
+          },
+          'foo-option-3': {
+            value: false // value inverted as defined in definition
+          },
+          'foo-option-4': {
+            value: false // value not set in spec always maps to false
           }
         }
       }

--- a/frontend/tests/unit/store.shoots.spec.js
+++ b/frontend/tests/unit/store.shoots.spec.js
@@ -16,7 +16,14 @@
 
 import Vuex from 'vuex'
 import { expect } from 'chai'
-import { state, actions, getters, mutations, modules } from '@/store'
+import {
+  state,
+  actions,
+  getters,
+  mutations,
+  modules,
+  mapAccessRestriction
+} from '@/store'
 
 let store
 
@@ -197,5 +204,84 @@ describe('Store.Shoots', function () {
     expect(sortedShoots[0].metadata.name).to.equal('shoot3')
     expect(sortedShoots[1].metadata.name).to.equal('shoot1')
     expect(sortedShoots[2].metadata.name).to.equal('shoot2')
+  })
+})
+
+describe('Store.AccessRestrictions', function () {
+  let definition
+  let shootResource
+
+  beforeEach(() => {
+    definition = {
+      key: 'foo',
+      input: {
+        inverted: false
+      },
+      options: [
+        {
+          key: 'foo-option-1',
+          input: {
+            inverted: false
+          }
+        },
+        {
+          key: 'foo-option-2',
+          input: {
+            inverted: true
+          }
+        }
+      ]
+    }
+
+    shootResource = {
+      metadata: {
+        annotations: {
+          'foo-option-1': 'false'
+        }
+      },
+      spec: {
+        seedSelector: {
+          matchLabels: {
+            foo: 'true'
+          }
+        }
+      }
+    }
+  })
+
+  it('should map definition and shoot resources to access restriction data model', function () {
+    const accessRestrictionPair = mapAccessRestriction(definition, shootResource)
+    expect(accessRestrictionPair).to.eql([
+      'foo',
+      {
+        value: true,
+        options: {
+          'foo-option-1': {
+            value: false
+          },
+          'foo-option-2': {
+            value: true // value inverted as defined in definition
+          }
+        }
+      }
+    ])
+  })
+
+  it('should invert access restriction', function () {
+    definition.input.inverted = true
+    const [, accessRestriction] = mapAccessRestriction(definition, shootResource)
+    expect(accessRestriction.value).to.equal(false)
+  })
+
+  it('should not invert option', function () {
+    definition.options[1].input.inverted = false
+    const [, accessRestriction] = mapAccessRestriction(definition, shootResource)
+    expect(accessRestriction.options['foo-option-2'].value).to.equal(false)
+  })
+
+  it('should invert option', function () {
+    definition.options[1].input.inverted = true
+    const [, accessRestriction] = mapAccessRestriction(definition, shootResource)
+    expect(accessRestriction.options['foo-option-2'].value).to.equal(true)
   })
 })

--- a/frontend/tests/unit/store.shoots.spec.js
+++ b/frontend/tests/unit/store.shoots.spec.js
@@ -22,7 +22,7 @@ import {
   getters,
   mutations,
   modules,
-  mapAccessRestriction
+  mapAccessRestrictionForInput
 } from '@/store'
 
 let store
@@ -264,7 +264,7 @@ describe('Store.AccessRestrictions', function () {
   })
 
   it('should map definition and shoot resources to access restriction data model', function () {
-    const accessRestrictionPair = mapAccessRestriction(definition, shootResource)
+    const accessRestrictionPair = mapAccessRestrictionForInput(definition, shootResource)
     expect(accessRestrictionPair).to.eql([
       'foo',
       {
@@ -289,19 +289,19 @@ describe('Store.AccessRestrictions', function () {
 
   it('should invert access restriction', function () {
     definition.input.inverted = true
-    const [, accessRestriction] = mapAccessRestriction(definition, shootResource)
+    const [, accessRestriction] = mapAccessRestrictionForInput(definition, shootResource)
     expect(accessRestriction.value).to.equal(false)
   })
 
   it('should not invert option', function () {
     definition.options[1].input.inverted = false
-    const [, accessRestriction] = mapAccessRestriction(definition, shootResource)
+    const [, accessRestriction] = mapAccessRestrictionForInput(definition, shootResource)
     expect(accessRestriction.options['foo-option-2'].value).to.equal(false)
   })
 
   it('should invert option', function () {
     definition.options[1].input.inverted = true
-    const [, accessRestriction] = mapAccessRestriction(definition, shootResource)
+    const [, accessRestriction] = mapAccessRestrictionForInput(definition, shootResource)
     expect(accessRestriction.options['foo-option-2'].value).to.equal(true)
   })
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
The dashboard can now be configured with access restrictions.

<img width="2489" alt="Screenshot 2020-05-19 at 16 24 52" src="https://user-images.githubusercontent.com/5526658/82338536-4d377380-99ed-11ea-94a6-24d47b540c50.png">

Access restrictions are shown for regions that have a matching label in the `CloudProfile`
```yaml
  regions:
  - name: pangaea-north-1
    zones:
    - name: pangaea-north-1a
    - name: pangaea-north-1b
    - name: pangaea-north-1c
    labels:
      seed.gardener.cloud/eu-access: "true"
```

- If the user selects the access restriction, `spec.seedSelector.matchLabels[key]` will be set.
- When selecting an option, `metadata.annotations[optionKey]` will be set.

The value that is set depends on the configuration. See _2._ under _Configuration_ section below.

```yaml
apiVersion: core.gardener.cloud/v1beta1
kind: Shoot
metadata:
  annotations:
    support.gardener.cloud/eu-access-for-cluster-addons: "true"
    support.gardener.cloud/eu-access-for-cluster-nodes: "true"
  ...
spec:
  seedSelector:
    matchLabels:
      seed.gardener.cloud/eu-access: "true"
```

<img width="1905" alt="Screenshot 2020-05-19 at 16 33 33" src="https://user-images.githubusercontent.com/5526658/82339640-8c19f900-99ee-11ea-889c-a93958d00b6f.png">

**Configuration**
As gardener administrator:
1. you can control the visibility of the chips with the `accessRestriction.items[].display.visibleIf` and `accessRestriction.items[].options[].display.visibleIf` property. E.g. in this example the access restriction chip is shown if the value is true and the option is shown if the value is false.
2. you can control the value of the input field (switch / checkbox) with the `accessRestriction.items[].input.inverted` and `accessRestriction.items[].options[].input.inverted` property. Setting the `inverted` property to `true` will invert the value. That means that when selecting the input field the value will be`'false'` instead of `'true'`.
3. you can configure the text that is displayed when no access restriction options are available by setting `accessRestriction.noItemsText`
example `values.yaml`:
```yaml
accessRestriction:
  noItemsText: No access restriction options available for region {region} and cloud profile {cloudProfile}
  items:
  - key: seed.gardener.cloud/eu-access
    display:
      visibleIf: true
      # title: foo # optional title, if not defined key will be used
      # description: bar # optional description displayed in a tooltip
    input:
      title: EU Access
      description: |
        This service is offered to you with our regular SLAs and 24x7 support for the control plane of the cluster. 24x7 support for cluster add-ons and nodes is only available if you meet the following conditions:
    options:
    - key: support.gardener.cloud/eu-access-for-cluster-addons
      display:
        visibleIf: false
        # title: bar # optional title, if not defined key will be used
        # description: baz # optional description displayed in a tooltip
      input:
        title: No personal data is used as name or in the content of Gardener or Kubernetes resources (e.g. Gardener project name or Kubernetes namespace, configMap or secret in Gardener or Kubernetes)
        description: |
          If you can't comply, only third-level/dev support at usual 8x5 working hours in EEA will be available to you for all cluster add-ons such as DNS and certificates, Calico overlay network and network policies, kube-proxy and services, and everything else that would require direct inspection of your cluster through its API server
        inverted: true
    - key: support.gardener.cloud/eu-access-for-cluster-nodes
      display:
        visibleIf: false
      input:
        title: No personal data is stored in any Kubernetes volume except for container file system, emptyDirs, and persistentVolumes (in particular, not on hostPath volumes)
        description: |
          If you can't comply, only third-level/dev support at usual 8x5 working hours in EEA will be available to you for all node-related components such as Docker and Kubelet, the operating system, and everything else that would require direct inspection of your nodes through a privileged pod or SSH
        inverted: true
```

**Which issue(s) this PR fixes**:
Fixes #689

**Special notes for your reviewer**:
related gardener PR https://github.com/gardener/gardener/pull/2340

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
The dashboard can now be configured with access restrictions. See PR [#694](https://github.com/gardener/dashboard/pull/694) for more details
```

```action operator
This Dashboard version requires Gardener version `v1.5.x` or higher
```
