### PR TITLE
Handle unreachable seeds in terminal bootstrap logic

### DIFF
--- a/backend/lib/services/seeds.js
+++ b/backend/lib/services/seeds.js
@@ -20,10 +20,10 @@ const _ = require('lodash')
 const { Forbidden } = require('http-errors')
 const authorization = require('./authorization')
 const { getSeeds } = require('../cache')
-const config = require('../config')
+const { isSeedUnreachable } = require('../utils')
 
 function fromResource (seed) {
-  const unreachable = isUnreachable(seed)
+  const unreachable = isSeedUnreachable(seed)
   const metadata = {
     name: _.get(seed, 'metadata.name'),
     unreachable
@@ -42,14 +42,6 @@ function fromResource (seed) {
   }
 
   return { metadata, data }
-}
-
-function isUnreachable (seed) {
-  const matchLabels = _.get(config, 'unreachableSeeds.matchLabels')
-  if (!matchLabels) {
-    return false
-  }
-  return _.isMatch(seed, { metadata: { labels: matchLabels } })
 }
 
 exports.list = async function ({ user }) {

--- a/backend/lib/utils/index.js
+++ b/backend/lib/utils/index.js
@@ -53,10 +53,19 @@ function shootHasIssue (shoot) {
   return _.get(shoot, ['metadata', 'labels', 'shoot.gardener.cloud/status'], 'healthy') !== 'healthy'
 }
 
+function isSeedUnreachable (seed) {
+  const matchLabels = _.get(config, 'unreachableSeeds.matchLabels')
+  if (!matchLabels) {
+    return false
+  }
+  return _.isMatch(seed, { metadata: { labels: matchLabels } })
+}
+
 module.exports = {
   decodeBase64,
   encodeBase64,
   getConfigValue,
   getSeedNameFromShoot,
-  shootHasIssue
+  shootHasIssue,
+  isSeedUnreachable
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Handle unreachable seeds in terminal bootstrap logic

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
enhancement to https://github.com/gardener/dashboard/pull/831

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user

```
