### PR TITLE
Improve mock implementations

### DIFF
--- a/backend/__fixtures__/auth.js
+++ b/backend/__fixtures__/auth.js
@@ -7,6 +7,9 @@
 'use strict'
 
 const { split, join, reduce } = require('lodash')
+const createError = require('http-errors')
+const pathToRegexp = require('path-to-regexp')
+
 const {
   COOKIE_HEADER_PAYLOAD,
   COOKIE_TOKEN,
@@ -66,7 +69,12 @@ const auth = {
 
 const mocks = {
   reviewSelfSubjectRules () {
+    const match = pathToRegexp.match('/apis/authorization.k8s.io/v1/selfsubjectrulesreviews')
     return (headers, json) => {
+      const matchResult = match(headers[':path'])
+      if (matchResult === false) {
+        return Promise.reject(createError(503))
+      }
       const payload = auth.getTokenPayload(headers)
       const resourceRules = []
       const nonResourceRules = []
@@ -102,7 +110,12 @@ const mocks = {
     }
   },
   reviewSelfSubjectAccess ({ allowed = true } = {}) {
+    const match = pathToRegexp.match('/apis/authorization.k8s.io/v1/selfsubjectaccessreviews')
     return (headers, json) => {
+      const matchResult = match(headers[':path'])
+      if (matchResult === false) {
+        return Promise.reject(createError(503))
+      }
       const { id } = auth.getTokenPayload(headers)
       const { resourceAttributes, nonResourceAttributes } = json.spec
       if (resourceAttributes) {
@@ -125,7 +138,12 @@ const mocks = {
     }
   },
   reviewToken ({ domain = 'example.org' } = {}) {
+    const match = pathToRegexp.match('/apis/authentication.k8s.io/v1/tokenreviews')
     return (headers, json) => {
+      const matchResult = match(headers[':path'])
+      if (matchResult === false) {
+        return Promise.reject(createError(503))
+      }
       const { spec: { token } } = json
       const { id: username, groups } = decode(token)
       const authenticated = username.endsWith(domain)

--- a/backend/__fixtures__/nodes.js
+++ b/backend/__fixtures__/nodes.js
@@ -7,6 +7,8 @@
 'use strict'
 
 const { cloneDeep, find, set } = require('lodash')
+const createError = require('http-errors')
+const pathToRegexp = require('path-to-regexp')
 
 const nodeList = [
   getNode({ name: 'node-1', hostname: 'host-1' }),
@@ -49,11 +51,16 @@ const nodes = {
   }
 }
 
+const matchOptions = { decode: decodeURIComponent }
+const matchList = pathToRegexp.match('/api/v1/nodes', matchOptions)
+
 const mocks = {
   list () {
-    // eslint-disable-next-line no-unused-vars
-    const path = '/api/v1/nodes'
-    return () => {
+    return headers => {
+      const matchResult = matchList(headers[':path'])
+      if (matchResult === false) {
+        return Promise.reject(createError(503))
+      }
       const items = nodes.list()
       return Promise.resolve({ items })
     }

--- a/backend/__fixtures__/serviceaccounts.js
+++ b/backend/__fixtures__/serviceaccounts.js
@@ -5,7 +5,7 @@
 'use strict'
 
 const { PassThrough } = require('stream')
-const { cloneDeep, merge, get, set, filter, find } = require('lodash')
+const { cloneDeep, merge, get, set, filter, find, split } = require('lodash')
 const createError = require('http-errors')
 const pathToRegexp = require('path-to-regexp')
 
@@ -58,33 +58,47 @@ const serviceaccounts = {
   }
 }
 
+const matchOptions = { decode: decodeURIComponent }
+const matchList = pathToRegexp.match('/api/v1/namespaces/:namespace/serviceaccounts', matchOptions)
+const matchItem = pathToRegexp.match('/api/v1/namespaces/:namespace/serviceaccounts/:name', matchOptions)
+
 const mocks = {
   list () {
-    const path = '/api/v1/namespaces/:namespace/serviceaccounts'
-    const match = pathToRegexp.match(path, { decode: decodeURIComponent })
     return headers => {
-      const { params: { namespace } = {} } = match(headers[':path']) || {}
+      const matchResult = matchList(headers[':path'])
+      if (matchResult === false) {
+        return Promise.reject(createError(503))
+      }
+      const { params: { namespace } = {} } = matchResult
       const items = serviceaccounts.list(namespace)
       return Promise.resolve({ items })
     }
   },
-  get () {
-    const path = '/api/v1/namespaces/:namespace/serviceaccounts/:name'
-    const match = pathToRegexp.match(path, { decode: decodeURIComponent })
-    return headers => {
-      const { params: { namespace, name } = {} } = match(headers[':path']) || {}
-      const item = serviceaccounts.get(namespace, name)
-      if (!item) {
-        return Promise.reject(createError(404))
+  create ({ uid = 21, resourceVersion = '42', creationTimestamp = 'now' } = {}) {
+    return (headers, json) => {
+      const matchResult = matchList(headers[':path'])
+      if (matchResult === false) {
+        return Promise.reject(createError(503))
       }
+      const { params: { namespace } = {} } = matchResult
+      const payload = getTokenPayload(headers)
+      const item = cloneDeep(json)
+      set(item, 'metadata.namespace', namespace)
+      set(item, 'metadata.resourceVersion', resourceVersion)
+      set(item, 'metadata.uid', uid)
+      set(item, 'metadata.creationTimestamp', creationTimestamp)
+      set(item, 'metadata.annotations["gardener.cloud/created-by"]', payload.id)
       return Promise.resolve(item)
     }
   },
   watch () {
-    const path = '/api/v1/namespaces/:namespace/serviceaccounts'
-    const match = pathToRegexp.match(path, { decode: decodeURIComponent })
     return headers => {
-      const { params: { namespace } = {} } = match(headers[':path']) || {}
+      const [pathname] = split(headers[':path'], '?')
+      const matchResult = matchList(pathname)
+      if (matchResult === false) {
+        return Promise.reject(createError(503))
+      }
+      const { params: { namespace } = {} } = matchResult
       const fieldSelector = parseFieldSelector(headers)
       const items = filter(serviceaccounts.list(namespace), fieldSelector)
       const stream = new PassThrough()
@@ -102,26 +116,27 @@ const mocks = {
       return stream
     }
   },
-  create ({ uid = 21, resourceVersion = '42', creationTimestamp = 'now' } = {}) {
-    const path = '/apis/core.gardener.cloud/v1beta1/namespaces/:namespace/shoots'
-    const match = pathToRegexp.match(path, { decode: decodeURIComponent })
-    return (headers, json) => {
-      const { params: { namespace } = {} } = match(headers[':path']) || {}
-      const payload = getTokenPayload(headers)
-      const item = cloneDeep(json)
-      set(item, 'metadata.namespace', namespace)
-      set(item, 'metadata.resourceVersion', resourceVersion)
-      set(item, 'metadata.uid', uid)
-      set(item, 'metadata.creationTimestamp', creationTimestamp)
-      set(item, 'metadata.annotations["gardener.cloud/created-by"]', payload.id)
+  get () {
+    return headers => {
+      const matchResult = matchItem(headers[':path'])
+      if (matchResult === false) {
+        return Promise.reject(createError(503))
+      }
+      const { params: { namespace, name } = {} } = matchResult
+      const item = serviceaccounts.get(namespace, name)
+      if (!item) {
+        return Promise.reject(createError(404))
+      }
       return Promise.resolve(item)
     }
   },
   patch () {
-    const path = '/apis/core.gardener.cloud/v1beta1/namespaces/:namespace/shoots/:name'
-    const match = pathToRegexp.match(path, { decode: decodeURIComponent })
     return (headers, json) => {
-      const { params: { namespace, name } = {} } = match(headers[':path']) || {}
+      const matchResult = matchItem(headers[':path'])
+      if (matchResult === false) {
+        return Promise.reject(createError(503))
+      }
+      const { params: { namespace, name } = {} } = matchResult
       const item = serviceaccounts.get(namespace, name)
       const resourceVersion = get(item, 'metadata.resourceVersion', '42')
       merge(item, json)
@@ -130,10 +145,12 @@ const mocks = {
     }
   },
   delete () {
-    const path = '/apis/core.gardener.cloud/v1beta1/namespaces/:namespace/shoots/:name'
-    const match = pathToRegexp.match(path, { decode: decodeURIComponent })
     return headers => {
-      const { params: { namespace, name } = {} } = match(headers[':path']) || {}
+      const matchResult = matchItem(headers[':path'])
+      if (matchResult === false) {
+        return Promise.reject(createError(503))
+      }
+      const { params: { namespace, name } = {} } = matchResult
       const item = serviceaccounts.get(namespace, name)
       return Promise.resolve(item)
     }

--- a/backend/__fixtures__/shoots.js
+++ b/backend/__fixtures__/shoots.js
@@ -118,12 +118,18 @@ const shoots = {
   }
 }
 
+const matchOptions = { decode: decodeURIComponent }
+const matchList = pathToRegexp.match('/apis/core.gardener.cloud/v1beta1/namespaces/:namespace/shoots', matchOptions)
+const matchItem = pathToRegexp.match('/apis/core.gardener.cloud/v1beta1/namespaces/:namespace/shoots/:name', matchOptions)
+
 const mocks = {
   list () {
-    const path = '/apis/core.gardener.cloud/v1beta1/namespaces/:namespace/shoots'
-    const match = pathToRegexp.match(path, { decode: decodeURIComponent })
     return headers => {
-      const { params: { namespace } = {} } = match(headers[':path']) || {}
+      const matchResult = matchList(headers[':path'])
+      if (matchResult === false) {
+        return Promise.reject(createError(503))
+      }
+      const { params: { namespace } = {} } = matchResult
       const payload = getTokenPayload(headers)
       const project = projects.getByNamespace(namespace)
       if (!projects.isMember(project, payload)) {
@@ -134,10 +140,12 @@ const mocks = {
     }
   },
   create ({ uid = 21, resourceVersion = '42', phase = 'Ready' } = {}) {
-    const path = '/apis/core.gardener.cloud/v1beta1/namespaces/:namespace/shoots'
-    const match = pathToRegexp.match(path, { decode: decodeURIComponent })
     return (headers, json) => {
-      const { params: { namespace } = {} } = match(headers[':path']) || {}
+      const matchResult = matchList(headers[':path'])
+      if (matchResult === false) {
+        return Promise.reject(createError(503))
+      }
+      const { params: { namespace } = {} } = matchResult
       const payload = getTokenPayload(headers)
       const project = projects.getByNamespace(namespace)
       if (!projects.isMember(project, payload)) {
@@ -154,10 +162,12 @@ const mocks = {
     }
   },
   get () {
-    const path = '/apis/core.gardener.cloud/v1beta1/namespaces/:namespace/shoots/:name'
-    const match = pathToRegexp.match(path, { decode: decodeURIComponent })
     return headers => {
-      const { params: { namespace, name } = {} } = match(headers[':path']) || {}
+      const matchResult = matchItem(headers[':path'])
+      if (matchResult === false) {
+        return Promise.reject(createError(503))
+      }
+      const { params: { namespace, name } = {} } = matchResult
       const payload = getTokenPayload(headers)
       const project = projects.getByNamespace(namespace)
       if (!projects.isMember(project, payload)) {
@@ -171,10 +181,12 @@ const mocks = {
     }
   },
   patch () {
-    const path = '/apis/core.gardener.cloud/v1beta1/namespaces/:namespace/shoots/:name'
-    const match = pathToRegexp.match(path, { decode: decodeURIComponent })
     return (headers, json) => {
-      const { params: { namespace, name } = {} } = match(headers[':path']) || {}
+      const matchResult = matchItem(headers[':path'])
+      if (matchResult === false) {
+        return Promise.reject(createError(503))
+      }
+      const { params: { namespace, name } = {} } = matchResult
       let item = shoots.get(namespace, name)
       if (!item) {
         return Promise.reject(createError(404))
@@ -193,10 +205,12 @@ const mocks = {
     }
   },
   put () {
-    const path = '/apis/core.gardener.cloud/v1beta1/namespaces/:namespace/shoots/:name'
-    const match = pathToRegexp.match(path, { decode: decodeURIComponent })
     return (headers, json) => {
-      const { params: { namespace, name } = {} } = match(headers[':path']) || {}
+      const matchResult = matchItem(headers[':path'])
+      if (matchResult === false) {
+        return Promise.reject(createError(503))
+      }
+      const { params: { namespace, name } = {} } = matchResult
       let item = shoots.get(namespace, name)
       if (!item) {
         return Promise.reject(createError(404))
@@ -208,10 +222,12 @@ const mocks = {
     }
   },
   delete () {
-    const path = '/apis/core.gardener.cloud/v1beta1/namespaces/:namespace/shoots/:name'
-    const match = pathToRegexp.match(path, { decode: decodeURIComponent })
     return headers => {
-      const { params: { namespace, name } = {} } = match(headers[':path']) || {}
+      const matchResult = matchItem(headers[':path'])
+      if (matchResult === false) {
+        return Promise.reject(createError(503))
+      }
+      const { params: { namespace, name } = {} } = matchResult
       const item = shoots.get(namespace, name)
       set(item, 'metadata.annotations["confirmation.gardener.cloud/deletion"]', 'true')
       return Promise.resolve(item)


### PR DESCRIPTION
**What this PR does / why we need it**:
Reject with HttpError 503  in all mock implementations of mockRequest if the `header[':path']` does not match the pattern. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
