### PR TITLE
[hotfix-1.45] Segregation for managing human and technical users

### DIFF
--- a/frontend/src/components/ProjectServiceAccountRow.vue
+++ b/frontend/src/components/ProjectServiceAccountRow.vue
@@ -86,7 +86,7 @@ limitations under the License.
           <span>Show Kubeconfig</span>
         </v-tooltip>
       </v-list-item-action>
-      <v-list-item-action v-if="canManageMembers" class="ml-1">
+      <v-list-item-action v-if="canManageServiceAccountMembers" class="ml-1">
         <v-tooltip top>
           <template v-slot:activator="{ on }">
             <v-btn v-on="on" icon @click.native.stop="onEdit">
@@ -96,7 +96,7 @@ limitations under the License.
           <span>Update Service Account</span>
         </v-tooltip>
       </v-list-item-action>
-      <v-list-item-action v-if="canManageMembers" class="ml-1">
+      <v-list-item-action v-if="canManageServiceAccountMembers" class="ml-1">
         <v-tooltip top>
           <template v-slot:activator="{ on }">
             <v-btn v-on="on" icon color="red" @click.native.stop="onDelete">
@@ -162,7 +162,7 @@ export default {
       'namespace'
     ]),
     ...mapGetters([
-      'canManageMembers',
+      'canManageServiceAccountMembers',
       'canGetSecrets'
     ]),
     isServiceAccountFromCurrentNamespace () {

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -841,6 +841,9 @@ const getters = {
     const name = getters.projectName
     return canI(state.subjectRules, 'manage-members', 'core.gardener.cloud', 'projects', name)
   },
+  canManageServiceAccountMembers (state, getters) {
+    return getters.canPatchProject || getters.canManageMembers
+  },
   canDeleteProject (state, getters) {
     const name = getters.projectName
     return canI(state.subjectRules, 'delete', 'core.gardener.cloud', 'projects', name)

--- a/frontend/src/views/Members.vue
+++ b/frontend/src/views/Members.vue
@@ -120,7 +120,7 @@ limitations under the License.
           v-model="serviceAccountFilter"
           @keyup.esc="serviceAccountFilter=''"
         ></v-text-field>
-        <v-btn v-if="canManageMembers" icon @click.native.stop="openServiceAccountAddDialog">
+        <v-btn v-if="canManageServiceAccountMembers" icon @click.native.stop="openServiceAccountAddDialog">
           <v-icon class="white--text">add</v-icon>
         </v-btn>
         <v-btn icon @click.native.stop="openServiceAccountHelpDialog">
@@ -179,7 +179,7 @@ limitations under the License.
       </v-card>
     </v-dialog>
     <confirm-dialog ref="confirmDialog"></confirm-dialog>
-    <v-fab-transition v-if="canManageMembers">
+    <v-fab-transition v-if="canManageServiceAccountMembers || canManageMembers">
       <v-speed-dial v-model="fab" v-show="floatingButton" fixed bottom right direction="top" transition="slide-y-reverse-transition"  >
         <template v-slot:activator>
           <v-btn v-model="fab" color="teal darken-2" dark fab>
@@ -187,10 +187,10 @@ limitations under the License.
             <v-icon v-else>add</v-icon>
           </v-btn>
         </template>
-        <v-btn fab small color="grey lighten-2" light @click="openServiceAccountAddDialog">
+        <v-btn v-if="canManageServiceAccountMembers" fab small color="grey lighten-2" light @click="openServiceAccountAddDialog">
           <v-icon color="blue-grey darken-2">mdi-monitor</v-icon>
         </v-btn>
-        <v-btn fab small color="grey lighten-2" @click="openUserAddDialog">
+        <v-btn v-if="canManageMembers" fab small color="grey lighten-2" @click="openUserAddDialog">
           <v-icon color="green darken-2">person</v-icon>
         </v-btn>
       </v-speed-dial>
@@ -267,6 +267,7 @@ export default {
       'memberList',
       'projectFromProjectList',
       'canManageMembers',
+      'canManageServiceAccountMembers',
       'username',
       'isAdmin',
       'projectList'


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to manage human project members (not starting with system:serviceaccount:) a user need the uam role (canManageProject).
In order to manage technical project members (starting with system:serviceaccount:) a user need the uam or the admin role (canManageProject or canPatchProject).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Fixed: Project `Admin` can manage technical users. `uam` role is not needed in this case.
```
