### PR TITLE
EditableText should not allow to save if an error exists

### DIFF
--- a/frontend/src/components/editable/EditableText.vue
+++ b/frontend/src/components/editable/EditableText.vue
@@ -173,6 +173,9 @@ export default {
       this.isActive = false
     },
     async onSave (value) {
+      if (this.error) {
+        return
+      }
       this.loading = this.color
       try {
         await this.save(this.internalValue)


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR it is no longer possible to save invalid data of an `EditableText` when the ENTER key is pressed. 

**Which issue(s) this PR fixes**:
Fixes #908

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
An invalid Cost Object cannot be saved by pressing the ENTER key. The popover remains open and the error message persists.
```
