### PR TITLE
Declare "node-gyp@latest" as development dependency

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -72,7 +72,8 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         [null, {
           "packageLocation": "./",
           "packageDependencies": [
-            ["eslint", "npm:6.8.0"]
+            ["eslint", "npm:6.8.0"],
+            ["node-gyp", "npm:7.1.0"]
           ],
           "linkType": "SOFT",
         }]
@@ -10051,7 +10052,8 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./",
           "packageDependencies": [
             ["gardener-dashboard", "workspace:."],
-            ["eslint", "npm:6.8.0"]
+            ["eslint", "npm:6.8.0"],
+            ["node-gyp", "npm:7.1.0"]
           ],
           "linkType": "SOFT",
         }]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -99,7 +99,7 @@
     "vue-template-compiler": "^2.6.11",
     "vuetify-loader": "^1.3.0",
     "webpack": "^4.44.2"
-  },  
+  },
   "engines": {
     "node": "^14.15.0",
     "yarn": "^2.3.3"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "Sutter, Peter <peter.sutter@sap.com>"
   ],
   "devDependencies": {
-    "eslint": "^6.8.0"
+    "eslint": "^6.8.0",
+    "node-gyp": "latest"
   },
   "engines": {
     "node": "^14.15.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8352,6 +8352,7 @@ fsevents@^1.2.7:
   resolution: "gardener-dashboard@workspace:."
   dependencies:
     eslint: ^6.8.0
+    node-gyp: latest
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR declares "node-gyp@latest" as development dependency in the root workspace. We currently have the following 5 transitive dependencies that directly depend on [node-gyp@npm:latest](https://github.com/gardener/dashboard/blob/master/yarn.lock#L12699)
1. [evp_bytestokey@npm:1.0.3](https://github.com/gardener/dashboard/blob/master/yarn.lock#L7625)
2. [fsevents@npm:2.1.3](https://github.com/gardener/dashboard/blob/master/yarn.lock#L8312)
3. [fsevents@patch:fsevents@npm%3A2.1.3#builtin<compat/fsevents>::version=2.1.3&hash=127e8e](https://github.com/gardener/dashboard/blob/master/yarn.lock#L8331)
4. [nan@npm:2.14.1](https://github.com/gardener/dashboard/blob/master/yarn.lock#L12547)
5. [node-addon-api@npm:1.7.2](https://github.com/gardener/dashboard/blob/master/yarn.lock#L12653)

We transitively depend on [deasync](https://github.com/gardener/dashboard/blob/master/yarn.lock#L6222) via `vue-jest`, which  also depends on `node-gyp@latest`. Unfortunately deasync does not declare this dependency and it is not maintained (PR makes no sense).

But we cannot completely skip the build during the link step, because some required dependencies like `vue-popperjs` or `core-js` have a build script. These scripts must be executed when the dependency tree is changed. This can happen on major but also minor version updates.

If we declare  "node-gyp@latest" as development dependency "node-gyp" is available in the top-level workspace and the resolved dependencies in `yarn.lock` and the the `.yarn/cache` are not cached at all.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user

```
