### PR TITLE
Adapt chart to include unreachableSeeds config

### DIFF
--- a/charts/__tests__/gardener-dashboard.spec.js
+++ b/charts/__tests__/gardener-dashboard.spec.js
@@ -385,6 +385,32 @@ describe('gardener-dashboard', function () {
         })
       })
 
+      describe('unreachableSeeds', function () {
+        it('should render the template', async function () {
+          // eslint-disable-next-line no-unused-vars
+          const values = writeValues(filename, {
+            unreachableSeeds: {
+              matchLabels: {
+                seed: 'unreachable'
+              }
+            }
+          })
+
+          const documents = await helmTemplate(template, filename)
+          const config = chain(documents)
+            .find(['metadata.name', name])
+            .get('data["config.yaml"]')
+            .thru(yaml.safeLoad)
+            .value()
+          const { unreachableSeeds } = config
+          expect(unreachableSeeds).toEqual({
+            matchLabels: {
+              seed: 'unreachable'
+            }
+          })
+        })
+      })
+
       describe('terminal', function () {
         describe('shortcuts', function () {
           it('should render the template', async function () {

--- a/charts/gardener-dashboard/templates/configmap.yaml
+++ b/charts/gardener-dashboard/templates/configmap.yaml
@@ -36,6 +36,13 @@ data:
       pollIntervalSeconds: {{ .Values.gitHub.pollIntervalSeconds }}
       {{- end }}
     {{- end }}
+    {{- if .Values.unreachableSeeds }}
+    unreachableSeeds:
+      {{- with .Values.unreachableSeeds.matchLabels }}
+      matchLabels:
+{{ toYaml . | trim | indent 8 }}
+      {{- end }}
+    {{- end }}
     {{- if .Values.oidc }}
     oidc:
       issuer: {{ required ".Values.oidc.issuerUrl is required" .Values.oidc.issuerUrl }}

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -268,3 +268,7 @@ readinessProbe:
 #           -----BEGIN RSA PRIVATE KEY-----
 #           Li4u
 #           -----END RSA PRIVATE KEY-----
+
+# unreachableSeeds: # disables some UI features for seeds that are unreachable by the dashboard
+#   matchLabels:
+#     seed.gardener.cloud/network: private


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enhances the gardener-dashboard chart to include the unreachableSeeds config

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Unreachable Seeds PR https://github.com/gardener/dashboard/pull/831

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user

```
