### PR TITLE
add media.github to permitted csp for images

### DIFF
--- a/backend/lib/app.js
+++ b/backend/lib/app.js
@@ -32,6 +32,8 @@ if (gitHubRepoUrl) {
   imgSrc.push(url.origin)
   url.hostname = 'avatars.' + url.hostname
   imgSrc.push(url.origin)
+  url.hostname = 'media.' + url.hostname
+  imgSrc.push(url.origin)
 }
 
 // configure app

--- a/backend/lib/app.js
+++ b/backend/lib/app.js
@@ -29,10 +29,10 @@ const imgSrc = ['\'self\'', 'data:', 'https://www.gravatar.com']
 const gitHubRepoUrl = _.get(config, 'frontend.ticket.gitHubRepoUrl')
 if (gitHubRepoUrl) {
   const url = new URL(gitHubRepoUrl)
+  const gitHubHostname = url.hostname
+  url.hostname = 'avatars.' + gitHubHostname
   imgSrc.push(url.origin)
-  url.hostname = 'avatars.' + url.hostname
-  imgSrc.push(url.origin)
-  url.hostname = 'media.' + url.hostname
+  url.hostname = 'media.' + gitHubHostname
   imgSrc.push(url.origin)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the media.$ghe domain to the list of allowed domains for cross-domain requests. 
This is required to allow the embedding of images from tickets, which are uploaded to GitHub issues in the dashboard. 
If not added the browser will refuse to load them with a CSP error:
```
Refused to load the image 'https://media.$GHE/user/36/files/xxxxxx' because it violates the following Content Security Policy directive: "img-src 'self' data: https://www.gravatar.com https://$GHE https://avatars.$GHE".
```

and will render a broken image in the UI like this: 
![image](https://user-images.githubusercontent.com/16856448/98910578-acb99c00-24c3-11eb-8fc7-bfcfb29c1c4a.png)



**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
add media subdomain to list of allowed GitHub subdomains for image cross-domain requests 
```
