### PR TITLE
Automatically select region without seed

### DIFF
--- a/frontend/src/components/NewShoot/NewShootInfrastructureDetails.vue
+++ b/frontend/src/components/NewShoot/NewShootInfrastructureDetails.vue
@@ -430,8 +430,10 @@ export default {
     regionsWithoutSeed () {
       return this.regionsWithoutSeedByCloudProfileName(this.cloudProfileName)
     },
+    showAllRegions () {
+      return !isEmpty(this.cfg.seedCandidateDeterminationStrategy) && this.cfg.seedCandidateDeterminationStrategy !== 'SameRegion'
+    },
     regionItems () {
-      const showAllRegions = !isEmpty(this.cfg.seedCandidateDeterminationStrategy) && this.cfg.seedCandidateDeterminationStrategy !== 'SameRegion'
       const regionItems = []
       if (!isEmpty(this.regionsWithSeed)) {
         regionItems.push({ header: 'Recommended Regions (API servers in same region)' })
@@ -439,7 +441,7 @@ export default {
       forEach(this.regionsWithSeed, region => {
         regionItems.push({ text: region })
       })
-      if (showAllRegions && !isEmpty(this.regionsWithoutSeed)) {
+      if (this.showAllRegions && !isEmpty(this.regionsWithoutSeed)) {
         regionItems.push({ header: 'Supported Regions (API servers in another region)' })
         forEach(this.regionsWithoutSeed, region => {
           regionItems.push({ text: region })
@@ -511,6 +513,9 @@ export default {
       this.secret = head(this.infrastructureSecretsByProfileName)
       this.onInputSecret()
       this.region = head(this.regionsWithSeed)
+      if (!this.region && this.showAllRegions) {
+        this.region = head(this.regionsWithoutSeed)
+      }
       this.onInputRegion()
       this.loadBalancerProviderName = head(this.allLoadBalancerProviderNames)
       this.onInputLoadBalancerProviderName()

--- a/frontend/src/components/NewShoot/NewShootInfrastructureDetails.vue
+++ b/frontend/src/components/NewShoot/NewShootInfrastructureDetails.vue
@@ -431,7 +431,7 @@ export default {
       return this.regionsWithoutSeedByCloudProfileName(this.cloudProfileName)
     },
     showAllRegions () {
-      return !isEmpty(this.cfg.seedCandidateDeterminationStrategy) && this.cfg.seedCandidateDeterminationStrategy !== 'SameRegion'
+      return this.cfg.seedCandidateDeterminationStrategy && this.cfg.seedCandidateDeterminationStrategy !== 'SameRegion'
     },
     regionItems () {
       const regionItems = []


### PR DESCRIPTION
**What this PR does / why we need it**:
Automatically select region without seed in case there is no region with a seed

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @rfranzke 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user

```
