### PR TITLE
Fixed subcomponent validation state reset

### DIFF
--- a/frontend/src/components/NewShoot/NewShootInfrastructureDetails.vue
+++ b/frontend/src/components/NewShoot/NewShootInfrastructureDetails.vue
@@ -290,7 +290,9 @@ export default {
       secret: undefined,
       region: undefined,
       floatingPoolName: undefined,
+      // default validation status of subcomponents is true, as they are not shown in all cases
       floatingPoolValid: true,
+      cloudProfileValid: true,
       fpname: undefined,
       loadBalancerProviderName: undefined,
       loadBalancerClassNames: [],
@@ -300,7 +302,6 @@ export default {
       firewallNetworks: undefined,
       projectID: undefined,
       valid: false,
-      cloudProfileValid: true, // selection not shown in all cases, default to true
       addSecretDialogState: {
         aws: {
           visible: false,
@@ -510,6 +511,11 @@ export default {
       return getValidationErrors(this, field)
     },
     setDefaultsDependingOnCloudProfile () {
+      // Reset subcomponent valid states
+      // default validation status of subcomponents is true, as they are not shown in all cases
+      this.floatingPoolValid = true
+      this.cloudProfileValid = true
+
       this.secret = head(this.infrastructureSecretsByProfileName)
       this.onInputSecret()
       this.region = head(this.regionsWithSeed)


### PR DESCRIPTION
Fixed subcomponent validation state reset in new shoot infrastructure details

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Fixed: Create button on new cluster page was sometimes disabled after switching cloud profile / infrastructure even if there was no validation error for the current selection
```
