### PR TITLE
Fix multiline strings in chart

### DIFF
--- a/charts/gardener-dashboard/templates/configmap.yaml
+++ b/charts/gardener-dashboard/templates/configmap.yaml
@@ -171,8 +171,7 @@ data:
         {{- end }}
         gitHubRepoUrl: {{ .Values.frontendConfig.ticket.gitHubRepoUrl }}
         avatarSource: {{ .Values.frontendConfig.ticket.avatarSource | default "github" }}
-        issueDescriptionTemplate: |-
-{{ .Values.frontendConfig.ticket.issueDescriptionTemplate | trim | indent 10 }}
+        issueDescriptionTemplate: {{ toJson .Values.frontendConfig.ticket.issueDescriptionTemplate }}
       {{- end }}
       features:
         terminalEnabled: {{ .Values.frontendConfig.features.terminalEnabled | default false }}
@@ -236,8 +235,7 @@ data:
       {{- if .Values.frontendConfig.accessRestriction }}
       accessRestriction:
         {{- if  .Values.frontendConfig.accessRestriction.noItemsText }}
-        noItemsText: |-
-{{  .Values.frontendConfig.accessRestriction.noItemsText | trim | indent 10 }}
+        noItemsText: {{ toJson .Values.frontendConfig.accessRestriction.noItemsText }}
         {{- end }}
         items:
         {{- range .Values.frontendConfig.accessRestriction.items }}
@@ -247,11 +245,9 @@ data:
             title: {{ .display.title }}{{- end }}{{- if .display.description }}
             description: {{ .display.description }}{{- end }}
           input:
-            title: |-
-{{ .input.title | trim | indent 14 }}
+            title: {{ toJson .input.title }}
             {{- if .input.description }}
-            description: |-
-{{ .input.description | trim | indent 14 }}
+            description: {{ toJson .input.description }}
             {{- end }}
             {{- if .input.inverted }}
             inverted: {{ .input.inverted }}
@@ -265,11 +261,9 @@ data:
               title: {{ .display.title }}{{- end }}{{- if .display.description }}
               description: {{ .display.description }}{{- end }}
             input:
-              title: |-
-{{ .input.title | trim | indent 16 }}
+              title: {{ toJson .input.title }}
               {{- if .input.description }}
-              description: |-
-{{ .input.description | trim | indent 16 }}
+              description: {{ toJson .input.description }}
               {{- end }}
               {{- if .input.inverted }}
               inverted: {{ .input.inverted }}


### PR DESCRIPTION
**What this PR does / why we need it**:
In case e.g. `frontendConfig.ticket.issueDescriptionTemplate` contains multiline strings with two or more consecutive newlines, it could be that `data["config.yaml"]` of the `gardener-dashboard-configmap` will be treated as one large json string which makes it hard to read and edit the content. 

We are now using toJson for multiline strings

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user

```
