### PR TITLE
Upgrade dex to version v2.24.0

### DIFF
--- a/charts/identity/values.yaml
+++ b/charts/identity/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 
 image:
   repository: quay.io/dexidp/dex
-  tag: v2.15.0
+  tag: v2.24.0
   pullPolicy: IfNotPresent
 
 containerPort: 5556


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade [`dex`](https://github.com/dexidp/dex/releases/tag/v2.24.0) default version to `v2.24.0`.

**Which issue(s) this PR fixes**:
Fixes #693 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Upgrade dex to version `v2.24.0`.
```
