### PR TITLE
Show link only for shooted Seeds

### DIFF
--- a/backend/lib/services/shoots.js
+++ b/backend/lib/services/shoots.js
@@ -223,7 +223,9 @@ exports.info = async function ({ user, namespace, name }) {
     })
   ])
 
-  const data = {}
+  const data = {
+    canLinkToSeed: false
+  }
   let seed
   if (shoot.spec.seedName) {
     seed = getSeed(getSeedNameFromShoot(shoot))
@@ -232,6 +234,14 @@ exports.info = async function ({ user, namespace, name }) {
       const ingressDomain = _.get(seed, 'spec.dns.ingressDomain')
       if (ingressDomain) {
         data.seedShootIngressDomain = `${prefix}.${ingressDomain}`
+      }
+    }
+    if (seed) {
+      try {
+        data.canLinkToSeed = !!(await client['core.gardener.cloud'].shoots.get('garden', seed.metadata.name))
+      } catch (err) {
+        console.log(err)
+        data.canLinkToSeed = false
       }
     }
   }

--- a/backend/lib/services/shoots.js
+++ b/backend/lib/services/shoots.js
@@ -236,11 +236,10 @@ exports.info = async function ({ user, namespace, name }) {
         data.seedShootIngressDomain = `${prefix}.${ingressDomain}`
       }
     }
-    if (seed) {
+    if (seed && namespace !== 'garden') {
       try {
         data.canLinkToSeed = !!(await client['core.gardener.cloud'].shoots.get('garden', seed.metadata.name))
       } catch (err) {
-        console.log(err)
         data.canLinkToSeed = false
       }
     }

--- a/backend/test/acceptance/api.shoots.spec.js
+++ b/backend/test/acceptance/api.shoots.spec.js
@@ -131,8 +131,9 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
     expect(res).to.have.status(200)
     expect(res).to.be.json
     expect(cleanKubeconfigSpy).to.have.callCount(2)
-    expect(_.keys(res.body).length).to.equal(6)
+    expect(_.keys(res.body).length).to.equal(7)
     expect(res.body).to.have.own.property('kubeconfig')
+    expect(res.body.canLinkToSeed).to.equal(true)
     expect(res.body.cluster_username).to.eql(shootUser)
     expect(res.body.cluster_password).to.eql(shootPassword)
     expect(res.body.serverUrl).to.eql(shootServerUrl)

--- a/backend/test/support/nocks/k8s.js
+++ b/backend/test/support/nocks/k8s.js
@@ -557,6 +557,12 @@ const stub = {
         allowed: true
       }
     }
+    const shootedSeedResult = {
+      metadata: {
+        name: seedName,
+        namespace: 'garden'
+      }
+    }
 
     return [nockWithAuthorization(bearer)
       .get(`/apis/core.gardener.cloud/v1beta1/namespaces/${namespace}/shoots/${name}`)
@@ -564,7 +570,10 @@ const stub = {
       .get(`/api/v1/namespaces/${namespace}/secrets/${name}.kubeconfig`)
       .reply(200, () => kubecfgResult)
       .post('/apis/authorization.k8s.io/v1/selfsubjectaccessreviews')
-      .reply(200, () => isAdminResult)]
+      .reply(200, () => isAdminResult)
+      .get(`/apis/core.gardener.cloud/v1beta1/namespaces/garden/shoots/${seedName}`)
+      .reply(200, () => shootedSeedResult)
+    ]
   },
   getSeedInfo ({
     bearer,

--- a/frontend/src/components/ShootSeedName.vue
+++ b/frontend/src/components/ShootSeedName.vue
@@ -21,13 +21,13 @@ limitations under the License.
         <div v-on="on">
           <template v-if="isControlPlaneMigrating">
             <v-progress-circular indeterminate size=12 width=2 color="cyan darken-2" class="mr-1"></v-progress-circular>
-            <router-link v-if="canLinkToSeed(shootStatusSeedName)" class="cyan--text text--darken-2" :to="{ name: 'ShootItem', params: { name: shootStatusSeedName, namespace:'garden' } }">
+            <router-link v-if="canLinkToSeed" class="cyan--text text--darken-2" :to="{ name: 'ShootItem', params: { name: shootStatusSeedName, namespace:'garden' } }">
               <span>{{shootStatusSeedName}}</span>
             </router-link>
             <span v-else>{{shootSeedName}}</span>
             <v-icon small class="mx-1">mdi-arrow-right</v-icon>
           </template>
-          <router-link v-if="canLinkToSeed(shootSeedName)" class="cyan--text text--darken-2" :to="{ name: 'ShootItem', params: { name: shootSeedName, namespace:'garden' } }">
+          <router-link v-if="canLinkToSeed" class="cyan--text text--darken-2" :to="{ name: 'ShootItem', params: { name: shootSeedName, namespace:'garden' } }">
             <span>{{shootSeedName}}</span>
           </router-link>
           <span v-else>{{shootSeedName}}</span>
@@ -44,7 +44,6 @@ limitations under the License.
 <script>
 
 import { shootItem } from '@/mixins/shootItem'
-import { canLinkToSeed } from '@/utils'
 
 export default {
   props: {
@@ -52,11 +51,6 @@ export default {
       type: Object
     }
   },
-  mixins: [shootItem],
-  methods: {
-    canLinkToSeed (seedName) {
-      return canLinkToSeed({ namespace: this.shootNamespace, seedName })
-    }
-  }
+  mixins: [shootItem]
 }
 </script>

--- a/frontend/src/components/TicketsCard.vue
+++ b/frontend/src/components/TicketsCard.vue
@@ -49,7 +49,6 @@ import template from 'lodash/template'
 import uniq from 'lodash/uniq'
 import { mapState } from 'vuex'
 import Ticket from '@/components/ShootTickets/Ticket'
-import { canLinkToSeed } from '@/utils'
 import { shootItem } from '@/mixins/shootItem'
 import moment from 'moment-timezone'
 
@@ -92,9 +91,6 @@ export default {
         utcDateTimeNow: moment().utc().format(),
         seedName: this.shootSeedName
       })
-    },
-    canLinkToSeed () {
-      return canLinkToSeed({ namespace: this.shootNamespace, seedName: this.shootSeedName })
     },
     shootUrl () {
       return `${window.location.origin}/namespace/${this.shootNamespace}/shoots/${this.shootName}`

--- a/frontend/src/mixins/shootItem.js
+++ b/frontend/src/mixins/shootItem.js
@@ -153,6 +153,9 @@ export const shootItem = {
     seedShootIngressDomain () {
       return this.shootInfo.seedShootIngressDomain || ''
     },
+    canLinkToSeed () {
+      return get(this.shootItem, 'info.canLinkToSeed', false)
+    },
 
     isShootLastOperationTypeDelete () {
       return isTypeDelete(this.shootLastOperation)

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -361,16 +361,6 @@ export function isShootStatusHibernated (status) {
   return get(status, 'hibernated', false)
 }
 
-export function canLinkToSeed ({ namespace, seedName }) {
-  /*
-  * Soils cannot be linked currently as they have representation as "shoot".
-  * Currently there is only the secret available.
-  * If we are not in the garden namespace we expect a seed to be present
-  * TODO refactor once we have an owner ref on the shoot pointing to the seed
-  */
-  return seedName && namespace !== 'garden'
-}
-
 export function shootHasIssue (shoot) {
   return get(shoot, ['metadata', 'labels', 'shoot.gardener.cloud/status'], 'healthy') !== 'healthy'
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This is an implementation proposal that solves the issue that we currently show links to all seeds, even if no corresponding shoot exists in the garden namespace.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user

```
