### PR TITLE
Allow endusers to create garden webterminals

### DIFF
--- a/backend/test/services.terminals.spec.js
+++ b/backend/test/services.terminals.spec.js
@@ -391,18 +391,6 @@ describe('services', function () {
           expect(err).to.be.instanceof(Forbidden)
         }
       })
-
-      it('should disallow garden terminals for project admins', function () {
-        const isAdmin = false
-        const method = 'create'
-        const target = 'garden'
-        try {
-          ensureTerminalAllowed({ method, isAdmin, body: { coordinate: { target } } })
-          expect.fail('Forbidden error expected')
-        } catch (err) {
-          expect(err).to.be.instanceof(Forbidden)
-        }
-      })
     })
 
     describe('resources', function () {

--- a/frontend/src/components/AccountAvatar.vue
+++ b/frontend/src/components/AccountAvatar.vue
@@ -10,7 +10,8 @@ SPDX-License-Identifier: Apache-2.0
       <img :src="avatarUrl"/>
     </v-avatar>
     <a v-if="mailTo && isEmail" :href="`mailto:${accountName}`" class="pl-2" :class="textColor">{{accountName}}</a>
-    <span v-else class="pl-2">{{accountName || '-unknown-'}}</span>
+    <span v-else-if="accountName" class="pl-2">{{accountName}}</span>
+    <span v-else class="pl-2 font-weight-light text--disabled">Unknown</span>
   </div>
 </template>
 

--- a/frontend/src/components/ProjectServiceAccountRow.vue
+++ b/frontend/src/components/ProjectServiceAccountRow.vue
@@ -29,6 +29,13 @@ SPDX-License-Identifier: Apache-2.0
               </v-list-item>
               <v-list-item class="px-0">
                 <v-list-item-content class="pt-1">
+                  <v-list-item-subtitle>Description</v-list-item-subtitle>
+                  <v-list-item-title v-if="description">{{description}}</v-list-item-title>
+                  <v-list-item-title v-else class="font-weight-light text--disabled">Not defined</v-list-item-title>
+                </v-list-item-content>
+              </v-list-item>
+              <v-list-item class="px-0">
+                <v-list-item-content class="pt-1">
                   <v-list-item-subtitle>Created</v-list-item-subtitle>
                   <v-list-item-title>
                     <v-tooltip top>
@@ -59,16 +66,7 @@ SPDX-License-Identifier: Apache-2.0
         </v-list-item-subtitle>
       </v-list-item-content>
       <v-list-item-action class="ml-1">
-        <div d-flex flex-row>
-           <v-tooltip top v-for="{ displayName, notEditable, tooltip } in roleDisplayNames" :key="displayName" :disabled="!tooltip">
-            <template v-slot:activator="{ on }">
-              <v-chip v-on="on" class="mr-3" small :color="notEditable ? 'grey' : 'black'" outlined>
-                {{displayName}}
-              </v-chip>
-            </template>
-            <span>{{tooltip}}</span>
-          </v-tooltip>
-        </div>
+        <service-account-roles :role-display-names="roleDisplayNames"></service-account-roles>
       </v-list-item-action>
       <v-list-item-action v-if="isServiceAccountFromCurrentNamespace && canGetSecrets" class="ml-1">
         <v-tooltip top>
@@ -121,6 +119,7 @@ import { mapState, mapGetters } from 'vuex'
 import TimeString from '@/components/TimeString'
 import GPopper from '@/components/GPopper'
 import AccountAvatar from '@/components/AccountAvatar'
+import ServiceAccountRoles from '@/components/ServiceAccountRoles'
 import {
   isForeignServiceAccount,
   parseServiceAccountUsername
@@ -131,7 +130,8 @@ export default {
   components: {
     TimeString,
     GPopper,
-    AccountAvatar
+    AccountAvatar,
+    ServiceAccountRoles
   },
   props: {
     username: {
@@ -147,6 +147,9 @@ export default {
       required: true
     },
     createdBy: {
+      type: String
+    },
+    description: {
       type: String
     },
     creationTimestamp: {
@@ -191,7 +194,7 @@ export default {
       this.$emit('kubeconfig', this.username)
     },
     onEdit (username) {
-      this.$emit('edit', this.username, this.roles)
+      this.$emit('edit', this.username, this.roles, this.description)
     },
     onDelete (username) {
       this.$emit('delete', this.username)

--- a/frontend/src/components/ServiceAccountRoles.vue
+++ b/frontend/src/components/ServiceAccountRoles.vue
@@ -1,17 +1,7 @@
 <!--
-Copyright (c) 2020 by SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+SPDX-License-Identifier: Apache-2.0
  -->
 
 <template>
@@ -38,6 +28,3 @@ export default {
   }
 }
 </script>
-
-<style lang="scss" scoped>
-</style>

--- a/frontend/src/components/ServiceAccountRoles.vue
+++ b/frontend/src/components/ServiceAccountRoles.vue
@@ -1,0 +1,43 @@
+<!--
+Copyright (c) 2020 by SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ -->
+
+<template>
+  <div d-flex flex-row>
+    <v-tooltip top v-for="{ displayName, notEditable, tooltip } in roleDisplayNames" :key="displayName" :disabled="!tooltip">
+      <template v-slot:activator="{ on }">
+        <v-chip v-on="on" class="mr-3" small :color="notEditable ? 'grey' : 'black'" outlined>
+          {{displayName}}
+        </v-chip>
+      </template>
+      <span>{{tooltip}}</span>
+    </v-tooltip>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'role-display-names',
+  props: {
+    roleDisplayNames: {
+      type: Array,
+      required: true
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+</style>

--- a/frontend/src/components/ShootDetails/TerminalShortcutsTile.vue
+++ b/frontend/src/components/ShootDetails/TerminalShortcutsTile.vue
@@ -107,7 +107,7 @@ export default {
       if (!this.isAdmin && isGardenTarget) {
         const { data: projectMembers } = await getMembers({ namespace: this.shootNamespace })
         const serviceAccountName = `system:serviceaccount:${this.shootNamespace}:dashboard-webterminal`
-        const member = find(projectMembers, { username: serviceAccountName })
+        const member = find(projectMembers, ['username', serviceAccountName])
         const roles = get(member, 'roles')
         if (!includes(roles, 'admin')) {
           const confirmation = await this.$refs.serviceAccount.promptForConfirmation(member)

--- a/frontend/src/components/ShootDetails/TerminalShortcutsTile.vue
+++ b/frontend/src/components/ShootDetails/TerminalShortcutsTile.vue
@@ -39,17 +39,30 @@ SPDX-License-Identifier: Apache-2.0
     <unverified-terminal-shortcuts-dialog
       ref="unverified"
     ></unverified-terminal-shortcuts-dialog>
+    <webterminal-service-account-dialog
+      :namespace="shootNamespace"
+      ref="serviceAccount"
+    ></webterminal-service-account-dialog>
   </div>
 </template>
 
 <script>
 
+import { mapGetters } from 'vuex'
 import TerminalShortcuts from '@/components/TerminalShortcuts'
 import IconBase from '@/components/icons/IconBase'
 import TerminalShortcutIcon from '@/components/icons/TerminalShortcutIcon'
 import UnverifiedTerminalShortcutsDialog from '@/components/dialogs/UnverifiedTerminalShortcutsDialog'
+import WebterminalServiceAccountDialog from '@/components/dialogs/WebterminalServiceAccountDialog'
+import { TargetEnum } from '@/utils'
+import { shootItem } from '@/mixins/shootItem'
+import { getMembers } from '@/utils/api'
+import get from 'lodash/get'
+import find from 'lodash/find'
+import includes from 'lodash/includes'
 
 export default {
+  mixins: [shootItem],
   props: {
     shootItem: {
       type: Object
@@ -67,9 +80,13 @@ export default {
     TerminalShortcuts,
     IconBase,
     TerminalShortcutIcon,
-    UnverifiedTerminalShortcutsDialog
+    UnverifiedTerminalShortcutsDialog,
+    WebterminalServiceAccountDialog
   },
   computed: {
+    ...mapGetters([
+      'isAdmin'
+    ]),
     expansionPanelIcon () {
       return this.expansionPanel ? 'mdi-chevron-up' : 'mdi-chevron-down'
     },
@@ -85,6 +102,21 @@ export default {
           return
         }
       }
+
+      const isGardenTarget = get(shortcut, 'target') === TargetEnum.GARDEN
+      if (!this.isAdmin && isGardenTarget) {
+        const { data: projectMembers } = await getMembers({ namespace: this.shootNamespace })
+        const serviceAccountName = `system:serviceaccount:${this.shootNamespace}:dashboard-webterminal`
+        const member = find(projectMembers, { username: serviceAccountName })
+        const roles = get(member, 'roles')
+        if (!includes(roles, 'admin')) {
+          const confirmation = await this.$refs.serviceAccount.promptForConfirmation(member)
+          if (!confirmation) {
+            return
+          }
+        }
+      }
+
       this.$emit('addTerminalShortcut', shortcut)
     }
   }

--- a/frontend/src/components/TerminalTarget.vue
+++ b/frontend/src/components/TerminalTarget.vue
@@ -5,37 +5,55 @@ SPDX-License-Identifier: Apache-2.0
  -->
 
 <template>
-  <v-radio-group
-    v-model="selectedTarget"
-    label="Terminal Target"
-    class="mt-6"
-    :hint="hint"
-    persistent-hint
-  >
-    <v-radio
-      v-if="shootItem && hasControlPlaneTerminalAccess"
-      label="Control Plane"
-      value="cp"
-      color="cyan darken-2"
-    ></v-radio>
-    <v-radio
-      v-if="shootItem && hasShootTerminalAccess"
-      value="shoot"
-      color="cyan darken-2"
-      :disabled="isShootStatusHibernated"
+  <div>
+    <v-radio-group
+      v-model="selectedTarget"
+      label="Terminal Target"
+      class="mt-6"
+      :hint="hint"
+      persistent-hint
     >
-      <template v-slot:label>
-        <div>Cluster</div>
-        <v-icon v-if="isShootStatusHibernated" class="vertical-align-middle ml-2">mdi-sleep</v-icon>
-      </template>
-    </v-radio>
-    <v-radio
-      v-if="hasGardenTerminalAccess"
-      label="Garden Cluster"
-      value="garden"
+      <v-radio
+        v-if="shootItem && hasControlPlaneTerminalAccess"
+        label="Control Plane"
+        value="cp"
+        color="cyan darken-2"
+      ></v-radio>
+      <v-radio
+        v-if="shootItem && hasShootTerminalAccess"
+        value="shoot"
+        color="cyan darken-2"
+        :disabled="isShootStatusHibernated"
+      >
+        <template v-slot:label>
+          <div>Cluster</div>
+          <v-icon v-if="isShootStatusHibernated" class="vertical-align-middle ml-2">mdi-sleep</v-icon>
+        </template>
+      </v-radio>
+      <v-radio
+        v-if="hasGardenTerminalAccess"
+        value="garden"
+        color="cyan darken-2"
+        :disabled="!isAdmin && isShootStatusHibernated"
+      >
+        <template v-slot:label>
+          <div>Garden Cluster</div>
+          <v-icon v-if="!isAdmin && isShootStatusHibernated" class="vertical-align-middle ml-2">mdi-sleep</v-icon>
+        </template>
+      </v-radio>
+    </v-radio-group>
+    <v-alert
+      v-if="!isAdmin && selectedTarget === 'garden'"
+      class="mt-2 mb-2"
+      :value="true"
+      type="info"
       color="cyan darken-2"
-    ></v-radio>
-  </v-radio-group>
+      outlined
+    >
+      <strong>Terminal will be running on <tt>{{shootName}}</tt> cluster</strong><br>
+      Make sure that only gardener project members with <tt>admin</tt> role have privileged access to the <tt>{{shootName}}</tt> cluster before creating this terminal session.
+    </v-alert>
+  </div>
 </template>
 
 <script>

--- a/frontend/src/components/dialogs/CreateTerminalSessionDialog.vue
+++ b/frontend/src/components/dialogs/CreateTerminalSessionDialog.vue
@@ -213,7 +213,7 @@ export default {
 
           const { data: projectMembers } = await getMembers({ namespace: this.namespace })
           const serviceAccountName = `system:serviceaccount:${this.namespace}:dashboard-webterminal`
-          const member = find(projectMembers, { username: serviceAccountName })
+          const member = find(projectMembers, ['username', serviceAccountName])
           const roles = get(member, 'roles')
           if (includes(roles, 'admin')) {
             return true

--- a/frontend/src/components/dialogs/CreateTerminalSessionDialog.vue
+++ b/frontend/src/components/dialogs/CreateTerminalSessionDialog.vue
@@ -87,6 +87,7 @@ import WebterminalServiceAccountDialog from '@/components/dialogs/WebterminalSer
 import ConfirmDialog from '@/components/dialogs/ConfirmDialog'
 import { mapGetters } from 'vuex'
 import { getMembers, terminalConfig } from '@/utils/api'
+import { TargetEnum } from '@/utils'
 import { shootItem } from '@/mixins/shootItem'
 import filter from 'lodash/filter'
 import get from 'lodash/get'
@@ -205,7 +206,7 @@ export default {
               return false
             }
           }
-          const selectionContainsGardenTarget = some(this.selections, ['target', 'garden'])
+          const selectionContainsGardenTarget = some(this.selections, ['target', TargetEnum.GARDEN])
           if (this.isAdmin || !selectionContainsGardenTarget) {
             return true
           }

--- a/frontend/src/components/dialogs/MemberDialog.vue
+++ b/frontend/src/components/dialogs/MemberDialog.vue
@@ -44,6 +44,7 @@ SPDX-License-Identifier: Apache-2.0
                 @input="$v.internalRoles.$touch()"
                 :hint="rolesHint"
                 persistent-hint
+                tabindex="2"
                 >
                 <template v-slot:selection="{ item, index }">
                   <v-chip small color="black" outlined close @update:active="internalRoles.splice(index, 1); $v.internalRoles.$touch()">
@@ -53,14 +54,26 @@ SPDX-License-Identifier: Apache-2.0
               </v-select>
             </v-col>
           </v-row>
+          <v-row v-if="isServiceDialog">
+            <v-col cols="12">
+              <v-text-field
+                color="black"
+                ref="internalDescription"
+                label="Description"
+                v-model.trim="internalDescription"
+                @keyup.enter="submitAddMember()"
+                tabindex="3"
+              ></v-text-field>
+            </v-col>
+          </v-row>
           <g-alert color="error" :message.sync="errorMessage" :detailedMessage.sync="detailedErrorMessage"></g-alert>
         </v-container>
       </v-card-text>
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn text @click.stop="cancel" tabindex="3">Cancel</v-btn>
-        <v-btn v-if="isUpdateDialog" text @click.stop="submitUpdateMember" :disabled="!valid" class="black--text" tabindex="2">Update</v-btn>
-        <v-btn v-else text @click.stop="submitAddMember" :disabled="!valid" class="black--text" tabindex="2">{{addMemberButtonText}}</v-btn>
+        <v-btn text @click.stop="cancel" tabindex="5">Cancel</v-btn>
+        <v-btn v-if="isUpdateDialog" text @click.stop="submitUpdateMember" :disabled="!valid" class="black--text" tabindex="4">Update</v-btn>
+        <v-btn v-else text @click.stop="submitAddMember" :disabled="!valid" class="black--text" tabindex="4">{{addMemberButtonText}}</v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>
@@ -102,6 +115,9 @@ export default {
     name: {
       type: String
     },
+    description: {
+      type: String
+    },
     roles: {
       type: Array
     },
@@ -113,6 +129,7 @@ export default {
     return {
       internalName: undefined,
       internalRoles: undefined,
+      internalDescription: undefined,
       unsupportedRoles: undefined,
       errorMessage: undefined,
       detailedErrorMessage: undefined
@@ -316,7 +333,7 @@ export default {
         const name = this.memberName
         const roles = this.internalRoles
         try {
-          await this.addMember({ name, roles })
+          await this.addMember({ name, roles, description: this.internalDescription })
           this.hide()
         } catch (err) {
           const errorDetails = errorDetailsFromError(err)
@@ -340,7 +357,7 @@ export default {
         try {
           const name = this.memberName
           const roles = [...this.internalRoles, ...this.unsupportedRoles]
-          await this.updateMember({ name, roles })
+          await this.updateMember({ name, roles, description: this.internalDescription })
 
           if (this.isCurrentUser && !this.isAdmin) {
             await this.refreshSubjectRules()
@@ -361,6 +378,7 @@ export default {
     reset () {
       this.$v.$reset()
 
+      this.internalDescription = this.description
       if (this.isUserDialog) {
         if (this.name) {
           this.internalName = this.name

--- a/frontend/src/components/dialogs/MemberDialog.vue
+++ b/frontend/src/components/dialogs/MemberDialog.vue
@@ -58,7 +58,6 @@ SPDX-License-Identifier: Apache-2.0
             <v-col cols="12">
               <v-text-field
                 color="black"
-                ref="internalDescription"
                 label="Description"
                 v-model.trim="internalDescription"
                 @keyup.enter="submitAddMember()"

--- a/frontend/src/components/dialogs/WebterminalServiceAccountDialog.vue
+++ b/frontend/src/components/dialogs/WebterminalServiceAccountDialog.vue
@@ -1,17 +1,7 @@
 <!--
-Copyright (c) 2020 by SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+SPDX-License-Identifier: Apache-2.0
  -->
 
 <template>

--- a/frontend/src/components/dialogs/WebterminalServiceAccountDialog.vue
+++ b/frontend/src/components/dialogs/WebterminalServiceAccountDialog.vue
@@ -1,0 +1,174 @@
+<!--
+Copyright (c) 2020 by SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ -->
+
+<template>
+  <g-dialog
+    :confirmButtonText="confirmButtonText"
+    max-width="750px"
+    max-height="100vh"
+    defaultColor="cyan-darken-2"
+    ref="gDialog"
+    >
+    <template v-slot:caption>
+      <template v-if="needsUpdate">
+        Update Service Account
+      </template>
+      <template v-else>
+        Add Service Account
+      </template>
+    </template>
+    <template v-slot:message>
+      <div key="confirm-message" style="min-height:100px">
+        <div>
+          <span v-if="needsUpdate">To access the garden cluster the <tt>{{serviceAccountName}}</tt> service account requires the <tt>admin</tt> role.</span>
+          <span v-else>To access the garden cluster a dedicated service account is required.</span>
+        </div>
+        <div>
+           <span v-if="needsUpdate">Do you want grant the <tt>admin</tt> role to the service account?</span>
+           <span v-else>Do you want to create the <tt>{{serviceAccountName}}</tt> service account and add it as member with <tt>admin</tt> role to this project?</span>
+          <v-list>
+            <v-list-item>
+              <v-list-item-content>
+                <v-list-item-title class="wrap-text">
+                  <account-avatar :account-name="serviceAccountUsername"></account-avatar>
+                </v-list-item-title>
+              </v-list-item-content>
+              <v-list-item-action>
+                <service-account-roles :role-display-names="desiredRoleDisplayNames"></service-account-roles>
+              </v-list-item-action>
+            </v-list-item>
+          </v-list>
+        </div>
+      </div>
+      <g-alert
+        color="error"
+        class="ma-0"
+        :message.sync="errorMessage"
+        :detailedMessage.sync="detailedErrorMessage"
+      ></g-alert>
+    </template>
+  </g-dialog>
+</template>
+
+<script>
+import GDialog from '@/components/dialogs/GDialog'
+import AccountAvatar from '@/components/AccountAvatar'
+import GAlert from '@/components/GAlert'
+import ServiceAccountRoles from '@/components/ServiceAccountRoles'
+import { errorDetailsFromError, isConflict } from '@/utils/error'
+import { mapActions } from 'vuex'
+import get from 'lodash/get'
+import { sortedRoleDisplayNames } from '@/utils'
+
+export default {
+  name: 'WebterminalServiceAccountDialog',
+  components: {
+    GDialog,
+    GAlert,
+    AccountAvatar,
+    ServiceAccountRoles
+  },
+  props: {
+    namespace: {
+      type: String
+    }
+  },
+  data () {
+    return {
+      errorMessage: undefined,
+      detailedErrorMessage: undefined,
+      member: undefined
+    }
+  },
+  computed: {
+    needsUpdate () {
+      return !!this.member
+    },
+    confirmButtonText () {
+      if (this.needsUpdate) {
+        return 'Update'
+      }
+      return 'Add'
+    },
+    serviceAccountName () {
+      return 'dashboard-webterminal'
+    },
+    serviceAccountUsername () {
+      return `system:serviceaccount:${this.namespace}:${this.serviceAccountName}`
+    },
+    desiredRoleDisplayNames () {
+      return sortedRoleDisplayNames(this.desiredRoles)
+    },
+    desiredRoles () {
+      const roles = [...get(this.member, 'roles', [])]
+      roles.push('admin')
+      return roles
+    }
+  },
+  methods: {
+    ...mapActions([
+      'addMember',
+      'updateMember'
+    ]),
+    async promptForConfirmation (member) {
+      this.member = member
+
+      return await this.$refs.gDialog.confirmWithDialog(async () => {
+        return this.addServiceAccount()
+      })
+    },
+    async addServiceAccount () {
+      if (!this.namespace) {
+        console.error('no namespace set')
+        return false
+      }
+
+      try {
+        if (this.needsUpdate) {
+          await this.updateMember({
+            name: this.serviceAccountUsername,
+            roles: this.desiredRoles,
+            description: 'Service account required to manage temporary service accounts for the webterminal feature of the gardener dashboard'
+          })
+        } else {
+          await this.addMember({
+            name: this.serviceAccountUsername,
+            roles: ['admin'],
+            description: 'Service account required to manage temporary service accounts for the webterminal feature of the gardener dashboard'
+          })
+        }
+        return true
+      } catch (err) {
+        const errorDetails = errorDetailsFromError(err)
+        if (isConflict(err)) {
+          return true // service account already exists
+        } else {
+          this.errorMessage = 'Failed to add service account'
+        }
+        this.detailedErrorMessage = errorDetails.detailedMessage
+        console.error(this.errorMessage, errorDetails.errorCode, errorDetails.detailedMessage, err)
+        return false
+      }
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+  .wrap-text {
+    white-space: normal;
+  }
+</style>

--- a/frontend/src/components/dialogs/WebterminalServiceAccountDialog.vue
+++ b/frontend/src/components/dialogs/WebterminalServiceAccountDialog.vue
@@ -122,6 +122,7 @@ export default {
     },
     async addServiceAccount () {
       if (!this.namespace) {
+        // eslint-disable-next-line no-console
         console.error('no namespace set')
         return false
       }
@@ -149,6 +150,7 @@ export default {
           this.errorMessage = 'Failed to add service account'
         }
         this.detailedErrorMessage = errorDetails.detailedMessage
+        // eslint-disable-next-line no-console
         console.error(this.errorMessage, errorDetails.errorCode, errorDetails.detailedMessage, err)
         return false
       }

--- a/frontend/src/router/routes.js
+++ b/frontend/src/router/routes.js
@@ -436,7 +436,7 @@ function gardenTerminalRoute ({ getters }, path) {
         title: 'Garden Cluster',
         icon: 'mdi-console',
         get hidden () {
-          return !getters.hasGardenTerminalAccess
+          return !(getters.hasGardenTerminalAccess && getters.isAdmin)
         }
       },
       breadcrumbs: terminalBreadcrumbs

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -836,7 +836,7 @@ const getters = {
     return getters['shoots/initialNewShootResource']
   },
   hasGardenTerminalAccess (state, getters) {
-    return getters.isTerminalEnabled && getters.canCreateTerminals && getters.isAdmin
+    return getters.isTerminalEnabled && getters.canCreateTerminals
   },
   hasControlPlaneTerminalAccess (state, getters) {
     return getters.isTerminalEnabled && getters.canCreateTerminals && getters.isAdmin

--- a/frontend/src/store/modules/members.js
+++ b/frontend/src/store/modules/members.js
@@ -32,9 +32,9 @@ const actions = {
     const res = await addMember({ namespace, data })
     commit('RECEIVE', res.data)
   },
-  async update ({ commit, rootState }, { name, roles }) {
+  async update ({ commit, rootState }, { name, roles, description }) {
     const namespace = rootState.namespace
-    const res = await updateMember({ namespace, name, data: { roles } })
+    const res = await updateMember({ namespace, name, data: { roles, description } })
     commit('RECEIVE', res.data)
   },
   async delete ({ commit, rootState }, name) {

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -785,13 +785,7 @@ export function expiringWorkerGroupsForShoot (shootWorkerGroups, shootCloudProfi
 }
 
 export function sortedRoleDisplayNames (roleNames) {
-  const displayNames = []
-  forEach(roleNames, roleName => {
-    const roleDescriptor = find(MEMBER_ROLE_DESCRIPTORS, { name: roleName })
-    if (roleDescriptor) {
-      displayNames.push(roleDescriptor)
-    }
-  })
+  const displayNames = filter(MEMBER_ROLE_DESCRIPTORS, role => includes(roleNames, role.name))
   return sortBy(displayNames, 'displayName')
 }
 

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -22,6 +22,7 @@ import forEach from 'lodash/forEach'
 import words from 'lodash/words'
 import find from 'lodash/find'
 import some from 'lodash/some'
+import sortBy from 'lodash/sortBy'
 import isEmpty from 'lodash/isEmpty'
 import includes from 'lodash/includes'
 import startsWith from 'lodash/startsWith'
@@ -781,6 +782,17 @@ export function expiringWorkerGroupsForShoot (shootWorkerGroups, shootCloudProfi
   return filter(workerGroups, ({ expirationDate, isError, isWarning, isInfo }) => {
     return expirationDate && (isError || isWarning || isInfo)
   })
+}
+
+export function sortedRoleDisplayNames (roleNames) {
+  const displayNames = []
+  forEach(roleNames, roleName => {
+    const roleDescriptor = find(MEMBER_ROLE_DESCRIPTORS, { name: roleName })
+    if (roleDescriptor) {
+      displayNames.push(roleDescriptor)
+    }
+  })
+  return sortBy(displayNames, 'displayName')
 }
 
 export default {

--- a/frontend/src/views/Members.vue
+++ b/frontend/src/views/Members.vue
@@ -108,6 +108,7 @@ SPDX-License-Identifier: Apache-2.0
             :createdBy="serviceAccount.createdBy"
             :creationTimestamp="serviceAccount.creationTimestamp"
             :created="serviceAccount.created"
+            :description="serviceAccount.description"
             :roles="serviceAccount.roles"
             :roleDisplayNames="serviceAccount.roleDisplayNames"
             :key="`${serviceAccount.namespace}_${serviceAccount.username}`"
@@ -122,8 +123,8 @@ SPDX-License-Identifier: Apache-2.0
 
     <member-dialog type="adduser" v-model="userAddDialog"></member-dialog>
     <member-dialog type="addservice" v-model="serviceAccountAddDialog"></member-dialog>
-    <member-dialog type="updateuser" :name="updatedMemberName" :isCurrentUser="isCurrentUser(updatedMemberName)" :roles="updatedMemberRoles" v-model="userUpdateDialog"></member-dialog>
-    <member-dialog type="updateservice" :name="updatedMemberName" :isCurrentUser="isCurrentUser(updatedMemberName)" :roles="updatedMemberRoles" v-model="serviceAccountUpdateDialog"></member-dialog>
+    <member-dialog type="updateuser" :name="memberName" :isCurrentUser="isCurrentUser(memberName)" :roles="memberRoles" v-model="userUpdateDialog"></member-dialog>
+    <member-dialog type="updateservice" :name="memberName" :description="serviceAccountDescription" :isCurrentUser="isCurrentUser(memberName)" :roles="memberRoles" v-model="serviceAccountUpdateDialog"></member-dialog>
     <member-help-dialog type="user" v-model="userHelpDialog"></member-help-dialog>
     <member-help-dialog type="service" v-model="serviceAccountHelpDialog"></member-help-dialog>
     <v-dialog v-model="kubeconfigDialog" persistent max-width="67%">
@@ -171,7 +172,6 @@ import filter from 'lodash/filter'
 import forEach from 'lodash/forEach'
 import join from 'lodash/join'
 import map from 'lodash/map'
-import find from 'lodash/find'
 import escape from 'lodash/escape'
 import get from 'lodash/get'
 
@@ -189,8 +189,8 @@ import {
   isForeignServiceAccount,
   isServiceAccountUsername,
   getTimestampFormatted,
-  MEMBER_ROLE_DESCRIPTORS,
-  getProjectDetails
+  getProjectDetails,
+  sortedRoleDisplayNames
 } from '@/utils'
 
 import { getMember } from '@/utils/api'
@@ -214,8 +214,9 @@ export default {
       userHelpDialog: false,
       serviceAccountHelpDialog: false,
       kubeconfigDialog: false,
-      updatedMemberName: undefined,
-      updatedMemberRoles: undefined,
+      memberName: undefined,
+      memberRoles: undefined,
+      serviceAccountDescription: undefined,
       userFilter: '',
       serviceAccountFilter: '',
       fab: false,
@@ -445,24 +446,18 @@ export default {
       })
     },
     onEditUser (username, roles) {
-      this.updatedMemberName = username
-      this.updatedMemberRoles = roles
+      this.memberName = username
+      this.memberRoles = roles
       this.openUserUpdateDialog()
     },
-    onEditServiceAccount (username, roles) {
-      this.updatedMemberName = username
-      this.updatedMemberRoles = roles
+    onEditServiceAccount (username, roles, description) {
+      this.memberName = username
+      this.memberRoles = roles
+      this.serviceAccountDescription = description
       this.openServiceAccountUpdateDialog()
     },
     sortedRoleDisplayNames (roleNames) {
-      const displayNames = []
-      forEach(roleNames, roleName => {
-        const roleDescriptor = find(MEMBER_ROLE_DESCRIPTORS, { name: roleName })
-        if (roleDescriptor) {
-          displayNames.push(roleDescriptor)
-        }
-      })
-      return sortBy(displayNames, 'displayName')
+      return sortedRoleDisplayNames(roleNames)
     },
     isCurrentUser (username) {
       return this.username === username


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables endusers to create webterminals for the garden cluster, in addition to the shoot cluster webterminals.

See also discussion in #796. With this PR, to grab the low hanging fruits so to say, the enduser terminals run on their own shoot clusters.

/hold until https://github.com/gardener/terminal-controller-manager/pull/47 is merged and released

<img width="1675" alt="Screenshot 2020-10-29 at 12 09 16" src="https://user-images.githubusercontent.com/5526658/97576505-8ccba800-19ee-11eb-9456-23406d60cb09.png">

<img width="1679" alt="Screenshot 2020-10-29 at 12 09 57" src="https://user-images.githubusercontent.com/5526658/97576558-9bb25a80-19ee-11eb-8249-32e49572d9e8.png">

<img width="1217" alt="Screenshot 2020-10-29 at 12 10 50" src="https://user-images.githubusercontent.com/5526658/97576587-a371ff00-19ee-11eb-9a54-5824e150e074.png">


**Which issue(s) this PR fixes**:
Fixes #796 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
When creating a new terminal, you can now choose the target `Garden Cluster`. This allows you to talk directly to the gardener api server, e.g. run `kubectl get shoots` or `kubectl get project my-project -oyaml`
```

```action operator
This dashboard version requires terminal-controller-manager v0.14.0 or higher, in case the terminal feature is enabled
```
