### PR TITLE
Fix terminal runtime selection

### DIFF
--- a/frontend/src/components/GTerminal.vue
+++ b/frontend/src/components/GTerminal.vue
@@ -39,10 +39,10 @@ limitations under the License.
           </v-btn>
         </template>
       </g-popper>
-      <v-btn text color="cyan darken-2" @click="retry()">
+      <v-btn text color="cyan darken-2" @click="retry">
         Retry
       </v-btn>
-      <v-btn text color="cyan darken-2" @click="hideSnackbar()">
+      <v-btn text color="cyan darken-2" @click="hideSnackbarAndClose">
         Close
       </v-btn>
     </v-snackbar>
@@ -54,7 +54,7 @@ limitations under the License.
       color="red"
     >
       {{ snackbarText }}
-      <v-btn text @click="hideSnackbar()">
+      <v-btn text @click="hideSnackbarAndClose">
         Close
       </v-btn>
     </v-snackbar>
@@ -429,6 +429,11 @@ export default {
       if (this.fitAddon) {
         this.fitAddon.fit()
       }
+    },
+    hideSnackbarAndClose () {
+      this.hideSnackbar()
+
+      return this.deleteTerminal()
     },
     hideSnackbar () {
       this.snackbarTop = false

--- a/frontend/src/components/TerminalSettings.vue
+++ b/frontend/src/components/TerminalSettings.vue
@@ -195,20 +195,20 @@ export default {
       const node = this.selectedNode === this.autoSelectNodeItem.data.kubernetesHostname
         ? undefined
         : this.selectedNode
+
+      const preferredHost = this.selectedRunOnShootWorker ? 'shoot' : 'seed'
+
       const selectedConfig = {
         container: {
           image: this.selectedContainerImage
         },
-        node
+        node,
+        preferredHost,
+        privileged: this.selectedPrivilegedMode,
+        hostPID: this.selectedPrivilegedMode,
+        hostNetwork: this.selectedPrivilegedMode
       }
-      if (this.selectedPrivilegedMode) {
-        selectedConfig.container.privileged = true
-        selectedConfig.hostPID = true
-        selectedConfig.hostNetwork = true
-      }
-      if (this.selectedRunOnShootWorker) {
-        selectedConfig.preferredHost = 'shoot'
-      }
+
       return selectedConfig
     }
   },


### PR DESCRIPTION
**What this PR does / why we need it**:
- As operator, when changing the terminal settings and selecting `Cluster` as runtime for the terminal pod and afterwards try to change the runtime to `Infrastructure (Seed)` it wouldn't work. This is now fixed.
- Also the behavior was changed when closing snackbar (that is displayed on connection loss / connection error). It will also close the terminal window

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->

```improvement operator
Fixed issue that when changing the terminal settings and selecting `Cluster` as runtime for the terminal pod and afterwards try to change the runtime to `Infrastructure (Seed)` it wouldn't work
```
