### PR TITLE
Allow wakeup of shoot in certain condition

### DIFF
--- a/frontend/src/components/ShootHibernation/ChangeHibernation.vue
+++ b/frontend/src/components/ShootHibernation/ChangeHibernation.vue
@@ -23,7 +23,7 @@ limitations under the License.
     :icon="icon"
     :confirmButtonText="confirmText"
     :confirmRequired="confirmRequired"
-    :disabled="!isHibernationPossible"
+    :disabled="!isHibernationPossible && !isShootSettingHibernated"
     maxWidth="600">
     <template v-slot:actionComponent>
       <template v-if="!isShootSettingHibernated">
@@ -78,7 +78,7 @@ export default {
       }
     },
     caption () {
-      if (!this.isHibernationPossible) {
+      if (!this.isHibernationPossible && !this.isShootSettingHibernated) {
         return this.hibernationPossibleMessage
       }
       if (!this.isShootSettingHibernated) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently it is not possible to wake up a cluster from the dashboard in case the `HibernationPossible` constraint reports `False` status. However, waking up a cluster should still be possible from the UI. This is fixed with this PR.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Fixed: Shoots can be woken up from the dashboard even if the `HibernationPossible` constraint reports `False` status
```
