### PR TITLE
Fix broken splitpanes

### DIFF
--- a/frontend/src/components/GSplitpane.vue
+++ b/frontend/src/components/GSplitpane.vue
@@ -38,7 +38,6 @@ limitations under the License.
 import { mapActions } from 'vuex'
 import { Splitpanes, Pane } from 'splitpanes'
 import GSplitpane from '@/components/GSplitpane'
-import { SplitpaneTree } from '@/lib/g-symbol-tree'
 
 export default {
   name: 'GSplitpane',
@@ -58,7 +57,8 @@ export default {
       'setSplitpaneResize'
     ]),
     hasChildren (item) {
-      return item instanceof SplitpaneTree
+      const isSplitpaneTree = Reflect.has(item, 'horizontal')
+      return isSplitpaneTree
     },
     resize () {
       // use $nextTick as splitpanes library needs to be finished with rendering because fitAddon relies on


### PR DESCRIPTION
**What this PR does / why we need it**:
With the latest changes on master the `GSplitpane` `hasChildren` function broke and the splitpanes could not be rearranged.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This PR fixes an issue from the `master` branch. It's not an issue of a released dashboard version

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user

```
