### PR TITLE
[hotfix-1.43] update chart's api versions

### DIFF
--- a/charts/_versions.tpl
+++ b/charts/_versions.tpl
@@ -4,21 +4,11 @@ modified only for a file in charts/_versions.tpl
 */}}
 
 {{- define "rbacversion" -}}
-{{- if semverCompare ">= 1.8" .Capabilities.KubeVersion.GitVersion -}}
 rbac.authorization.k8s.io/v1
-{{- else -}}
-rbac.authorization.k8s.io/v1beta1
-{{- end -}}
 {{- end -}}
 
 {{- define "deploymentversion" -}}
-{{- if semverCompare ">= 1.9" .Capabilities.KubeVersion.GitVersion -}}
 apps/v1
-{{- else if semverCompare "= 1.8" .Capabilities.KubeVersion.GitVersion -}}
-apps/v1beta2
-{{- else -}}
-apps/v1beta1
-{{- end -}}
 {{- end -}}
 
 {{- define "ingressversion" -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Update chart's api versions as Gardener is [supposed to be installed](https://github.com/gardener/gardener/blob/master/docs/usage/supported_k8s_versions.md) in k8s v1.11+

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cherry pick of #766 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Updated Helm Chart API versions
```
