### PR TITLE
Fix retry button not shown

### DIFF
--- a/frontend/src/components/RetryOperation.vue
+++ b/frontend/src/components/RetryOperation.vue
@@ -46,7 +46,7 @@ export default {
   mixins: [shootItem],
   computed: {
     canRetry () {
-      const reconcileScheduled = this.shootGenerationValue !== this.shootObservedGeneration
+      const reconcileScheduled = this.shootGenerationValue !== this.shootObservedGeneration && !!this.shootObservedGeneration
 
       return get(this.shootLastOperation, 'state') === 'Failed' &&
           !this.isShootReconciliationDeactivated &&

--- a/frontend/src/mixins/shootItem.js
+++ b/frontend/src/mixins/shootItem.js
@@ -167,7 +167,7 @@ export const shootItem = {
       return get(this.shootItem, 'status.conditions', [])
     },
     shootObservedGeneration () {
-      return get(this.shootItem, 'status.observedGeneration', [])
+      return get(this.shootItem, 'status.observedGeneration')
     },
     shootTechnicalId () {
       return get(this.shootItem, 'status.technicalID')


### PR DESCRIPTION
**What this PR does / why we need it**:
In some cases the retry button was not shown for some clusters in failed state.

The retry button is hidden once the reconcile is scheduled. We figure it out by comparing status.observedGeneration against metadata.generation. If they differ it means the reconcile is or will be scheduled.

This PR enhances the reconcileScheduled flag by also checking that status.observedGeneration is set.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Fixed: Retry button not shown in edge case
```
