### PR TITLE
Import more Roboto font variants ...

### DIFF
--- a/frontend/src/plugins/styles.js
+++ b/frontend/src/plugins/styles.js
@@ -14,12 +14,18 @@
 // limitations under the License.
 //
 
-import './styles'
-import './vuelidate'
-import './shortkey'
-import './snotify'
-import './cookie'
-import './bus'
-import './auth'
-import './storage'
-import './yaml'
+/** Material Design Icons Webfont */
+import '@mdi/font/css/materialdesignicons.css'
+
+/** Roboto Webfont */
+import 'fontsource-roboto/100-normal.css'
+import 'fontsource-roboto/300-normal.css'
+import 'fontsource-roboto/400-normal.css'
+import 'fontsource-roboto/500-normal.css'
+import 'fontsource-roboto/700-normal.css'
+import 'fontsource-roboto/900-normal.css'
+
+import 'fontsource-roboto/400-italic.css'
+
+/** Gardener Styles */
+import '@/sass/main.scss'

--- a/frontend/src/plugins/vuetify.dev.js
+++ b/frontend/src/plugins/vuetify.dev.js
@@ -14,22 +14,9 @@
 // limitations under the License.
 //
 
-import 'fontsource-roboto/latin-300-normal.css'
-import 'fontsource-roboto/latin-400-normal.css'
-import 'fontsource-roboto/latin-400-italic.css'
-import 'fontsource-roboto/latin-500-normal.css'
-import 'fontsource-roboto/latin-700-normal.css'
-import 'fontsource-roboto/latin-ext-300-normal.css'
-import 'fontsource-roboto/latin-ext-400-normal.css'
-import 'fontsource-roboto/latin-ext-400-italic.css'
-import 'fontsource-roboto/latin-ext-500-normal.css'
-import 'fontsource-roboto/latin-ext-700-normal.css'
-import '@mdi/font/css/materialdesignicons.css'
-import 'vuetify/dist/vuetify.min.css'
-import '@/sass/main.scss'
-
 import Vue from 'vue'
 import Vuetify from 'vuetify'
+import 'vuetify/dist/vuetify.min.css'
 
 Vue.use(Vuetify)
 

--- a/frontend/src/plugins/vuetify.dev.js
+++ b/frontend/src/plugins/vuetify.dev.js
@@ -14,7 +14,16 @@
 // limitations under the License.
 //
 
-import 'fontsource-roboto'
+import 'fontsource-roboto/latin-300-normal.css'
+import 'fontsource-roboto/latin-400-normal.css'
+import 'fontsource-roboto/latin-400-italic.css'
+import 'fontsource-roboto/latin-500-normal.css'
+import 'fontsource-roboto/latin-700-normal.css'
+import 'fontsource-roboto/latin-ext-300-normal.css'
+import 'fontsource-roboto/latin-ext-400-normal.css'
+import 'fontsource-roboto/latin-ext-400-italic.css'
+import 'fontsource-roboto/latin-ext-500-normal.css'
+import 'fontsource-roboto/latin-ext-700-normal.css'
 import '@mdi/font/css/materialdesignicons.css'
 import 'vuetify/dist/vuetify.min.css'
 import '@/sass/main.scss'

--- a/frontend/src/plugins/vuetify.js
+++ b/frontend/src/plugins/vuetify.js
@@ -14,7 +14,16 @@
 // limitations under the License.
 //
 
-import 'fontsource-roboto'
+import 'fontsource-roboto/latin-300-normal.css'
+import 'fontsource-roboto/latin-400-normal.css'
+import 'fontsource-roboto/latin-400-italic.css'
+import 'fontsource-roboto/latin-500-normal.css'
+import 'fontsource-roboto/latin-700-normal.css'
+import 'fontsource-roboto/latin-ext-300-normal.css'
+import 'fontsource-roboto/latin-ext-400-normal.css'
+import 'fontsource-roboto/latin-ext-400-italic.css'
+import 'fontsource-roboto/latin-ext-500-normal.css'
+import 'fontsource-roboto/latin-ext-700-normal.css'
 import '@mdi/font/css/materialdesignicons.css'
 import 'vuetify/dist/vuetify.min.css'
 import '@/sass/main.scss'

--- a/frontend/src/plugins/vuetify.js
+++ b/frontend/src/plugins/vuetify.js
@@ -14,20 +14,6 @@
 // limitations under the License.
 //
 
-import 'fontsource-roboto/latin-300-normal.css'
-import 'fontsource-roboto/latin-400-normal.css'
-import 'fontsource-roboto/latin-400-italic.css'
-import 'fontsource-roboto/latin-500-normal.css'
-import 'fontsource-roboto/latin-700-normal.css'
-import 'fontsource-roboto/latin-ext-300-normal.css'
-import 'fontsource-roboto/latin-ext-400-normal.css'
-import 'fontsource-roboto/latin-ext-400-italic.css'
-import 'fontsource-roboto/latin-ext-500-normal.css'
-import 'fontsource-roboto/latin-ext-700-normal.css'
-import '@mdi/font/css/materialdesignicons.css'
-import 'vuetify/dist/vuetify.min.css'
-import '@/sass/main.scss'
-
 import Vue from 'vue'
 import Vuetify from 'vuetify/lib'
 

--- a/frontend/src/router/guards.js
+++ b/frontend/src/router/guards.js
@@ -47,6 +47,9 @@ function setLoading (store, value) {
 function ensureConfigurationLoaded (store) {
   return async function (to, from, next) {
     try {
+      if (to.name === 'Error') {
+        return next()
+      }
       if (!store.state.cfg) {
         const { data } = await getConfiguration()
         await store.dispatch('setConfiguration', data)

--- a/frontend/src/sass/main.scss
+++ b/frontend/src/sass/main.scss
@@ -14,8 +14,8 @@
  *  limitations under the License.
  */
 
- /** Gardener Styles */
- @import '~vuetify/src/styles/styles.sass';
+/** Gardener Styles */
+@import '~vuetify/src/styles/styles.sass';
 
 [data-app] {
   .v-main > .container {


### PR DESCRIPTION
**What this PR does / why we need it**:
1. This PR imports more [Roboto](https://github.com/fontsource/fontsource/tree/master/packages/roboto#readme) font variants with the full CSS unicode-range.
* `normal`:  [100,300,400,500,700,900]
* `italic`: [400]

2. If the the request to `/config.json` fails during bootstrap the frontend was stuck in an endlessloop. This is also fixed with this PR.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user

```
