### PR TITLE
Show correct navigation menu in case of ALL PROJECTS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .DS_Store
 .idea
 .vscode
+.yarn
+coverage
 
 # Ignore kubeconfig
 kubeconfig*

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -233,7 +233,7 @@ export function routes (router, includeRoutesWithProjectScope) {
     return children && children.length
   }
   const hasMenu = ({ meta: { menu, projectScope } = {} }) => {
-    return menu && (includeRoutesWithProjectScope || !projectScope)
+    return menu && (includeRoutesWithProjectScope || projectScope === false)
   }
   const traverseRoutes = routes => {
     for (const route of routes) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the issue with the wrong menu item in case of `ALL PROJECTS`. The menu items `SECRETS`, `MEMBERS` and `ADMINISTRATION` menu items will now only be visible if a single project is selected.

<img width="200" alt="Screen Shot 2020-09-29 at 16 39 48" src="https://user-images.githubusercontent.com/1574023/94573481-6ccf8a00-0272-11eb-8dff-5871be5208d9.png">

**Which issue(s) this PR fixes**:
Fixes #813

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
The correct navigation menu is shown if ALL PROJECTS is selected
```

