### PR TITLE
Not found is thrown for missing seed secrets 

### DIFF
--- a/backend/lib/services/shoots.js
+++ b/backend/lib/services/shoots.js
@@ -354,9 +354,9 @@ function assignComponentSecrets (client, data, namespace, name) {
   }))
 }
 
-function getSecret (client, { namespace, name }) {
+async function getSecret (client, { namespace, name }) {
   try {
-    return client.core.secrets.get(namespace, name)
+    return await client.core.secrets.get(namespace, name)
   } catch (err) {
     if (isHttpError(err, 404)) {
       return


### PR DESCRIPTION
**What this PR does / why we need it**:
If one of the component secrets of a shoot cluster does not exist sometimes other existing secrets are nor present in the seed-shoot-info.

**Which issue(s) this PR fixes**:
Fixes #762

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
NONE
```
