### PR TITLE
Add auto select node option

### DIFF
--- a/frontend/src/components/TerminalSettings.vue
+++ b/frontend/src/components/TerminalSettings.vue
@@ -192,7 +192,9 @@ export default {
       return this.selectedRunOnShootWorker ? 'black--text' : 'grey--text'
     },
     selectedConfig () {
-      const node = this.selectedNode === this.autoSelectNodeItem.data.kubernetesHostname ? undefined : this.selectedNode
+      const node = this.selectedNode === this.autoSelectNodeItem.data.kubernetesHostname 
+        ? undefined 
+        : this.selectedNode
       const selectedConfig = {
         container: {
           image: this.selectedContainerImage
@@ -214,7 +216,9 @@ export default {
     initialize ({ container = {}, defaultNode, currentNode, privilegedMode, nodes = [] }) {
       this.selectedContainerImage = container.image
       if (!defaultNode) {
-        defaultNode = this.isAdmin ? get(head(nodes), 'data.kubernetesHostname') : this.autoSelectNodeItem.data.kubernetesHostname
+        defaultNode = this.isAdmin 
+          ? get(head(nodes), 'data.kubernetesHostname') 
+          : this.autoSelectNodeItem.data.kubernetesHostname
       }
       this.selectedNode = defaultNode
       this.shootNodes = [this.autoSelectNodeItem, ...nodes]

--- a/frontend/src/components/TerminalSettings.vue
+++ b/frontend/src/components/TerminalSettings.vue
@@ -73,16 +73,23 @@ limitations under the License.
         class="ml-2"
       >
         <template v-slot:item="{ item }">
-          <v-list-item-content>
+          <v-list-item-content v-if="item !== autoSelectNodeItem">
             <v-list-item-title>{{item.data.kubernetesHostname}}</v-list-item-title>
             <v-list-item-subtitle>
               <span>Ready: {{item.data.readyStatus}} | Version: {{item.data.version}} | Created: <time-string :date-time="item.metadata.creationTimestamp" :pointInTime="-1"></time-string></span>
             </v-list-item-subtitle>
           </v-list-item-content>
+          <v-list-item-content v-else>
+            <v-list-item-title>Auto select node</v-list-item-title>
+            <v-list-item-subtitle>Let the kube-scheduler decide on which node the terminal pod will be scheduled</v-list-item-subtitle>
+          </v-list-item-content>
         </template>
         <template v-slot:selection="{ item }">
           <span :class="nodeTextColor" class="ml-2">
-          {{item.data.kubernetesHostname}} [{{item.data.version}}]
+            <template v-if="item !== autoSelectNodeItem">
+              {{item.data.kubernetesHostname}} [{{item.data.version}}]
+            </template>
+            <template v-else>Auto select node</template>
           </span>
         </template>
       </v-select>
@@ -128,6 +135,11 @@ export default {
   },
   data () {
     return {
+      autoSelectNodeItem: {
+        data: {
+          kubernetesHostname: -1 // node will be auto selected by the kube-scheduler. Value needs to be set to any value
+        }
+      },
       selectedRunOnShootWorkerInternal: false,
       selectedContainerImage: undefined,
       selectedNode: undefined,
@@ -180,11 +192,12 @@ export default {
       return this.selectedRunOnShootWorker ? 'black--text' : 'grey--text'
     },
     selectedConfig () {
+      const node = this.selectedNode === this.autoSelectNodeItem.data.kubernetesHostname ? undefined : this.selectedNode
       const selectedConfig = {
         container: {
           image: this.selectedContainerImage
         },
-        node: this.selectedNode
+        node
       }
       if (this.selectedPrivilegedMode) {
         selectedConfig.container.privileged = true
@@ -198,11 +211,13 @@ export default {
     }
   },
   methods: {
-    initialize ({ container = {}, defaultNode, currentNode, privilegedMode, nodes }) {
+    initialize ({ container = {}, defaultNode, currentNode, privilegedMode, nodes = [] }) {
       this.selectedContainerImage = container.image
-      defaultNode = defaultNode || get(head(nodes), 'data.kubernetesHostname')
+      if (!defaultNode) {
+        defaultNode = this.isAdmin ? get(head(nodes), 'data.kubernetesHostname') : this.autoSelectNodeItem.data.kubernetesHostname
+      }
       this.selectedNode = defaultNode
-      this.shootNodes = nodes
+      this.shootNodes = [this.autoSelectNodeItem, ...nodes]
       if (!this.isAdmin) {
         this.selectedRunOnShootWorker = true
       } else {
@@ -210,6 +225,10 @@ export default {
         this.selectedRunOnShootWorker = currentNodeIsShootWorker
       }
       this.selectedPrivilegedMode = privilegedMode
+
+      // in case "initialize" is called with the same parameters, selectedConfig does not change and hence the watch is not called. Make sure that selectedConfig is emitted in any case
+      this.$emit('selectedConfig', this.selectedConfig)
+      this.$emit('validSettings', this.validSettings)
     },
     getErrorMessages (field) {
       return getValidationErrors(this, field)

--- a/frontend/src/lib/terminal.js
+++ b/frontend/src/lib/terminal.js
@@ -102,7 +102,7 @@ export class TerminalSession {
 
     const hostConfig = pick(this.vm.data, ['node', 'hostPID', 'hostNetwork', 'preferredHost'])
     const selectedConfigHost = pick(this.vm.selectedConfig, ['node', 'hostPID', 'hostNetwork', 'preferredHost'])
-    const body = merge(hostConfig, selectedConfigHost)
+    const body = assign(hostConfig, selectedConfigHost) // node: undefined (auto select node) should overwrite the value from hostConfig, hence using lodash assign
     body.identifier = this.vm.uuid
     body.container = merge(container, selectedConfigContainer)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
On the terminal settings dialog you are now able to choose `Auto select node` to let the kube-schedule decide on which node the terminal should be scheduled.
<img width="909" alt="Screenshot 2020-09-04 at 17 06 44" src="https://user-images.githubusercontent.com/5526658/92254345-08b6e180-eed1-11ea-9aca-83398abb88f8.png">

**Which issue(s) this PR fixes**:
Fixes #793 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
On the terminal settings dialog you can now choose `Auto select node` to let the `kube-schedule` decide on which node the terminal pod should be scheduled
```
