### PR TITLE
Hide terminal shortcuts tab if disabled

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -59,7 +59,7 @@
     "vuelidate": "^0.7.5",
     "vuetify": "^2.2.11",
     "vuex": "^3.1.3",
-    "xterm": "^4.8.1",
+    "xterm": "^4.9.0",
     "xterm-addon-fit": "^0.4.0",
     "xterm-addon-web-links": "^0.4.0"
   },

--- a/frontend/src/components/TerminalSettings.vue
+++ b/frontend/src/components/TerminalSettings.vue
@@ -192,8 +192,8 @@ export default {
       return this.selectedRunOnShootWorker ? 'black--text' : 'grey--text'
     },
     selectedConfig () {
-      const node = this.selectedNode === this.autoSelectNodeItem.data.kubernetesHostname 
-        ? undefined 
+      const node = this.selectedNode === this.autoSelectNodeItem.data.kubernetesHostname
+        ? undefined
         : this.selectedNode
       const selectedConfig = {
         container: {
@@ -216,8 +216,8 @@ export default {
     initialize ({ container = {}, defaultNode, currentNode, privilegedMode, nodes = [] }) {
       this.selectedContainerImage = container.image
       if (!defaultNode) {
-        defaultNode = this.isAdmin 
-          ? get(head(nodes), 'data.kubernetesHostname') 
+        defaultNode = this.isAdmin
+          ? get(head(nodes), 'data.kubernetesHostname')
           : this.autoSelectNodeItem.data.kubernetesHostname
       }
       this.selectedNode = defaultNode

--- a/frontend/src/components/TerminalShortcut.vue
+++ b/frontend/src/components/TerminalShortcut.vue
@@ -23,11 +23,10 @@ limitations under the License.
       <v-list-item-content class="py-0">
         <v-list-item-title>
           {{shortcut.title}}
-          <v-tooltip top max-width="400px">
+          <v-tooltip v-if="isUnverified" top max-width="400px">
             <template v-slot:activator="{ on }">
               <v-chip
                 v-on="on"
-                v-if="isUnverified"
                 small
                 class="my-0 ml-2"
                 outlined

--- a/frontend/src/components/TerminalShortcut.vue
+++ b/frontend/src/components/TerminalShortcut.vue
@@ -28,7 +28,7 @@ limitations under the License.
               <v-chip
                 v-on="on"
                 small
-                class="my-0 ml-2"
+                class="my-0 ml-2 enablePointerEvents"
                 outlined
                 color="orange darken-2">
                 Unverified

--- a/frontend/src/components/dialogs/CreateTerminalSessionDialog.vue
+++ b/frontend/src/components/dialogs/CreateTerminalSessionDialog.vue
@@ -27,7 +27,7 @@ limitations under the License.
     <template v-slot:message>
       <v-tabs v-model="tab" color="cyan darken-2">
         <v-tab key="target-tab" href="#target-tab">Terminal</v-tab>
-        <v-tab key="shortcut-tab" href="#shortcut-tab">Terminal Shortcuts</v-tab>
+        <v-tab v-if="isTerminalShortcutsFeatureEnabled" key="shortcut-tab" href="#shortcut-tab">Terminal Shortcuts</v-tab>
       </v-tabs>
       <v-tabs-items v-model="tab">
         <v-tab-item key="target-tab" value="target-tab">
@@ -132,7 +132,8 @@ export default {
       'hasShootTerminalAccess',
       'hasGardenTerminalAccess',
       'isAdmin',
-      'shootByNamespaceAndName'
+      'shootByNamespaceAndName',
+      'isTerminalShortcutsFeatureEnabled'
     ]),
     shootItem () {
       return this.shootByNamespaceAndName({ name: this.name, namespace: this.namespace })

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -9775,10 +9775,10 @@ xterm-addon-web-links@^0.4.0:
   resolved "https://registry.yarnpkg.com/xterm-addon-web-links/-/xterm-addon-web-links-0.4.0.tgz#265cbf8221b9b315d0a748e1323bee331cd5da03"
   integrity sha512-xv8GeiINmx0zENO9hf5k+5bnkaE8mRzF+OBAr9WeFq2eLaQSudioQSiT34M1ofKbzcdjSsKiZm19Rw3i4eXamg==
 
-xterm@^4.8.1:
-  version "4.8.1"
-  resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.8.1.tgz#155a1729a43e1a89b406524e22c5634339e39ca1"
-  integrity sha512-ax91ny4tI5eklqIfH79OUSGE2PUX2rGbwONmB6DfqpyhSZO8/cf++sqiaMWEVCMjACyMfnISW7C3gGMoNvNolQ==
+xterm@^4.9.0:
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.9.0.tgz#7a4c097a433d565339b5533b468bbc60c6c87969"
+  integrity sha512-wGfqufmioctKr8VkbRuZbVDfjlXWGZZ1PWHy1yqqpGT3Nm6yaJx8lxDbSEBANtgaiVPTcKSp97sxOy5IlpqYfw==
 
 y18n@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
**What this PR does / why we need it**:
<img width="803" alt="Screenshot 2020-09-16 at 21 50 55" src="https://user-images.githubusercontent.com/5526658/93385574-ba0d2e00-f866-11ea-8ca0-f9298119f506.png">

- The terminal shortcuts tab should be hidden if there is no terminal shortcuts configuration `frontendConfig.terminal.shortcuts` or `frontendConfig.features.projectTerminalShortcutsEnabled = false`.
- This PR also fixes the issue that the tooltip was not showing on the `Unverified` chip for hibernated clusters.
- Bump xtermjs to 4.9.0
<img width="773" alt="Screenshot 2020-09-16 at 21 52 03" src="https://user-images.githubusercontent.com/5526658/93385695-e4f78200-f866-11ea-8ade-a432f7caa5b4.png">



**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user

```
