### PR TITLE
Fixed issue that workers could not be modified via dashboard if unuse…

### DIFF
--- a/frontend/src/utils/createShoot.js
+++ b/frontend/src/utils/createShoot.js
@@ -282,7 +282,7 @@ export function getZonesNetworkConfiguration (oldZonesNetworkConfiguration, newW
     if (availableNetworksLength < newUniqueZones.length) {
       return undefined
     }
-    return map(newUniqueZones, zone => {
+    const newZonesNetworkConfiguration = map(newUniqueZones, zone => {
       let zoneConfiguration = find(existingZonesNetworkConfiguration, { name: zone })
       if (zoneConfiguration) {
         return zoneConfiguration
@@ -293,11 +293,15 @@ export function getZonesNetworkConfiguration (oldZonesNetworkConfiguration, newW
         ...zoneConfiguration
       }
     })
+
+    // order is important => keep oldZonesNetworkConfiguration order
+    return uniq([...oldZonesNetworkConfiguration, ...newZonesNetworkConfiguration])
   }
 
   if (existingZonesNetworkConfiguration.length !== newUniqueZones.length) {
     return defaultZonesNetworkConfiguration
   }
+
   return existingZonesNetworkConfiguration
 }
 

--- a/frontend/tests/unit/utils.createShoot.spec.js
+++ b/frontend/tests/unit/utils.createShoot.spec.js
@@ -200,7 +200,7 @@ describe('utils', function () {
         expect(zonesNetworkConfiguration).to.have.length(2)
       })
 
-      it('should keep network config for if zones are the same', function () {
+      it('should keep network config if zones are the same', function () {
         const zonesNetworkConfiguration = getZonesNetworkConfiguration(customZonesNetworkConfiguration, workers, 'aws', 3)
         expect(zonesNetworkConfiguration).to.be.an.instanceof(Array)
         expect(zonesNetworkConfiguration).to.have.length(2)
@@ -225,6 +225,21 @@ describe('utils', function () {
         expect(zonesNetworkConfiguration).to.be.an.instanceof(Array)
         expect(zonesNetworkConfiguration).to.have.length(2)
         expect(zonesNetworkConfiguration).to.not.eql(customZonesNetworkConfiguration)
+      })
+
+      it('should return existing unused zone network configurations', function () {
+        const oneZoneWorkers = [
+          {
+            zones: [
+              'barZone'
+            ]
+          }
+        ]
+
+        const zonesNetworkConfiguration = getZonesNetworkConfiguration(customZonesNetworkConfiguration, oneZoneWorkers, 'aws', 3, '10.250.0.0/16')
+        expect(zonesNetworkConfiguration).to.be.an.instanceof(Array)
+        expect(zonesNetworkConfiguration).to.have.length(2)
+        expect(zonesNetworkConfiguration).to.eql(customZonesNetworkConfiguration)
       })
 
       it('should extend network config for existing shoot if additional zones are added', function () {


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #805

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Fixed: Workers can not be modified via the Dashboard UI if unused zone configurations exist for a cluster
```
