### PR TITLE
Do not wrap warnings

### DIFF
--- a/frontend/src/components/ShootListRow.vue
+++ b/frontend/src/components/ShootListRow.vue
@@ -29,13 +29,15 @@ limitations under the License.
           </router-link>
         </v-col>
         <v-col class="shrink" >
-          <self-termination-warning :expirationTimestamp="shootExpirationTimestamp"></self-termination-warning>
-          <hibernation-schedule-warning
-            v-if="isShootHasNoHibernationScheduleWarning"
-            :name="shootName"
-            :namespace="shootNamespace"
-            :purpose="shootPurpose">
-          </hibernation-schedule-warning>
+          <div class="d-flex flew-row">
+            <self-termination-warning :expirationTimestamp="shootExpirationTimestamp"></self-termination-warning>
+            <hibernation-schedule-warning
+              v-if="isShootHasNoHibernationScheduleWarning"
+              :name="shootName"
+              :namespace="shootNamespace"
+              :purpose="shootPurpose">
+            </hibernation-schedule-warning>
+          </div>
         </v-col>
       </v-row>
     </td>


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes sure that the warnings in the shoot row do not wrap
bug:
<img width="410" alt="Screenshot 2020-05-27 at 13 40 16" src="https://user-images.githubusercontent.com/5526658/83014920-df5bff00-a01f-11ea-9a68-1e5c71cf29be.png">

fixed: 
<img width="401" alt="Screenshot 2020-05-27 at 13 39 37" src="https://user-images.githubusercontent.com/5526658/83014924-e1be5900-a01f-11ea-9645-8ae4847d18f9.png">


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user

```
