### PR TITLE
Fix terminal service test

### DIFF
--- a/backend/test/services.terminals.spec.js
+++ b/backend/test/services.terminals.spec.js
@@ -619,7 +619,7 @@ describe('services', function () {
           uid: '4'
         },
         spec: {
-          seedName: unreachableSeedName // unreachable seed
+          seedName: unreachableSeedName
         },
         status: {
           technicalID: 'shoot--foo--unreachable',

--- a/backend/test/services.terminals.spec.js
+++ b/backend/test/services.terminals.spec.js
@@ -603,7 +603,7 @@ describe('services', function () {
           uid: '3'
         },
         spec: {
-          seedName: seedWithoutSecretRefName // seed without spec.secretRef
+          seedName: seedWithoutSecretRefName
         },
         status: {
           technicalID: 'shoot--foo--dummy',


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the problem with a duplicate `uid` in a terminal test. The `kube-client` stubs have been implemented async to prevent possible timing problems or forgotten awaits. And in bootstrapping the stub for `client.getShoot` has been removed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user

```
