### PR TITLE
Fix unreachable seed check

### DIFF
--- a/backend/lib/services/seeds.js
+++ b/backend/lib/services/seeds.js
@@ -45,7 +45,10 @@ function fromResource (seed) {
 }
 
 function isUnreachable (seed) {
-  const matchLabels = _.get(config, 'unreachableSeeds.matchLabels', {})
+  const matchLabels = _.get(config, 'unreachableSeeds.matchLabels')
+  if (!matchLabels) {
+    return false
+  }
   return _.isMatch(seed, { metadata: { labels: matchLabels } })
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixed issue that seed is considered as unreachable if the `unreachableSeeds.matchLabels` configuration was missing

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Only an issue on the master branch (bug is not on released version)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user

```
