### PR TITLE
Add iam:UpdateAssumeRolePolicy to the AWS policy

### DIFF
--- a/frontend/src/components/dialogs/SecretDialogAwsHelp.vue
+++ b/frontend/src/components/dialogs/SecretDialogAwsHelp.vue
@@ -101,7 +101,8 @@ export default {
               'iam:DeleteRolePolicy',
               'iam:DeleteInstanceProfile',
               'iam:PutRolePolicy',
-              'iam:PassRole'
+              'iam:PassRole',
+              'iam:UpdateAssumeRolePolicy'
             ],
             Effect: 'Allow',
             Resource: '*'


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently adding a trust relationship for gardener managed role manually, in the next `Infrastructure` reconciliation results in:
```
aws_route_table_association.routetable_private_utility_z0_association_private_utility_z0: Refreshing state... [id=rtbassoc-0d2f39dfab0034153]
aws_iam_role.nodes: Modifying... [id=shoot--foo--bar]

Error: Error Updating IAM Role (shoot--foo--bar-nodes) Assume Role Policy: AccessDenied: User: arn:aws:iam::foo:user/bar is not authorized to perform: iam:UpdateAssumeRolePolicy on resource: role shoot--foo--bar-nodes
	status code: 403, request id: b9220012-9b94-4809-9ed8-foo

  on tf/main.tf line 322, in resource "aws_iam_role" "nodes":
 322: resource "aws_iam_role" "nodes" {
```

Adding `iam:UpdateAssumeRolePolicy` to the policy allows terraform to bring back the role trust relationships to the default ones.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Updated AWS secret help dialog as policy does now contain a new action `iam:UpdateAssumeRolePolicy`
```
