### PR TITLE
[hotfix-1.46] Return 404 Not Found for not existing static assets #819

### DIFF
--- a/backend/lib/app.js
+++ b/backend/lib/app.js
@@ -83,13 +83,13 @@ app.use(helmet.referrerPolicy({
 }))
 
 app.use(express.static(PUBLIC_DIRNAME))
+app.use(['/css', '/fonts', '/img', '/js'], notFound)
 
 app.use(helmet.frameguard({
   action: 'deny'
 }))
 app.use(historyFallback(INDEX_FILENAME))
 
-app.use(notFound)
 app.use(renderError)
 
 module.exports = app


### PR DESCRIPTION
**What this PR does / why we need it**:
If an old client refers to static assets (css, fonts, js, img) which do not exist anymore the server returns the index.html with status code 200. With this PR the server returns a 404 Not Found in this case. This should avoid the following kind of error messages in the browser after dashboard updates.
![Screen Shot 2020-09-29 at 1 46 39 PM](https://user-images.githubusercontent.com/1574023/94795844-3a42a000-03de-11eb-871b-e7705749836c.png)

**Which issue(s) this PR fixes**:
Fixes #816

**Special notes for your reviewer**:
The commit #7ccfda577887ff9b510744c903565a9722d38f37 which is already in the `hotfix-1.46` branch but not part of this PR fixes issue #813. The note below has been added here that occurs in the release notes of the hotfix. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user github.com/gardener/dashboard $7ccfda577887ff9b510744c903565a9722d38f37 @holgerkoser
The correct navigation menu is shown if ALL PROJECTS is selected
```

```improvement user
Avoid the "Loading CSS chunk `chunk-xxxxxxxx (/css/chunk-xxxxxxxx.yyyyyyyy.css)` failed" error messages 
```
