### PR TITLE
Use binding name/namespace as infrastructure secret identifier

### DIFF
--- a/backend/lib/routes/infrastructureSecrets.js
+++ b/backend/lib/routes/infrastructureSecrets.js
@@ -39,9 +39,9 @@ router.route('/:name')
     try {
       const user = req.user
       const namespace = req.params.namespace
-      const bindingName = req.params.name
+      const name = req.params.name
       const body = req.body
-      res.send(await infrastructureSecrets.patch({ user, namespace, bindingName, body }))
+      res.send(await infrastructureSecrets.patch({ user, namespace, name, body }))
     } catch (err) {
       next(err)
     }
@@ -50,8 +50,8 @@ router.route('/:name')
     try {
       const user = req.user
       const namespace = req.params.namespace
-      const bindingName = req.params.name
-      res.send(await infrastructureSecrets.remove({ user, namespace, bindingName }))
+      const name = req.params.name
+      res.send(await infrastructureSecrets.remove({ user, namespace, name }))
     } catch (err) {
       next(err)
     }

--- a/backend/lib/routes/infrastructureSecrets.js
+++ b/backend/lib/routes/infrastructureSecrets.js
@@ -38,8 +38,7 @@ router.route('/:name')
   .put(async (req, res, next) => {
     try {
       const user = req.user
-      const namespace = req.params.namespace
-      const name = req.params.name
+      const { namespace, name } = req.params
       const body = req.body
       res.send(await infrastructureSecrets.patch({ user, namespace, name, body }))
     } catch (err) {
@@ -49,8 +48,7 @@ router.route('/:name')
   .delete(async (req, res, next) => {
     try {
       const user = req.user
-      const namespace = req.params.namespace
-      const name = req.params.name
+      const { namespace, name } = req.params
       res.send(await infrastructureSecrets.remove({ user, namespace, name }))
     } catch (err) {
       next(err)

--- a/backend/lib/services/infrastructureSecrets.js
+++ b/backend/lib/services/infrastructureSecrets.js
@@ -22,8 +22,10 @@ function fromResource ({ secretBinding, cloudProviderKind, secret, quotas = [], 
     metadata: {
       namespace: _.get(secretBinding, 'metadata.namespace'),
       name: _.get(secretBinding, 'metadata.name'),
-      secretName: _.get(secretBinding, 'secretRef.name'),
-      secretNamespace: _.get(secretBinding, 'secretRef.namespace'),
+      secretRef: {
+        name: _.get(secretBinding, 'secretRef.name'),
+        namespace: _.get(secretBinding, 'secretRef.namespace')
+      },
       cloudProviderKind,
       cloudProfileName,
       projectName,
@@ -73,8 +75,8 @@ function toSecretResource ({ metadata, data }) {
   const kind = resource.kind
   const type = 'Opaque'
   metadata = {
-    name: metadata.secretName,
-    namespace: metadata.secretNamespace
+    name: metadata.secretRef.name,
+    namespace: metadata.secretRef.namespace
   }
   try {
     data = _.mapValues(data, encodeBase64)
@@ -89,10 +91,7 @@ function toSecretBindingResource ({ metadata }) {
   const apiVersion = resource.apiVersion
   const kind = resource.kind
   const name = metadata.name
-  const secretRef = {
-    name: metadata.secretName,
-    namespace: metadata.secretNamespace
-  }
+  const secretRef = metadata.secretRef
   const labels = {
     'cloudprofile.garden.sapcloud.io/name': metadata.cloudProfileName
   }
@@ -275,8 +274,10 @@ exports.remove = async function ({ user, namespace, name }) {
     metadata: {
       name,
       namespace,
-      secretName,
-      secretNamespace
+      secretRef: {
+        name: secretName,
+        namespace: secretNamespace
+      }
     }
   }
 }

--- a/backend/lib/services/infrastructureSecrets.js
+++ b/backend/lib/services/infrastructureSecrets.js
@@ -74,10 +74,7 @@ function toSecretResource ({ metadata, data }) {
   const apiVersion = resource.apiVersion
   const kind = resource.kind
   const type = 'Opaque'
-  metadata = {
-    name: metadata.secretRef.name,
-    namespace: metadata.secretRef.namespace
-  }
+  metadata = { ...metadata.secretRef }
   try {
     data = _.mapValues(data, encodeBase64)
   } catch (err) {
@@ -90,8 +87,7 @@ function toSecretBindingResource ({ metadata }) {
   const resource = Resources.SecretBinding
   const apiVersion = resource.apiVersion
   const kind = resource.kind
-  const name = metadata.name
-  const secretRef = metadata.secretRef
+  const { name, secretRef } = metadata
   const labels = {
     'cloudprofile.garden.sapcloud.io/name': metadata.cloudProfileName
   }
@@ -216,11 +212,9 @@ exports.create = async function ({ user, namespace, body }) {
   })
 }
 
-function isOwnSecret (secretBinding) {
-  const secretNamespace = _.get(secretBinding, 'secretRef.namespace')
-  const namespace = _.get(secretBinding, 'metadata.namespace')
+function isOwnSecret ({ metadata, secretRef }) {
 
-  return secretNamespace === namespace
+  return secretRef.namespace === metadata.namespace
 }
 
 exports.patch = async function ({ user, namespace, name, body }) {

--- a/backend/test/acceptance/api.infrastructureSecrets.spec.js
+++ b/backend/test/acceptance/api.infrastructureSecrets.spec.js
@@ -119,7 +119,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
       .set('cookie', await user.cookie)
       .send({ metadata, data })
 
-    expect(res).to.have.status(405)
+    expect(res).to.have.status(422)
   })
 
   it('should delete an own infrastructure secret', async function () {
@@ -149,7 +149,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
       .delete(`/api/namespaces/${namespace}/infrastructure-secrets/${name}`)
       .set('cookie', await user.cookie)
 
-    expect(res).to.have.status(405)
+    expect(res).to.have.status(422)
   })
 
   it('should not delete infrastructure secret if referenced by shoot', async function () {
@@ -159,6 +159,6 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
       .delete(`/api/namespaces/${namespace}/infrastructure-secrets/${name}`)
       .set('cookie', await user.cookie)
 
-    expect(res).to.have.status(412)
+    expect(res).to.have.status(422)
   })
 }

--- a/backend/test/acceptance/api.infrastructureSecrets.spec.js
+++ b/backend/test/acceptance/api.infrastructureSecrets.spec.js
@@ -108,9 +108,12 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
   it('should not patch a shared infrastructure secret', async function () {
     const bearer = await user.bearer
     const otherNamespace = 'garden-bar'
+    const secretRef = {
+      namespace: otherNamespace
+    }
     common.stub.getQuotas(sandbox)
     common.stub.getCloudProfiles(sandbox)
-    k8s.stub.patchSharedInfrastructureSecret({ bearer, name, namespace: otherNamespace, secretRef, data, cloudProfileName, resourceVersion })
+    k8s.stub.patchSharedInfrastructureSecret({ bearer, name, namespace, secretRef, data, cloudProfileName, resourceVersion })
     const res = await agent
       .put(`/api/namespaces/${namespace}/infrastructure-secrets/${name}`)
       .set('cookie', await user.cookie)
@@ -136,9 +139,12 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
   it('should not delete a shared infrastructure secret', async function () {
     const bearer = await user.bearer
     const otherNamespace = 'garden-bar'
+    const secretRef = {
+      namespace: otherNamespace
+    }
     common.stub.getQuotas(sandbox)
     common.stub.getCloudProfiles(sandbox)
-    k8s.stub.deleteSharedInfrastructureSecret({ bearer, name, namespace: otherNamespace, project, secretRef, cloudProfileName, resourceVersion })
+    k8s.stub.deleteSharedInfrastructureSecret({ bearer, name, namespace, project, secretRef, cloudProfileName, resourceVersion })
     const res = await agent
       .delete(`/api/namespaces/${namespace}/infrastructure-secrets/${name}`)
       .set('cookie', await user.cookie)

--- a/backend/test/acceptance/api.infrastructureSecrets.spec.js
+++ b/backend/test/acceptance/api.infrastructureSecrets.spec.js
@@ -17,7 +17,11 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
   const namespace = `garden-${project}`
   const cloudProfileName = 'infra1-profileName'
   const cloudProviderKind = 'infra1'
-  const metadata = { name, namespace, secretName, secretNamespace: namespace, cloudProfileName, cloudProviderKind }
+  const secretRef = {
+    name: secretName,
+    namespace
+  }
+  const metadata = { name, namespace, secretRef, cloudProfileName, cloudProviderKind }
   const username = `${name}@example.org`
   const id = username
   const user = auth.createUser({ id })
@@ -69,7 +73,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
     const bearer = await user.bearer
     common.stub.getQuotas(sandbox)
     common.stub.getCloudProfiles(sandbox)
-    k8s.stub.createInfrastructureSecret({ bearer, namespace, data, cloudProfileName, resourceVersion })
+    k8s.stub.createInfrastructureSecret({ bearer, namespace, secretRef, data, cloudProfileName, resourceVersion })
     k8s.stub.getCloudProfiles({ bearer, verb: 'get' })
     const res = await agent
       .post(`/api/namespaces/${namespace}/infrastructure-secrets`)
@@ -78,7 +82,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
 
     expect(res).to.have.status(200)
     expect(res).to.be.json
-    expect(res.body.metadata).to.eql({ name, namespace, secretName, secretNamespace: namespace, resourceVersion, cloudProfileName, cloudProviderKind, hasCostObject, projectName: project })
+    expect(res.body.metadata).to.eql({ name, namespace, secretRef, resourceVersion, cloudProfileName, cloudProviderKind, hasCostObject, projectName: project })
     expect(res.body.data).to.have.own.property('key')
     expect(res.body.data).to.have.own.property('secret')
   })
@@ -87,7 +91,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
     const bearer = await user.bearer
     common.stub.getQuotas(sandbox)
     common.stub.getCloudProfiles(sandbox)
-    k8s.stub.patchInfrastructureSecret({ bearer, name, namespace, secretName, secretNamespace: namespace, data, cloudProfileName, resourceVersion })
+    k8s.stub.patchInfrastructureSecret({ bearer, name, namespace, secretRef, data, cloudProfileName, resourceVersion })
     k8s.stub.getCloudProfiles({ bearer, verb: 'get' })
     const res = await agent
       .put(`/api/namespaces/${namespace}/infrastructure-secrets/${name}`)
@@ -96,7 +100,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
 
     expect(res).to.have.status(200)
     expect(res).to.be.json
-    expect(res.body.metadata).to.eql({ name, namespace, secretName, secretNamespace: namespace, cloudProfileName, cloudProviderKind, resourceVersion, hasCostObject, projectName: project })
+    expect(res.body.metadata).to.eql({ name, namespace, secretRef, cloudProfileName, cloudProviderKind, resourceVersion, hasCostObject, projectName: project })
     expect(res.body.data).to.have.own.property('key')
     expect(res.body.data).to.have.own.property('secret')
   })
@@ -106,7 +110,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
     const otherNamespace = 'garden-bar'
     common.stub.getQuotas(sandbox)
     common.stub.getCloudProfiles(sandbox)
-    k8s.stub.patchSharedInfrastructureSecret({ bearer, name, namespace: otherNamespace, secretName, secretNamespace: namespace, data, cloudProfileName, resourceVersion })
+    k8s.stub.patchSharedInfrastructureSecret({ bearer, name, namespace: otherNamespace, secretRef, data, cloudProfileName, resourceVersion })
     const res = await agent
       .put(`/api/namespaces/${namespace}/infrastructure-secrets/${name}`)
       .set('cookie', await user.cookie)
@@ -119,14 +123,14 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
     const bearer = await user.bearer
     common.stub.getQuotas(sandbox)
     common.stub.getCloudProfiles(sandbox)
-    k8s.stub.deleteInfrastructureSecret({ bearer, name, namespace, project, secretName, secretNamespace: namespace, cloudProfileName, resourceVersion })
+    k8s.stub.deleteInfrastructureSecret({ bearer, name, namespace, project, secretRef, cloudProfileName, resourceVersion })
     const res = await agent
       .delete(`/api/namespaces/${namespace}/infrastructure-secrets/${name}`)
       .set('cookie', await user.cookie)
 
     expect(res).to.have.status(200)
     expect(res).to.be.json
-    expect(res.body.metadata).to.eql({ secretName, name, namespace })
+    expect(res.body.metadata).to.eql({ name, namespace, secretRef })
   })
 
   it('should not delete a shared infrastructure secret', async function () {
@@ -134,7 +138,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
     const otherNamespace = 'garden-bar'
     common.stub.getQuotas(sandbox)
     common.stub.getCloudProfiles(sandbox)
-    k8s.stub.deleteSharedInfrastructureSecret({ bearer, name, namespace: otherNamespace, project, secretName, secretNamespace: namespace, cloudProfileName, resourceVersion })
+    k8s.stub.deleteSharedInfrastructureSecret({ bearer, name, namespace: otherNamespace, project, secretRef, cloudProfileName, resourceVersion })
     const res = await agent
       .delete(`/api/namespaces/${namespace}/infrastructure-secrets/${name}`)
       .set('cookie', await user.cookie)
@@ -144,7 +148,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
 
   it('should not delete infrastructure secret if referenced by shoot', async function () {
     const bearer = await user.bearer
-    k8s.stub.deleteInfrastructureSecretReferencedByShoot({ bearer, name, namespace, project, secretName, secretNamespace: namespace, cloudProfileName, resourceVersion })
+    k8s.stub.deleteInfrastructureSecretReferencedByShoot({ bearer, name, namespace, project, secretRef, cloudProfileName, resourceVersion })
     const res = await agent
       .delete(`/api/namespaces/${namespace}/infrastructure-secrets/${name}`)
       .set('cookie', await user.cookie)

--- a/backend/test/acceptance/api.shoots.spec.js
+++ b/backend/test/acceptance/api.shoots.spec.js
@@ -36,7 +36,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
     kind,
     profile,
     region,
-    bindingName: secret,
+    secretBindingName: secret,
     seed: seedName
   })
   const resourceVersion = 42
@@ -75,7 +75,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
 
   it('should return a shoot', async function () {
     const bearer = await user.bearer
-    k8s.stub.getShoot({ bearer, namespace, name, uid, createdBy, purpose, kind, profile, region, bindingName: secret })
+    k8s.stub.getShoot({ bearer, namespace, name, uid, createdBy, purpose, kind, profile, region, secretBindingName: secret })
     const res = await agent
       .get(`/api/namespaces/${namespace}/shoots/${name}`)
       .set('cookie', await user.cookie)
@@ -247,7 +247,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
     }
     const zonesNetworkConfiguration = {
       workers: '10.250.0.0/20'
-     }
+    }
     const data = {
       workers: [worker],
       network: {

--- a/backend/test/acceptance/api.shoots.spec.js
+++ b/backend/test/acceptance/api.shoots.spec.js
@@ -24,7 +24,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
   const user = auth.createUser({ id })
   const kind = 'infra1'
   const region = 'foo-east'
-  const secret = 'fooSecretName' // pragma: whitelist secret
+  const secretBindingName = 'fooSecretName' // pragma: whitelist secret
   const seedName = 'infra1-seed'
   const seedSecretName = `seedsecret-${seedName}`
   const profile = 'infra1-profileName'
@@ -36,7 +36,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
     kind,
     profile,
     region,
-    secretBindingName: secret,
+    secretBindingName,
     seed: seedName
   })
   const resourceVersion = 42
@@ -75,7 +75,7 @@ module.exports = function ({ agent, sandbox, k8s, auth }) {
 
   it('should return a shoot', async function () {
     const bearer = await user.bearer
-    k8s.stub.getShoot({ bearer, namespace, name, uid, createdBy, purpose, kind, profile, region, secretBindingName: secret })
+    k8s.stub.getShoot({ bearer, namespace, name, uid, createdBy, purpose, kind, profile, region, secretBindingName })
     const res = await agent
       .get(`/api/namespaces/${namespace}/shoots/${name}`)
       .set('cookie', await user.cookie)

--- a/backend/test/support/nocks/k8s.js
+++ b/backend/test/support/nocks/k8s.js
@@ -144,7 +144,7 @@ const shootList = [
     project: 'foo',
     createdBy: 'fooCreator',
     purpose: 'fooPurpose',
-    bindingName: 'fooSecretName'
+    secretBindingName: 'fooSecretName'
   }),
   getShoot({
     name: 'barShoot',
@@ -152,7 +152,7 @@ const shootList = [
     project: 'foo',
     createdBy: 'barCreator',
     purpose: 'barPurpose',
-    bindingName: 'barSecretName'
+    secretBindingName: 'barSecretName'
   }),
   getShoot({
     name: 'dummyShoot',
@@ -160,7 +160,7 @@ const shootList = [
     project: 'foo',
     createdBy: 'fooCreator',
     purpose: 'fooPurpose',
-    bindingName: 'barSecretName',
+    secretBindingName: 'barSecretName',
     seed: 'infra4-seed-without-secretRef'
   })
 ]
@@ -245,18 +245,18 @@ function getServiceAccountSecret (namespace, serviceAccountName) {
   }
 }
 
-function prepareSecretAndBindingMeta ({ name, namespace, data, resourceVersion, bindingName, bindingNamespace, cloudProfileName }) {
+function prepareSecretAndBindingMeta ({ secretName, secretNamespace, data, resourceVersion, name, namespace, cloudProfileName }) {
   const metadataSecretBinding = {
     resourceVersion,
-    name: bindingName,
-    namespace: bindingNamespace,
+    name,
+    namespace,
     labels: {
       'cloudprofile.garden.sapcloud.io/name': cloudProfileName
     }
   }
   const secretRef = {
-    name,
-    namespace
+    name: secretName,
+    namespace: secretNamespace
   }
   const resultSecretBinding = {
     metadata: metadataSecretBinding,
@@ -265,7 +265,7 @@ function prepareSecretAndBindingMeta ({ name, namespace, data, resourceVersion, 
 
   const metadataSecret = {
     resourceVersion,
-    namespace
+    namespace: secretNamespace
   }
   const resultSecret = {
     metadata: metadataSecret,
@@ -498,7 +498,7 @@ function getShoot ({
   kind = 'fooInfra',
   profile = 'infra1-profileName',
   region = 'foo-west',
-  bindingName = 'foo-secret',
+  secretBindingName = 'foo-secret',
   seed = 'infra1-seed',
   hibernation = { enabled: false },
   kubernetesVersion = '1.16.0'
@@ -512,7 +512,7 @@ function getShoot ({
       annotations: {}
     },
     spec: {
-      secretBindingName: bindingName,
+      secretBindingName,
       cloudProfileName: profile,
       region,
       hibernation,
@@ -867,7 +867,8 @@ const stub = {
       resultSecretBinding,
       resultSecret
     } = prepareSecretAndBindingMeta({
-      bindingNamespace: namespace,
+      namespace,
+      secretNamespace: namespace,
       data,
       resourceVersion,
       cloudProfileName
@@ -888,7 +889,7 @@ const stub = {
       })
       .reply(200, () => resultSecretBinding)
   },
-  patchInfrastructureSecret ({ bearer, namespace, name, bindingName, bindingNamespace, data, cloudProfileName, resourceVersion = 42 }) {
+  patchInfrastructureSecret ({ bearer, namespace, name, secretName, secretNamespace, data, cloudProfileName, resourceVersion = 42 }) {
     const {
       resultSecretBinding,
       resultSecret
@@ -897,22 +898,22 @@ const stub = {
       namespace,
       data,
       resourceVersion,
-      bindingName,
-      bindingNamespace,
+      secretName,
+      secretNamespace,
       cloudProfileName
     })
 
     return nockWithAuthorization(bearer)
-      .get(`/apis/core.gardener.cloud/v1beta1/namespaces/${bindingNamespace}/secretbindings/${bindingName}`)
+      .get(`/apis/core.gardener.cloud/v1beta1/namespaces/${namespace}/secretbindings/${name}`)
       .reply(200, () => resultSecretBinding)
-      .patch(`/api/v1/namespaces/${namespace}/secrets/${name}`, body => {
+      .patch(`/api/v1/namespaces/${secretNamespace}/secrets/${secretName}`, body => {
         expect(body).to.not.have.nested.property('metadata.resourceVersion')
         _.assign(resultSecret.metadata, body.metadata)
         return true
       })
       .reply(200, () => resultSecret)
   },
-  patchSharedInfrastructureSecret ({ bearer, namespace, name, bindingName, bindingNamespace, data, cloudProfileName, resourceVersion = 42 }) {
+  patchSharedInfrastructureSecret ({ bearer, namespace, name, secretName, secretNamespace, data, cloudProfileName, resourceVersion = 42 }) {
     const {
       resultSecretBinding
     } = prepareSecretAndBindingMeta({
@@ -920,74 +921,74 @@ const stub = {
       namespace,
       data,
       resourceVersion,
-      bindingName,
-      bindingNamespace,
+      secretName,
+      secretNamespace,
       cloudProfileName
     })
 
     return nockWithAuthorization(bearer)
-      .get(`/apis/core.gardener.cloud/v1beta1/namespaces/${bindingNamespace}/secretbindings/${bindingName}`)
+      .get(`/apis/core.gardener.cloud/v1beta1/namespaces/${namespace}/secretbindings/${name}`)
       .reply(200, () => resultSecretBinding)
   },
-  deleteInfrastructureSecret ({ bearer, namespace, project, name, bindingName, bindingNamespace, cloudProfileName, resourceVersion = 42 }) {
-    const shoot = getShoot({ name: 'fooShoot', project, bindingName: 'someOtherSecretName' })
+  deleteInfrastructureSecret ({ bearer, namespace, project, name, secretName, secretNamespace, cloudProfileName, resourceVersion = 42 }) {
+    const shoot = getShoot({ name: 'fooShoot', project, secretBindingName: 'someOtherSecretBindingName' })
     const {
       resultSecretBinding
     } = prepareSecretAndBindingMeta({
       name,
       namespace,
       resourceVersion,
-      bindingName,
-      bindingNamespace,
+      secretName,
+      secretNamespace,
       cloudProfileName
     })
 
     return nockWithAuthorization(bearer)
-      .get(`/apis/core.gardener.cloud/v1beta1/namespaces/${bindingNamespace}/secretbindings/${bindingName}`)
+      .get(`/apis/core.gardener.cloud/v1beta1/namespaces/${namespace}/secretbindings/${name}`)
       .reply(200, () => resultSecretBinding)
-      .get(`/apis/core.gardener.cloud/v1beta1/namespaces/${bindingNamespace}/shoots`)
+      .get(`/apis/core.gardener.cloud/v1beta1/namespaces/${namespace}/shoots`)
       .reply(200, {
         items: [shoot]
       })
-      .delete(`/apis/core.gardener.cloud/v1beta1/namespaces/${bindingNamespace}/secretbindings/${bindingName}`)
+      .delete(`/apis/core.gardener.cloud/v1beta1/namespaces/${namespace}/secretbindings/${name}`)
       .reply(200)
-      .delete(`/api/v1/namespaces/${bindingNamespace}/secrets/${name}`)
+      .delete(`/api/v1/namespaces/${secretNamespace}/secrets/${name}`)
       .reply(200)
   },
-  deleteSharedInfrastructureSecret ({ bearer, namespace, project, name, bindingName, bindingNamespace, cloudProfileName, resourceVersion = 42 }) {
+  deleteSharedInfrastructureSecret ({ bearer, namespace, name, secretName, secretNamespace, cloudProfileName, resourceVersion = 42 }) {
     const {
       resultSecretBinding
     } = prepareSecretAndBindingMeta({
       name,
       namespace,
       resourceVersion,
-      bindingName,
-      bindingNamespace,
+      secretName,
+      secretNamespace,
       cloudProfileName
     })
 
     return nockWithAuthorization(bearer)
-      .get(`/apis/core.gardener.cloud/v1beta1/namespaces/${bindingNamespace}/secretbindings/${bindingName}`)
+      .get(`/apis/core.gardener.cloud/v1beta1/namespaces/${namespace}/secretbindings/${name}`)
       .reply(200, () => resultSecretBinding)
   },
-  deleteInfrastructureSecretReferencedByShoot ({ bearer, namespace, project, name, bindingName, bindingNamespace, cloudProfileName, resourceVersion = 42 }) {
-    const referencingShoot = getShoot({ name: 'referencingShoot', project, bindingName })
-    const shoot = getShoot({ name: 'fooShoot', project, bindingName: 'someOtherSecretName' })
+  deleteInfrastructureSecretReferencedByShoot ({ bearer, namespace, project, name, secretName, secretNamespace, cloudProfileName, resourceVersion = 42 }) {
+    const referencingShoot = getShoot({ name: 'referencingShoot', project, secretBindingName: name })
+    const shoot = getShoot({ name: 'fooShoot', project, secretBindingName: 'someOtherSecretName' })
     const {
       resultSecretBinding
     } = prepareSecretAndBindingMeta({
       name,
       namespace,
       resourceVersion,
-      bindingName,
-      bindingNamespace,
+      secretName,
+      secretNamespace,
       cloudProfileName
     })
 
     return nockWithAuthorization(bearer)
-      .get(`/apis/core.gardener.cloud/v1beta1/namespaces/${bindingNamespace}/secretbindings/${bindingName}`)
+      .get(`/apis/core.gardener.cloud/v1beta1/namespaces/${namespace}/secretbindings/${name}`)
       .reply(200, () => resultSecretBinding)
-      .get(`/apis/core.gardener.cloud/v1beta1/namespaces/${bindingNamespace}/shoots`)
+      .get(`/apis/core.gardener.cloud/v1beta1/namespaces/${namespace}/shoots`)
       .reply(200, {
         items: [shoot, referencingShoot]
       })

--- a/frontend/src/components/NewShoot/NewShootInfrastructureDetails.vue
+++ b/frontend/src/components/NewShoot/NewShootInfrastructureDetails.vue
@@ -41,14 +41,14 @@ SPDX-License-Identifier: Apache-2.0
             </template>
             <template v-else>
               <span>{{get(item, 'metadata.name')}}</span>
-              <v-icon v-if="!isOwnSecretBinding(item)">mdi-share</v-icon>
+              <v-icon v-if="!isOwnSecret(item)">mdi-share</v-icon>
             </template>
           </template>
           <template v-slot:selection="{ item }">
             <span>
               {{get(item, 'metadata.name')}}
             </span>
-            <v-icon v-if="!isOwnSecretBinding(item)">mdi-share</v-icon>
+            <v-icon v-if="!isOwnSecret(item)">mdi-share</v-icon>
           </template>
         </v-select>
       </v-col>
@@ -196,7 +196,7 @@ import CloudProfile from '@/components/CloudProfile'
 import WildcardSelect from '@/components/WildcardSelect'
 import SecretDialogWrapper from '@/components/dialogs/SecretDialogWrapper'
 import { required, requiredIf } from 'vuelidate/lib/validators'
-import { getValidationErrors, isOwnSecretBinding, selfTerminationDaysForSecret } from '@/utils'
+import { getValidationErrors, isOwnSecret, selfTerminationDaysForSecret } from '@/utils'
 import { includesIfAvailable, requiresCostObjectIfEnabled } from '@/utils/validators'
 import sortBy from 'lodash/sortBy'
 import head from 'lodash/head'
@@ -446,9 +446,9 @@ export default {
       }
       return 'API servers in another region than your workers (expect a somewhat higher latency; picked by Gardener based on internal considerations such as geographic proximity)'
     },
-    isOwnSecretBinding () {
+    isOwnSecret () {
       return (secret) => {
-        return isOwnSecretBinding(secret)
+        return isOwnSecret(secret)
       }
     },
     allLoadBalancerProviderNames () {

--- a/frontend/src/components/PurposeConfiguration.vue
+++ b/frontend/src/components/PurposeConfiguration.vue
@@ -67,7 +67,7 @@ export default {
     },
     secret () {
       const secrets = this.infrastructureSecretsByCloudProfileName(this.shootCloudProfileName)
-      const secret = find(secrets, ['metadata.bindingName', this.shootSecretBindingName])
+      const secret = find(secrets, ['metadata.name', this.shootSecretBindingName])
       if (!secret) {
         console.error('Secret must not be undefined')
       }

--- a/frontend/src/components/Secret.vue
+++ b/frontend/src/components/Secret.vue
@@ -29,16 +29,16 @@ SPDX-License-Identifier: Apache-2.0
     <v-list two-line v-else>
       <secret-row
         v-for="secret in rows"
-        :key="secret.metadata.bindingName"
+        :key="secret.metadata.name"
         :secret="secret"
         :secretDescriptorKey="secretDescriptorKey"
         @update="onUpdate"
         @delete="onDelete"
       >
-       <template v-if="infrastructureKey === 'openstack' && isOwnSecretBinding(secret)" v-slot:rowSubTitle>
+       <template v-if="infrastructureKey === 'openstack' && isOwnSecret(secret)" v-slot:rowSubTitle>
           {{secret.data.domainName}} / {{secret.data.tenantName}}
         </template>
-        <template v-else-if="infrastructureKey === 'vsphere' && isOwnSecretBinding(secret)" v-slot:rowSubTitle>
+        <template v-else-if="infrastructureKey === 'vsphere' && isOwnSecret(secret)" v-slot:rowSubTitle>
           <v-tooltip top>
             <template v-slot:activator="{ on }">
               <span v-on="on">{{secret.data.vsphereUsername}}</span>
@@ -61,7 +61,7 @@ SPDX-License-Identifier: Apache-2.0
 import { mapGetters } from 'vuex'
 import SecretRow from '@/components/SecretRow'
 import InfraIcon from '@/components/VendorIcon'
-import { isOwnSecretBinding } from '@/utils'
+import { isOwnSecret } from '@/utils'
 
 export default {
   components: {
@@ -132,8 +132,8 @@ export default {
     onDelete (row) {
       this.$emit('delete', row)
     },
-    isOwnSecretBinding (secret) {
-      return isOwnSecretBinding(secret)
+    isOwnSecret (secret) {
+      return isOwnSecret(secret)
     }
   }
 }

--- a/frontend/src/components/SecretRow.vue
+++ b/frontend/src/components/SecretRow.vue
@@ -81,7 +81,7 @@ export default {
       }
     },
     secretOwner () {
-      return get(this.secret, 'metadata.secretNamespace')
+      return get(this.secret, 'metadata.secretRef.namespace')
     },
     relatedShootCount () {
       return this.shootsByInfrastructureSecret.length

--- a/frontend/src/components/SecretRow.vue
+++ b/frontend/src/components/SecretRow.vue
@@ -8,8 +8,8 @@ SPDX-License-Identifier: Apache-2.0
   <v-list-item>
     <v-list-item-content>
       <v-list-item-title class="mb-1">
-        {{secret.metadata.bindingName}}
-        <v-tooltip v-if="!isOwnSecretBinding" top>
+        {{secret.metadata.name}}
+        <v-tooltip v-if="!isOwnSecret" top>
           <template v-slot:activator="{ on }">
             <v-icon v-on="on" small class="mx-1">mdi-account-arrow-left</v-icon>
           </template>
@@ -31,7 +31,7 @@ SPDX-License-Identifier: Apache-2.0
             </v-btn>
           </div>
         </template>
-        <span v-if="!isOwnSecretBinding">You can only delete secrets that are owned by you</span>
+        <span v-if="!isOwnSecret">You can only delete secrets that are owned by you</span>
         <span v-else-if="relatedShootCount > 0">You can only delete secrets that are currently unused</span>
         <span v-else>Delete Secret</span>
       </v-tooltip>
@@ -41,12 +41,12 @@ SPDX-License-Identifier: Apache-2.0
       <v-tooltip top>
         <template v-slot:activator="{ on }">
           <div v-on="on">
-            <v-btn :disabled="!isOwnSecretBinding" icon @click.native.stop="onUpdate">
+            <v-btn :disabled="!isOwnSecret" icon @click.native.stop="onUpdate">
               <v-icon class="cyan--text text--darken-2">mdi-pencil</v-icon>
             </v-btn>
           </div>
         </template>
-        <span v-if="!isOwnSecretBinding">You can only edit secrets that are owned by you</span>
+        <span v-if="!isOwnSecret">You can only edit secrets that are owned by you</span>
         <span v-else>Edit Secret</span>
       </v-tooltip>
     </v-list-item-action>
@@ -57,7 +57,7 @@ SPDX-License-Identifier: Apache-2.0
 import { mapGetters } from 'vuex'
 import get from 'lodash/get'
 import filter from 'lodash/filter'
-import { isOwnSecretBinding } from '@/utils'
+import { isOwnSecret } from '@/utils'
 
 export default {
   props: {
@@ -74,7 +74,7 @@ export default {
       'shootList'
     ]),
     secretDescriptor () {
-      if (this.isOwnSecretBinding) {
+      if (this.isOwnSecret) {
         return get(this.secret, `data.${this.secretDescriptorKey}`)
       } else {
         return `Owner: ${this.secretOwner}`
@@ -87,11 +87,8 @@ export default {
       return this.shootsByInfrastructureSecret.length
     },
     shootsByInfrastructureSecret () {
-      const secretBindingName = this.secret.metadata.bindingName
-      const predicate = item => {
-        return get(item, 'spec.secretBindingName') === secretBindingName
-      }
-      return filter(this.shootList, predicate)
+      const name = this.secret.metadata.name
+      return filter(this.shootList, ['spec.secretBindingName', name])
     },
     relatedShootCountLabel () {
       const count = this.relatedShootCount
@@ -101,11 +98,11 @@ export default {
         return `used by ${count} ${count > 1 ? 'clusters' : 'cluster'}`
       }
     },
-    isOwnSecretBinding () {
-      return isOwnSecretBinding(this.secret)
+    isOwnSecret () {
+      return isOwnSecret(this.secret)
     },
     isDeleteButtonDisabled () {
-      return this.relatedShootCount > 0 || !this.isOwnSecretBinding
+      return this.relatedShootCount > 0 || !this.isOwnSecret
     }
   },
   methods: {

--- a/frontend/src/components/ShootMessageDetails.vue
+++ b/frontend/src/components/ShootMessageDetails.vue
@@ -80,11 +80,11 @@ SPDX-License-Identifier: Apache-2.0
                     <code>
                       <router-link v-if="canLinkToSecret"
                         class="cyan--text text--darken-2"
-                        :to="{ name: 'Secret', params: { name: secretName, namespace: namespace } }"
+                        :to="{ name: 'Secret', params: { name: secretBindingName, namespace: namespace } }"
                       >
-                        <span>{{secretName}}</span>
+                        <span>{{secretBindingName}}</span>
                       </router-link>
-                      <span v-else>{{secretName}}</span>
+                      <span v-else>{{secretBindingName}}</span>
                     </code>:</span>
                   {{description}}
                 </span>
@@ -124,7 +124,7 @@ export default {
     lastTransitionTime: {
       type: String
     },
-    secretName: {
+    secretBindingName: {
       type: String
     },
     namespace: {
@@ -136,7 +136,7 @@ export default {
       return !isEmpty(this.errorDescriptions)
     },
     canLinkToSecret () {
-      return this.secretName && this.namespace
+      return this.secretBindingName && this.namespace
     }
   }
 }

--- a/frontend/src/components/ShootStatus.vue
+++ b/frontend/src/components/ShootStatus.vue
@@ -53,7 +53,7 @@ SPDX-License-Identifier: Apache-2.0
       :lastMessage="lastMessage"
       :errorDescriptions="errorDescriptions"
       :lastUpdateTime="shootLastOperation.lastUpdateTime"
-      :secretName="shootSecretBindingName"
+      :secretBindingName="shootSecretBindingName"
       :namespace="shootNamespace"
     />
   </g-popper>

--- a/frontend/src/components/StatusTag.vue
+++ b/frontend/src/components/StatusTag.vue
@@ -49,7 +49,7 @@ SPDX-License-Identifier: Apache-2.0
         :lastMessage="nonErrorMessage"
         :errorDescriptions="errorDescriptions"
         :lastTransitionTime="tag.lastTransitionTime"
-        :secretName="secretName"
+        :secretBindingName="secretBindingName"
         :namespace="namespace"
       />
     </g-popper>
@@ -86,7 +86,7 @@ export default {
       type: Object,
       required: true
     },
-    secretName: {
+    secretBindingName: {
       type: String
     },
     namespace: {

--- a/frontend/src/components/StatusTags.vue
+++ b/frontend/src/components/StatusTags.vue
@@ -12,7 +12,7 @@ SPDX-License-Identifier: Apache-2.0
       :popper-key="condition.type"
       :key="condition.type"
       :popperPlacement="popperPlacement"
-      :secretName="shootSecretBindingName"
+      :secretBindingName="shootSecretBindingName"
       :namespace="shootNamespace">
     </status-tag>
   </div>

--- a/frontend/src/components/dialogs/SecretDialog.vue
+++ b/frontend/src/components/dialogs/SecretDialog.vue
@@ -267,8 +267,10 @@ export default {
         const metadata = {
           name: this.name,
           namespace: this.namespace,
-          secretName: this.name,
-          secretNamespacenamespace: this.namespace,
+          secretRef: {
+            name: this.name,
+            namespace: this.namespace
+          },
           cloudProviderKind: this.cloudProviderKind,
           cloudProfileName: this.cloudProfileName
         }

--- a/frontend/src/components/dialogs/SecretDialogDelete.vue
+++ b/frontend/src/components/dialogs/SecretDialogDelete.vue
@@ -92,9 +92,9 @@ export default {
       this.visible = false
     },
     async onDeleteSecret () {
-      const bindingName = get(this.secret, 'metadata.bindingName')
+      const name = get(this.secret, 'metadata.name')
       try {
-        await this.deleteSecret(bindingName)
+        await this.deleteSecret(name)
         this.hide()
       } catch (err) {
         const errorDetails = errorDetailsFromError(err)

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -549,9 +549,9 @@ const getters = {
   infrastructureSecretList (state) {
     return state.infrastructureSecrets.all
   },
-  getInfrastructureSecretByBindingName (state, getters) {
+  getInfrastructureSecretByName (state, getters) {
     return ({ namespace, name }) => {
-      return getters['infrastructureSecrets/getInfrastructureSecretByBindingName']({ namespace, name })
+      return getters['infrastructureSecrets/getInfrastructureSecretByName']({ namespace, name })
     }
   },
   namespaces (state) {

--- a/frontend/src/store/modules/infrastructureSecrets.js
+++ b/frontend/src/store/modules/infrastructureSecrets.js
@@ -24,7 +24,6 @@ const getters = {
   getInfrastructureSecretByName (state) {
     return ({ name, namespace }) => find(state.all, eqlNameAndNamespace({ name, namespace }))
   }
-  }
 }
 
 // actions
@@ -42,8 +41,7 @@ const actions = {
       })
   },
   update: ({ commit, rootState }, { metadata, data }) => {
-    const namespace = metadata.namespace || rootState.namespace
-    const name = metadata.name
+    const { namespace = rootState.namespace, name } = metadata
     return updateInfrastructureSecret({ namespace, name, data: { metadata, data } })
       .then(res => {
         commit('ITEM_PUT', res.data)
@@ -51,7 +49,7 @@ const actions = {
       })
   },
   create: ({ commit, rootState }, { metadata, data }) => {
-    const namespace = metadata.namespace || rootState.namespace
+    const { namespace = rootState.namespace } = metadata
     return createInfrastructureSecret({ namespace, data: { metadata, data } })
       .then(res => {
         commit('ITEM_PUT', res.data)

--- a/frontend/src/store/modules/infrastructureSecrets.js
+++ b/frontend/src/store/modules/infrastructureSecrets.js
@@ -10,8 +10,8 @@ import find from 'lodash/find'
 import matches from 'lodash/matches'
 import { getInfrastructureSecrets, updateInfrastructureSecret, createInfrastructureSecret, deleteInfrastructureSecret } from '@/utils/api'
 
-const eqlBindingNameAndNamespace = ({ bindingNamespace, bindingName }) => {
-  return matches({ metadata: { bindingNamespace, bindingName } })
+const eqlNameAndNamespace = ({ namespace, name }) => {
+  return matches({ metadata: { namespace, name } })
 }
 
 // initial state
@@ -21,8 +21,8 @@ const state = {
 
 // getters
 const getters = {
-  getInfrastructureSecretByBindingName: (state) => ({ name, namespace }) => {
-    return find(state.all, eqlBindingNameAndNamespace({ bindingName: name, bindingNamespace: namespace }))
+  getInfrastructureSecretByName: (state) => ({ name, namespace }) => {
+    return find(state.all, eqlNameAndNamespace({ name, namespace }))
   }
 }
 
@@ -42,8 +42,8 @@ const actions = {
   },
   update: ({ commit, rootState }, { metadata, data }) => {
     const namespace = metadata.namespace || rootState.namespace
-    const bindingName = metadata.bindingName
-    return updateInfrastructureSecret({ namespace, bindingName, data: { metadata, data } })
+    const name = metadata.name
+    return updateInfrastructureSecret({ namespace, name, data: { metadata, data } })
       .then(res => {
         commit('ITEM_PUT', res.data)
         return res.data
@@ -57,9 +57,9 @@ const actions = {
         return res.data
       })
   },
-  delete ({ dispatch, commit, rootState }, bindingName) {
+  delete ({ dispatch, commit, rootState }, name) {
     const namespace = rootState.namespace
-    return deleteInfrastructureSecret({ namespace, bindingName })
+    return deleteInfrastructureSecret({ namespace, name })
       .then(res => {
         commit('ITEM_DELETED', res.data)
         return res.data
@@ -76,8 +76,10 @@ const mutations = {
     state.all = []
   },
   ITEM_PUT (state, newItem) {
-    const iteratee = item => item.metadata.name === newItem.metadata.name
-    const index = findIndex(state.all, iteratee)
+    const index = findIndex(state.all, eqlNameAndNamespace({
+      name: newItem.metadata.name,
+      namespace: newItem.metadata.namespace
+    }))
     if (index !== -1) {
       const item = state.all[index]
       state.all.splice(index, 1, assign({}, item, newItem))
@@ -86,8 +88,10 @@ const mutations = {
     }
   },
   ITEM_DELETED (state, deletedItem) {
-    const predicate = item => item.metadata.name === deletedItem.metadata.name
-    const index = findIndex(state.all, predicate)
+    const index = findIndex(state.all, eqlNameAndNamespace({
+      name: deletedItem.metadata.name,
+      namespace: deletedItem.metadata.namespace
+    }))
     if (index !== -1) {
       state.all.splice(index, 1)
     }

--- a/frontend/src/store/modules/infrastructureSecrets.js
+++ b/frontend/src/store/modules/infrastructureSecrets.js
@@ -21,8 +21,9 @@ const state = {
 
 // getters
 const getters = {
-  getInfrastructureSecretByName: (state) => ({ name, namespace }) => {
-    return find(state.all, eqlNameAndNamespace({ name, namespace }))
+  getInfrastructureSecretByName (state) {
+    return ({ name, namespace }) => find(state.all, eqlNameAndNamespace({ name, namespace }))
+  }
   }
 }
 

--- a/frontend/src/store/modules/shoots.js
+++ b/frontend/src/store/modules/shoots.js
@@ -219,7 +219,7 @@ const actions = {
     set(shootResource, 'spec.cloudProfileName', cloudProfileName)
 
     const secret = head(rootGetters.infrastructureSecretsByCloudProfileName(cloudProfileName))
-    set(shootResource, 'spec.secretBindingName', get(secret, 'metadata.bindingName'))
+    set(shootResource, 'spec.secretBindingName', get(secret, 'metadata.name'))
 
     let region = head(rootGetters.regionsWithSeedByCloudProfileName(cloudProfileName))
     if (!region) {

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -48,10 +48,10 @@ export function getInfrastructureSecrets ({ namespace }) {
   return getResource(`/api/namespaces/${namespace}/infrastructure-secrets`)
 }
 
-export function updateInfrastructureSecret ({ namespace, bindingName, data }) {
+export function updateInfrastructureSecret ({ namespace, name, data }) {
   namespace = encodeURIComponent(namespace)
-  bindingName = encodeURIComponent(bindingName)
-  return updateResource(`/api/namespaces/${namespace}/infrastructure-secrets/${bindingName}`, data)
+  name = encodeURIComponent(name)
+  return updateResource(`/api/namespaces/${namespace}/infrastructure-secrets/${name}`, data)
 }
 
 export function createInfrastructureSecret ({ namespace, data }) {
@@ -59,10 +59,10 @@ export function createInfrastructureSecret ({ namespace, data }) {
   return createResource(`/api/namespaces/${namespace}/infrastructure-secrets`, data)
 }
 
-export function deleteInfrastructureSecret ({ namespace, bindingName }) {
+export function deleteInfrastructureSecret ({ namespace, name }) {
   namespace = encodeURIComponent(namespace)
-  bindingName = encodeURIComponent(bindingName)
-  return deleteResource(`/api/namespaces/${namespace}/infrastructure-secrets/${bindingName}`)
+  name = encodeURIComponent(name)
+  return deleteResource(`/api/namespaces/${namespace}/infrastructure-secrets/${name}`)
 }
 
 /* Shoot Clusters */

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -288,8 +288,8 @@ export function getTimeStringTo (time, toTime, withoutPrefix = false) {
   }
 }
 
-export function isOwnSecretBinding (secret) {
-  return get(secret, 'metadata.secretNamespace') === get(secret, 'metadata.bindingNamespace')
+export function isOwnSecret (secret) {
+  return get(secret, 'metadata.secretNamespace') === get(secret, 'metadata.namespace')
 }
 
 const availableK8sUpdatesCache = {}

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -288,8 +288,8 @@ export function getTimeStringTo (time, toTime, withoutPrefix = false) {
   }
 }
 
-export function isOwnSecret (secret) {
-  return get(secret, 'metadata.secretRef.namespace') === get(secret, 'metadata.namespace')
+export function isOwnSecret (infrastructureSecret) {
+  return get(infrastructureSecret, 'metadata.secretRef.namespace') === get(infrastructureSecret, 'metadata.namespace')
 }
 
 const availableK8sUpdatesCache = {}

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -289,7 +289,7 @@ export function getTimeStringTo (time, toTime, withoutPrefix = false) {
 }
 
 export function isOwnSecret (secret) {
-  return get(secret, 'metadata.secretNamespace') === get(secret, 'metadata.namespace')
+  return get(secret, 'metadata.secretRef.namespace') === get(secret, 'metadata.namespace')
 }
 
 const availableK8sUpdatesCache = {}

--- a/frontend/src/views/NewShoot.vue
+++ b/frontend/src/views/NewShoot.vue
@@ -251,7 +251,7 @@ export default {
       }
       set(shootResource, 'spec.cloudProfileName', cloudProfileName)
       set(shootResource, 'spec.region', region)
-      set(shootResource, 'spec.secretBindingName', get(secret, 'metadata.bindingName'))
+      set(shootResource, 'spec.secretBindingName', get(secret, 'metadata.name'))
       if (!isEmpty(floatingPoolName)) {
         set(shootResource, 'spec.provider.infrastructureConfig.floatingPoolName', floatingPoolName)
       }
@@ -345,7 +345,7 @@ export default {
       const cloudProfileName = get(shootResource, 'spec.cloudProfileName')
       const region = get(shootResource, 'spec.region')
       const secretBindingName = get(shootResource, 'spec.secretBindingName')
-      const secret = this.infrastructureSecretsByBindingName({ secretBindingName, cloudProfileName })
+      const secret = this.infrastructureSecretsByName({ secretBindingName, cloudProfileName })
 
       const floatingPoolName = get(shootResource, 'spec.provider.infrastructureConfig.floatingPoolName')
       const loadBalancerProviderName = get(shootResource, 'spec.provider.controlPlaneConfig.loadBalancerProvider')
@@ -441,9 +441,9 @@ export default {
         messageHtml: 'Your cluster has validation errors.<br/>If you navigate to the yaml editor, you may lose data.'
       })
     },
-    infrastructureSecretsByBindingName ({ secretBindingName, cloudProfileName }) {
+    infrastructureSecretsByName ({ secretBindingName, cloudProfileName }) {
       const secrets = this.infrastructureSecretsByCloudProfileName(cloudProfileName)
-      return find(secrets, ['metadata.bindingName', secretBindingName])
+      return find(secrets, ['metadata.name', secretBindingName])
     }
   },
   async beforeRouteLeave (to, from, next) {

--- a/frontend/src/views/Secrets.vue
+++ b/frontend/src/views/Secrets.vue
@@ -177,7 +177,7 @@ SPDX-License-Identifier: Apache-2.0
 
 <script>
 import { mapGetters } from 'vuex'
-import { isOwnSecretBinding } from '@/utils'
+import { isOwnSecret } from '@/utils'
 import get from 'lodash/get'
 import DeleteDialog from '@/components/dialogs/SecretDialogDelete'
 import SecretDialogWrapper from '@/components/dialogs/SecretDialogWrapper'
@@ -238,7 +238,7 @@ export default {
   computed: {
     ...mapGetters([
       'cloudProfilesByCloudProviderKind',
-      'getInfrastructureSecretByBindingName'
+      'getInfrastructureSecretByName'
     ]),
     backgroundForSelectedSecret () {
       const kind = get(this.selectedSecret, 'metadata.cloudProviderKind')
@@ -302,8 +302,8 @@ export default {
     if (!get(this.$route.params, 'name')) {
       return
     }
-    const infrastructureSecret = this.getInfrastructureSecretByBindingName(this.$route.params)
-    if (!infrastructureSecret || !isOwnSecretBinding(infrastructureSecret)) {
+    const infrastructureSecret = this.getInfrastructureSecretByName(this.$route.params)
+    if (!infrastructureSecret || !isOwnSecret(infrastructureSecret)) {
       return
     }
     this.onUpdate(infrastructureSecret)


### PR DESCRIPTION
**What this PR does / why we need it**:
Re-introduce name and namespace for infrastructure secrets by using bindingName and bindingSecret.
This also fixes secret related bugs introduced with https://github.com/gardener/dashboard/pull/860.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user

```
