### PR TITLE
Automatically select region without seed

### DIFF
--- a/frontend/src/store/modules/shoots.js
+++ b/frontend/src/store/modules/shoots.js
@@ -231,7 +231,13 @@ const actions = {
     const secret = head(rootGetters.infrastructureSecretsByCloudProfileName(cloudProfileName))
     set(shootResource, 'spec.secretBindingName', get(secret, 'metadata.bindingName'))
 
-    const region = head(rootGetters.regionsWithSeedByCloudProfileName(cloudProfileName))
+    let region = head(rootGetters.regionsWithSeedByCloudProfileName(cloudProfileName))
+    if (!region) {
+      const seedDeterminationStrategySameRegion = rootState.cfg.seedCandidateDeterminationStrategy === 'SameRegion'
+      if (!seedDeterminationStrategySameRegion) {
+        region = head(rootGetters.regionsWithoutSeedByCloudProfileName(cloudProfileName))
+      }
+    }
     set(shootResource, 'spec.region', region)
 
     const loadBalancerProviderName = head(rootGetters.loadBalancerProviderNamesByCloudProfileNameAndRegion({ cloudProfileName, region }))


### PR DESCRIPTION
**What this PR does / why we need it**:
Automatically select region without seed in case there is no region with a seed

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
missing part of #809

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user

```
