### PR TITLE
Wrong default loadBalancerClasses for new shoots

### DIFF
--- a/frontend/src/store/modules/shoots.js
+++ b/frontend/src/store/modules/shoots.js
@@ -243,12 +243,13 @@ const actions = {
 
     const allLoadBalancerClassNames = rootGetters.loadBalancerClassNamesByCloudProfileName(cloudProfileName)
     if (!isEmpty(allLoadBalancerClassNames)) {
-      const loadBalancerClassNames = [
-        includes(allLoadBalancerClassNames, 'default')
-          ? 'default'
-          : head(allLoadBalancerClassNames)
-      ]
-      set(shootResource, 'spec.provider.controlPlaneConfig.loadBalancerClasses', loadBalancerClassNames)
+      const defaultLoadBalancerClassName = includes(allLoadBalancerClassNames, 'default')
+        ? 'default'
+        : head(allLoadBalancerClassNames)
+      const loadBalancerClasses = [{
+        name: defaultLoadBalancerClassName
+      }]
+      set(shootResource, 'spec.provider.controlPlaneConfig.loadBalancerClasses', loadBalancerClasses)
     }
 
     const partitionIDs = rootGetters.partitionIDsByCloudProfileNameAndRegion({ cloudProfileName, region })


### PR DESCRIPTION
**What this PR does / why we need it**:
If the first supported infrastructure provider has load balancer classes in the cloudProfile the default list loadBalancerClasses in the shoot spec has the wrong format. As a result the default loadBalancerClass disabled and not selected.
<img width="640" src="https://user-images.githubusercontent.com/1574023/90793195-b770f480-e30b-11ea-972b-1fa21541a4b7.png">

**Which issue(s) this PR fixes**:
Fixes #786 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
The default load balancer class for new shoot is selected correctly
```
