### PR TITLE
[hotfix-1.46] Fix: project creation not possible

### DIFF
--- a/frontend/src/router/routes.js
+++ b/frontend/src/router/routes.js
@@ -191,7 +191,7 @@ function errorRoute (context, path) {
   }
 }
 
-function homeRoute ({ getters }, path) {
+function homeRoute ({ getters, dispatch }, path) {
   return {
     path,
     name: 'Home',
@@ -201,8 +201,14 @@ function homeRoute ({ getters }, path) {
       projectScope: false,
       breadcrumbs: homeBreadcrumbs
     },
-    beforeEnter (to, from, next) {
+    async beforeEnter (to, from, next) {
       const namespace = getters.defaultNamespace
+      try {
+        await dispatch('refreshSubjectRules', namespace) // namespace may also be undefined and will be defaulted
+      } catch (error) {
+        console.error('could not refresh subject rules', error.message)
+      }
+
       if (namespace) {
         return next({
           name: 'ShootList',


### PR DESCRIPTION
**What this PR does / why we need it**:
(cherry picked from commit a32463a812d043187c6e9e7fa333b2903ccd31ac)

Fixed issue that project creation was not possible unless you were assigned to at least one project

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Fixed issue that project creation was not possible unless you were assigned to at least one project
```
