### PR TITLE
Hide alert banner if no alert message is set

### DIFF
--- a/frontend/src/components/GAlert.vue
+++ b/frontend/src/components/GAlert.vue
@@ -79,7 +79,7 @@ export default {
       return permanentlyHiddenIds[this.identifier] === true
     },
     updateAlertVisibility () {
-      const visible = !this.isPermanentlyHidden(this.identifier)
+      const visible = !!this.message && !this.isPermanentlyHidden(this.identifier)
       this.setAlertVisibility(visible)
     },
     setAlertVisibility (visible) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the bug that an alert banner is shown even though no alert message was configured.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Bugfix for unreleased feature, introduced with #899

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
