### PR TITLE
Fixed secret handling for cases where secretBindingName != secretName

### DIFF
--- a/frontend/src/components/SecretRow.vue
+++ b/frontend/src/components/SecretRow.vue
@@ -97,9 +97,9 @@ export default {
       return this.shootsByInfrastructureSecret.length
     },
     shootsByInfrastructureSecret () {
-      const secretName = this.secret.metadata.name
+      const secretBindingName = this.secret.metadata.bindingName
       const predicate = item => {
-        return get(item, 'spec.secretBindingName') === secretName
+        return get(item, 'spec.secretBindingName') === secretBindingName
       }
       return filter(this.shootList, predicate)
     },

--- a/frontend/src/components/dialogs/SecretDialogDelete.vue
+++ b/frontend/src/components/dialogs/SecretDialogDelete.vue
@@ -36,12 +36,8 @@ limitations under the License.
 
       <v-card-text>
         <v-container fluid>
-          <template v-slot:message>
-            <div>
-              Are you sure to delete the secret <span class="font-weight-bold">{{name}}</span>?<br/>
-              <span class="red--text font-weight-bold">The operation can not be undone.</span>
-            </div>
-          </template>
+          Are you sure to delete the secret <span class="font-weight-bold">{{name}}</span>?<br/>
+          <span class="red--text font-weight-bold">The operation can not be undone.</span>
         </v-container>
         <g-alert color="error" :message.sync="errorMessage" :detailedMessage.sync="detailedErrorMessage"></g-alert>
       </v-card-text>

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -525,9 +525,9 @@ const getters = {
   infrastructureSecretList (state) {
     return state.infrastructureSecrets.all
   },
-  getInfrastructureSecretByName (state, getters) {
+  getInfrastructureSecretByBindingName (state, getters) {
     return ({ namespace, name }) => {
-      return getters['infrastructureSecrets/getInfrastructureSecretByName']({ namespace, name })
+      return getters['infrastructureSecrets/getInfrastructureSecretByBindingName']({ namespace, name })
     }
   },
   namespaces (state) {

--- a/frontend/src/store/modules/infrastructureSecrets.js
+++ b/frontend/src/store/modules/infrastructureSecrets.js
@@ -20,8 +20,8 @@ import find from 'lodash/find'
 import matches from 'lodash/matches'
 import { getInfrastructureSecrets, updateInfrastructureSecret, createInfrastructureSecret, deleteInfrastructureSecret } from '@/utils/api'
 
-const eqlNameAndNamespace = ({ namespace, name }) => {
-  return matches({ metadata: { namespace, name } })
+const eqlBindingNameAndNamespace = ({ bindingNamespace, bindingName }) => {
+  return matches({ metadata: { bindingNamespace, bindingName } })
 }
 
 // initial state
@@ -31,8 +31,8 @@ const state = {
 
 // getters
 const getters = {
-  getInfrastructureSecretByName: (state) => ({ name, namespace }) => {
-    return find(state.all, eqlNameAndNamespace({ name, namespace }))
+  getInfrastructureSecretByBindingName: (state) => ({ name, namespace }) => {
+    return find(state.all, eqlBindingNameAndNamespace({ bindingName: name, bindingNamespace: namespace }))
   }
 }
 

--- a/frontend/src/views/Secrets.vue
+++ b/frontend/src/views/Secrets.vue
@@ -187,6 +187,7 @@ limitations under the License.
 
 <script>
 import { mapGetters } from 'vuex'
+import { isOwnSecretBinding } from '@/utils'
 import get from 'lodash/get'
 import DeleteDialog from '@/components/dialogs/SecretDialogDelete'
 import SecretDialogWrapper from '@/components/dialogs/SecretDialogWrapper'
@@ -247,7 +248,7 @@ export default {
   computed: {
     ...mapGetters([
       'cloudProfilesByCloudProviderKind',
-      'getInfrastructureSecretByName'
+      'getInfrastructureSecretByBindingName'
     ]),
     backgroundForSelectedSecret () {
       const kind = get(this.selectedSecret, 'metadata.cloudProviderKind')
@@ -308,13 +309,14 @@ export default {
   },
   mounted () {
     this.floatingButton = true
-
-    if (get(this.$route.params, 'name')) {
-      const infrastructureSecret = this.getInfrastructureSecretByName(this.$route.params)
-      if (infrastructureSecret) {
-        this.onUpdate(infrastructureSecret)
-      }
+    if (!get(this.$route.params, 'name')) {
+      return
     }
+    const infrastructureSecret = this.getInfrastructureSecretByBindingName(this.$route.params)
+    if (!infrastructureSecret || !isOwnSecretBinding(infrastructureSecret)) {
+      return
+    }
+    this.onUpdate(infrastructureSecret)
   },
   created () {
     merge(this.initialDialogState, this.dialogState)


### PR DESCRIPTION
**What this PR does / why we need it**:
Secret Bindings where name is not equal to Secret name did not show correct number of used clusters. Furthermore these secrets did not open on navigation (even if own secrets).
Also, I fixed the delete secret dialog which showed up blank (without any message), probably we broke the dialog with the latest vuetify upgrade.

**Which issue(s) this PR fixes**:
Fixes #701 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Fixed: Some Secrets were shown as 'currently unused' even if used by clusters. This happened for Secrets where the Secret Binding name is different from the Secret name
```
