### PR TITLE
Disable build of "deasync" as it breaks execution of "yarn"

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,11 @@
     "Koser, Holger <holger.koser@sap.com>",
     "Sutter, Peter <peter.sutter@sap.com>"
   ],
+  "dependenciesMeta": {
+    "deasync": {
+      "built": false
+    }
+  },
   "devDependencies": {
     "eslint": "^6.8.0"
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR started adding a development dependency for "node-gyp". Otherwise the following error occured:

```
Usage Error: Couldn't find a script name "node-gyp" in the top-level (used by deasync@npm:0.1.20). 
This typically happens because some package depends on "node-gyp" to build itself, but didn't list
it in their dependencies. To fix that, please run "yarn add node-gyp" into your top-level workspace.
You also can open an issue on the repository of the specified package to suggest them to use an 
optional peer dependency.
```

After further investigation disabling the build of "deasync" was suggested.