### PR TITLE
Use base images from GCR

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -29,7 +29,7 @@ dashboard:
         pull-request: ~
       steps:
         check:
-          image: 'node:14-alpine3.12'
+          image: 'eu.gcr.io/gardener-project/3rd/node:14-alpine3.12'
     release:
       traits:
         version:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 #### Builder ####
-FROM node:14-alpine3.12 as builder
+FROM  eu.gcr.io/gardener-project/3rd/node:14-alpine3.12 as builder
 
 WORKDIR /usr/src/app
 
@@ -33,7 +33,7 @@ RUN cp -r frontend/dist /usr/src/build/public \
     && find /usr/src/build/.yarn -mindepth 1 -name cache -prune -o -exec rm -rf {} +
 
 #### Release ####
-FROM alpine:3.12 as release
+FROM eu.gcr.io/gardener-project/3rd/alpine:3.12 as release
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \

--- a/backend/test/docker.spec.js
+++ b/backend/test/docker.spec.js
@@ -49,6 +49,8 @@ async function getDashboardDockerfile () {
 }
 
 describe('dockerfile', function () {
+  /* eslint-disable no-unused-expressions */
+
   this.timeout(15000)
   this.slow(5000)
 
@@ -67,10 +69,10 @@ describe('dockerfile', function () {
     const endOfLife = activeNodeReleases[nodeRelease].endOfLife
     expect(endOfLife, `Node release ${nodeRelease} reached end of life. Update node base image in Dockerfile.`).to.be.above(new Date())
     const dashboardReleaseBaseImage = buildStages.release.getImage()
-    const [, alpineVersion] = /^alpine:(\d+\.\d+)/.exec(dashboardReleaseBaseImage)
+    const [, alpineVersion] = /alpine:(\d+\.\d+)/.exec(dashboardReleaseBaseImage)
     const nodeDockerfile = await getNodeDockerfile(nodeRelease, alpineVersion)
     expect(nodeDockerfile.getFROMs()).to.have.length(1)
     const nodeBaseImage = _.first(nodeDockerfile.getFROMs()).getImage()
-    expect(nodeBaseImage, 'Alpine base images of "dashboard-release" image and "node" image do not match!').to.be.equal(dashboardReleaseBaseImage)
+    expect(dashboardReleaseBaseImage.endsWith(nodeBaseImage), 'Alpine base images of "dashboard-release" image and "node" image do not match!').to.be.true
   })
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
To prevent running into [rate limit](https://www.docker.com/increase-rate-limits) issues with docker hub use the mirrored images from our GCR.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user

```
