### PR TITLE
ServiceAccount Member Dashboard Access

### DIFF
--- a/backend/lib/services/projects.js
+++ b/backend/lib/services/projects.js
@@ -130,14 +130,23 @@ exports.list = async function ({ user, qs = {} }) {
       .gt(0)
       .value()
 
-    const member = Member.parseUsername(user.id)
-    const hasMembership = _
+    const hasUserMembership = _
       .chain(project)
       .get('spec.members')
+      .filter(['kind', 'User'])
+      .map('name')
+      .includes(user.id)
+      .value()
+
+    const member = Member.parseUsername(user.id)
+    const hasServiceAccountMembership = _
+      .chain(project)
+      .get('spec.members')
+      .filter(['kind', 'ServiceAccount'])
       .find(member)
       .value()
 
-    return hasGroupMembership || hasMembership
+    return hasGroupMembership || hasUserMembership || hasServiceAccountMembership
   }
 
   const phases = _

--- a/backend/test/services.projects.spec.js
+++ b/backend/test/services.projects.spec.js
@@ -1,0 +1,139 @@
+//
+// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+'use strict'
+
+const delay = require('delay')
+const projects = require('../lib/services/projects')
+const cache = require('../lib/cache')
+const authorization = require('../lib/services/authorization')
+
+const { expect } = require('chai')
+
+describe('services', function () {
+  /* eslint no-unused-expressions: 0 */
+  const sandbox = sinon.createSandbox()
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  describe('projects', function () {
+    const projectList = [
+      {
+        spec: {
+          members: [
+            {
+              kind: 'User',
+              name: 'foo@bar.com'
+            },
+            {
+              kind: 'User',
+              name: 'system:serviceaccount:garden-foo:robot-user'
+            },
+            {
+              kind: 'ServiceAccount',
+              name: 'robot-sa',
+              namespace: 'garden-foo'
+            }
+          ]
+        },
+        metadata: {
+          name: 'foo'
+        },
+        status: {
+          phase: 'Ready'
+        }
+      },
+      {
+        spec: {
+          members: [
+            {
+              apiGroup: 'rbac.authorization.k8s.io',
+              kind: 'User',
+              name: 'bar@bar.com',
+              role: 'admin',
+              roles: [
+                'owner'
+              ]
+            }
+          ]
+        },
+        metadata: {
+          name: 'bar'
+        },
+        status: {
+          phase: 'Ready'
+        }
+      },
+      {
+        spec: {
+          members: [
+            {
+              apiGroup: 'rbac.authorization.k8s.io',
+              kind: 'User',
+              name: 'bar@bar.com',
+              role: 'admin',
+              roles: [
+                'owner'
+              ]
+            }
+          ]
+        },
+        metadata: {
+          name: 'notReady'
+        }
+      }
+    ]
+
+    const createUser = (username) => {
+      return {
+        id: username
+      }
+    }
+
+    beforeEach(function () {
+      sandbox.stub(cache, 'getProjects').returns(projectList)
+      sandbox.stub(authorization, 'isAdmin').callsFake(async (user) => {
+        await delay(1)
+        if (user.id === 'admin@bar.com') {
+          return true
+        }
+        return false
+      })
+    })
+
+    describe('#list', function () {
+      it('should return all ready projects if user is admin', async function () {
+        const userProjects = await projects.list({ user: createUser('admin@bar.com') })
+        expect(userProjects).to.have.length(2)
+      })
+
+      it('should return project for user member', async function () {
+        const userProjects = await projects.list({ user: createUser('system:serviceaccount:garden-foo:robot-user') })
+        expect(userProjects).to.have.length(1)
+        expect(userProjects[0].metadata.name).to.eql('foo')
+      })
+
+      it('should return project for serviceaccount user member', async function () {
+        const userProjects = await projects.list({ user: createUser('system:serviceaccount:garden-foo:robot-user') })
+        expect(userProjects).to.have.length(1)
+        expect(userProjects[0].metadata.name).to.eql('foo')
+      })
+
+      it('should return project for serviceaccount member', async function () {
+        const userProjects = await projects.list({ user: createUser('system:serviceaccount:garden-foo:robot-sa') })
+        expect(userProjects).to.have.length(1)
+        expect(userProjects[0].metadata.name).to.eql('foo')
+      })
+
+      it('should not return project if not in member list', async function () {
+        const userProjects = await projects.list({ user: createUser('other@bar.com') })
+        expect(userProjects).to.have.length(0)
+      })
+    })
+  })
+})

--- a/backend/test/services.projects.spec.js
+++ b/backend/test/services.projects.spec.js
@@ -52,13 +52,8 @@ describe('services', function () {
         spec: {
           members: [
             {
-              apiGroup: 'rbac.authorization.k8s.io',
               kind: 'User',
-              name: 'bar@bar.com',
-              role: 'admin',
-              roles: [
-                'owner'
-              ]
+              name: 'bar@bar.com'
             }
           ]
         },
@@ -75,11 +70,7 @@ describe('services', function () {
             {
               apiGroup: 'rbac.authorization.k8s.io',
               kind: 'User',
-              name: 'bar@bar.com',
-              role: 'admin',
-              roles: [
-                'owner'
-              ]
+              name: 'bar@bar.com'
             }
           ]
         },

--- a/backend/test/services.projects.spec.js
+++ b/backend/test/services.projects.spec.js
@@ -6,12 +6,10 @@
 
 'use strict'
 
-const delay = require('delay')
 const projects = require('../lib/services/projects')
 const cache = require('../lib/cache')
 const authorization = require('../lib/services/authorization')
-
-const { expect } = require('chai')
+const nextTick = () => new Promise(process.nextTick)
 
 describe('services', function () {
   /* eslint no-unused-expressions: 0 */
@@ -89,7 +87,7 @@ describe('services', function () {
     beforeEach(function () {
       sandbox.stub(cache, 'getProjects').returns(projectList)
       sandbox.stub(authorization, 'isAdmin').callsFake(async (user) => {
-        await delay(1)
+        await nextTick()
         if (user.id === 'admin@bar.com') {
           return true
         }


### PR DESCRIPTION
**What this PR does / why we need it**:
allow all kind of members to access the dashboard (including ServiceAccount members)
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user

```
