### PR TITLE
Handle unreachable seeds

### DIFF
--- a/backend/lib/config/test.yaml
+++ b/backend/lib/config/test.yaml
@@ -43,6 +43,9 @@ terminal:
         namespace: garden
   bootstrap:
     disabled: true
+unreachableSeeds:
+  matchLabels:
+    test-unreachable: 'true'
 frontend:
   features:
     terminalEnabled: true
@@ -57,4 +60,3 @@ frontend:
   - title: Issues
     icon: mdi-bug
     url: https://github.com/gardener/dashboard/issues/
-

--- a/backend/lib/routes/index.js
+++ b/backend/lib/routes/index.js
@@ -24,6 +24,7 @@ module.exports = {
   '/openapi': require('../openapi'),
   '/user': require('./user'),
   '/cloudprofiles': require('./cloudprofiles'),
+  '/seeds': require('./seeds'),
   '/shoots': require('./shoots'),
   '/namespaces': require('./namespaces'),
   '/namespaces/:namespace/shoots': require('./shoots'),

--- a/backend/lib/routes/seeds.js
+++ b/backend/lib/routes/seeds.js
@@ -14,15 +14,19 @@
 // limitations under the License.
 //
 
-module.exports = {
-  cloudprofiles: require('./cloudprofiles'),
-  seeds: require('./seeds'),
-  projects: require('./projects'),
-  shoots: require('./shoots'),
-  infrastructureSecrets: require('./infrastructureSecrets'),
-  members: require('./members'),
-  authorization: require('./authorization'),
-  authentication: require('./authentication'),
-  tickets: require('./tickets'),
-  terminals: require('./terminals')
-}
+'use strict'
+
+const express = require('express')
+const { seeds } = require('../services')
+
+const router = module.exports = express.Router()
+
+router.route('/')
+  .get(async (req, res, next) => {
+    try {
+      const user = req.user
+      res.send(await seeds.list({ user }))
+    } catch (err) {
+      next(err)
+    }
+  })

--- a/backend/lib/services/authorization.js
+++ b/backend/lib/services/authorization.js
@@ -72,6 +72,17 @@ exports.canGetShoot = function (user, namespace, name) {
   })
 }
 
+exports.canListSeeds = function (user, name) {
+  return hasAuthorization(user, {
+    resourceAttributes: {
+      verb: 'list',
+      group: 'core.gardener.cloud',
+      resource: 'seeds',
+      name
+    }
+  })
+}
+
 /*
 SelfSubjectRulesReview should only be used to hide/show actions or views on the UI and not for authorization checks.
 */

--- a/backend/lib/services/authorization.js
+++ b/backend/lib/services/authorization.js
@@ -72,12 +72,33 @@ exports.canGetShoot = function (user, namespace, name) {
   })
 }
 
-exports.canListSeeds = function (user, name) {
+exports.canListSeeds = function (user) {
   return hasAuthorization(user, {
     resourceAttributes: {
       verb: 'list',
       group: 'core.gardener.cloud',
-      resource: 'seeds',
+      resource: 'seeds'
+    }
+  })
+}
+
+exports.canListCloudProfiles = function (user, name) {
+  return hasAuthorization(user, {
+    resourceAttributes: {
+      verb: 'list',
+      group: 'core.gardener.cloud',
+      resource: 'cloudprofiles',
+      name
+    }
+  })
+}
+
+exports.canGetCloudProfiles = function (user, name) {
+  return hasAuthorization(user, {
+    resourceAttributes: {
+      verb: 'get',
+      group: 'core.gardener.cloud',
+      resource: 'cloudprofiles',
       name
     }
   })

--- a/backend/lib/services/infrastructureSecrets.js
+++ b/backend/lib/services/infrastructureSecrets.js
@@ -164,8 +164,8 @@ async function getInfrastructureSecrets ({ secretBindings, cloudProfileList, sec
     .value()
 }
 
-function getCloudProviderKind (name) {
-  const cloudProfile = cloudprofiles.read({ name })
+async function getCloudProviderKind (user, name) {
+  const cloudProfile = await cloudprofiles.read({ user, name })
   return _.get(cloudProfile, 'metadata.cloudProviderKind')
 }
 
@@ -187,7 +187,7 @@ exports.list = async function ({ user, namespace }) {
   const client = user.client
 
   try {
-    const cloudProfileList = cloudprofiles.list()
+    const cloudProfileList = await cloudprofiles.list({ user })
     const [
       { items: secretList },
       { items: secretBindings }
@@ -216,7 +216,7 @@ exports.create = async function ({ user, namespace, body }) {
   const secretBinding = await client['core.gardener.cloud'].secretbindings.create(namespace, toSecretBindingResource(body))
 
   const cloudProfileName = _.get(body, 'metadata.cloudProfileName')
-  const cloudProviderKind = getCloudProviderKind(cloudProfileName)
+  const cloudProviderKind = await getCloudProviderKind(user, cloudProfileName)
   const projectInfo = getProjectNameAndHasCostObject(namespace)
 
   return fromResource({
@@ -248,7 +248,7 @@ exports.patch = async function ({ user, namespace, bindingName, body }) {
   const secret = await client.core.secrets.mergePatch(namespace, secretName, toSecretResource(body))
 
   const cloudProfileName = _.get(body, 'metadata.cloudProfileName')
-  const cloudProviderKind = getCloudProviderKind(cloudProfileName)
+  const cloudProviderKind = await getCloudProviderKind(user, cloudProfileName)
   const projectInfo = getProjectNameAndHasCostObject(namespace)
 
   return fromResource({

--- a/backend/lib/services/seeds.js
+++ b/backend/lib/services/seeds.js
@@ -1,0 +1,60 @@
+//
+// Copyright (c) 2020 by SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+'use strict'
+
+// const { Forbidden } = require('http-errors')
+const _ = require('lodash')
+const { getSeeds } = require('../cache')
+const config = require('../config')
+// const authorization = require('./services/authorization')
+
+function fromResource (seed) {
+  const unreachable = isUnreachable(seed)
+  const metadata = {
+    name: _.get(seed, 'metadata.name'),
+    unreachable
+  }
+
+  const taints = _.get(seed, 'spec.taints')
+  const unprotected = !_.find(taints, ['key', 'seed.gardener.cloud/protected'])
+  const visible = !_.find(taints, ['key', 'seed.gardener.cloud/invisible'])
+  const provider = _.get(seed, 'spec.provider')
+  const volume = _.get(seed, 'spec.volume')
+  const data = {
+    volume,
+    ...provider,
+    visible,
+    unprotected
+  }
+
+  return { metadata, data }
+}
+
+function isUnreachable (seed) {
+  const matchLabels = _.get(config, 'unreachableSeeds.matchLabels', {})
+  return _.isMatch(seed, { metadata: { labels: matchLabels }})
+}
+
+exports.list = async function ({ user }) {
+  // const allowed = await authorization.canListSeeds(user)
+  // if (!allowed) {
+  //   throw new Forbidden('You are not allowed to list seeds')
+  // }
+
+  const seeds = getSeeds()
+  return _.map(seeds, fromResource)
+}

--- a/backend/lib/services/seeds.js
+++ b/backend/lib/services/seeds.js
@@ -16,11 +16,11 @@
 
 'use strict'
 
-// const { Forbidden } = require('http-errors')
 const _ = require('lodash')
+const { Forbidden } = require('http-errors')
+const authorization = require('./authorization')
 const { getSeeds } = require('../cache')
 const config = require('../config')
-// const authorization = require('./services/authorization')
 
 function fromResource (seed) {
   const unreachable = isUnreachable(seed)
@@ -46,14 +46,14 @@ function fromResource (seed) {
 
 function isUnreachable (seed) {
   const matchLabels = _.get(config, 'unreachableSeeds.matchLabels', {})
-  return _.isMatch(seed, { metadata: { labels: matchLabels }})
+  return _.isMatch(seed, { metadata: { labels: matchLabels } })
 }
 
 exports.list = async function ({ user }) {
-  // const allowed = await authorization.canListSeeds(user)
-  // if (!allowed) {
-  //   throw new Forbidden('You are not allowed to list seeds')
-  // }
+  const allowed = await authorization.canListSeeds(user)
+  if (!allowed) {
+    throw new Forbidden('You are not allowed to list seeds')
+  }
 
   const seeds = getSeeds()
   return _.map(seeds, fromResource)

--- a/backend/test/acceptance.spec.js
+++ b/backend/test/acceptance.spec.js
@@ -48,6 +48,10 @@ describe('acceptance', function () {
       require('./acceptance/api.cloudprofiles.spec.js')(context)
     })
 
+    describe('seeds', function () {
+      require('./acceptance/api.seeds.spec.js')(context)
+    })
+
     describe('info', function () {
       require('./acceptance/api.info.spec.js')(context)
     })

--- a/backend/test/acceptance/api.cloudprofiles.spec.js
+++ b/backend/test/acceptance/api.cloudprofiles.spec.js
@@ -19,14 +19,18 @@
 const _ = require('lodash')
 const common = require('../support/common')
 
-module.exports = function ({ agent, sandbox, auth }) {
+module.exports = function ({ agent, sandbox, auth, k8s }) {
   /* eslint no-unused-expressions: 0 */
   const username = 'john.doe@example.org'
   const id = username
   const user = auth.createUser({ id })
 
   it('should return all cloudprofiles', async function () {
+    const bearer = await user.bearer
+
     common.stub.getCloudProfiles(sandbox)
+    k8s.stub.getCloudProfiles({ bearer, verb: 'list' })
+
     const res = await agent
       .get('/api/cloudprofiles')
       .set('cookie', await user.cookie)

--- a/backend/test/acceptance/api.infrastructureSecrets.spec.js
+++ b/backend/test/acceptance/api.infrastructureSecrets.spec.js
@@ -47,6 +47,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
     common.stub.getQuotas(sandbox)
     common.stub.getCloudProfiles(sandbox)
     k8s.stub.getInfrastructureSecrets({ bearer, namespace, empty: false })
+    k8s.stub.getCloudProfiles({ bearer, verb: 'list' })
     const res = await agent
       .get(`/api/namespaces/${namespace}/infrastructure-secrets`)
       .set('cookie', await user.cookie)
@@ -66,6 +67,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
     common.stub.getQuotas(sandbox)
     common.stub.getCloudProfiles(sandbox)
     k8s.stub.getInfrastructureSecrets({ bearer, namespace, empty: true })
+    k8s.stub.getCloudProfiles({ bearer, verb: 'list' })
     const res = await agent
       .get(`/api/namespaces/${namespace}/infrastructure-secrets`)
       .set('cookie', await user.cookie)
@@ -80,6 +82,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
     common.stub.getQuotas(sandbox)
     common.stub.getCloudProfiles(sandbox)
     k8s.stub.createInfrastructureSecret({ bearer, namespace, data, cloudProfileName, resourceVersion })
+    k8s.stub.getCloudProfiles({ bearer, verb: 'get' })
     const res = await agent
       .post(`/api/namespaces/${namespace}/infrastructure-secrets`)
       .set('cookie', await user.cookie)
@@ -97,6 +100,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
     common.stub.getQuotas(sandbox)
     common.stub.getCloudProfiles(sandbox)
     k8s.stub.patchInfrastructureSecret({ bearer, namespace, name, bindingName, bindingNamespace: namespace, data, cloudProfileName, resourceVersion })
+    k8s.stub.getCloudProfiles({ bearer, verb: 'get' })
     const res = await agent
       .put(`/api/namespaces/${namespace}/infrastructure-secrets/${bindingName}`)
       .set('cookie', await user.cookie)

--- a/backend/test/acceptance/api.seeds.spec.js
+++ b/backend/test/acceptance/api.seeds.spec.js
@@ -19,14 +19,17 @@
 const _ = require('lodash')
 const common = require('../support/common')
 
-module.exports = function ({ agent, sandbox, auth }) {
+module.exports = function ({ agent, sandbox, auth, k8s }) {
   /* eslint no-unused-expressions: 0 */
   const username = 'john.doe@example.org'
   const id = username
   const user = auth.createUser({ id })
 
   it('should return all seeds', async function () {
+    const bearer = await user.bearer
+
     common.stub.getSeeds(sandbox)
+    k8s.stub.getSeeds({ bearer })
     const res = await agent
       .get('/api/seeds')
       .set('cookie', await user.cookie)

--- a/backend/test/acceptance/api.seeds.spec.js
+++ b/backend/test/acceptance/api.seeds.spec.js
@@ -25,22 +25,18 @@ module.exports = function ({ agent, sandbox, auth }) {
   const id = username
   const user = auth.createUser({ id })
 
-  it('should return all cloudprofiles', async function () {
-    common.stub.getCloudProfiles(sandbox)
+  it('should return all seeds', async function () {
+    common.stub.getSeeds(sandbox)
     const res = await agent
-      .get('/api/cloudprofiles')
+      .get('/api/seeds')
       .set('cookie', await user.cookie)
 
     expect(res).to.have.status(200)
     expect(res).to.be.json
-    expect(res.body).to.have.length(4)
-    let predicate = item => item.metadata.name === 'infra1-profileName'
-    expect(_.find(res.body, predicate).data.seedNames).to.have.length(3)
-    predicate = item => item.metadata.name === 'infra1-profileName2'
-    expect(_.find(res.body, predicate).data.seedNames).to.have.length(2)
-    predicate = item => item.metadata.name === 'infra3-profileName'
-    expect(_.find(res.body, predicate).data.seedNames).to.have.length(1)
-    predicate = item => item.metadata.name === 'infra3-profileName2'
-    expect(_.find(res.body, predicate).data.seedNames).to.have.length(2)
+    expect(res.body).to.have.length(8)
+    let predicate = item => item.metadata.name === 'infra1-seed'
+    expect(_.find(res.body, predicate).metadata.unreachable).to.be.false
+    predicate = item => item.metadata.name === 'infra3-seed'
+    expect(_.find(res.body, predicate).metadata.unreachable).to.be.true
   })
 }

--- a/backend/test/support/common.js
+++ b/backend/test/support/common.js
@@ -118,7 +118,7 @@ function getQuota ({ name, namespace = 'garden-trial', scope = { apiVersion: 'v1
 
 const cloudProfileList = [
   getCloudProfile('infra1-profileName', 'infra1'),
-  getCloudProfile('infra1-profileName2', 'infra1', { providerTypes: ['infra2', 'infra3']}),
+  getCloudProfile('infra1-profileName2', 'infra1', { providerTypes: ['infra2', 'infra3'] }),
   getCloudProfile('infra2-profileName', 'infra2'),
   getCloudProfile('infra3-profileName', 'infra3', { matchLabels: { foo: 'bar' } }),
   getCloudProfile('infra3-profileName2', 'infra3')
@@ -128,7 +128,7 @@ const seedList = [
   getSeed({ name: 'soil-infra1', region: 'foo-east', kind: 'infra1', seedProtected: true, seedVisible: false }),
   getSeed({ name: 'infra1-seed', region: 'foo-east', kind: 'infra1' }),
   getSeed({ name: 'infra1-seed2', region: 'foo-west', kind: 'infra1' }),
-  getSeed({ name: 'infra3-seed', region: 'foo-europe', kind: 'infra3' }),
+  getSeed({ name: 'infra3-seed', region: 'foo-europe', kind: 'infra3', labels: { 'test-unreachable': 'true', biz: 'baz' } }),
   getSeed({ name: 'infra4-seed-without-secretRef', region: 'foo-south', kind: 'infra1', withSecretRef: false }),
   getSeed({ name: 'infra3-seed-with-selector', region: 'foo-europe', kind: 'infra3', seedProtected: false, seedVisible: true, labels: { foo: 'bar' } }),
   getSeed({ name: 'infra3-seed-protected', region: 'foo-europe', kind: 'infra3', seedProtected: true }),
@@ -146,6 +146,10 @@ const stub = {
     const getCloudProfilesStub = sandbox.stub(cache, 'getCloudProfiles')
     getCloudProfilesStub.returns(cloudProfileList)
 
+    const getSeedsStub = sandbox.stub(cache, 'getSeeds')
+    getSeedsStub.returns(seedList)
+  },
+  getSeeds (sandbox) {
     const getSeedsStub = sandbox.stub(cache, 'getSeeds')
     getSeedsStub.returns(seedList)
   },

--- a/frontend/src/components/ClusterMetrics.vue
+++ b/frontend/src/components/ClusterMetrics.vue
@@ -45,7 +45,18 @@ limitations under the License.
       content-class="pt-0"
     ></link-list-tile>
     <v-divider v-show="!!username && !!password" inset></v-divider>
-    <username-password :username="username" :password="password"></username-password>
+    <username-password v-if="isAdmin" :username="username" :password="password" :showNotAvailablePlaceholder="isSeedUnreachable">
+      <template v-slot:notAvailablePlaceholder>
+        <v-list-item-content>
+          <v-list-item-subtitle>Operator Credentials</v-list-item-subtitle>
+          <v-list-item-title class="pt-1">
+            <v-icon color="cyan darken-2">mdi-alert-circle-outline</v-icon>
+            Credentials not available as the Seed {{shootSeedName}} is not reachable by the dashboard
+          </v-list-item-title>
+        </v-list-item-content>
+      </template>
+    </username-password>
+    <username-password v-else :username="username" :password="password"></username-password>
   </v-list>
 </template>
 

--- a/frontend/src/components/ClusterMetrics.vue
+++ b/frontend/src/components/ClusterMetrics.vue
@@ -49,7 +49,7 @@ limitations under the License.
       <template v-slot:notAvailablePlaceholder>
         <v-list-item-content>
           <v-list-item-subtitle>Operator Credentials</v-list-item-subtitle>
-          <v-list-item-title class="pt-1">
+          <v-list-item-title class="wrap-text pt-1">
             <v-icon color="cyan darken-2">mdi-alert-circle-outline</v-icon>
             Credentials not available as the Seed {{shootSeedName}} is not reachable by the dashboard
           </v-list-item-title>
@@ -108,3 +108,9 @@ export default {
   }
 }
 </script>
+
+<style lang="scss" scoped>
+  .wrap-text {
+    white-space: normal;
+  }
+</style>

--- a/frontend/src/components/ShootDetails/ShootAccessCard.vue
+++ b/frontend/src/components/ShootDetails/ShootAccessCard.vue
@@ -270,10 +270,10 @@ export default {
       return this.isAdmin
     },
     isTerminalTileVisible () {
-      return !isEmpty(this.shootItem) && this.hasShootTerminalAccess
+      return !isEmpty(this.shootItem) && this.hasShootTerminalAccess && !this.isSeedUnreachable
     },
     isTerminalShortcutsTileVisible () {
-      return !isEmpty(this.shootItem) && this.isTerminalShortcutsFeatureEnabled && this.hasShootTerminalAccess && !this.hideTerminalShortcuts
+      return !isEmpty(this.shootItem) && this.isTerminalShortcutsFeatureEnabled && this.hasShootTerminalAccess && !this.hideTerminalShortcuts && !this.isSeedUnreachable
     },
     token () {
       return this.shootInfo.cluster_token || ''

--- a/frontend/src/components/UsernamePasswordListTile.vue
+++ b/frontend/src/components/UsernamePasswordListTile.vue
@@ -15,8 +15,8 @@ limitations under the License.
 -->
 
 <template>
-  <div v-show="((!!username || !!email) && !!password) || showNotAvailablePlaceholder">
-    <template v-if="(!!username || !!email) && !!password">
+  <div v-if="showCredentials || showNotAvailablePlaceholder">
+    <template v-if="showCredentials">
       <v-list-item v-if="username">
         <v-list-item-icon>
           <v-icon color="cyan darken-2">{{icon}}</v-icon>
@@ -136,6 +136,9 @@ export default {
     },
     visibilityIcon () {
       return this.showPassword ? 'mdi-eye-off' : 'mdi-eye'
+    },
+    showCredentials () {
+      return (!!this.username || !!this.email) && !!this.password
     }
   },
   watch: {

--- a/frontend/src/components/UsernamePasswordListTile.vue
+++ b/frontend/src/components/UsernamePasswordListTile.vue
@@ -15,50 +15,66 @@ limitations under the License.
 -->
 
 <template>
-  <div v-show="(!!username || !!email) && !!password">
-    <v-list-item v-if="username">
+  <div v-show="((!!username || !!email) && !!password) || showNotAvailablePlaceholder">
+    <template v-if="(!!username || !!email) && !!password">
+      <v-list-item v-if="username">
+        <v-list-item-icon>
+          <v-icon color="cyan darken-2">{{icon}}</v-icon>
+        </v-list-item-icon>
+        <v-list-item-content>
+          <v-list-item-subtitle>{{usernameTitle}}</v-list-item-subtitle>
+          <v-list-item-title class="pt-1">{{username}}</v-list-item-title>
+        </v-list-item-content>
+        <v-list-item-action>
+          <copy-btn :clipboard-text="username"></copy-btn>
+        </v-list-item-action>
+      </v-list-item>
+      <v-list-item v-if="email">
+        <v-list-item-icon>
+          <v-icon v-if="!username" color="cyan darken-2">{{icon}}</v-icon>
+        </v-list-item-icon>
+        <v-list-item-content class="pt-0">
+          <v-list-item-subtitle>{{emailTitle}}</v-list-item-subtitle>
+          <v-list-item-title class="pt-1">{{email}}</v-list-item-title>
+        </v-list-item-content>
+        <v-list-item-action>
+          <copy-btn :clipboard-text="email"></copy-btn>
+        </v-list-item-action>
+      </v-list-item>
+      <v-list-item>
+        <v-list-item-icon/>
+        <v-list-item-content class="pt-0">
+          <v-list-item-subtitle>{{passwordTitle}}</v-list-item-subtitle>
+          <v-list-item-title class="pt-1">{{passwordText}}</v-list-item-title>
+        </v-list-item-content>
+        <v-list-item-action class="mx-0">
+          <copy-btn :clipboard-text="password"></copy-btn>
+        </v-list-item-action>
+        <v-list-item-action class="mx-0">
+          <v-tooltip top>
+            <template v-slot:activator="{ on }">
+              <v-btn v-on="on" icon @click.native.stop="showPassword = !showPassword">
+                <v-icon>{{visibilityIcon}}</v-icon>
+              </v-btn>
+            </template>
+            <span>{{passwordVisibilityTitle}}</span>
+          </v-tooltip>
+        </v-list-item-action>
+      </v-list-item>
+    </template>
+    <v-list-item v-else-if="showNotAvailablePlaceholder">
       <v-list-item-icon>
-        <v-icon color="cyan darken-2">mdi-account-outline</v-icon>
+        <v-icon color="cyan darken-2">{{icon}}</v-icon>
       </v-list-item-icon>
-      <v-list-item-content>
-        <v-list-item-subtitle>User</v-list-item-subtitle>
-        <v-list-item-title class="pt-1">{{username}}</v-list-item-title>
-      </v-list-item-content>
-      <v-list-item-action>
-        <copy-btn :clipboard-text="username"></copy-btn>
-      </v-list-item-action>
-    </v-list-item>
-    <v-list-item v-if="email">
-      <v-list-item-icon>
-        <v-icon v-if="!username" color="cyan darken-2">mdi-account-outline</v-icon>
-      </v-list-item-icon>
-      <v-list-item-content class="pt-0">
-        <v-list-item-subtitle>Email</v-list-item-subtitle>
-        <v-list-item-title class="pt-1">{{email}}</v-list-item-title>
-      </v-list-item-content>
-      <v-list-item-action>
-        <copy-btn :clipboard-text="email"></copy-btn>
-      </v-list-item-action>
-    </v-list-item>
-    <v-list-item>
-      <v-list-item-icon/>
-      <v-list-item-content class="pt-0">
-        <v-list-item-subtitle>Password</v-list-item-subtitle>
-        <v-list-item-title class="pt-1">{{passwordText}}</v-list-item-title>
-      </v-list-item-content>
-      <v-list-item-action class="mx-0">
-        <copy-btn :clipboard-text="password"></copy-btn>
-      </v-list-item-action>
-      <v-list-item-action class="mx-0">
-        <v-tooltip top>
-          <template v-slot:activator="{ on }">
-            <v-btn v-on="on" icon @click.native.stop="showPassword = !showPassword">
-              <v-icon>{{visibilityIcon}}</v-icon>
-            </v-btn>
-          </template>
-          <span>{{passwordVisibilityTitle}}</span>
-        </v-tooltip>
-      </v-list-item-action>
+      <slot name="notAvailablePlaceholder">
+        <v-list-item-content>
+          <v-list-item-subtitle>Credentials</v-list-item-subtitle>
+          <v-list-item-title class="pt-1">
+            <v-icon color="cyan darken-2">mdi-alert-circle-outline</v-icon>
+            Currently not available
+          </v-list-item-title>
+        </v-list-item-content>
+      </slot>
     </v-list-item>
   </div>
 </template>
@@ -71,6 +87,22 @@ export default {
     CopyBtn
   },
   props: {
+    icon: {
+      type: String,
+      default: 'mdi-account-outline'
+    },
+    usernameTitle: {
+      type: String,
+      default: 'User'
+    },
+    passwordTitle: {
+      type: String,
+      default: 'Password'
+    },
+    emailTitle: {
+      type: String,
+      default: 'Email'
+    },
     username: {
       type: String
     },
@@ -79,6 +111,10 @@ export default {
     },
     password: {
       type: String
+    },
+    showNotAvailablePlaceholder: {
+      type: Boolean,
+      default: true
     }
   },
   data () {

--- a/frontend/src/mixins/shootItem.js
+++ b/frontend/src/mixins/shootItem.js
@@ -33,7 +33,8 @@ import {
 export const shootItem = {
   computed: {
     ...mapGetters([
-      'selectedAccessRestrictionsForShootByCloudProfileNameAndRegion'
+      'selectedAccessRestrictionsForShootByCloudProfileNameAndRegion',
+      'isSeedUnreachableByName'
     ]),
     shootMetadata () {
       return get(this.shootItem, 'metadata', {})
@@ -177,6 +178,9 @@ export const shootItem = {
     },
     shootSeedName () {
       return get(this.shootSpec, 'seedName')
+    },
+    isSeedUnreachable () {
+      return this.isSeedUnreachableByName(this.shootSeedName)
     },
     shootStatusSeedName () {
       return get(this.shootItem, 'status.seed')

--- a/frontend/src/router/guards.js
+++ b/frontend/src/router/guards.js
@@ -103,6 +103,7 @@ function ensureDataLoaded (store) {
       await Promise.all([
         ensureProjectsLoaded(store),
         ensureCloudProfilesLoaded(store),
+        ensureSeedsLoaded(store),
         ensureKubeconfigDataLoaded(store)
       ])
 
@@ -172,6 +173,12 @@ function ensureProjectsLoaded (store) {
 function ensureCloudProfilesLoaded (store) {
   if (isEmpty(store.getters.cloudProfileList)) {
     return store.dispatch('fetchCloudProfiles')
+  }
+}
+
+function ensureSeedsLoaded (store) {
+  if (isEmpty(store.getters.seedList)) {
+    return store.dispatch('fetchSeeds')
   }
 }
 

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -321,17 +321,13 @@ const getters = {
     return state.seeds.all
   },
   cloudProfileByName (state, getters) {
-    return (name) => {
-      return getters['cloudProfiles/cloudProfileByName'](name)
-    }
+    return name => getters['cloudProfiles/cloudProfileByName'](name)
   },
   seedByName (state, getters) {
-    return (name) => {
-      return getters['seeds/seedByName'](name)
-    }
+    return name => getters['seeds/seedByName'](name)
   },
   isSeedUnreachableByName (state, getters) {
-    return (name) => {
+    return name => {
       const seed = getters.seedByName(name)
       return get(seed, 'metadata.unreachable')
     }
@@ -597,9 +593,7 @@ const getters = {
     }
   },
   seedsByNames (state, getters) {
-    return (seedNames) => {
-      return map(seedNames, getters.seedByName)
-    }
+    return seedNames => map(seedNames, getters.seedByName)
   },
   regionsWithoutSeedByCloudProfileName (state, getters) {
     return (cloudProfileName) => {
@@ -957,11 +951,12 @@ const actions = {
         dispatch('setError', err)
       })
   },
-  fetchSeeds ({ dispatch }) {
-    return dispatch('seeds/getAll')
-      .catch(err => {
-        dispatch('setError', err)
-      })
+  async fetchSeeds ({ dispatch }) {
+    try {
+      await dispatch('seeds/getAll')
+    } catch (err) {
+      dispatch('setError', err)
+    }
   },
   fetchProjects ({ dispatch }) {
     return dispatch('projects/getAll')

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -61,6 +61,7 @@ import moment from 'moment-timezone'
 
 import shoots from './modules/shoots'
 import cloudProfiles from './modules/cloudProfiles'
+import seeds from './modules/seeds'
 import projects from './modules/projects'
 import draggable from './modules/draggable'
 import members from './modules/members'
@@ -316,9 +317,23 @@ const getters = {
   cloudProfileList (state) {
     return state.cloudProfiles.all
   },
+  seedList (state) {
+    return state.seeds.all
+  },
   cloudProfileByName (state, getters) {
     return (name) => {
       return getters['cloudProfiles/cloudProfileByName'](name)
+    }
+  },
+  seedByName (state, getters) {
+    return (name) => {
+      return getters['seeds/seedByName'](name)
+    }
+  },
+  isSeedUnreachableByName (state, getters) {
+    return (name) => {
+      const seed = getters.seedByName(name)
+      return get(seed, 'metadata.unreachable')
     }
   },
   cloudProfilesByCloudProviderKind (state) {
@@ -571,13 +586,19 @@ const getters = {
       if (!cloudProfile) {
         return []
       }
-      const seeds = cloudProfile.data.seeds
-      if (!seeds) {
+      const seedNames = cloudProfile.data.seedNames
+      if (!seedNames) {
         return []
       }
+      const seeds = getters.seedsByNames(seedNames)
       const uniqueSeedRegions = uniq(map(seeds, 'data.region'))
       const uniqueSeedRegionsWithZones = filter(uniqueSeedRegions, isValidRegion(getters, cloudProfileName, cloudProfile.metadata.cloudProviderKind))
       return uniqueSeedRegionsWithZones
+    }
+  },
+  seedsByNames (state, getters) {
+    return (seedNames) => {
+      return map(seedNames, getters.seedByName)
     }
   },
   regionsWithoutSeedByCloudProfileName (state, getters) {
@@ -936,6 +957,12 @@ const actions = {
         dispatch('setError', err)
       })
   },
+  fetchSeeds ({ dispatch }) {
+    return dispatch('seeds/getAll')
+      .catch(err => {
+        dispatch('setError', err)
+      })
+  },
   fetchProjects ({ dispatch }) {
     return dispatch('projects/getAll')
       .catch(err => {
@@ -1025,12 +1052,13 @@ const actions = {
           object
         }]
       })
-      const fetchShootAndShootSeedInfo = async ({ metadata }) => {
+      const fetchShootAndShootSeedInfo = async ({ metadata, spec }) => {
         const promises = []
         if (store.getters.canGetSecrets) {
           promises.push(store.dispatch('getShootInfo', metadata))
         }
-        if (store.getters.isAdmin) {
+        const seedName = spec.seedName
+        if (store.getters.isAdmin && !store.getters.isSeedUnreachableByName(seedName)) {
           promises.push(store.dispatch('getShootSeedInfo', metadata))
         }
         try {
@@ -1378,6 +1406,7 @@ const modules = {
   members,
   draggable,
   cloudProfiles,
+  seeds,
   shoots,
   infrastructureSecrets,
   tickets

--- a/frontend/src/store/modules/cloudProfiles.js
+++ b/frontend/src/store/modules/cloudProfiles.js
@@ -24,21 +24,20 @@ const state = {
 
 // getters
 const getters = {
-  items: state => state.all,
-  cloudProfileByName: (state) => (name) => {
-    const predicate = item => item.metadata.name === name
-    return find(state.all, predicate)
+  items (state) {
+    return state.all
+  },
+  cloudProfileByName (state) {
+    return name => find(state.all, ['metadata.name', name])
   }
 }
 
 // actions
 const actions = {
-  getAll: ({ commit, rootState }) => {
-    return getCloudprofiles()
-      .then(res => {
-        commit('RECEIVE', res.data)
-        return state.all
-      })
+  async getAll ({ commit, state }) {
+    const { data } = await getCloudprofiles()
+    commit('RECEIVE', data)
+    return state.all
   }
 }
 

--- a/frontend/src/store/modules/seeds.js
+++ b/frontend/src/store/modules/seeds.js
@@ -36,7 +36,7 @@ const getters = {
 const actions = {
   async getAll ({ commit, state }) {
     const { data } = await getSeeds()
-    commit('RECEIVE', res.data)
+    commit('RECEIVE', data)
     return state.all
   }
 }

--- a/frontend/src/store/modules/seeds.js
+++ b/frontend/src/store/modules/seeds.js
@@ -14,15 +14,45 @@
 // limitations under the License.
 //
 
-module.exports = {
-  cloudprofiles: require('./cloudprofiles'),
-  seeds: require('./seeds'),
-  projects: require('./projects'),
-  shoots: require('./shoots'),
-  infrastructureSecrets: require('./infrastructureSecrets'),
-  members: require('./members'),
-  authorization: require('./authorization'),
-  authentication: require('./authentication'),
-  tickets: require('./tickets'),
-  terminals: require('./terminals')
+import { getSeeds } from '@/utils/api'
+import find from 'lodash/find'
+
+// initial state
+const state = {
+  all: []
+}
+
+// getters
+const getters = {
+  items: state => state.all,
+  seedByName: (state) => (name) => {
+    const predicate = item => item.metadata.name === name
+    return find(state.all, predicate)
+  }
+}
+
+// actions
+const actions = {
+  getAll: ({ commit, rootState }) => {
+    return getSeeds()
+      .then(res => {
+        commit('RECEIVE', res.data)
+        return state.all
+      })
+  }
+}
+
+// mutations
+const mutations = {
+  RECEIVE (state, items) {
+    state.all = items
+  }
+}
+
+export default {
+  namespaced: true,
+  state,
+  getters,
+  actions,
+  mutations
 }

--- a/frontend/src/store/modules/seeds.js
+++ b/frontend/src/store/modules/seeds.js
@@ -24,21 +24,20 @@ const state = {
 
 // getters
 const getters = {
-  items: state => state.all,
-  seedByName: (state) => (name) => {
-    const predicate = item => item.metadata.name === name
-    return find(state.all, predicate)
+  items (state) {
+    return state.all
+  },
+  seedByName (state) {
+    return name => find(state.all, ['metadata.name', name])
   }
 }
 
 // actions
 const actions = {
-  getAll: ({ commit, rootState }) => {
-    return getSeeds()
-      .then(res => {
-        commit('RECEIVE', res.data)
-        return state.all
-      })
+  async getAll ({ commit, state }) {
+    const { data } = await getSeeds()
+    commit('RECEIVE', res.data)
+    return state.all
   }
 }
 

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -165,6 +165,12 @@ export function getCloudprofiles () {
   return getResource('/api/cloudprofiles')
 }
 
+/* Seeds */
+
+export function getSeeds () {
+  return getResource('/api/seeds')
+}
+
 /* Projects */
 
 export function getProjects () {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR handles unreachable seeds
- Terminal feature is disabled in case the seed is not reachable by the dashboard
- A hint is shown that the monitoring credentials can't be fetched in case the seed is not reachable by the dashboard (only applies for operators)
<img width="1141" alt="Screenshot 2020-10-14 at 21 31 03" src="https://user-images.githubusercontent.com/5526658/96036348-9e487800-0e64-11eb-90aa-ed497c933f17.png">

example `values.yaml`
```yaml
unreachableSeeds:
  matchLabels:
    seed.gardener.cloud/network: private
```

example seed:
```yaml
apiVersion: core.gardener.cloud/v1beta1
kind: Seed
metadata:
  labels:
    seed.gardener.cloud/network: private
    gardener.cloud/role: seed
  name: my-seed
spec:
  ...
```

**Which issue(s) this PR fixes**:
Fixes #826 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
We are now handling the case when seed is not reachable by the dashboard backend
- Terminal feature is disabled
- A hint is shown that the monitoring credentials can't be fetched in case the seed is not reachable by the dashboard (only applies for operators)
```

```action operator
Seeds that are unreachable by the dashboard need to be flagged as such with a corresponding label. This label needs be manifested in the dashboard configuration under the property `unreachableSeeds.matchLabels` in the `values.yaml` file
```
