### PR TITLE
Remove "Last Updated" from conditions

### DIFF
--- a/frontend/src/components/ShootMessageDetails.vue
+++ b/frontend/src/components/ShootMessageDetails.vue
@@ -42,7 +42,7 @@ limitations under the License.
       </v-list-item>
     </template>
     <v-divider inset></v-divider>
-    <v-list-item>
+    <v-list-item v-if="lastUpdateTime">
       <v-list-item-icon>
         <v-icon color="cyan darken-2">mdi-clock-outline</v-icon>
       </v-list-item-icon>
@@ -139,12 +139,6 @@ export default {
     },
     namespace: {
       type: String
-    }
-  },
-  data () {
-    return {
-      showLastUpdateTimePlaceholder: true,
-      showLastTransitionTimePlaceholder: true
     }
   },
   computed: {

--- a/frontend/src/components/StatusTag.vue
+++ b/frontend/src/components/StatusTag.vue
@@ -189,11 +189,11 @@ export default {
       return `statusTag_${this.popperKey}`
     },
     tag () {
-      const { lastTransitionTime, lastUpdateTime, message, status, type, codes } = this.condition
+      const { lastTransitionTime, message, status, type, codes } = this.condition
       const id = type
       const { displayName: name, shortName, description } = this.conditionMetadataFromType(type)
 
-      return { id, name, shortName, description, message, lastTransitionTime, lastUpdateTime, status, codes }
+      return { id, name, shortName, description, message, lastTransitionTime, status, codes }
     },
     color () {
       if (this.isError) {

--- a/frontend/src/components/StatusTag.vue
+++ b/frontend/src/components/StatusTag.vue
@@ -58,7 +58,6 @@ limitations under the License.
         :statusTitle="chipStatus"
         :lastMessage="nonErrorMessage"
         :errorDescriptions="errorDescriptions"
-        :lastUpdateTime="tag.lastUpdateTime"
         :lastTransitionTime="tag.lastTransitionTime"
         :secretName="secretName"
         :namespace="namespace"


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove `Last Updated` from conditions / readiness chips as `lastUpdateTime` field will be not be updated anymore in future gardener versions

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @rfranzke 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user

```
