### PR TITLE
Wildcard Select: Support wildcard only values

### DIFF
--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -400,7 +400,6 @@ const getters = {
       const cloudProfile = getters.cloudProfileByName(cloudProfileName)
       const floatingPools = get(cloudProfile, 'data.providerConfig.constraints.floatingPools')
       const availableFloatingPools = filter(floatingPools, matchesPropertyOrEmpty('region', region))
-      availableFloatingPools.push({ name: '*' })
       return uniq(map(availableFloatingPools, 'name'))
     }
   },

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -400,6 +400,7 @@ const getters = {
       const cloudProfile = getters.cloudProfileByName(cloudProfileName)
       const floatingPools = get(cloudProfile, 'data.providerConfig.constraints.floatingPools')
       const availableFloatingPools = filter(floatingPools, matchesPropertyOrEmpty('region', region))
+      availableFloatingPools.push({ name: '*' })
       return uniq(map(availableFloatingPools, 'name'))
     }
   },

--- a/frontend/tests/unit/WildcardSelect.spec.js
+++ b/frontend/tests/unit/WildcardSelect.spec.js
@@ -27,6 +27,7 @@ Vue.use(Vuelidate)
 const sampleWildcardItems = [
   '*Foo',
   'Foo',
+  '*',
   'Bar*',
   'BarBla'
 ]
@@ -82,5 +83,32 @@ describe('WildcardSelect.vue', function () {
     expect(wildcardSelectedValue.value).to.equal('BarBla')
     expect(wildcardSelectedValue.isWildcard).to.be.false
     expect(wildcardVariablePart).to.equal('')
+  })
+
+  it('should select wildcard if inital value is wildcard', function () {
+    const wildcardSelect = createWildcardSelecteComponent('Bar*')
+    const wildcardSelectedValue = wildcardSelect.wildcardSelectedValue
+    const wildcardVariablePart = wildcardSelect.wildcardVariablePart
+    expect(wildcardSelectedValue.value).to.equal('Bar')
+    expect(wildcardSelectedValue.endsWithWildcard).to.be.true
+    expect(wildcardVariablePart).to.equal('')
+  })
+
+  it('Should select initial custom wildcard value', function () {
+    const wildcardSelect = createWildcardSelecteComponent('*')
+    const wildcardSelectedValue = wildcardSelect.wildcardSelectedValue
+    const wildcardVariablePart = wildcardSelect.wildcardVariablePart
+    expect(wildcardSelectedValue.value).to.equal('')
+    expect(wildcardSelectedValue.customWildcard).to.be.true
+    expect(wildcardVariablePart).to.equal('')
+  })
+
+  it('Should select custom wildcard', function () {
+    const wildcardSelect = createWildcardSelecteComponent('RandomValue')
+    const wildcardSelectedValue = wildcardSelect.wildcardSelectedValue
+    const wildcardVariablePart = wildcardSelect.wildcardVariablePart
+    expect(wildcardSelectedValue.value).to.equal('')
+    expect(wildcardSelectedValue.customWildcard).to.be.true
+    expect(wildcardVariablePart).to.equal('RandomValue')
   })
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for the case if the value of an item of a wildcard select is `*`only. In this case we want to have a free text input and not a fixed pre or suffix.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user

```
