### PR TITLE
Journals: Inline-code for error messages

### DIFF
--- a/frontend/src/components/ShootDetails/ShootJournalsCard.vue
+++ b/frontend/src/components/ShootDetails/ShootJournalsCard.vue
@@ -43,7 +43,6 @@ limitations under the License.
 
 <script>
 import get from 'lodash/get'
-import forEach from 'lodash/forEach'
 import join from 'lodash/join'
 import map from 'lodash/map'
 import compact from 'lodash/compact'
@@ -51,6 +50,10 @@ import { mapState } from 'vuex'
 import Journal from '@/components/ShootJournals/Journal'
 import { canLinkToSeed } from '@/utils'
 import { shootItem } from '@/mixins/shootItem'
+
+function code (value) {
+  return '` ' + value + ' `'
+}
 
 export default {
   components: {
@@ -71,11 +74,8 @@ export default {
       'cfg'
     ]),
     errorConditions () {
-      let errorConditions = ''
-      forEach(this.shootConditions, condition => {
-        errorConditions = `${errorConditions}\n**${condition.type}:** ${condition.message}`
-      })
-      return errorConditions
+      const errorConditions = map(this.shootConditions, ({ type, message }) => `**${type}:** ${code(message)}`)
+      return join(errorConditions, '\n')
     },
     gitHubRepoUrl () {
       return this.cfg.gitHubRepoUrl
@@ -93,8 +93,9 @@ export default {
       const seed = `**Seed:** ${seedLinkOrName}`
 
       const createdAt = `**Created At:** ${this.shootCreatedAt}`
-      const lastOperation = `**Last Op:** ${get(this.shootLastOperation, 'description', '')}`
+      const lastOperation = `**Last Operation:** ${code(get(this.shootLastOperation, 'description', ''))}`
       let shootLastErrorDescriptions = compact(map(this.shootLastErrors, 'description'))
+      shootLastErrorDescriptions = map(shootLastErrorDescriptions, code)
       shootLastErrorDescriptions = join(shootLastErrorDescriptions, '\n')
       const lastError = `**Last Errors:** ${shootLastErrorDescriptions || '-'}`
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds wraps error messages with inline-code for error messages when creating a new journal.
<img width="918" alt="Screenshot 2020-05-26 at 10 54 50" src="https://user-images.githubusercontent.com/5526658/82880937-579ec380-9f3f-11ea-8f23-4e6f91cf41ba.png">

**Which issue(s) this PR fixes**:
Fixes #697

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
To improve readability of error messages in journals, inline-code fencing is applied to the error messages when creating a new journal
```
