### PR TITLE
Update dex to v2.27.0

### DIFF
--- a/charts/identity/values.yaml
+++ b/charts/identity/values.yaml
@@ -8,8 +8,8 @@
 replicaCount: 1
 
 image:
-  repository: quay.io/dexidp/dex
-  tag: v2.24.0
+  repository: ghcr.io/dexidp/dex
+  tag: v2.27.0
   pullPolicy: IfNotPresent
 
 containerPort: 5556


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes for multiple CVEs

[Element namespace prefix instability (CVE-2020-29511)](https://github.com/mattermost/xml-roundtrip-validator/blob/master/advisories/unstable-elements.md)
[Attribute namespace prefix instability (CVE-2020-29509)](https://github.com/mattermost/xml-roundtrip-validator/blob/master/advisories/unstable-attributes.md)
[Directive comment instability (CVE-2020-29510)](https://github.com/mattermost/xml-roundtrip-validator/blob/master/advisories/unstable-directives.md)

Upgrade should happen as soon as possible.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Dex is upgraded to `v2.27.0` fixing multiple CVEs in  golang's `encoding/xml` package:

- [Element namespace prefix instability (CVE-2020-29511)](https://github.com/mattermost/xml-roundtrip-validator/blob/master/advisories/unstable-elements.md)
- [Attribute namespace prefix instability (CVE-2020-29509)](https://github.com/mattermost/xml-roundtrip-validator/blob/master/advisories/unstable-attributes.md)
- [Directive comment instability (CVE-2020-29510)](https://github.com/mattermost/xml-roundtrip-validator/blob/master/advisories/unstable-directives.md)
```
