### PR TITLE
[hotfix-1.43]Allow to specify new ticket labels

### DIFF
--- a/charts/gardener-dashboard/templates/configmap.yaml
+++ b/charts/gardener-dashboard/templates/configmap.yaml
@@ -157,6 +157,12 @@ data:
           - {{ . }}
           {{- end }}
         {{- end }}
+        {{- if .Values.frontendConfig.ticket.newTicketLabels }}
+        newTicketLabels:
+          {{- range .Values.frontendConfig.ticket.newTicketLabels }}
+          - {{ . }}
+          {{- end }}
+        {{- end }}
         gitHubRepoUrl: {{ .Values.frontendConfig.ticket.gitHubRepoUrl }}
         issueDescriptionTemplate: |-
 {{ .Values.frontendConfig.ticket.issueDescriptionTemplate | trim | indent 10 }}

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -79,6 +79,8 @@ frontendConfig:
   #   gitHubRepoUrl: https://foo-github.com/dummyorg/dummyrepo
   #   hideClustersWithLabels: # hides clusters with labels on the 'ALL PROJECTS' page if the respective table option is enabled
   #   - ignore
+  #   newTicketLabels: # these are the labels that are automatically preselected when creating a new ticket
+  #   - default-label
   #   # issueDescriptionTemplate variables:
   #   # - `${shootName}`: name of the shoot
   #   # - `${shootNamespace}`: namespace of the shoot

--- a/charts/test/gardener-dashboard.spec.js
+++ b/charts/test/gardener-dashboard.spec.js
@@ -325,6 +325,7 @@ describe('gardener-dashboard', function () {
               ticket: {
                 gitHubRepoUrl: 'https://github.com/gardener/tickets',
                 hideClustersWithLabels: ['ignore1', 'ignore2'],
+                newTicketLabels: ['default-label'],
                 issueDescriptionTemplate: 'issue description'
               }
             },
@@ -355,6 +356,7 @@ describe('gardener-dashboard', function () {
           expect(ticket).to.eql({
             gitHubRepoUrl: 'https://github.com/gardener/tickets',
             hideClustersWithLabels: ['ignore1', 'ignore2'],
+            newTicketLabels: ['default-label'],
             issueDescriptionTemplate: 'issue description'
           })
           expect(gitHub).to.eql({

--- a/frontend/src/components/ShootTickets/TicketComment.vue
+++ b/frontend/src/components/ShootTickets/TicketComment.vue
@@ -96,27 +96,33 @@ export default {
     word-break: break-word;
 
     ::v-deep > h1 {
-      font-size: 28px;
+      font-size: 21px;
+      font-weight: 600;
     }
 
     ::v-deep > h2 {
-      font-size: 21px;
+      font-size: 17.5px;
+      font-weight: 600;
     }
 
     ::v-deep > h3 {
-      font-size: 17,5px;
+      font-size: 14px;
+      font-weight: 600;
     }
 
     ::v-deep > h4 {
-      font-size: 14px;
+      font-size: 12.25px;
+      font-weight: 600;
     }
 
     ::v-deep > h5 {
-      font-size: 12.25px;
+      font-size: 11.9px;
+      font-weight: 600;
     }
 
     ::v-deep > h6 {
-      font-size: 11.9px;
+      font-size: 11.5px;
+      font-weight: 600;
     }
   }
 

--- a/frontend/src/components/TicketsCard.vue
+++ b/frontend/src/components/TicketsCard.vue
@@ -43,6 +43,7 @@ limitations under the License.
 
 <script>
 import get from 'lodash/get'
+import join from 'lodash/join'
 import map from 'lodash/map'
 import template from 'lodash/template'
 import uniq from 'lodash/uniq'
@@ -73,6 +74,9 @@ export default {
     gitHubRepoUrl () {
       return get(this.cfg, 'ticket.gitHubRepoUrl')
     },
+    newTicketLabels () {
+      return get(this.cfg, 'ticket.newTicketLabels')
+    },
     issueDescription () {
       const descriptionTemplate = get(this.cfg, 'ticket.issueDescriptionTemplate')
       const compiled = template(descriptionTemplate)
@@ -101,11 +105,15 @@ export default {
       imageNames = uniq(imageNames)
       return imageNames.join(', ')
     },
+    newTicketLabelsString () {
+      return join(this.newTicketLabels, ',')
+    },
     createTicketLink () {
       const ticketTitle = encodeURIComponent(`[${this.shootProjectName}/${this.shootName}]`)
       const body = encodeURIComponent(this.issueDescription)
+      const newTicketLabels = encodeURIComponent(this.newTicketLabelsString)
 
-      return `${this.gitHubRepoUrl}/issues/new?title=${ticketTitle}&body=${body}`
+      return `${this.gitHubRepoUrl}/issues/new?title=${ticketTitle}&body=${body}&labels=${newTicketLabels}`
     }
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR you can configure the labels that are automatically preselected when creating a new ticket.
In addition, the ticket headers are now shrinked to better fit in the overall shoot details picture.

example `values.yaml`
```yaml
frontendConfig:
  ...
  ticket:
    newTicketLabels: # these are the labels that are automatically preselected when creating a new ticket
    - topology/shoot
```

Full ticket configuration example `values.yaml`
```yaml
frontendConfig:
  ...
  ticket:
    gitHubRepoUrl: https://foo-github.com/dummyorg/dummyrepo
    hideClustersWithLabels: # hides clusters with labels on the 'ALL PROJECTS' page if the respective table option is enabled
    - triage/configuration-problem
    - triage/ignore
    - triage/infrastructure-dependencies
    - triage/invalid-credentials
    - triage/insufficient-privileges
    - triage/quota-exceeded
    - status/author-action
    newTicketLabels: # these are the labels that are automatically preselected when creating a new ticket
    - default-label
    issueDescriptionTemplate: |
      ## Which cluster is affected?

      `Cluster Details Dashboard Link`: [${projectName}/${shootName}](${shootUrl})
      `Operating System`: ${machineImageNames}
      `Platform`: ${providerType}

      ## What happened?

      ## What you expected to happen?

      ## When did it happen or started to happen?
      `Timestamp`: ${utcDateTimeNow}

      ## How would we reproduce it?

      ## Anything else we need to know?
...
gitHub:
  apiUrl: https://api.foo-github.com
  org: dummyorg
  repository: dummyrepo
  webhookSecret: foobar # optional if pollIntervalSeconds is defined
  authentication:
    username: dashboard
    token: dummytoken
  # pollIntervalSeconds: 30 # only necessary when dashboard's webhook can't be reached by github and thus polling needs to be done
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
You can now configure the labels that are automatically preselected when creating a new ticket by setting the property `frontendConfig.ticket.newTicketLabels` in the `gardener-dashboard` chart's `values.yaml` file
```
