### PR TITLE
Support seedSelector providerType and enhance project member check

### DIFF
--- a/backend/lib/services/cloudprofiles.js
+++ b/backend/lib/services/cloudprofiles.js
@@ -45,24 +45,17 @@ function emptyToUndefined (value) {
 
 function assignSeedsToCloudProfileIteratee (seeds) {
   return cloudProfileResource => {
-    function filterProviderType () {
-      if (!_.isEmpty(providerTypes)) {
-        return seed => {
-          const seedProviderType = _.get(seed, 'spec.provider.type')
-          return _.includes(providerTypes, seedProviderType)
-        }
-      }
-
-      return ['spec.provider.type', providerType]
+    function filterProviderType (seed) {
+      const seedProviderType = _.get(seed, 'spec.provider.type')
+      return _.includes(providerTypes, seedProviderType)
     }
-
     const providerType = cloudProfileResource.spec.type
     const matchLabels = _.get(cloudProfileResource, 'spec.seedSelector.matchLabels', {})
-    const providerTypes = _.get(cloudProfileResource, 'spec.seedSelector.providerTypes', [])
+    const providerTypes = _.get(cloudProfileResource, 'spec.seedSelector.providerTypes', [providerType])
 
     const seedsForCloudProfile = _
       .chain(seeds)
-      .filter(filterProviderType())
+      .filter(filterProviderType)
       .filter({ metadata: { labels: matchLabels } })
       .map(fromSeedResource)
       .thru(emptyToUndefined)

--- a/backend/lib/services/cloudprofiles.js
+++ b/backend/lib/services/cloudprofiles.js
@@ -45,10 +45,12 @@ function emptyToUndefined (value) {
 
 function assignSeedsToCloudProfileIteratee (seeds) {
   return cloudProfileResource => {
-    function filterProviderType (seed) {
+    function filterProviderType () {
       if (!_.isEmpty(providerTypes)) {
-        const seedProviderType = _.get(seed, 'spec.provider.type')
-        return _.includes(providerTypes, seedProviderType)
+        return seed => {
+          const seedProviderType = _.get(seed, 'spec.provider.type')
+          return _.includes(providerTypes, seedProviderType)
+        }
       }
 
       return ['spec.provider.type', providerType]
@@ -60,7 +62,7 @@ function assignSeedsToCloudProfileIteratee (seeds) {
 
     const seedsForCloudProfile = _
       .chain(seeds)
-      .filter(filterProviderType)
+      .filter(filterProviderType())
       .filter({ metadata: { labels: matchLabels } })
       .map(fromSeedResource)
       .thru(emptyToUndefined)

--- a/backend/lib/services/projects.js
+++ b/backend/lib/services/projects.js
@@ -155,7 +155,7 @@ exports.list = async function ({ user, qs = {} }) {
   return _
     .chain(projects)
     .filter(project => {
-      if (!isAdmin && !(isMemberOf(project) || isGroupMemberOf(project))) {
+      if (!isAdmin && !isMemberOf(project) && !isGroupMemberOf(project)) {
         return false
       }
       if (!_.isEmpty(phases)) {

--- a/backend/lib/services/projects.js
+++ b/backend/lib/services/projects.js
@@ -138,6 +138,14 @@ exports.list = async function ({ user, qs = {} }) {
     .gte(0)
     .value()
 
+  const isGroupMemberOf = project => !_
+    .chain(project)
+    .get('spec.members')
+    .filter(['kind', 'Group'])
+    .filter(({ name }) => _.includes(user.groups, name))
+    .isEmpty()
+    .value()
+
   const phases = _
     .chain(qs)
     .get('phase', 'Ready')
@@ -147,7 +155,7 @@ exports.list = async function ({ user, qs = {} }) {
   return _
     .chain(projects)
     .filter(project => {
-      if (!isAdmin && !isMemberOf(project)) {
+      if (!isAdmin && !(isMemberOf(project) || isGroupMemberOf(project))) {
         return false
       }
       if (!_.isEmpty(phases)) {

--- a/backend/test/acceptance/api.cloudprofiles.spec.js
+++ b/backend/test/acceptance/api.cloudprofiles.spec.js
@@ -33,9 +33,11 @@ module.exports = function ({ agent, sandbox, auth }) {
 
     expect(res).to.have.status(200)
     expect(res).to.be.json
-    expect(res.body).to.have.length(3)
+    expect(res.body).to.have.length(4)
     let predicate = item => item.metadata.name === 'infra1-profileName'
     expect(_.find(res.body, predicate).data.seeds).to.have.length(3)
+    predicate = item => item.metadata.name === 'infra1-profileName2'
+    expect(_.find(res.body, predicate).data.seeds).to.have.length(2)
     predicate = item => item.metadata.name === 'infra3-profileName'
     expect(_.find(res.body, predicate).data.seeds).to.have.length(1)
     predicate = item => item.metadata.name === 'infra3-profileName2'

--- a/backend/test/acceptance/api.projects.spec.js
+++ b/backend/test/acceptance/api.projects.spec.js
@@ -32,7 +32,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
   const metadata = { name }
   const username = `${name}@example.org`
   const id = username
-  const user = auth.createUser({ id })
+  const user = auth.createUser({ id, groups: ['group1'] })
   const admin = auth.createUser({ id: 'admin@example.org' })
   const role = 'project'
   const owner = 'owner'
@@ -44,7 +44,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
     cache.projects.replace(k8s.projectList)
   })
 
-  it('should return two projects', async function () {
+  it('should return three projects', async function () {
     const bearer = await user.bearer
     k8s.stub.getProjects({ bearer })
     const res = await agent
@@ -53,7 +53,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
 
     expect(res).to.have.status(200)
     expect(res).to.be.json
-    expect(res.body).to.have.length(2)
+    expect(res.body).to.have.length(3)
   })
 
   it('should return all projects', async function () {
@@ -65,7 +65,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
 
     expect(res).to.have.status(200)
     expect(res).to.be.json
-    expect(res.body).to.have.length(4)
+    expect(res.body).to.have.length(6)
   })
 
   it('should return the foo project', async function () {
@@ -104,7 +104,6 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
     // watch project stub
     const project = k8s.getProject({
       name,
-      namespace,
       createdBy,
       owner,
       description,
@@ -152,7 +151,6 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
     // watch project stub
     const project = k8s.getProject({
       name,
-      namespace,
       createdBy,
       owner,
       description,

--- a/backend/test/support/common.js
+++ b/backend/test/support/common.js
@@ -118,6 +118,7 @@ function getQuota ({ name, namespace = 'garden-trial', scope = { apiVersion: 'v1
 
 const cloudProfileList = [
   getCloudProfile('infra1-profileName', 'infra1'),
+  getCloudProfile('infra1-profileName2', 'infra1', { providerTypes: ['infra2', 'infra3']}),
   getCloudProfile('infra2-profileName', 'infra2'),
   getCloudProfile('infra3-profileName', 'infra3', { matchLabels: { foo: 'bar' } }),
   getCloudProfile('infra3-profileName2', 'infra3')


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR includes two improvements:
- `spec.seedSelector.providerTypes` on the cloudprofile is now supported
- is-member check on the project was enhanced to also consider the user's groups

Cloudprofiles need to have a matching seed, otherwise it is filtered out and not visible / selectable on the dashboard. The following describes how a cloudprofile is matched to a seed:
- **Provider type**
  - `spec.type` of the cloud profile has to match `spec.provider.type` of a seed
  - or one of  `spec.seedSelector.providerTypes` (array) of the cloud profile matches `spec.provider.type` of a seed
- **Optional: label selector**
  - in case `spec.seedSelector.matchLabels` is set of a cloud profile, there must be a seed with these `metadata.lables`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user

```
