### PR TITLE
Disallow the use of console

### DIFF
--- a/backend/.eslintrc.js
+++ b/backend/.eslintrc.js
@@ -11,11 +11,13 @@ module.exports = {
   // add your custom rules here
   rules: {
     // allow paren-less arrow functions
-    'arrow-parens': 0,
+    'arrow-parens': 'off',
     // allow async-await
-    'generator-star-spacing': 0,
+    'generator-star-spacing': 'off',
+    // disallow the use of console
+    'no-console': 'error',
     // allow debugger during development
-    'no-debugger': process.env.NODE_ENV === 'production' ? 2 : 0
+    'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off'
   },
   globals: {
     describe: true,

--- a/charts/package.json
+++ b/charts/package.json
@@ -58,7 +58,9 @@
     "parserOptions": {
       "ecmaVersion": 11
     },
-    "rules": {}
+    "rules": {
+      "no-console": "error"
+    }
   },
   "jest": {
     "testEnvironment": "node",

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+const production = process.env.NODE_ENV === 'production'
+
 module.exports = {
   root: true,
   env: {
@@ -18,8 +20,8 @@ module.exports = {
     'vuetify'
   ],
   rules: {
-    'no-console': ['error', { allow: ['error'] }],
-    'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
+    'no-console': [ production ? 'error' : 'off', { allow: ['error'] }],
+    'no-debugger': production ? 'error' : 'off',
     'vuetify/no-deprecated-classes': 'error',
     'vuetify/grid-unknown-attributes': 'error',
     'vuetify/no-legacy-grid': 'error'

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -18,8 +18,8 @@ module.exports = {
     'vuetify'
   ],
   rules: {
-    'no-console': 'off',
-    'no-debugger': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
+    'no-console': ['error', { allow: ['error'] }],
+    'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
     'vuetify/no-deprecated-classes': 'error',
     'vuetify/grid-unknown-attributes': 'error',
     'vuetify/no-legacy-grid': 'error'

--- a/frontend/src/components/GTerminal.vue
+++ b/frontend/src/components/GTerminal.vue
@@ -407,6 +407,7 @@ export default {
         try {
           await this.terminalSession.deleteTerminal()
         } catch (err) {
+          // eslint-disable-next-line no-console
           console.log('failed to cleanup terminal session on configuration change')
         }
         this.cancelConnectAndClose()

--- a/frontend/src/components/RetryOperation.vue
+++ b/frontend/src/components/RetryOperation.vue
@@ -55,6 +55,7 @@ export default {
       try {
         await addShootAnnotation({ namespace, name, data: retryAnnotation })
       } catch (err) {
+        // eslint-disable-next-line no-console
         console.log('failed to retry operation', err)
 
         this.$store.dispatch('setError', err)

--- a/frontend/src/components/ShootHibernation/ManageHibernationSchedule.vue
+++ b/frontend/src/components/ShootHibernation/ManageHibernationSchedule.vue
@@ -135,6 +135,7 @@ export default {
         })
         this.setParsedSchedules(parsedScheduleEvents)
       } catch (error) {
+        // eslint-disable-next-line no-console
         console.warn(error)
         this.parseError = true
       }

--- a/frontend/src/lib/terminal.js
+++ b/frontend/src/lib/terminal.js
@@ -200,12 +200,14 @@ export class TerminalSession {
 
       let timeoutSeconds
       if (wasConnected) {
-        timeoutSeconds = 0
         // do not start spinner as this would clear the console
+        timeoutSeconds = 0
+        // eslint-disable-next-line no-console
         console.log(`Websocket connection lost (code ${error.code}). Trying to reconnect..`)
       } else { // Try again later
         timeoutSeconds = RETRY_TIMEOUT_SECONDS
         this.vm.spinner.start()
+        // eslint-disable-next-line no-console
         console.log(`Pod not yet ready. Reconnecting in ${timeoutSeconds} seconds..`)
       }
       reconnectTimeoutId = setTimeout(() => this.attachTerminal(), timeoutSeconds * 1000)

--- a/frontend/src/lib/xterm-addon-k8s-attach.js
+++ b/frontend/src/lib/xterm-addon-k8s-attach.js
@@ -59,6 +59,7 @@ export class K8sAttachAddon {
 
     this.pingIntervalId = setInterval(() => {
       if (this._socket.readyState === WsReadyStateEnum.CONNECTING || this._socket.readyState === WsReadyStateEnum.CLOSED) {
+        // eslint-disable-next-line no-console
         console.log('Websocket closing or already closed. Stopping ping')
         clearTimeout(this.pingIntervalId)
         return

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -1238,6 +1238,7 @@ const actions = {
           items
         })
       } catch (err) {
+        // eslint-disable-next-line no-console
         console.warn('Failed to list project terminal shortcuts:', err.message)
       }
     }

--- a/frontend/src/utils/Emitter.js
+++ b/frontend/src/utils/Emitter.js
@@ -23,8 +23,10 @@ class Connector {
 
   onConnect (attempt) {
     if (attempt) {
+      // eslint-disable-next-line no-console
       console.log(`socket connection ${this.socket.id} established after '${attempt}' attempt(s)`)
     } else {
+      // eslint-disable-next-line no-console
       console.log(`socket connection ${this.socket.id} established`)
     }
     store.dispatch('unsetWebsocketConnectionError')
@@ -42,6 +44,7 @@ class Connector {
   }
 
   disconnect () {
+    // eslint-disable-next-line no-console
     console.log(`Disconnect socket ${this.socket.id}`)
     if (this.socket.connected) {
       this.socket.disconnect()
@@ -291,10 +294,12 @@ forEach([shootsConnector, ticketsConnector], connector => {
     console.error(`socket ${socket.id} connection timeout`)
   })
   socket.on('reconnect_attempt', () => {
+    // eslint-disable-next-line no-console
     console.log(`socket ${socket.id} reconnect attempt`)
   })
   socket.on('reconnecting', attempt => {
     store.dispatch('setWebsocketConnectionError', { reconnectAttempt: attempt })
+    // eslint-disable-next-line no-console
     console.log(`socket ${socket.id} reconnecting attempt number '${attempt}'`)
   })
   socket.on('reconnect_error', err => {

--- a/packages/kube-client/package.json
+++ b/packages/kube-client/package.json
@@ -73,7 +73,9 @@
     "parserOptions": {
       "ecmaVersion": 11
     },
-    "rules": {}
+    "rules": {
+      "no-console": "error"
+    }
   },
   "jest": {
     "restoreMocks": true,

--- a/packages/kube-config/package.json
+++ b/packages/kube-config/package.json
@@ -56,7 +56,9 @@
     "parserOptions": {
       "ecmaVersion": 11
     },
-    "rules": {}
+    "rules": {
+      "no-console": "error"
+    }
   },
   "jest": {
     "restoreMocks": true,

--- a/packages/logger/lib/Logger.js
+++ b/packages/logger/lib/Logger.js
@@ -24,7 +24,7 @@ class Logger {
     this.logHttpRequestBody = false
     this.setLogHttpRequestBody(logHttpRequestBody)
     this.silent = /^test/.test(process.env.NODE_ENV)
-    this.console = console
+    this.console = global.console
   }
 
   setLogLevel (value) {

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -56,7 +56,9 @@
     "parserOptions": {
       "ecmaVersion": 11
     },
-    "rules": {}
+    "rules": {
+      "no-console": "error"
+    }
   },
   "jest": {
     "restoreMocks": true,

--- a/packages/request/package.json
+++ b/packages/request/package.json
@@ -56,7 +56,9 @@
     "parserOptions": {
       "ecmaVersion": 11
     },
-    "rules": {}
+    "rules": {
+      "no-console": "error"
+    }
   },
   "jest": {
     "restoreMocks": true,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds an `eslint` rule which disallows the use of console for all packages. The only exception is the frontend the usage of `console.error` is still allowed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user

```
