### PR TITLE
Honor insecureSkipTLSVerify spec from gardener-apiserver

### DIFF
--- a/backend/lib/routes/info.js
+++ b/backend/lib/routes/info.js
@@ -31,12 +31,14 @@ async function fetchGardenerVersion () {
     const {
       spec: {
         service,
+        insecureSkipTLSVerify,
         caBundle
       }
     } = await dashboardClient['apiregistration.k8s.io'].apiservices.get('v1beta1.core.gardener.cloud')
     const client = extend({
       prefixUrl: `https://${service.name}.${service.namespace}`,
       ca: decodeBase64(caBundle),
+      rejectUnauthorized: !insecureSkipTLSVerify,
       resolveBodyOnly: true,
       responseType: 'json'
     })

--- a/backend/lib/routes/info.js
+++ b/backend/lib/routes/info.js
@@ -35,13 +35,17 @@ async function fetchGardenerVersion () {
         caBundle
       }
     } = await dashboardClient['apiregistration.k8s.io'].apiservices.get('v1beta1.core.gardener.cloud')
-    const client = extend({
+    const options = {
       prefixUrl: `https://${service.name}.${service.namespace}`,
-      ca: decodeBase64(caBundle),
-      rejectUnauthorized: !insecureSkipTLSVerify,
       resolveBodyOnly: true,
       responseType: 'json'
-    })
+    }
+    if (caBundle) {
+      options.ca = decodeBase64(caBundle)
+    } else if (process.env.NODE_ENV !== 'production' && insecureSkipTLSVerify === true) {
+      options.rejectUnauthorized = false
+    }
+    const client = extend(options)
     const version = await client.request('version')
     return version
   } catch (err) {


### PR DESCRIPTION
Signed-off-by: Lothar Gesslein <gesslein@23technologies.cloud>

**What this PR does / why we need it**:
The local development gardener-apiserver spec looks like this:
```
spec:
  group: core.gardener.cloud
  groupPriorityMinimum: 10000
  insecureSkipTLSVerify: true
  service:
    name: gardener-apiserver
    namespace: garden
    port: 8443
  version: v1beta1
  versionPriority: 20
```

The backend can/should not verify the SSL cert if insecureSkipTLSVerify is true.

**Special notes for your reviewer**:
Sorry, this is certainly a "now it works on my machine" type of patch because I'm just getting my feet wet right now.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Honor insecureSkipTLSVerify spec from gardener-apiserver
```
