### PR TITLE
Show link only for shooted Seeds

### DIFF
--- a/backend/lib/services/infrastructureSecrets.js
+++ b/backend/lib/services/infrastructureSecrets.js
@@ -164,8 +164,8 @@ async function getInfrastructureSecrets ({ secretBindings, cloudProfileList, sec
     .value()
 }
 
-function getCloudProviderKind (name) {
-  const cloudProfile = cloudprofiles.read({ name })
+async function getCloudProviderKind (name, user) {
+  const cloudProfile = await cloudprofiles.read({ name, user })
   return _.get(cloudProfile, 'metadata.cloudProviderKind')
 }
 
@@ -187,7 +187,7 @@ exports.list = async function ({ user, namespace }) {
   const client = user.client
 
   try {
-    const cloudProfileList = cloudprofiles.list()
+    const cloudProfileList = await cloudprofiles.list({ user })
     const [
       { items: secretList },
       { items: secretBindings }
@@ -216,7 +216,7 @@ exports.create = async function ({ user, namespace, body }) {
   const secretBinding = await client['core.gardener.cloud'].secretbindings.create(namespace, toSecretBindingResource(body))
 
   const cloudProfileName = _.get(body, 'metadata.cloudProfileName')
-  const cloudProviderKind = getCloudProviderKind(cloudProfileName)
+  const cloudProviderKind = await getCloudProviderKind(cloudProfileName, user)
   const projectInfo = getProjectNameAndHasCostObject(namespace)
 
   return fromResource({
@@ -248,7 +248,7 @@ exports.patch = async function ({ user, namespace, bindingName, body }) {
   const secret = await client.core.secrets.mergePatch(namespace, secretName, toSecretResource(body))
 
   const cloudProfileName = _.get(body, 'metadata.cloudProfileName')
-  const cloudProviderKind = getCloudProviderKind(cloudProfileName)
+  const cloudProviderKind = await getCloudProviderKind(cloudProfileName, user)
   const projectInfo = getProjectNameAndHasCostObject(namespace)
 
   return fromResource({

--- a/backend/test/acceptance/api.infrastructureSecrets.spec.js
+++ b/backend/test/acceptance/api.infrastructureSecrets.spec.js
@@ -126,7 +126,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
   it('should delete an own infrastructure secret', async function () {
     const bearer = await user.bearer
     common.stub.getQuotas(sandbox)
-    common.stub.getCloudProfiles(sandbox)
+    common.stub.getCloudProfiles(sandbox, false)
     k8s.stub.deleteInfrastructureSecret({ bearer, namespace, project, name, bindingName, bindingNamespace: namespace, cloudProfileName, resourceVersion })
     const res = await agent
       .delete(`/api/namespaces/${namespace}/infrastructure-secrets/${bindingName}`)

--- a/backend/test/support/common.js
+++ b/backend/test/support/common.js
@@ -19,6 +19,7 @@ const _ = require('lodash')
 const { EventEmitter } = require('events')
 const fnv = require('fnv-plus')
 const { cache } = require('../../lib/cache')
+const { shoots } = require('../../lib/services')
 const createTicketCache = require('../../lib/cache/tickets')
 const WatchBuilder = require('../../lib/kubernetes-client/WatchBuilder')
 
@@ -141,12 +142,17 @@ const quotaList = [
 ]
 
 const stub = {
-  getCloudProfiles (sandbox) {
+  getCloudProfiles (sandbox, stubShoots = true) {
     const getCloudProfilesStub = sandbox.stub(cache, 'getCloudProfiles')
     getCloudProfilesStub.returns(cloudProfileList)
 
     const getSeedsStub = sandbox.stub(cache, 'getSeeds')
     getSeedsStub.returns(seedList)
+
+    if (stubShoots) {
+      const getShootsStub = sandbox.stub(shoots, 'list')
+      getShootsStub.returns([])
+    }
   },
   getQuotas (sandbox) {
     const getQuotasStub = sandbox.stub(cache, 'getQuotas')

--- a/frontend/src/components/ShootSeedName.vue
+++ b/frontend/src/components/ShootSeedName.vue
@@ -43,6 +43,7 @@ limitations under the License.
 
 <script>
 
+import { mapGetters } from 'vuex'
 import { shootItem } from '@/mixins/shootItem'
 import { canLinkToSeed } from '@/utils'
 
@@ -53,9 +54,21 @@ export default {
     }
   },
   mixins: [shootItem],
+  computed: {
+    ...mapGetters([
+      'cloudProfileByName'
+    ]),
+    cloudProfileSeeds () {
+      const cloudProfile = this.cloudProfileByName(this.shootCloudProfileName)
+      if (!cloudProfile) {
+        return []
+      }
+      return cloudProfile.data.seeds
+    }
+  },
   methods: {
     canLinkToSeed (seedName) {
-      return canLinkToSeed({ namespace: this.shootNamespace, seedName })
+      return canLinkToSeed({ namespace: this.shootNamespace, seedName, cloudProfileSeeds: this.cloudProfileSeeds })
     }
   }
 }

--- a/frontend/src/components/TicketsCard.vue
+++ b/frontend/src/components/TicketsCard.vue
@@ -49,7 +49,6 @@ import template from 'lodash/template'
 import uniq from 'lodash/uniq'
 import { mapState } from 'vuex'
 import Ticket from '@/components/ShootTickets/Ticket'
-import { canLinkToSeed } from '@/utils'
 import { shootItem } from '@/mixins/shootItem'
 import moment from 'moment-timezone'
 
@@ -92,9 +91,6 @@ export default {
         utcDateTimeNow: moment().utc().format(),
         seedName: this.shootSeedName
       })
-    },
-    canLinkToSeed () {
-      return canLinkToSeed({ namespace: this.shootNamespace, seedName: this.shootSeedName })
     },
     shootUrl () {
       return `${window.location.origin}/namespace/${this.shootNamespace}/shoots/${this.shootName}`

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -363,14 +363,25 @@ export function isShootStatusHibernated (status) {
   return get(status, 'hibernated', false)
 }
 
-export function canLinkToSeed ({ namespace, seedName }) {
+export function canLinkToSeed ({ namespace, seedName, cloudProfileSeeds }) {
   /*
   * Soils cannot be linked currently as they have representation as "shoot".
   * Currently there is only the secret available.
   * If we are not in the garden namespace we expect a seed to be present
+  * Check if seed has shoot resource in garden namespace by evaluating flag
+  * in seed information attached to cloud profile. This check also guarantees
+  * that the user can access the (garden) namespace and shoot resource of the seed
   * TODO refactor once we have an owner ref on the shoot pointing to the seed
   */
-  return seedName && namespace !== 'garden'
+  if (!seedName || namespace === 'garden') {
+    return false
+  }
+
+  const shootResourceForSeed = some(cloudProfileSeeds, seed => {
+    return seed.metadata.name === seedName && seed.canGetShootForSeed
+  })
+
+  return shootResourceForSeed
 }
 
 export function shootHasIssue (shoot) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This is an implementation proposal that solves the issue that we currently show links to all seeds, even if no corresponding shoot exists in the garden namespace.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user

```
