### PR TITLE
Fix action button not being disabled when cluster is in deletion

### DIFF
--- a/frontend/src/mixins/shootItem.js
+++ b/frontend/src/mixins/shootItem.js
@@ -27,7 +27,8 @@ import {
   isShootStatusHibernated,
   isReconciliationDeactivated,
   getProjectName,
-  isTypeDelete
+  isTypeDelete,
+  isTruthyValue
 } from '@/utils'
 
 export const shootItem = {
@@ -50,7 +51,7 @@ export const shootItem = {
       const confirmation = get(this.shootAnnotations, ['confirmation.gardener.cloud/deletion'], confirmationDeprecated)
       const deletionTimestamp = this.shootDeletionTimestamp
 
-      return !!deletionTimestamp && confirmation === 'true'
+      return !!deletionTimestamp && isTruthyValue(confirmation)
     },
     shootCreatedBy () {
       return getCreatedBy(this.shootMetadata)

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -384,10 +384,14 @@ export function shootHasIssue (shoot) {
 }
 
 export function isReconciliationDeactivated (metadata) {
-  const truthyValues = ['1', 't', 'T', 'true', 'TRUE', 'True']
   const ignoreDeprecated = get(metadata, ['annotations', 'shoot.garden.sapcloud.io/ignore'])
   const ignore = get(metadata, ['annotations', 'shoot.gardener.cloud/ignore'], ignoreDeprecated)
-  return includes(truthyValues, ignore)
+  return isTruthyValue(ignore)
+}
+
+export function isTruthyValue (value) {
+  const truthyValues = ['1', 't', 'T', 'true', 'TRUE', 'True']
+  return includes(truthyValues, value)
 }
 
 export function isStatusProgressing (metadata) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixed bug that the action buttons in the lifecycle card were not disabled in some cases for clusters that are in the process of being deleted

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Fixed bug that the action buttons in the lifecycle card were not disabled in some cases for clusters that are in the process of being deleted
```
