### PR TITLE
Tickets: Configurable issue description template

### DIFF
--- a/charts/gardener-dashboard/templates/configmap.yaml
+++ b/charts/gardener-dashboard/templates/configmap.yaml
@@ -151,7 +151,12 @@ data:
 {{- end }}
 {{- if .Values.frontendConfig.ticket }}
       ticket:
-        hideClustersWithLabel: {{ .Values.frontendConfig.ticket.hideClustersWithLabel }}
+        {{- if .Values.frontendConfig.ticket.hideClustersWithLabels }}
+        hideClustersWithLabels:
+          {{- range .Values.frontendConfig.ticket.hideClustersWithLabels }}
+          - {{ . }}
+          {{- end }}
+        {{- end }}
         gitHubRepoUrl: {{ .Values.frontendConfig.ticket.gitHubRepoUrl }}
         issueDescriptionTemplate: |-
 {{ .Values.frontendConfig.ticket.issueDescriptionTemplate | trim | indent 10 }}

--- a/charts/gardener-dashboard/templates/configmap.yaml
+++ b/charts/gardener-dashboard/templates/configmap.yaml
@@ -153,6 +153,8 @@ data:
       ticket:
         hideClustersWithLabel: {{ .Values.frontendConfig.ticket.hideClustersWithLabel }}
         gitHubRepoUrl: {{ .Values.frontendConfig.ticket.gitHubRepoUrl }}
+        issueDescriptionTemplate: |-
+{{ .Values.frontendConfig.ticket.issueDescriptionTemplate | trim | indent 10 }}
 {{- end }}
       features:
         terminalEnabled: {{ .Values.frontendConfig.features.terminalEnabled | default false }}

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -78,6 +78,34 @@ frontendConfig:
   ticket:
     gitHubRepoUrl: https://foo-github.com/dummyorg/dummyrepo
     hideClustersWithLabel: ignore # hides clusters with label on the 'ALL PROJECTS' page if the respective table option is enabled
+    # issueDescriptionTemplate variables:
+    # - `${shootName}`: name of the shoot
+    # - `${shootNamespace}`: namespace of the shoot
+    # - `${shootCreatedAt}`: creation timestamp of the shoot, format 'YYYY-MM-DD'
+    # - `${shootUrl}`: dashboard url of the shoot
+    # - `${providerType}`: shoot provider type
+    # - `${region}`: region of the shoot
+    # - `${machineImageNames}`: comma separated list of (unique) machine image names from the shoot workers
+    # - `${projectName}`: name of the project
+    # - `${utcDateTimeNow}`: current date-time in utc format
+    # - `${seedName}`: shoot's seed name
+    issueDescriptionTemplate: |
+      ## Which cluster is affected?
+
+      `Cluster Details Dashboard Link`: ${shootUrl}
+      `Operating System`:  ${os}
+      `Platform`:                  ${providerType}
+
+      ## What happened?
+
+      ## What you expected to happen?
+
+      ## When did it happen or started to happen?
+      `Timestamp`: ${dateTime}
+
+      ## How would we reproduce it?
+
+      ## Anything else we need to know?
   defaultHibernationSchedule:
     evaluation:
     - start: 00 17 * * 1,2,3,4,5
@@ -116,7 +144,7 @@ frontendConfig:
 
   # # accessRestriction is used to define the access restricion text, keys and value mappings
   # accessRestriction:
-  #   noItemsText: No access restriction options available for region {region} and cloud profile {cloudProfile}
+  #   noItemsText: No access restriction options available for region ${region} and cloud profile ${cloudProfile}
   #   items:
   #   - key: seed.gardener.cloud/eu-access
   #     display:

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -77,7 +77,8 @@ frontendConfig:
     url: https://github.com/gardener/gardener/issues
   ticket:
     gitHubRepoUrl: https://foo-github.com/dummyorg/dummyrepo
-    hideClustersWithLabel: ignore # hides clusters with label on the 'ALL PROJECTS' page if the respective table option is enabled
+    hideClustersWithLabels: # hides clusters with labels on the 'ALL PROJECTS' page if the respective table option is enabled
+    - ignore
     # issueDescriptionTemplate variables:
     # - `${shootName}`: name of the shoot
     # - `${shootNamespace}`: namespace of the shoot

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -93,16 +93,16 @@ frontendConfig:
     issueDescriptionTemplate: |
       ## Which cluster is affected?
 
-      `Cluster Details Dashboard Link`: ${shootUrl}
-      `Operating System`:  ${os}
-      `Platform`:                  ${providerType}
+      `Cluster Details Dashboard Link`: [${projectName}/${shootName}](${shootUrl})
+      `Operating System`: ${machineImageNames}
+      `Platform`: ${providerType}
 
       ## What happened?
 
       ## What you expected to happen?
 
       ## When did it happen or started to happen?
-      `Timestamp`: ${dateTime}
+      `Timestamp`: ${utcDateTimeNow}
 
       ## How would we reproduce it?
 

--- a/charts/test/gardener-dashboard.spec.js
+++ b/charts/test/gardener-dashboard.spec.js
@@ -324,7 +324,8 @@ describe('gardener-dashboard', function () {
             frontendConfig: {
               ticket: {
                 gitHubRepoUrl: 'https://github.com/gardener/tickets',
-                hideClustersWithLabel: 'ignore'
+                hideClustersWithLabel: 'ignore',
+                issueDescriptionTemplate: 'issue description'
               }
             },
             gitHub: {
@@ -353,7 +354,8 @@ describe('gardener-dashboard', function () {
           } = config
           expect(ticket).to.eql({
             gitHubRepoUrl: 'https://github.com/gardener/tickets',
-            hideClustersWithLabel: 'ignore'
+            hideClustersWithLabel: 'ignore',
+            issueDescriptionTemplate: 'issue description'
           })
           expect(gitHub).to.eql({
             apiUrl: 'https://github.com/api/v3/',

--- a/charts/test/gardener-dashboard.spec.js
+++ b/charts/test/gardener-dashboard.spec.js
@@ -324,7 +324,7 @@ describe('gardener-dashboard', function () {
             frontendConfig: {
               ticket: {
                 gitHubRepoUrl: 'https://github.com/gardener/tickets',
-                hideClustersWithLabel: 'ignore',
+                hideClustersWithLabels: ['ignore1', 'ignore2'],
                 issueDescriptionTemplate: 'issue description'
               }
             },
@@ -354,7 +354,7 @@ describe('gardener-dashboard', function () {
           } = config
           expect(ticket).to.eql({
             gitHubRepoUrl: 'https://github.com/gardener/tickets',
-            hideClustersWithLabel: 'ignore',
+            hideClustersWithLabels: ['ignore1', 'ignore2'],
             issueDescriptionTemplate: 'issue description'
           })
           expect(gitHub).to.eql({

--- a/frontend/src/store/modules/shoots.js
+++ b/frontend/src/store/modules/shoots.js
@@ -30,6 +30,7 @@ import toLower from 'lodash/toLower'
 import padStart from 'lodash/padStart'
 import filter from 'lodash/filter'
 import includes from 'lodash/includes'
+import some from 'lodash/some'
 import split from 'lodash/split'
 import join from 'lodash/join'
 import set from 'lodash/set'
@@ -579,8 +580,8 @@ const setFilteredAndSortedItems = (state, rootState) => {
     }
     if (get(state, 'shootListFilters.hideTicketsWithLabel', false)) {
       const predicate = item => {
-        const hideClustersWithLabel = get(rootState.cfg, 'ticket.hideClustersWithLabel')
-        if (!hideClustersWithLabel) {
+        const hideClustersWithLabels = get(rootState.cfg, 'ticket.hideClustersWithLabels')
+        if (!hideClustersWithLabels) {
           return true
         }
 
@@ -591,7 +592,8 @@ const setFilteredAndSortedItems = (state, rootState) => {
 
         const ticketsWithoutHideLabel = filter(ticketsForCluster, ticket => {
           const labelNames = map(get(ticket, 'data.labels'), 'name')
-          return !includes(labelNames, hideClustersWithLabel)
+          const ticketHasHideLabel = some(hideClustersWithLabels, hideClustersWithLabel => includes(labelNames, hideClustersWithLabel))
+          return !ticketHasHideLabel
         })
         return ticketsWithoutHideLabel.length > 0
       }

--- a/frontend/src/views/ShootList.vue
+++ b/frontend/src/views/ShootList.vue
@@ -118,12 +118,21 @@ limitations under the License.
                 @click.stop="toggleFilter('hideTicketsWithLabel')"
                 :disabled="filtersDisabled"
                 :class="disabledFilterClass"
-                v-if="!!gitHubRepoUrl">
+                v-if="!!gitHubRepoUrl && hideClustersWithLabels.length">
                 <v-list-item-action>
                   <v-icon :color="checkboxColor(isFilterActive('hideTicketsWithLabel'))" v-text="checkboxIcon(isFilterActive('hideTicketsWithLabel'))"/>
                 </v-list-item-action>
                 <v-list-item-content class="grey--text text--darken-2">
-                  <v-list-item-title>Hide clusters with <code class="code">{{hideClustersWithLabel}}</code> ticket label</v-list-item-title>
+                  <v-list-item-title>
+                    Hide clusters with
+                    <v-tooltip top>
+                      <template v-slot:activator="{ on }">
+                        <span v-on="on"><tt>configured</tt><v-icon small>mdi-help-circle-outline</v-icon></span>
+                      </template>
+                      <div v-for="label in hideClustersWithLabels" :key="label">- {{label}}</div>
+                    </v-tooltip>
+                    ticket labels
+                  </v-list-item-title>
                 </v-list-item-content>
               </v-list-item>
             </template>
@@ -405,7 +414,7 @@ export default {
           subtitle.push('Deactivated Reconciliation')
         }
         if (this.isFilterActive('hideTicketsWithLabel')) {
-          subtitle.push('Has Tickets')
+          subtitle.push('Tickets with Ignore Labels')
         }
       }
       return join(subtitle, ', ')
@@ -413,8 +422,8 @@ export default {
     gitHubRepoUrl () {
       return get(this.cfg, 'ticket.gitHubRepoUrl')
     },
-    hideClustersWithLabel () {
-      return get(this.cfg, 'ticket.hideClustersWithLabel')
+    hideClustersWithLabels () {
+      return get(this.cfg, 'ticket.hideClustersWithLabels', [])
     }
   },
   mounted () {
@@ -425,7 +434,7 @@ export default {
       progressing: true,
       userIssues: this.isAdmin,
       deactivatedReconciliation: this.isAdmin,
-      hideTicketsWithLabel: false
+      hideTicketsWithLabel: this.isAdmin
     })
   },
   beforeRouteEnter (to, from, next) {
@@ -485,10 +494,6 @@ export default {
 
   .v-input__slot {
     margin: 0px;
-  }
-
-  code {
-    box-shadow: none !important;
   }
 
 </style>


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR the ticket issue description template is now configurable.

Example `values.yaml`:

```yaml
frontendConfig:
  ...
  ticket:
    gitHubRepoUrl: https://foo-github.com/dummyorg/dummyrepo
    hideClustersWithLabels: # hides clusters with labels on the 'ALL PROJECTS' page if the respective table option is enabled
    - triage/configuration-problem
    - triage/ignore
    - triage/infrastructure-dependencies
    - triage/invalid-credentials
    - triage/insufficient-privileges
    - triage/quota-exceeded
    - status/author-action
    issueDescriptionTemplate: |
      ## Which cluster is affected?

      `Cluster Details Dashboard Link`: [${projectName}/${shootName}](${shootUrl})
      `Operating System`: ${machineImageNames}
      `Platform`: ${providerType}

      ## What happened?

      ## What you expected to happen?

      ## When did it happen or started to happen?
      `Timestamp`: ${utcDateTimeNow}

      ## How would we reproduce it?

      ## Anything else we need to know?
...
gitHub:
  apiUrl: https://api.foo-github.com
  org: dummyorg
  repository: dummyrepo
  webhookSecret: foobar # optional if pollIntervalSeconds is defined
  authentication:
    username: dashboard
    token: dummytoken
  # pollIntervalSeconds: 30 # only necessary when dashboard's webhook can't be reached by github and thus polling needs to be done
```

Supported `frontendConfig.ticket.issueDescriptionTemplate` variables:
- `${shootName}`: name of the shoot
- `${shootNamespace}`: namespace of the shoot
- `${shootCreatedAt}`: creation timestamp of the shoot, format 'YYYY-MM-DD'
- `${shootUrl}`: dashboard url of the shoot
- `${providerType}`: shoot provider type
- `${region}`: region of the shoot
- `${machineImageNames}`: comma separated list of (unique) machine image names from the shoot workers
- `${projectName}`: name of the project
- `${utcDateTimeNow}`: current date-time in utc format
- `${seedName}`: shoot's seed name

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Clusters on the `ALL_PROJECTS` page, that have certain ticket labels are now hidden by default, if configured. To configure the list of labels, set `frontendConfig.ticket.hideClustersWithLabels` in the `gardener-dashboard` chart's `values.yaml` file.
```

```improvement operator
You can now configure the tickets issue description template with `frontendConfig.ticket.issueDescriptionTemplate` in the `gardener-dashboard` chart's `values.yaml` file
```
