### PR TITLE
Show warning for stale projects

### DIFF
--- a/backend/lib/services/projects.js
+++ b/backend/lib/services/projects.js
@@ -28,10 +28,11 @@ const cache = require('../cache')
 
 const PROJECT_INITIALIZATION_TIMEOUT = 30 * 1000
 
-function fromResource ({ metadata, spec = {} }) {
+function fromResource ({ metadata, spec = {}, status = {} }) {
   const role = 'project'
   const { name, resourceVersion, creationTimestamp, annotations } = metadata
   const { namespace, createdBy, owner, description, purpose } = spec
+  const { staleSinceTimestamp, staleAutoDeleteTimestamp } = status
   return {
     metadata: {
       name,
@@ -45,7 +46,9 @@ function fromResource ({ metadata, spec = {} }) {
       createdBy: fromSubject(createdBy),
       owner: fromSubject(owner),
       description,
-      purpose
+      purpose,
+      staleSinceTimestamp,
+      staleAutoDeleteTimestamp
     }
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.4.4",
-    "@mdi/font": "^4.9.95",
+    "@mdi/font": "^5.5.55",
     "ansi-html": "^0.0.7",
     "axios": "^0.19.2",
     "clipboard": "^2.0.6",

--- a/frontend/src/components/MainNavigation.vue
+++ b/frontend/src/components/MainNavigation.vue
@@ -58,6 +58,7 @@ limitations under the License.
             >
               <v-icon class="pr-6">mdi-grid-large</v-icon>
               <span class="ml-2">{{projectName}}</span>
+              <stale-project-warning :project="project" small></stale-project-warning>
               <v-spacer></v-spacer>
               <v-icon right>{{projectMenuIcon}}</v-icon>
             </v-btn>
@@ -106,6 +107,9 @@ limitations under the License.
                   <v-list-item-title class="project-name">{{project.metadata.name}}</v-list-item-title>
                   <v-list-item-subtitle class="project-owner">{{getProjectOwner(project)}}</v-list-item-subtitle>
                 </v-list-item-content>
+                <v-list-item-action>
+                  <stale-project-warning :project="project" small></stale-project-warning>
+                </v-list-item-action>
               </v-list-item>
             </v-list>
             <v-card-actions class="grey lighten-3">
@@ -181,12 +185,14 @@ import slice from 'lodash/slice'
 import last from 'lodash/last'
 import { emailToDisplayName, setDelayedInputFocus, routes, namespacedRoute, routeName } from '@/utils'
 import ProjectCreateDialog from '@/components/dialogs/ProjectDialog'
+import StaleProjectWarning from '@/components/StaleProjectWarning'
 
 const initialVisibleProjects = 10
 
 export default {
   components: {
-    ProjectCreateDialog
+    ProjectCreateDialog,
+    StaleProjectWarning
   },
   data () {
     return {

--- a/frontend/src/components/MainNavigation.vue
+++ b/frontend/src/components/MainNavigation.vue
@@ -58,7 +58,7 @@ limitations under the License.
             >
               <v-icon class="pr-6">mdi-grid-large</v-icon>
               <span class="ml-2">{{projectName}}</span>
-              <stale-project-warning :project="project" small></stale-project-warning>
+              <stale-project-warning :project="project" small color="white"></stale-project-warning>
               <v-spacer></v-spacer>
               <v-icon right>{{projectMenuIcon}}</v-icon>
             </v-btn>

--- a/frontend/src/components/SelfTerminationWarning.vue
+++ b/frontend/src/components/SelfTerminationWarning.vue
@@ -45,9 +45,6 @@ export default {
     },
     isSelfTerminationWarning () {
       return isSelfTerminationWarning(this.expirationTimestamp)
-    },
-    expirationAlertType () {
-      return this.isSelfTerminationWarning ? 'warning' : 'info'
     }
   }
 }

--- a/frontend/src/components/StaleProjectWarning.vue
+++ b/frontend/src/components/StaleProjectWarning.vue
@@ -18,7 +18,7 @@ limitations under the License.
   <v-tooltip top v-if="staleSinceTimestamp">
     <template v-slot:activator="{ on }">
       <v-icon :small="small" v-on="on" color="warning" class="staleIcon" v-if="staleAutoDeleteTimestamp">mdi-alert-circle</v-icon>
-      <v-icon :small="small" v-on="on" color="teal" class="staleIcon" v-else>mdi-information</v-icon>
+      <v-icon :small="small" v-on="on" :color="color" class="staleIcon" v-else>mdi-information</v-icon>
     </template>
      <span v-if="staleAutoDeleteTimestamp">
       This is a <span class="font-weight-bold">stale</span> project. Gardener will auto delete this project <span class="font-weight-bold"><time-string :date-time="staleAutoDeleteTimestamp"></time-string></span>
@@ -44,6 +44,10 @@ export default {
     },
     small: {
       type: Boolean
+    },
+    color: {
+      type: String,
+      default: 'teal'
     }
   },
   computed: {

--- a/frontend/src/components/StaleProjectWarning.vue
+++ b/frontend/src/components/StaleProjectWarning.vue
@@ -1,0 +1,67 @@
+<!--
+Copyright (c) 2020 by SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<template>
+  <v-tooltip top v-if="staleSinceTimestamp">
+    <template v-slot:activator="{ on }">
+      <v-icon :small="small" v-on="on" color="warning" class="staleIcon" v-if="staleAutoDeleteTimestamp">mdi-alert-circle</v-icon>
+      <v-icon :small="small" v-on="on" color="teal" class="staleIcon" v-else>mdi-information</v-icon>
+    </template>
+     <span v-if="staleAutoDeleteTimestamp">
+      This is a <span class="font-weight-bold">stale</span> project. Gardener will auto delete this project <span class="font-weight-bold"><time-string :date-time="staleAutoDeleteTimestamp"></time-string></span>
+    </span>
+    <span v-else>
+      This project is considered <span class="font-weight-bold">stale</span> since <span class="font-weight-bold"><time-string :date-time="staleSinceTimestamp" withoutPrefixOrSuffix></time-string></span>
+    </span>
+  </v-tooltip>
+</template>
+
+<script>
+import { getProjectDetails } from '@/utils'
+import TimeString from '@/components/TimeString'
+
+export default {
+  name: 'staleProjectWarning',
+  components: {
+    TimeString
+  },
+  props: {
+    project: {
+      type: Object
+    },
+    small: {
+      type: Boolean
+    }
+  },
+  computed: {
+    projectDetails () {
+      return getProjectDetails(this.project)
+    },
+    staleSinceTimestamp () {
+      return this.projectDetails.staleSinceTimestamp
+    },
+    staleAutoDeleteTimestamp () {
+      return this.projectDetails.staleAutoDeleteTimestamp
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+  .staleIcon {
+    margin-left: 10px;
+  }
+</style>

--- a/frontend/src/components/StaleProjectWarning.vue
+++ b/frontend/src/components/StaleProjectWarning.vue
@@ -17,8 +17,8 @@ limitations under the License.
 <template>
   <v-tooltip top v-if="staleSinceTimestamp">
     <template v-slot:activator="{ on }">
-      <v-icon :small="small" v-on="on" color="warning" class="staleIcon" v-if="staleAutoDeleteTimestamp">mdi-alert-circle</v-icon>
-      <v-icon :small="small" v-on="on" :color="color" class="staleIcon" v-else>mdi-information</v-icon>
+      <v-icon :small="small" v-on="on" :color="color" class="staleIcon" v-if="staleAutoDeleteTimestamp">mdi-delete-clock</v-icon>
+      <v-icon :small="small" v-on="on" :color="color" class="staleIcon" v-else>mdi-clock-alert-outline</v-icon>
     </template>
      <span v-if="staleAutoDeleteTimestamp">
       This is a <span class="font-weight-bold">stale</span> project. Gardener will auto delete this project <span class="font-weight-bold"><time-string :date-time="staleAutoDeleteTimestamp"></time-string></span>

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -346,6 +346,8 @@ export function getProjectDetails (project) {
   const description = projectData.description || ''
   const createdBy = projectData.createdBy || ''
   const purpose = projectData.purpose || ''
+  const staleSinceTimestamp = projectData.staleSinceTimestamp
+  const staleAutoDeleteTimestamp = projectData.staleAutoDeleteTimestamp
 
   return {
     projectName,
@@ -355,7 +357,9 @@ export function getProjectDetails (project) {
     creationTimestamp,
     createdBy,
     description,
-    purpose
+    purpose,
+    staleSinceTimestamp,
+    staleAutoDeleteTimestamp
   }
 }
 

--- a/frontend/src/views/Administration.vue
+++ b/frontend/src/views/Administration.vue
@@ -55,6 +55,37 @@ limitations under the License.
                     </v-list-item-title>
                   </v-list-item-content>
                 </v-list-item>
+                <template v-if="staleSinceTimestamp">
+                  <v-divider inset></v-divider>
+                  <v-list-item>
+                    <v-list-item-avatar>
+                      <v-icon :color="color">mdi-clock-outline</v-icon>
+                    </v-list-item-avatar>
+                    <v-list-item-content>
+                      <v-list-item-subtitle>Stale Project Information</v-list-item-subtitle>
+                      <v-list-item-title class="d-flex align-center pt-1">
+                        <v-icon
+                          v-if="!staleAutoDeleteTimestamp"
+                          :color="color"
+                          left
+                          size="18"
+                        >mdi-information</v-icon>
+                        <v-icon
+                          v-else
+                          color="warning"
+                          left
+                          size="18"
+                        >mdi-alert-circle</v-icon>
+                        <span v-if="staleAutoDeleteTimestamp">
+                          This is a <span class="font-weight-bold">stale</span> project. Gardener will auto delete this project <span class="font-weight-bold"><time-string :date-time="staleAutoDeleteTimestamp"></time-string></span>
+                        </span>
+                        <span v-else>
+                          This project is considered <span class="font-weight-bold">stale</span> since <span class="font-weight-bold"><time-string :date-time="staleSinceTimestamp" withoutPrefixOrSuffix></time-string></span>
+                        </span>
+                      </v-list-item-title>
+                    </v-list-item-content>
+                  </v-list-item>
+                </template>
                 <v-divider inset/>
                 <v-list-item>
                   <v-list-item-avatar>
@@ -375,6 +406,12 @@ export default {
     },
     purpose () {
       return this.projectDetails.purpose
+    },
+    staleSinceTimestamp () {
+      return this.projectDetails.staleSinceTimestamp
+    },
+    staleAutoDeleteTimestamp () {
+      return this.projectDetails.staleAutoDeleteTimestamp
     },
     isDeleteButtonDisabled () {
       return this.shootList.length > 0

--- a/frontend/src/views/Administration.vue
+++ b/frontend/src/views/Administration.vue
@@ -59,23 +59,12 @@ limitations under the License.
                   <v-divider inset></v-divider>
                   <v-list-item>
                     <v-list-item-avatar>
-                      <v-icon :color="color">mdi-clock-outline</v-icon>
+                      <v-icon v-if="staleAutoDeleteTimestamp" :color="color">mdi-delete-clock</v-icon>
+                      <v-icon v-else :color="color">mdi-clock-alert-outline</v-icon>
                     </v-list-item-avatar>
                     <v-list-item-content>
                       <v-list-item-subtitle>Stale Project Information</v-list-item-subtitle>
                       <v-list-item-title class="d-flex align-center pt-1">
-                        <v-icon
-                          v-if="!staleAutoDeleteTimestamp"
-                          :color="color"
-                          left
-                          size="18"
-                        >mdi-information</v-icon>
-                        <v-icon
-                          v-else
-                          color="warning"
-                          left
-                          size="18"
-                        >mdi-alert-circle</v-icon>
                         <span v-if="staleAutoDeleteTimestamp">
                           This is a <span class="font-weight-bold">stale</span> project. Gardener will auto delete this project <span class="font-weight-bold"><time-string :date-time="staleAutoDeleteTimestamp"></time-string></span>
                         </span>

--- a/frontend/tests/unit/MainNavigation.spec.js
+++ b/frontend/tests/unit/MainNavigation.spec.js
@@ -93,7 +93,7 @@ async function createMainNavigationComponent () {
       $router,
       $store
     },
-    stubs: ['ProjectCreateDialog', 'RouterLink']
+    stubs: ['ProjectCreateDialog', 'RouterLink', 'StaleProjectWarning']
   })
   wrapper.setData({ projectMenu: true })
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -879,10 +879,10 @@
     cssnano-preset-default "^4.0.0"
     postcss "^7.0.0"
 
-"@mdi/font@^4.9.95":
-  version "4.9.95"
-  resolved "https://registry.yarnpkg.com/@mdi/font/-/font-4.9.95.tgz#00ed2ffe289c9230f146e74559c07542d3f4475a"
-  integrity sha512-m2sbAs+SMwRnWpkMriBxEulwuhmqRyh6X+hdOZlqSxYZUM2C2TaDnQ4gcilzdoAgru2XYnWViZ/xPuSDGgRXVw==
+"@mdi/font@^5.5.55":
+  version "5.5.55"
+  resolved "https://registry.yarnpkg.com/@mdi/font/-/font-5.5.55.tgz#7f83d640f0692651f5e59558da99975f42114123"
+  integrity sha512-xrVCXiRMz7ubB8mu6ehDhMADmGpLBsk3GWZccs39jWmhoTxatFnOvW8STJjqMGtePPNgGYYu/6m/AJVyMjBxnw==
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"


### PR DESCRIPTION
**What this PR does / why we need it**:
Gardener flags inactive projects as stale and auto removes them after some time. This PR adds support for this information to the Dashboard. We show information about stale projects and when the deletion will take place.

<img width="942" alt="Screen Shot 2020-08-12 at 16 34 38" src="https://user-images.githubusercontent.com/35373687/90028414-eeb32600-dcb9-11ea-9caf-f80fe39bec20.png">
<img width="940" alt="Screen Shot 2020-08-12 at 16 33 02" src="https://user-images.githubusercontent.com/35373687/90028424-f1158000-dcb9-11ea-9371-9dd16a38e566.png">

**Which issue(s) this PR fixes**:
Fixes #721

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
The Dashboard now shows if projects are flagged as stale. If projects have an auto deletion timestamp assigned, information about when the deletion will happen is also shown
```
