### PR TITLE
[hotfix-1.44] Reflector not recovering from "Too large resource version"

### DIFF
--- a/backend/lib/http-client/HTTPClient.js
+++ b/backend/lib/http-client/HTTPClient.js
@@ -38,9 +38,9 @@ class HTTPClient {
     }
   }
 
-  request (url, options) {
+  async request (url, options) {
     try {
-      return this[request](url, this.constructor.normalizeOptions(options))
+      return await this[request](url, this.constructor.normalizeOptions(options))
     } catch (err) {
       if (err instanceof got.HTTPError) {
         throw new HTTPError(err.response)

--- a/backend/lib/kubernetes-client/cache/Reflector.js
+++ b/backend/lib/kubernetes-client/cache/Reflector.js
@@ -27,7 +27,6 @@ const {
   isExpiredError,
   isConnectionRefused,
   isTooLargeResourceVersionError,
-  getCurrentResourceVersion,
   StatusError
 } = require('../ApiErrors')
 
@@ -84,7 +83,7 @@ class Reflector {
     this.heartbeatInterval = moment.duration(30, 'seconds')
     this.heartbeatIntervalId = undefined
     this.minWatchTimeout = moment.duration(50, 'minutes')
-    this.isLastSyncResourceVersionExpired = false
+    this.isLastSyncResourceVersionUnavailable = false
     this.lastSyncResourceVersion = ''
     this.paginatedResult = false
     this.socket = undefined
@@ -107,7 +106,7 @@ class Reflector {
   }
 
   get relistResourceVersion () {
-    if (this.isLastSyncResourceVersionExpired) {
+    if (this.isLastSyncResourceVersionUnavailable) {
       // Since this reflector makes paginated list requests, and all paginated list requests skip the watch cache
       // if the lastSyncResourceVersion is expired, we set ResourceVersion="" and list again to re-establish reflector
       // to the latest available ResourceVersion, using a consistent read from etcd.
@@ -175,7 +174,23 @@ class Reflector {
       resourceVersion: this.relistResourceVersion
     }
 
-    if (!this.paginatedResult && options.resourceVersion !== '' && options.resourceVersion !== '0') {
+    if (this.paginatedResult) {
+      // We got a paginated result initially. Assume this resource and server honor
+      // paging requests (i.e. watch cache is probably disabled) and leave the default
+      // pager size set.
+    } else if (options.resourceVersion !== '' && options.resourceVersion !== '0') {
+      // User didn't explicitly request pagination.
+      //
+      // With ResourceVersion != "", we have a possibility to list from watch cache,
+      // but we do that (for ResourceVersion != "0") only if Limit is unset.
+      // To avoid thundering herd on etcd (e.g. on master upgrades), we explicitly
+      // switch off pagination to force listing from watch cache (if enabled).
+      // With the existing semantic of RV (result is at least as fresh as provided RV),
+      // this is correct and doesn't lead to going back in time.
+      //
+      // We also don't turn off pagination for ResourceVersion="0", since watch cache
+      // is ignoring Limit in that case anyway, and if watch cache is not enabled
+      // we don't introduce regression.
       pager.pageSize = 0
     }
 
@@ -186,13 +201,14 @@ class Reflector {
       logger.debug('List %s with resourceVersion %s', this.expectedTypeName, options.resourceVersion)
       list = await pager.list(options)
     } catch (err) {
-      if (isExpiredError(err)) {
-        this.isLastSyncResourceVersionExpired = true
-        // Retry immediately if the resource version used to list is expired.
+      if (isExpiredError(err) || isTooLargeResourceVersionError(err)) {
+        this.isLastSyncResourceVersionUnavailable = true
+        // Retry immediately if the resource version used to list is unavailable.
         // The pager already falls back to full list if paginated list calls fail due to an "Expired" error on
-        // continuation pages, but the pager might not be enabled, or the full list might fail because the
-        // resource version it is listing at is expired, so we need to fallback to resourceVersion="" in all
-        // to recover and ensure the reflector makes forward progress.
+        // continuation pages, but the pager might not be enabled, the full list might fail because the
+        // resource version it is listing at is expired or the cache may not yet be synced to the provided
+        // resource version. So we need to fallback to resourceVersion="" in all to recover and ensure
+        // the reflector makes forward progress.
         try {
           logger.debug('Falling back to full list %s', this.expectedTypeName)
           list = await pager.list({
@@ -202,9 +218,6 @@ class Reflector {
           logger.error('Failed to call full list %s: %s', this.expectedTypeName, err.message)
           return
         }
-      }
-      if (isTooLargeResourceVersionError(err)) {
-        this.lastSyncResourceVersion = getCurrentResourceVersion(err)
       }
       logger.error('Failed to call paginated list %s: %s', this.expectedTypeName, err.message)
       return
@@ -232,7 +245,7 @@ class Reflector {
       this.paginatedResult = true
     }
 
-    this.isLastSyncResourceVersionExpired = false
+    this.isLastSyncResourceVersionUnavailable = false
     this.store.replace(list.items)
     this.lastSyncResourceVersion = resourceVersion
     while (!this.stopRequested) {
@@ -277,7 +290,7 @@ class Reflector {
           await this.watchHandler(this.socket)
         } catch (err) {
           if (isExpiredError(err)) {
-            // Don't set LastSyncResourceVersionExpired - LIST call with ResourceVersion=RV already
+            // Don't set LastSyncResourceVersionUnavailable - LIST call with ResourceVersion=RV already
             // has a semantic that it returns data at least as fresh as provided RV.
             // So first try to LIST with setting RV to resource version of last observed object.
             logger.info('Watch of %s closed with: %s', this.expectedTypeName, err.message)

--- a/backend/test/http-client.spec.js
+++ b/backend/test/http-client.spec.js
@@ -20,7 +20,6 @@ const got = require('got')
 const http = require('http')
 const https = require('https')
 const { extend, HTTPClient, HTTPError } = require('../lib/http-client')
-const { expect } = require('chai')
 
 describe('http-client', function () {
   /* eslint no-unused-expressions: 0 */
@@ -89,7 +88,9 @@ describe('http-client', function () {
             Object.defineProperty(err, 'response', {
               value: response
             })
-            throw err
+            return new Promise((resolve, reject) => {
+              process.nextTick(() => reject(err))
+            })
           }
         })
         const client = new HTTPClient({ prefixUrl })
@@ -107,7 +108,9 @@ describe('http-client', function () {
         extendStub.callsFake(options => {
           return url => {
             expect(url).to.equal('test')
-            throw error
+            return new Promise((resolve, reject) => {
+              process.nextTick(() => reject(error))
+            })
           }
         })
         const client = new HTTPClient({ prefixUrl })

--- a/backend/test/kubernetes-client.api-errors.spec.js
+++ b/backend/test/kubernetes-client.api-errors.spec.js
@@ -18,7 +18,15 @@
 
 const { HTTPError } = require('../lib/http-client')
 
-const ApiErrors = require('../lib/kubernetes-client/ApiErrors')
+const {
+  StatusError,
+  CacheExpiredError,
+  isExpiredError,
+  isResourceExpired,
+  isGone,
+  isTooLargeResourceVersionError,
+  isGatewayTimeout
+} = require('../lib/kubernetes-client/ApiErrors')
 
 describe('kubernetes-client', function () {
   /* eslint no-unused-expressions: 0 */
@@ -30,7 +38,6 @@ describe('kubernetes-client', function () {
   })
 
   describe('ApiErrors', function () {
-    const { StatusError, isExpiredError, isResourceExpired, isGone } = ApiErrors
     const code = 'code'
     const message = 'message'
     const reason = 'reason'
@@ -42,6 +49,15 @@ describe('kubernetes-client', function () {
       expect(statusError.code).to.equal(code)
       expect(statusError.message).to.equal(message)
       expect(statusError.reason).to.equal(reason)
+    })
+
+    it('should create a CacheExpiredError instance', function () {
+      const error = new CacheExpiredError('Cache expired')
+      expect(error).to.be.an.instanceof(Error)
+      expect(error).to.have.property('stack')
+      expect(error.code).to.equal(410)
+      expect(error.message).to.equal('Cache expired')
+      expect(error.reason).to.equal('Expired')
     })
 
     it('should check if a status error has code "Gone"', function () {
@@ -68,6 +84,45 @@ describe('kubernetes-client', function () {
       const error = new Error()
       error.reason = 'Expired'
       expect(isExpiredError(error)).to.be.false
+    })
+
+    it('should handle "Resource version too large" errors correctly', function () {
+      const code = 504
+      const reason = 'Timeout'
+      let error = new HTTPError({
+        statusCode: code,
+        statusMessage: reason
+      })
+      expect(isGatewayTimeout(error)).to.be.true
+      expect(isTooLargeResourceVersionError(error)).to.be.true
+      error = new HTTPError({
+        body: {
+          code,
+          reason
+        }
+      })
+      expect(isGatewayTimeout(error)).to.be.true
+      expect(isTooLargeResourceVersionError(error)).to.be.true
+      error = new HTTPError({
+        body: {
+          code,
+          reason: 'Gateway Timeout',
+          details: {
+            causes: [{ message: 'Too large resource version' }]
+          }
+        }
+      })
+      expect(isGatewayTimeout(error)).to.be.false
+      expect(isTooLargeResourceVersionError(error)).to.be.true
+      error = new HTTPError({
+        body: {
+          details: {
+            causes: [{ reason: 'ResourceVersionTooLarge' }]
+          }
+        }
+      })
+      expect(isGatewayTimeout(error)).to.be.false
+      expect(isTooLargeResourceVersionError(error)).to.be.true
     })
   })
 })

--- a/backend/test/kubernetes-client.cache.spec.js
+++ b/backend/test/kubernetes-client.cache.spec.js
@@ -305,9 +305,9 @@ describe('kubernetes-client', function () {
       })
 
       it('should return a resourceVersion for listing', async function () {
-        reflector.isLastSyncResourceVersionExpired = true
+        reflector.isLastSyncResourceVersionUnavailable = true
         expect(reflector.relistResourceVersion).to.equal('')
-        reflector.isLastSyncResourceVersionExpired = false
+        reflector.isLastSyncResourceVersionUnavailable = false
         expect(reflector.relistResourceVersion).to.equal('0')
         reflector.lastSyncResourceVersion = '1'
         expect(reflector.relistResourceVersion).to.equal('1')


### PR DESCRIPTION
**What this PR does / why we need it**:
The Reflector was not handling "Too large resource version" errors (504 Gateway Timeout). The bug was introduced with commit 3a9c89576f16eedf16143b6581e095638a7d60fc. Another result of the bug has been that error details were not shown in the frontend anymore. This bug is related to go-client issues https://github.com/kubernetes/kubernetes/issues/91073. We aligned the handling of "Too large resource version" errors with the current go-client implementation and fallback to `resourceVersion=""`. 

**Which issue(s) this PR fixes**:
Fixes #771 
Fixes #774

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
The dashboard is showing more details when a request to the kube-apiserver fails
```

```improvement operator
The caches of the dashboard-backend are stable again and handle "Too large resource version" (504 Gateway Timeout) errors correctly
```
