### PR TITLE
Use visible seed settings field

### DIFF
--- a/backend/lib/cache/index.js
+++ b/backend/lib/cache/index.js
@@ -115,7 +115,7 @@ module.exports = {
     const predicate = item => {
       const taints = _.get(item, 'spec.taints')
       const unprotected = !_.find(taints, ['key', 'seed.gardener.cloud/protected'])
-      const visible = !_.find(taints, ['key', 'seed.gardener.cloud/invisible'])
+      const visible = _.get(item, 'spec.settings.scheduling.visible')
       return unprotected && visible
     }
     return _.filter(cache.getSeeds(), predicate)

--- a/backend/lib/services/seeds.js
+++ b/backend/lib/services/seeds.js
@@ -31,7 +31,7 @@ function fromResource (seed) {
 
   const taints = _.get(seed, 'spec.taints')
   const unprotected = !_.find(taints, ['key', 'seed.gardener.cloud/protected'])
-  const visible = !_.find(taints, ['key', 'seed.gardener.cloud/invisible'])
+  const visible = _.get(seed, 'spec.settings.scheduling.visible')
   const provider = _.get(seed, 'spec.provider')
   const volume = _.get(seed, 'spec.volume')
   const data = {

--- a/backend/test/support/common.js
+++ b/backend/test/support/common.js
@@ -48,17 +48,17 @@ function getSeed ({
       dns: {
         ingressDomain: `ingress.${region}.${kind}.example.org`
       },
-      taints: []
+      taints: [],
+      settings: {
+        scheduling: {
+          visible: seedVisible
+        }
+      }
     }
   }
   if (seedProtected) {
     seed.spec.taints.push({
       key: 'seed.gardener.cloud/protected'
-    })
-  }
-  if (!seedVisible) {
-    seed.spec.taints.push({
-      key: 'seed.gardener.cloud/invisible'
     })
   }
   if (withSecretRef) {

--- a/frontend/src/store/modules/shoots.js
+++ b/frontend/src/store/modules/shoots.js
@@ -288,7 +288,7 @@ const actions = {
     const purpose = head(purposesForSecret(secret))
     set(shootResource, 'spec.purpose', purpose)
 
-    const kubernetesVersion = rootGetters.defaultKubernetesVersionForCloudProfileName(cloudProfileName)
+    const kubernetesVersion = rootGetters.defaultKubernetesVersionForCloudProfileName(cloudProfileName) || {}
     set(shootResource, 'spec.kubernetes.version', kubernetesVersion.version)
 
     const allZones = rootGetters.zonesByCloudProfileNameAndRegion({ cloudProfileName, region })


### PR DESCRIPTION
**What this PR does / why we need it**:
The `seed.gardener.cloud/invisible` taint was removed in https://github.com/gardener/gardener/pull/2955 and is replaced with `.spec.settings.scheduling.visible`

**Which issue(s) this PR fixes**:
Fixes #848

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The dashboard is now using the field `.spec.settings.scheduling.visible` instead of the taint `seed.gardener.cloud/invisible`
```
