### PR TITLE
Terminal Bootstrap: Skip seed with missing secretRef

### DIFF
--- a/backend/lib/services/shoots.js
+++ b/backend/lib/services/shoots.js
@@ -330,6 +330,11 @@ exports.seedInfo = async function ({ user, namespace, name }) {
     return data
   }
 
+  if (!seed.spec.secretRef) {
+    logger.info(`Could not fetch info from seed. 'spec.secretRef' on the seed ${seed.metadata.name} is missing. In case a shoot is used as seed, add the flag \`with-secret-ref\` to the \`shoot.gardener.cloud/use-as-seed\` annotation`)
+    return data
+  }
+
   try {
     const seedClient = await client.createKubeconfigClient(seed.spec.secretRef)
     const seedShootNamespace = shoot.status.technicalID

--- a/backend/lib/services/terminals/terminalBootstrap.js
+++ b/backend/lib/services/terminals/terminalBootstrap.js
@@ -311,7 +311,7 @@ async function ensureTrustedCertForSeedApiServer (client, seed) {
   const seedName = seed.metadata.name
   const namespace = 'garden'
 
-  if (!seedResource.spec.secretRef) {
+  if (!seed.spec.secretRef) {
     logger.info(`Bootstrapping Seed ${seedName} aborted as 'spec.secretRef' on the seed is missing`)
     return
   }

--- a/backend/lib/services/terminals/terminalBootstrap.js
+++ b/backend/lib/services/terminals/terminalBootstrap.js
@@ -248,6 +248,11 @@ async function ensureTrustedCertForShootApiServer (client, shootResource) {
   const seedName = getSeedNameFromShoot(shootResource)
   const seedResource = await client['core.gardener.cloud'].seeds.get(seedName)
 
+  if (!seedResource.spec.secretRef) {
+    logger.info(`Bootstrapping Shoot ${namespace}/${name} aborted as 'spec.secretRef' on the seed is missing. In case a shoot is used as seed, add the flag \`with-secret-ref\` to the \`shoot.gardener.cloud/use-as-seed\` annotation`)
+    return
+  }
+
   // calculate ingress domain
   const apiServerIngressHost = getKubeApiServerHostForShoot(shootResource, seedResource)
   const seedWildcardIngressDomain = getWildcardIngressDomainForSeed(seedResource)
@@ -305,6 +310,11 @@ async function ensureTrustedCertForGardenTerminalHostApiServer () {
 async function ensureTrustedCertForSeedApiServer (client, seed) {
   const seedName = seed.metadata.name
   const namespace = 'garden'
+
+  if (!seedResource.spec.secretRef) {
+    logger.info(`Bootstrapping Seed ${seedName} aborted as 'spec.secretRef' on the seed is missing`)
+    return
+  }
 
   const seedClient = await client.createKubeconfigClient(seed.spec.secretRef)
 

--- a/backend/test/acceptance/api.cloudprofiles.spec.js
+++ b/backend/test/acceptance/api.cloudprofiles.spec.js
@@ -35,7 +35,7 @@ module.exports = function ({ agent, sandbox, auth }) {
     expect(res).to.be.json
     expect(res.body).to.have.length(3)
     let predicate = item => item.metadata.name === 'infra1-profileName'
-    expect(_.find(res.body, predicate).data.seeds).to.have.length(2)
+    expect(_.find(res.body, predicate).data.seeds).to.have.length(3)
     predicate = item => item.metadata.name === 'infra3-profileName'
     expect(_.find(res.body, predicate).data.seeds).to.have.length(1)
     predicate = item => item.metadata.name === 'infra3-profileName2'

--- a/backend/test/support/nocks/k8s.js
+++ b/backend/test/support/nocks/k8s.js
@@ -623,6 +623,31 @@ const stub = {
       .get(`/api/v1/namespaces/${technicalID}/secrets/logging-ingress-credentials`)
       .reply(200, loggingSecretResult)]
   },
+  getSeedInfoNoSecretRef ({
+    bearer,
+    namespace,
+    name,
+    project,
+    kind,
+    region,
+    seedName
+  }) {
+    const shootResult = getShoot({ name, project, kind, region, seed: seedName })
+    shootResult.status.technicalID = `shoot--${project}--${name}`
+
+    const isAdminResult = {
+      status: {
+        allowed: true
+      }
+    }
+
+    return [nockWithAuthorization(bearer)
+      .get(`/apis/core.gardener.cloud/v1beta1/namespaces/${namespace}/shoots/${name}`)
+      .reply(200, () => shootResult)
+      .post('/apis/authorization.k8s.io/v1/selfsubjectaccessreviews')
+      .reply(200, () => isAdminResult)
+    ]
+  },
   replaceShoot ({ bearer, namespace, name, project, createdBy }) {
     const shoot = getShoot({ name, project, createdBy })
     return nockWithAuthorization(bearer)

--- a/backend/test/support/nocks/k8s.js
+++ b/backend/test/support/nocks/k8s.js
@@ -127,7 +127,8 @@ const shootList = [
     project: 'foo',
     createdBy: 'fooCreator',
     purpose: 'fooPurpose',
-    bindingName: 'barSecretName'
+    bindingName: 'barSecretName',
+    seed: 'infra4-seed-without-secretRef'
   })
 ]
 


### PR DESCRIPTION
**What this PR does / why we need it**:
With the introduction of the [gardenlet](https://github.com/gardener/gardener/releases/tag/v0.33.0) the `spec.secretRef` is optional on the seed resource.
If it is missing, the shoot cannot be bootstrapped and needs to be skipped.

In case a shoot is used as seed, the flag `with-secret-ref` has to be added to the `shoot.gardener.cloud/use-as-seed` annotation so that the `spec.secretRef` is set on the seed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user

```
