### PR TITLE
Support Floating Pool domain restrictions

### DIFF
--- a/frontend/src/components/NewShoot/NewShootInfrastructureDetails.vue
+++ b/frontend/src/components/NewShoot/NewShootInfrastructureDetails.vue
@@ -347,7 +347,7 @@ export default {
       'loadBalancerProviderNamesByCloudProfileNameAndRegion',
       'loadBalancerClassesByCloudProfileName',
       'loadBalancerClassNamesByCloudProfileName',
-      'floatingPoolNamesByCloudProfileNameAndRegion',
+      'floatingPoolNamesByCloudProfileNameAndRegionAndDomain',
       'partitionIDsByCloudProfileNameAndRegion',
       'firewallImagesByCloudProfileName',
       'firewallNetworksByCloudProfileNameAndPartitionId',
@@ -459,7 +459,7 @@ export default {
       }
     },
     allLoadBalancerProviderNames () {
-      return this.loadBalancerProviderNamesByCloudProfileNameAndRegion(this.cloudProfileName, this.region)
+      return this.loadBalancerProviderNamesByCloudProfileNameAndRegion({ cloudProfileName: this.cloudProfileName, region: this.region })
     },
     allLoadBalancerClassNames () {
       return this.loadBalancerClassNamesByCloudProfileName(this.cloudProfileName)
@@ -491,7 +491,10 @@ export default {
       return loadBalancerClasses
     },
     allFloatingPoolNames () {
-      return this.floatingPoolNamesByCloudProfileNameAndRegion(this.cloudProfileName, this.region)
+      const cloudProfileName = this.cloudProfileName
+      const region = this.region
+      const secretDomain = get(this.secret, 'data.domainName')
+      return this.floatingPoolNamesByCloudProfileNameAndRegionAndDomain({ cloudProfileName, region, secretDomain })
     },
     selfTerminationDays () {
       return selfTerminationDaysForSecret(this.secret)

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -402,14 +402,12 @@ const getters = {
       let availableFloatingPools = filter(floatingPools, matchesPropertyOrEmpty('region', region))
       availableFloatingPools = filter(availableFloatingPools, matchesPropertyOrEmpty('domain', secretDomain))
 
-      if (find(availableFloatingPools, fp => {
-        return !!fp.region && !fp.nonConstraining
-      })) {
+      const hasRegionSpecificFloatingPool = find(availableFloatingPools, fp => !!fp.region && !fp.nonConstraining)
+      if (hasRegionSpecificFloatingPool) {
         availableFloatingPools = filter(availableFloatingPools, { region })
       }
-      if (find(availableFloatingPools, fp => {
-        return !!fp.domain && !fp.nonConstraining
-      })) {
+      const hasDomainSpecificFloatingPool = find(availableFloatingPools, fp => !!fp.domain && !fp.nonConstraining)
+      if (hasDomainSpecificFloatingPool) {
         availableFloatingPools = filter(availableFloatingPools, { domain: secretDomain })
       }
 
@@ -421,9 +419,8 @@ const getters = {
       const cloudProfile = getters.cloudProfileByName(cloudProfileName)
       const loadBalancerProviders = get(cloudProfile, 'data.providerConfig.constraints.loadBalancerProviders')
       let availableLoadBalancerProviders = filter(loadBalancerProviders, matchesPropertyOrEmpty('region', region))
-      if (find(availableLoadBalancerProviders, lb => {
-        return !!lb.region
-      })) {
+      const hasRegionSpecificLoadBalancerProvider = find(availableLoadBalancerProviders, lb => !!lb.region)
+      if (hasRegionSpecificLoadBalancerProvider) {
         availableLoadBalancerProviders = filter(availableLoadBalancerProviders, { region })
       }
       return uniq(map(availableLoadBalancerProviders, 'name'))

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -395,19 +395,37 @@ const getters = {
       return max(map(seedsMatchingCloudProfileAndRegion, 'volume.minimumSize')) || defaultMinimumSize
     }
   },
-  floatingPoolNamesByCloudProfileNameAndRegion (state, getters) {
-    return (cloudProfileName, region) => {
+  floatingPoolNamesByCloudProfileNameAndRegionAndDomain (state, getters) {
+    return ({ cloudProfileName, region, secretDomain }) => {
       const cloudProfile = getters.cloudProfileByName(cloudProfileName)
       const floatingPools = get(cloudProfile, 'data.providerConfig.constraints.floatingPools')
-      const availableFloatingPools = filter(floatingPools, matchesPropertyOrEmpty('region', region))
+      let availableFloatingPools = filter(floatingPools, matchesPropertyOrEmpty('region', region))
+      availableFloatingPools = filter(availableFloatingPools, matchesPropertyOrEmpty('domain', secretDomain))
+
+      if (find(availableFloatingPools, fp => {
+        return !!fp.region && !fp.nonConstraining
+      })) {
+        availableFloatingPools = filter(availableFloatingPools, { region })
+      }
+      if (find(availableFloatingPools, fp => {
+        return !!fp.domain && !fp.nonConstraining
+      })) {
+        availableFloatingPools = filter(availableFloatingPools, { domain: secretDomain })
+      }
+
       return uniq(map(availableFloatingPools, 'name'))
     }
   },
   loadBalancerProviderNamesByCloudProfileNameAndRegion (state, getters) {
-    return (cloudProfileName, region) => {
+    return ({ cloudProfileName, region }) => {
       const cloudProfile = getters.cloudProfileByName(cloudProfileName)
       const loadBalancerProviders = get(cloudProfile, 'data.providerConfig.constraints.loadBalancerProviders')
-      const availableLoadBalancerProviders = filter(loadBalancerProviders, matchesPropertyOrEmpty('region', region))
+      let availableLoadBalancerProviders = filter(loadBalancerProviders, matchesPropertyOrEmpty('region', region))
+      if (find(availableLoadBalancerProviders, lb => {
+        return !!lb.region
+      })) {
+        availableLoadBalancerProviders = filter(availableLoadBalancerProviders, { region })
+      }
       return uniq(map(availableLoadBalancerProviders, 'name'))
     }
   },

--- a/frontend/src/store/modules/shoots.js
+++ b/frontend/src/store/modules/shoots.js
@@ -246,11 +246,12 @@ const actions = {
     const region = head(rootGetters.regionsWithSeedByCloudProfileName(cloudProfileName))
     set(shootResource, 'spec.region', region)
 
-    const loadBalancerProviderName = head(rootGetters.loadBalancerProviderNamesByCloudProfileNameAndRegion(cloudProfileName, region))
+    const loadBalancerProviderName = head(rootGetters.loadBalancerProviderNamesByCloudProfileNameAndRegion({ cloudProfileName, region }))
     if (!isEmpty(loadBalancerProviderName)) {
       set(shootResource, 'spec.provider.controlPlaneConfig.loadBalancerProvider', loadBalancerProviderName)
     }
-    const floatingPoolName = head(rootGetters.floatingPoolNamesByCloudProfileNameAndRegion(cloudProfileName, region))
+    const secretDomain = get(secret, 'data.domainName')
+    const floatingPoolName = head(rootGetters.floatingPoolNamesByCloudProfileNameAndRegionAndDomain({ cloudProfileName, region, secretDomain }))
     if (!isEmpty(floatingPoolName)) {
       set(shootResource, 'spec.provider.infrastructureConfig.floatingPoolName', floatingPoolName)
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support to restrict Floating Pools per domain. It also now respects the nonConstraining option. See also https://github.com/gardener/gardener-extension-provider-openstack/pull/76
Furthermore this PR fixes the bug that previously regionalized FPs and LBs did not overwrite the generic ones.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Added support for optional Floating Pools domain restrictions
```
```improvement user
Fixed: It was possible to select a generic Floating Pool or Load Balancer Provider even if a regionalized exists
```