### PR TITLE
Ticket usability improvements

### DIFF
--- a/charts/__tests__/gardener-dashboard.spec.js
+++ b/charts/__tests__/gardener-dashboard.spec.js
@@ -326,6 +326,7 @@ describe('gardener-dashboard', function () {
           const values = writeValues(filename, {
             frontendConfig: {
               ticket: {
+                avatarSource: 'gravatar',
                 gitHubRepoUrl: 'https://github.com/gardener/tickets',
                 hideClustersWithLabels: ['ignore1', 'ignore2'],
                 newTicketLabels: ['default-label'],
@@ -357,6 +358,7 @@ describe('gardener-dashboard', function () {
             gitHub
           } = config
           expect(ticket).toEqual({
+            avatarSource: 'gravatar',
             gitHubRepoUrl: 'https://github.com/gardener/tickets',
             hideClustersWithLabels: ['ignore1', 'ignore2'],
             newTicketLabels: ['default-label'],

--- a/charts/gardener-dashboard/templates/configmap.yaml
+++ b/charts/gardener-dashboard/templates/configmap.yaml
@@ -170,6 +170,7 @@ data:
           {{- end }}
         {{- end }}
         gitHubRepoUrl: {{ .Values.frontendConfig.ticket.gitHubRepoUrl }}
+        avatarSource: {{ .Values.frontendConfig.ticket.avatarSource | default "github" }}
         issueDescriptionTemplate: |-
 {{ .Values.frontendConfig.ticket.issueDescriptionTemplate | trim | indent 10 }}
       {{- end }}

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -76,6 +76,7 @@ frontendConfig:
     icon: bug_report
     url: https://github.com/gardener/gardener/issues
   # ticket:
+  #   avatarSource: github # Define from which source the avatar is fetched. For enterprise github instances it is recommended to use gravatar or none. Possible values: github, gravatar, none
   #   gitHubRepoUrl: https://foo-github.com/dummyorg/dummyrepo
   #   hideClustersWithLabels: # hides clusters with labels on the 'ALL PROJECTS' page if the respective table option is enabled
   #   - ignore

--- a/frontend/src/components/ShootListRow.vue
+++ b/frontend/src/components/ShootListRow.vue
@@ -103,9 +103,9 @@ limitations under the License.
       <template v-if="shootLastUpdatedTicketTimestamp && !shootTicketsLabels.length">
         None
       </template>
-      <template v-else>
-        <ticket-labels :labels="shootTicketsLabels"></ticket-labels>
-      </template>
+      <div class="labels" v-else>
+        <ticket-label v-for="label in shootTicketsLabels" :key="label.id" :label="label"></ticket-label>
+      </div>
     </td>
     <td class="action-button-group text-right nowrap" v-if="this.headerVisible['actions']">
       <v-row class="fill-height" align="center" justify="end" >
@@ -139,7 +139,7 @@ import StatusTags from '@/components/StatusTags'
 import PurposeTag from '@/components/PurposeTag'
 import TimeString from '@/components/TimeString'
 import ShootVersion from '@/components/ShootVersion/ShootVersion'
-import TicketLabels from '@/components/ShootTickets/TicketLabels'
+import TicketLabel from '@/components/ShootTickets/TicketLabel'
 import SelfTerminationWarning from '@/components/SelfTerminationWarning'
 import HibernationScheduleWarning from '@/components/ShootHibernation/HibernationScheduleWarning'
 import ShootSeedName from '@/components/ShootSeedName'
@@ -162,7 +162,7 @@ export default {
     ShootStatus,
     TimeString,
     ShootVersion,
-    TicketLabels,
+    TicketLabel,
     SelfTerminationWarning,
     HibernationScheduleWarning,
     AccountAvatar,
@@ -252,6 +252,10 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
+  .labels {
+    line-height: 10px;
+  }
+
   .action-button-group {
     white-space: nowrap;
 

--- a/frontend/src/components/ShootTickets/Ticket.vue
+++ b/frontend/src/components/ShootTickets/Ticket.vue
@@ -16,8 +16,11 @@ limitations under the License.
 
 <template>
   <v-card>
-    <v-card-title class="subtitle-1 white--text cyan darken-2 mt-4 ticketTitle">
-      Ticket {{ticketTitle}}<ticket-labels class="ml-2" :labels="ticket.data.labels"></ticket-labels>
+    <v-card-title class="subtitle-1 white--text cyan darken-2 mt-4 ticket-toolbar">
+      <div class="d-flex flex-wrap align-center">
+        <div class="ticket-title mr-2">Ticket {{ticketTitle}}</div>
+        <div v-if="labels.length" class="labels"><ticket-label v-for="label in labels" :key="label.id" :label="label"></ticket-label></div>
+      </div>
     </v-card-title>
 
     <v-container>
@@ -45,13 +48,13 @@ limitations under the License.
 import get from 'lodash/get'
 import { mapState, mapGetters } from 'vuex'
 import TimeString from '@/components/TimeString'
-import TicketLabels from '@/components/ShootTickets/TicketLabels'
+import TicketLabel from '@/components/ShootTickets/TicketLabel'
 import TicketComment from '@/components/ShootTickets/TicketComment'
 
 export default {
   components: {
     TimeString,
-    TicketLabels,
+    TicketLabel,
     TicketComment
   },
   props: {
@@ -77,6 +80,9 @@ export default {
     ticketHtmlUrl () {
       return get(this.ticket, 'data.html_url')
     },
+    labels () {
+      return get(this.ticket, 'data.labels', [])
+    },
     commentsForTicket () {
       const issueNumber = get(this.ticket, 'metadata.number')
       return this.ticketCommentsByIssueNumber({ issueNumber })
@@ -92,8 +98,14 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-
-  .ticketTitle {
+  .ticket-toolbar {
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+  .ticket-title {
+    line-height: 20px;
+  }
+  .labels {
     line-height: 10px;
   }
 

--- a/frontend/src/components/ShootTickets/Ticket.vue
+++ b/frontend/src/components/ShootTickets/Ticket.vue
@@ -29,10 +29,10 @@ limitations under the License.
       <a :href="ticketHtmlUrl" target="_blank" class="link-icon"><v-icon color="cyan darken-2" class="link-icon">mdi-open-in-new</v-icon></a>
       <time-string :dateTime="ticket.metadata.created_at" mode="past"></time-string>
     </v-container>
-    <v-container>
+    <v-list>
       <ticket-comment :comment="ticket"></ticket-comment>
       <ticket-comment v-for="comment in commentsForTicket" :key="comment.metadata.id" :comment="comment"></ticket-comment>
-    </v-container>
+    </v-list>
     <v-card-actions v-if="!!gitHubRepoUrl">
       <v-spacer></v-spacer>
       <v-btn text class="action-button cyan--text text--darken-2" :href="addCommentLink" target="_blank" title="Add Comment">

--- a/frontend/src/components/ShootTickets/TicketComment.vue
+++ b/frontend/src/components/ShootTickets/TicketComment.vue
@@ -91,7 +91,7 @@ export default {
 <style lang="scss" scoped>
   @import '~vuetify/src/styles/styles.sass';
 
-  $cyan-darken-2: map-get($cyan, 'darken-1');
+  $cyan-darken-1: map-get($cyan, 'darken-1');
 
   .comment {
     padding: 0;
@@ -105,24 +105,18 @@ export default {
     border-top-left-radius: 2px;
     border-top-right-radius: 2px;
     border: 0.5px;
-    border-bottom: 0.5px solid$cyan-darken-2;
-    background-color:$cyan-darken-2;
+    border-bottom: 0.5px solid $cyan-darken-1;
+    background-color: $cyan-darken-1;
     color: white;
 
-    padding-left: 8px;
-    padding-right: 8px;
-    padding-top: 4px;
-    padding-bottom: 4px;
+    padding: 4px 8px;
     margin-bottom: 0;
   }
 
   .comment-body {
-    border: 0.5px solid$cyan-darken-2;
+    border: 0.5px solid $cyan-darken-1;
 
-    padding-left: 8px;
-    padding-right: 8px;
-    padding-top: 4px;
-    padding-bottom: 4px;
+    padding: 4px 8px;
 
     /* not needed for chrome, but kept for firefox */
     word-wrap: break-word;

--- a/frontend/src/components/ShootTickets/TicketComment.vue
+++ b/frontend/src/components/ShootTickets/TicketComment.vue
@@ -15,22 +15,22 @@ limitations under the License.
 -->
 
 <template>
-  <v-row dense class="flex-nowrap">
-    <v-col cols="1" v-if="avatarUrl" style="min-width: 50px;">
+  <v-list-item>
+    <v-list-item-avatar v-if="avatarUrl" class="align-self-start">
       <v-avatar size="40px">
         <img :src="avatarUrl" :title="login"/>
       </v-avatar>
-    </v-col>
-    <v-col :cols="!avatarUrl ? 12 : 11">
-      <div :class="{ comment: true, 'comment-no-avatar': !avatarUrl}">
-        <div class="comment-header">
-          <span style="font-weight: 700">{{login}}</span> commented <a :href="htmlUrl" target="_blank"><time-string :dateTime="createdAt" mode="past"></time-string></a>
-        </div>
-        <div class="comment-body" v-html="compiledMarkdown"></div>
-      </div>
-    </v-col>
-  </v-row>
-
+    </v-list-item-avatar>
+    <v-list-item-icon v-else class="align-self-start">
+      <v-icon color="cyan darken-2">mdi-comment-outline</v-icon>
+    </v-list-item-icon>
+    <v-list-item-content class="comment">
+      <v-list-item-title class="comment-header">
+        <span class="font-weight-bold">{{login}}</span> commented <a :href="htmlUrl" target="_blank"><time-string :dateTime="createdAt" mode="past"></time-string></a>
+      </v-list-item-title>
+      <v-list-item-subtitle class="wrap-text comment-body" v-html="compiledMarkdown"></v-list-item-subtitle>
+    </v-list-item-content>
+    </v-list-item>
 </template>
 
 <script>
@@ -89,30 +89,40 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+  @import '~vuetify/src/styles/styles.sass';
 
-  .comment-no-avatar {
-    margin-left: 16px;
-  }
+  $cyan-darken-2: map-get($cyan, 'darken-1');
 
   .comment {
-    border-radius: 2px;
-    border: 0.5px;
-    border-color: #00acc1;
-    border-style: solid;
-    margin-right: 16px;
+    padding: 0;
+    margin-bottom: 12px;
   }
+  .wrap-text {
+    white-space: normal;
+  }
+
   .comment-header {
     border-top-left-radius: 2px;
     border-top-right-radius: 2px;
     border: 0.5px;
-    padding: 5px;
-    border-bottom: 0.5px solid #00acc1;
-    background-color: #00acc1;
+    border-bottom: 0.5px solid$cyan-darken-2;
+    background-color:$cyan-darken-2;
     color: white;
-    font-weight: 400;
+
+    padding-left: 8px;
+    padding-right: 8px;
+    padding-top: 4px;
+    padding-bottom: 4px;
+    margin-bottom: 0;
   }
+
   .comment-body {
-    padding: 5px;
+    border: 0.5px solid$cyan-darken-2;
+
+    padding-left: 8px;
+    padding-right: 8px;
+    padding-top: 4px;
+    padding-bottom: 4px;
 
     /* not needed for chrome, but kept for firefox */
     word-wrap: break-word;

--- a/frontend/src/components/ShootTickets/TicketLabel.vue
+++ b/frontend/src/components/ShootTickets/TicketLabel.vue
@@ -15,12 +15,9 @@ limitations under the License.
 -->
 
 <template>
-  <span v-if="labels.length">
-    <span v-for="label in labels" :key="label.id" class="label-color" :style="labelStyle(label)">
-      {{ label.name }}
-    </span>
+  <span class="label-color" :style="labelStyle(label)">
+    {{ label.name }}
   </span>
-
 </template>
 
 <script>
@@ -29,8 +26,8 @@ import get from 'lodash/get'
 
 export default {
   props: {
-    labels: {
-      type: Array,
+    label: {
+      type: Object,
       required: true
     }
   },
@@ -49,12 +46,14 @@ export default {
 <style lang="scss" scoped>
 
   .label-color {
-      margin-left: 4px;
-      padding: 2px 4px;
-      font-size: 12px;
-      font-weight: 600;
-      border-radius: 2px;
-      box-shadow: inset 0 -1px 0 rgba(27,31,35,0.12);
+    line-height: 10px;
+    margin: 2px;
+    padding: 2px 4px;
+    font-size: 12px;
+    font-weight: 600;
+    border-radius: 2px;
+    box-shadow: inset 0 -1px 0 rgba(27,31,35,0.12);
+    display: inline-block;
   }
 
 </style>


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes several issues with the ticket feature

- line height of the title is wrong
- avatar is not loading when using enterprise github instance
- layout is broken
- code block exceeds parent container

It introduces a setting to specify the avatar source to be either
- `github`(default) - uses the avatar_url to fetch the avatar from github. Fetching the avatar image from an enterprise github could fail in case an authentication is required. In this case, use either `gravatar` or `none`
- `gravatar` - uses logon name to fetch the avatar from gravatar
- `none` - no avatar is displayed

Example `values.yaml`:
```yaml
frontendConfig:
  ticket:
    avatarSource: gravatar
```

Gravatar:
<img width="483" alt="Screenshot 2020-10-08 at 11 28 00" src="https://user-images.githubusercontent.com/5526658/95441022-ed207a00-0959-11eb-8fea-09c69141096c.png">

No avatar:
<img width="490" alt="Screenshot 2020-10-08 at 11 30 32" src="https://user-images.githubusercontent.com/5526658/95441008-e8f45c80-0959-11eb-85b0-e78ae5e23e44.png">

Fixed UI issues:
<img width="482" alt="Screenshot 2020-10-08 at 11 31 23" src="https://user-images.githubusercontent.com/5526658/95441026-f01b6a80-0959-11eb-88bd-a461e538bebf.png">


**Which issue(s) this PR fixes**:
Fixes #824 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Fixed some UI issues of the tickets feature
```
