### PR TITLE
Fix markdown converter initialization if no gitHub.apiUrl is configured

### DIFF
--- a/backend/lib/services/tickets.js
+++ b/backend/lib/services/tickets.js
@@ -21,10 +21,15 @@ function fromLabel (item) {
   ])
 }
 
-const converter = exports.converter = markdown.createConverter({
-  ghMentions: true,
-  ghMentionsLink: new URL(config.gitHub.apiUrl).origin + '/{u}'
-})
+const apiUrl = _.get(config, 'gitHub.apiUrl')
+const options = {}
+
+if (apiUrl) {
+  options.ghMentions = true
+  options.ghMentionsLink = new URL(apiUrl).origin + '/{u}'
+}
+
+const converter = exports.converter = markdown.createConverter(options)
 
 function fromIssue (issue) {
   const labels = _.map(issue.labels, fromLabel)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR validates the existence of "config.gitHub.apiUrl" before usage.

**Which issue(s) this PR fixes**:
Fixes #896