### PR TITLE
Improve wording in shoot action tooltip

### DIFF
--- a/frontend/src/mixins/shootItem.js
+++ b/frontend/src/mixins/shootItem.js
@@ -207,7 +207,7 @@ export const shootItem = {
       if (!this.isShootActionsDisabledForPurpose) {
         return tooltip
       }
-      return 'Actions disabled for cluster purpose infrastructure'
+      return 'Actions disabled for cluster with purpose infrastructure'
     }
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

As a new operator, we were confused by the wording: "Actions disabled for cluster purpose infrastructure".
We think that by adding a "with" preposition, it becomes clear that purpose is a property of the cluster and infrastructure is the value of the purpose property.

<img width="817" alt="image" src="https://user-images.githubusercontent.com/23032437/103339940-177a6300-4a83-11eb-96ea-70112cca149c.png">

@BeckerMax 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
