### PR TITLE
Avoid false bottoms

### DIFF
--- a/frontend/src/components/ShootHibernation/ManageHibernationSchedule.vue
+++ b/frontend/src/components/ShootHibernation/ManageHibernationSchedule.vue
@@ -29,7 +29,7 @@ limitations under the License.
           @valid="onScheduleEventValid">
         </hibernation-schedule-event>
       </v-row>
-      <v-row v-if="!parseError" key="addSchedule" class="list-item pt-2">
+      <v-row v-if="!parseError" key="addSchedule" class="list-item">
         <v-col>
           <v-btn
             small

--- a/frontend/src/components/ShootWorkers/ManageWorkers.vue
+++ b/frontend/src/components/ShootWorkers/ManageWorkers.vue
@@ -39,7 +39,7 @@ limitations under the License.
         </template>
       </worker-input-generic>
     </v-row>
-    <v-row key="addWorker" class="list-item pt-2">
+    <v-row key="addWorker" class="list-item">
       <v-col>
         <v-btn
           :disabled="!(allMachineTypes.length > 0)"

--- a/frontend/src/components/dialogs/GDialog.vue
+++ b/frontend/src/components/dialogs/GDialog.vue
@@ -203,10 +203,14 @@ export default {
       }
       this.visible = false
     },
-    showScrollBar () {
+    showScrollBar (retryCount = 0) {
+      if (retryCount > 10) {
+        // circuit breaker
+        return
+      }
       const contentCardRef = this.$refs.contentCard
       if (!contentCardRef || !contentCardRef.clientHeight) {
-        this.$nextTick(() => this.showScrollBar())
+        this.$nextTick(() => this.showScrollBar(retryCount + 1))
         return
       }
       const scrollTopVal = contentCardRef.scrollTop

--- a/frontend/src/components/dialogs/GDialog.vue
+++ b/frontend/src/components/dialogs/GDialog.vue
@@ -204,7 +204,7 @@ export default {
       this.visible = false
     },
     showScrollBar (retryCount = 0) {
-      if (retryCount > 10) {
+      if (!this.visible || retryCount > 10) {
         // circuit breaker
         return
       }

--- a/frontend/src/components/dialogs/GDialog.vue
+++ b/frontend/src/components/dialogs/GDialog.vue
@@ -28,7 +28,7 @@ limitations under the License.
           </template>
         </v-toolbar-title>
       </v-toolbar>
-      <v-card-text class="pa-3" :style="{'max-height': maxHeight}">
+      <v-card-text class="pa-3" :style="{'max-height': maxHeight}" ref="contentCard" @scroll="onContentScrolled()">
         <slot name="message">
           This is a generic dialog template.
         </slot>
@@ -44,6 +44,7 @@ limitations under the License.
           :color="textFieldColor">
         </v-text-field>
         <g-alert color="error" class="mt-4" :message.sync="message" :detailedMessage.sync="detailedMessage"></g-alert>
+        <div class="bottom-overlay" v-show="bottomOverlayVisible"></div>
       </v-card-text>
       <v-divider></v-divider>
       <v-card-actions>
@@ -102,13 +103,17 @@ export default {
     maxHeight: {
       type: String,
       default: '50vh'
+    },
+    disableBottomOverlay: {
+      type: Boolean
     }
   },
   data () {
     return {
       userInput: '',
       visible: false,
-      resolve: noop
+      resolve: noop,
+      bottomOverlayVisible: true
     }
   },
   computed: {
@@ -174,6 +179,10 @@ export default {
     },
     showDialog () {
       this.visible = true
+      this.$nextTick(() => {
+        this.onContentScrolled()
+        this.showScrollBar()
+      })
     },
     titleColorClassForString (titleColorClass) {
       switch (titleColorClass) {
@@ -202,6 +211,24 @@ export default {
         resolve(value)
       }
       this.visible = false
+    },
+    onContentScrolled () {
+      if (this.disableBottomOverlay) {
+        this.bottomOverlayVisible = false
+      } else if (!this.$refs.contentCard) {
+        this.bottomOverlayVisible = false
+      } else if (this.$refs.contentCard.clientHeight + this.$refs.contentCard.scrollTop < this.$refs.contentCard.scrollHeight - 1) {
+        this.bottomOverlayVisible = true
+      } else {
+        this.bottomOverlayVisible = false
+      }
+    },
+    showScrollBar () {
+      if (this.$refs.contentCard) {
+        const scrollTopVal = this.$refs.contentCard.scrollTop
+        this.$refs.contentCard.scrollTop = scrollTopVal + 10
+        this.$refs.contentCard.scrollTop = scrollTopVal - 10
+      }
     }
   }
 }
@@ -212,5 +239,15 @@ export default {
     code {
       box-shadow: none !important;
     }
+  }
+
+  .bottom-overlay {
+    background-image: linear-gradient(to bottom, rgba(255,255,255,0.2), rgba(255,255,255,1));
+    position: absolute;
+    pointer-events: none;
+    height: 50px;
+    bottom: 53px;
+    left: 10px;
+    right: 10px;
   }
 </style>

--- a/frontend/src/components/dialogs/GDialog.vue
+++ b/frontend/src/components/dialogs/GDialog.vue
@@ -15,7 +15,7 @@ limitations under the License.
  -->
 
 <template>
-  <v-dialog v-model="visible" scrollable persistent :max-width="maxWidth" @keydown.esc="resolveAction(false)">
+  <v-dialog v-model="visible" v-if="visible" scrollable persistent :max-width="maxWidth" @keydown.esc="resolveAction(false)">
     <v-card>
       <v-toolbar flat :class="titleColorClass">
         <v-toolbar-title class="dialog-title align-center justify-start">
@@ -180,6 +180,7 @@ export default {
     showDialog () {
       this.visible = true
       this.$nextTick(() => {
+        window.addEventListener('resize', this.onResize)
         this.onContentScrolled()
         this.showScrollBar()
       })
@@ -222,6 +223,9 @@ export default {
       } else {
         this.bottomOverlayVisible = false
       }
+    },
+    onResize () {
+      this.onContentScrolled()
     },
     showScrollBar () {
       if (this.$refs.contentCard) {

--- a/frontend/src/components/dialogs/GDialog.vue
+++ b/frontend/src/components/dialogs/GDialog.vue
@@ -17,7 +17,7 @@ limitations under the License.
 <template>
   <v-dialog v-model="visible" scrollable persistent :max-width="maxWidth" @keydown.esc="resolveAction(false)">
     <v-card>
-      <v-toolbar flat :class="[{ 'elevation-4': topBarElevation }, titleColorClass]">
+      <v-toolbar flat :class="titleColorClass">
         <v-toolbar-title class="dialog-title align-center justify-start">
           <slot name="caption">
             Confirm Dialog
@@ -46,7 +46,7 @@ limitations under the License.
         <g-alert color="error" class="mt-4" :message.sync="message" :detailedMessage.sync="detailedMessage"></g-alert>
       </v-card-text>
       <v-divider></v-divider>
-      <v-card-actions :class="{ 'elevation-4': bottomBarElevation }">
+      <v-card-actions>
         <v-spacer></v-spacer>
         <v-btn text @click="resolveAction(false)">{{cancelButtonText}}</v-btn>
         <v-btn text @click="resolveAction(true)" :disabled="!valid" :class="textColorClass">{{confirmButtonText}}</v-btn>
@@ -109,8 +109,6 @@ export default {
       userInput: '',
       visible: false,
       resolve: noop,
-      topBarElevation: false,
-      bottomBarElevation: false,
       intervalId: undefined
     }
   },
@@ -206,22 +204,6 @@ export default {
       }
       this.visible = false
     },
-    updateElevation () {
-      const contentCardRef = this.$refs.contentCard
-      if (contentCardRef) {
-        if (contentCardRef.scrollTop > 0) {
-          this.topBarElevation = true
-        } else {
-          this.topBarElevation = false
-        }
-
-        if (contentCardRef.clientHeight + contentCardRef.scrollTop < contentCardRef.scrollHeight) {
-          this.bottomBarElevation = true
-        } else {
-          this.bottomBarElevation = false
-        }
-      }
-    },
     showScrollBar () {
       const contentCardRef = this.$refs.contentCard
       if (!contentCardRef || !contentCardRef.clientHeight) {
@@ -236,10 +218,7 @@ export default {
   watch: {
     visible (value) {
       if (value) {
-        this.intervalId = setInterval(() => this.updateElevation(), 100)
-        this.$nextTick(() => this.showScrollBar())
-      } else {
-        clearInterval(this.intervalId)
+        this.showScrollBar()
       }
     }
   }

--- a/frontend/src/components/dialogs/GDialog.vue
+++ b/frontend/src/components/dialogs/GDialog.vue
@@ -108,8 +108,7 @@ export default {
     return {
       userInput: '',
       visible: false,
-      resolve: noop,
-      intervalId: undefined
+      resolve: noop
     }
   },
   computed: {

--- a/frontend/src/components/dialogs/GDialog.vue
+++ b/frontend/src/components/dialogs/GDialog.vue
@@ -208,7 +208,7 @@ export default {
     },
     updateElevation () {
       const contentCardRef = this.$refs.contentCard
-      if(contentCardRef) {
+      if (contentCardRef) {
         if (contentCardRef.scrollTop > 0) {
           this.topBarElevation = true
         } else {
@@ -239,7 +239,7 @@ export default {
         this.intervalId = setInterval(() => this.updateElevation(), 100)
         this.$nextTick(() => this.showScrollBar())
       } else {
-         clearInterval(this.intervalId)
+        clearInterval(this.intervalId)
       }
     }
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently our dialogs tend to have false bottoms. For users it is often not clear that there is more content, that needs to be scrolled into view. For Mac users this is even more an issue as scrollbars are hidden on macOS by default. With this PR we show the scrollbar briefly when a dialog is opened. This indicates that there is more content and hopefully helps to mitigate this problem.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user

```
