### PR TITLE
Improve error handling for cluster details

### DIFF
--- a/backend/lib/services/authorization.js
+++ b/backend/lib/services/authorization.js
@@ -60,6 +60,18 @@ exports.canGetOpenAPI = function (user) {
   })
 }
 
+exports.canGetShoot = function (user, namespace, name) {
+  return hasAuthorization(user, {
+    resourceAttributes: {
+      verb: 'get',
+      group: 'core.gardener.cloud',
+      resource: 'shoots',
+      namespace,
+      name
+    }
+  })
+}
+
 /*
 SelfSubjectRulesReview should only be used to hide/show actions or views on the UI and not for authorization checks.
 */

--- a/backend/lib/watches/shoots.js
+++ b/backend/lib/watches/shoots.js
@@ -58,7 +58,7 @@ module.exports = (io, { shootsWithIssues = new Set() } = {}) => {
 
     const namespacedEvents = toNamespacedEvents(event)
     nsp.to(`shoots_${namespace}`).emit('namespacedEvents', namespacedEvents)
-    nsp.to(`shoot_${namespace}_${name}`).emit('namespacedEvents', namespacedEvents)
+    nsp.to(`shoot_${namespace}_${name}`).emit('namespacedEvents', { ...namespacedEvents, kind: 'shoot' })
 
     if (shootHasIssue(object)) {
       nsp.to(`shoots_${namespace}_issues`).emit('namespacedEvents', namespacedEvents)

--- a/backend/test/acceptance/io.spec.js
+++ b/backend/test/acceptance/io.spec.js
@@ -218,10 +218,7 @@ module.exports = function ({ sandbox, auth }) {
       expect(isAdminStub).to.not.be.called
       expect(readShootStub).to.be.calledOnce
       expect(listShootsStub).to.not.be.called
-      expect(event).to.eql({
-        type: 'ADDED',
-        object: find(shootList, { metadata })
-      })
+      expect(event).to.eql(find(shootList, { metadata }))
     })
   })
 

--- a/backend/test/watches.spec.js
+++ b/backend/test/watches.spec.js
@@ -127,14 +127,15 @@ describe('watches', function () {
 
   describe('shoots', function () {
     class Room {
-      constructor (namespace, events) {
+      constructor (namespace, events, kind = 'shoots') {
+        this.kind = kind
         this.namespace = namespace
         this.events = events
       }
 
       emit (event, { kind, namespaces }) {
         expect(event).to.equal('namespacedEvents')
-        expect(kind).to.equal('shoots')
+        expect(kind).to.equal(this.kind)
         expect(namespaces[this.namespace]).to.have.length(1)
         const { objectKey, ...actualEvent } = namespaces[this.namespace][0]
         expect(objectKey).to.equal(actualEvent.object.metadata.uid)
@@ -232,9 +233,9 @@ describe('watches', function () {
         { type: 'ADDED', object: foobar },
         { type: 'MODIFIED', object: foobar },
         { type: 'DELETED', object: foobar }
-      ])
+      ], 'shoot')
 
-      fooBazRoom = new Room('foo', [])
+      fooBazRoom = new Room('foo', [], 'shoot')
 
       fooIssuesRoom = new Room('foo', [])
 
@@ -275,13 +276,13 @@ describe('watches', function () {
       fooBarRoom = new Room('foo', [
         { type: 'ADDED', object: foobarUnhealthy },
         { type: 'MODIFIED', object: foobar }
-      ])
+      ], 'shoot')
 
       fooBazRoom = new Room('foo', [
         { type: 'ADDED', object: foobazUnhealthy },
         { type: 'MODIFIED', object: foobazUnhealthy },
         { type: 'DELETED', object: foobazUnhealthy }
-      ])
+      ], 'shoot')
 
       fooIssuesRoom = new Room('foo', [
         { type: 'ADDED', object: foobarUnhealthy },
@@ -331,11 +332,11 @@ describe('watches', function () {
 
       fooBarRoom = new Room('foo', [
         { type: 'DELETED', object: foobar }
-      ])
+      ], 'shoot')
 
       fooBazRoom = new Room('foo', [
         { type: 'DELETED', object: foobaz }
-      ])
+      ], 'shoot')
 
       fooIssuesRoom = new Room('foo', [])
 

--- a/frontend/src/components/MainNavigation.vue
+++ b/frontend/src/components/MainNavigation.vue
@@ -57,7 +57,7 @@ limitations under the License.
               @keyup.enter="navigateToHighlightedProject"
             >
               <v-icon class="pr-6">mdi-grid-large</v-icon>
-              <span class="ml-2">{{projectName}}</span>
+              <span class="ml-2" :class="{ placeholder: !project }" >{{projectName}}</span>
               <template v-if="project">
                 <stale-project-warning :project="project" small color="white"></stale-project-warning>
               </template>
@@ -522,6 +522,12 @@ export default {
       font-weight: 700;
       font-size: 16px;
       background-color: rgba(0,0,0,0.1) !important;
+      .placeholder::before {
+        content: 'Project';
+        font-weight: 400;
+        color: hsla(0,0%,100%,.7);
+        text-transform: none;
+      }
     }
 
     .v-footer{

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -990,10 +990,9 @@ const actions = {
           reason: 'Timeout'
         }))
       }
-      const handleSubscriptionAcknowledgement = event => {
-        if (event.type === 'ERROR') {
-          const code = event.object.code
-          let { reason, message } = event.object
+      const handleSubscriptionAcknowledgement = object => {
+        if (object.kind === 'Status') {
+          let { code, reason, message } = object
           if (code === 404) {
             reason = 'Cluster not found'
             message = 'The cluster you are looking for doesn\'t exist'
@@ -1017,11 +1016,14 @@ const actions = {
       EmitterWrapper.shootEmitter.subscribeShoot({ name, namespace })
     })
   },
-  subscribeShootAcknowledgement ({ commit, state }, event) {
-    if (event.type !== 'ERROR') {
+  subscribeShootAcknowledgement ({ commit, state }, object) {
+    if (object.kind === 'Shoot') {
       commit('shoots/HANDLE_EVENTS', {
         rootState: state,
-        events: [event]
+        events: [{
+          type: 'ADDED',
+          object
+        }]
       })
       const fetchShootAndShootSeedInfo = async ({ metadata }) => {
         const promises = []
@@ -1037,7 +1039,7 @@ const actions = {
           console.error('Failed to fetch shoot or shootSeed info:', err.message)
         }
       }
-      fetchShootAndShootSeedInfo(event.object)
+      fetchShootAndShootSeedInfo(object)
     }
   },
   getShootInfo ({ dispatch, commit }, { name, namespace }) {

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -989,15 +989,19 @@ const actions = {
       }
       const handleSubscriptionAcknowledgement = event => {
         if (event.type === 'ERROR') {
-          const { message, code } = event.object
-          switch (code) {
-            case 404:
-              done(new Error('Failed to fetch cluster'))
-              break
-            default:
-              done(new Error(message))
-              break
+          const { code, reason } = event.object
+          let text = reason
+          let message = event.object.message
+          if (code === 404) {
+            text = 'Cluster not found'
+            message = 'The cluster you are looking for doesn\'t exist!'
+          } else if (code === 403) {
+            text = 'Access to cluster denied'
+          } else if (code >= 500) {
+            text = 'Oops, something went wrong'
+            message = 'An unexpected error occurred. Please try again later.'
           }
+          done(Object.assign(new Error(message), { code, text }))
         } else {
           done()
         }

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -1223,7 +1223,7 @@ const actions = {
           items
         })
       } catch (err) {
-        dispatch('setError', err)
+        console.warn('Failed to list project terminal shortcuts:', err.message)
       }
     }
   },

--- a/frontend/src/store/modules/shoots.js
+++ b/frontend/src/store/modules/shoots.js
@@ -692,8 +692,6 @@ const mutations = {
     state.shoots = {}
     state.sortedShoots = []
     state.filteredAndSortedShoots = []
-    state.subscriptionError = undefined
-    state.subscriptionDone = undefined
   },
   SET_SHOOT_LIST_FILTERS (state, { rootState, value }) {
     state.shootListFilters = value

--- a/frontend/src/utils/Emitter.js
+++ b/frontend/src/utils/Emitter.js
@@ -186,6 +186,16 @@ class ShootsSubscription extends AbstractSubscription {
 }
 
 class ShootSubscription extends AbstractSubscription {
+  constructor (connector) {
+    super(connector)
+
+    this.socket.on('namespacedEvents', ({ kind, namespaces }) => {
+      if (kind === 'shoot') {
+        this.emit(kind, namespaces)
+      }
+    })
+  }
+
   subscribeShoot ({ name, namespace }) {
     this.subscribeOnNextTrigger({ name, namespace })
     this.subscribe()

--- a/frontend/src/utils/Emitter.js
+++ b/frontend/src/utils/Emitter.js
@@ -204,8 +204,8 @@ class ShootSubscription extends AbstractSubscription {
   async _subscribe () {
     const { namespace, name } = this.subscribeTo
     // TODO clear shoot from store?
-    this.socket.emit('subscribeShoot', { namespace, name }, event => {
-      store.dispatch('subscribeShootAcknowledgement', event)
+    this.socket.emit('subscribeShoot', { namespace, name }, object => {
+      store.dispatch('subscribeShootAcknowledgement', object)
     })
     return true
   }

--- a/frontend/src/views/ShootItemPlaceholder.vue
+++ b/frontend/src/views/ShootItemPlaceholder.vue
@@ -69,13 +69,18 @@ export default {
     handleShootEvents (events) {
       const { namespace, name } = get(this.$route, 'params', {})
       for (const { type, object: { metadata = {} } } of events) {
-        if (type === 'DELETED' && metadata.namespace === namespace && metadata.name === name) {
-          this.error = Object.assign(new Error('The cluster you are looking for is no longer available'), {
-            code: 410,
-            reason: 'Cluster is gone'
-          })
-          this.component = 'shoot-item-error'
-          return
+        if (metadata.namespace === namespace && metadata.name === name) {
+          if (type === 'DELETED') {
+            this.error = Object.assign(new Error('The cluster you are looking for is no longer available'), {
+              code: 410,
+              reason: 'Cluster is gone'
+            })
+            this.component = 'shoot-item-error'
+          } else if (type === 'ADDED' && includes([404, 410], get(this.error, 'code'))) {
+            this.error = undefined
+            this.component = 'router-view'
+          }
+          break
         }
       }
     },

--- a/frontend/src/views/ShootItemPlaceholder.vue
+++ b/frontend/src/views/ShootItemPlaceholder.vue
@@ -45,8 +45,12 @@ export default {
     componentProperties () {
       switch (this.component) {
         case 'shoot-item-error': {
-          const { code, text, message } = this.error
-          return { code, text, message }
+          const {
+            code = 500,
+            reason = 'Oops, something went wrong',
+            message = 'An unexpected error occurred. Please try again later'
+          } = this.error
+          return { code, text: reason, message }
         }
         default: {
           return {}
@@ -66,9 +70,9 @@ export default {
       const { namespace, name } = get(this.$route, 'params', {})
       for (const { type, object: { metadata = {} } } of events) {
         if (type === 'DELETED' && metadata.namespace === namespace && metadata.name === name) {
-          this.error = Object.assign(new Error('The cluster you are looking for is no longer available!'), {
+          this.error = Object.assign(new Error('The cluster you are looking for is no longer available'), {
             code: 410,
-            text: 'Cluster is gone'
+            reason: 'Cluster is gone'
           })
           this.component = 'shoot-item-error'
           return


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves the error handling for the cluster details page.
1. More user friendly error messages and correct error codes.
2. Fixes the bug when switching project from the cluster details page.
3. Better handling for cluster deletion while the user in on the cluster details page.

**Which issue(s) this PR fixes**:
Fixes #800, Fixes #801 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
NONE
```
