### PR TITLE
Dashboard doesn’t show the name of the conflicting service account 

### DIFF
--- a/backend/lib/middleware.js
+++ b/backend/lib/middleware.js
@@ -55,8 +55,9 @@ function errorToLocals (err, req) {
   const message = err.message
   let reason = err.reason || 'Internal Error'
   const name = err.name
+  const stack = err.stack
 
-  const error = req.app.get('env') === 'development' ? err : { name }
+  const error = req.app.get('env') === 'development' ? { name, stack } : { name }
   let status = 500
   if (isHttpError(err) && err.response) {
     status = err.response.statusCode

--- a/frontend/src/components/dialogs/MemberDialog.vue
+++ b/frontend/src/components/dialogs/MemberDialog.vue
@@ -262,9 +262,9 @@ export default {
     async submitAddMember () {
       this.$v.$touch()
       if (this.valid) {
+        const name = this.memberName
+        const roles = this.internalRoles
         try {
-          const name = this.memberName
-          const roles = this.internalRoles
           await this.addMember({ name, roles })
           this.hide()
         } catch (err) {


### PR DESCRIPTION
**What this PR does / why we need it**:
If you try to add an already existing service account to a project you get an error message that shows an empty name.

**Which issue(s) this PR fixes**:
Fixes #782

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Dashboard shows the name of the conflicting service account if you try to add an already existing service account to a project
```
