### PR TITLE
Show monitoring credentials if permitted

### DIFF
--- a/backend/test/acceptance/__snapshots__/api.shoots.spec.js.snap
+++ b/backend/test/acceptance/__snapshots__/api.shoots.spec.js.snap
@@ -884,8 +884,8 @@ Array [
 
 exports[`api shoots should return shoot seed info 2`] = `
 Object {
-  "monitoring_password": "pass-foo-barShoot",
-  "monitoring_username": "user-foo-barShoot",
+  "monitoringPassword": "pass-foo-barShoot",
+  "monitoringUsername": "user-foo-barShoot",
 }
 `;
 

--- a/frontend/src/components/ClusterMetrics.vue
+++ b/frontend/src/components/ClusterMetrics.vue
@@ -86,10 +86,10 @@ export default {
       return get(this.shootItem, 'info.alertmanagerUrl', '')
     },
     username () {
-      return this.isAdmin ? get(this.shootItem, 'seedInfo.monitoring_username', '') : get(this.shootItem, 'info.monitoring_username', '')
+      return this.isAdmin ? get(this.shootItem, 'seedInfo.monitoringUsername', '') : get(this.shootItem, 'info.monitoringUsername', '')
     },
     password () {
-      return this.isAdmin ? get(this.shootItem, 'seedInfo.monitoring_password', '') : get(this.shootItem, 'info.monitoring_password', '')
+      return this.isAdmin ? get(this.shootItem, 'seedInfo.monitoringPassword', '') : get(this.shootItem, 'info.monitoringPassword', '')
     },
     hasAlertmanager () {
       const emailReceivers = get(this.shootItem, 'spec.monitoring.alerting.emailReceivers', [])

--- a/frontend/src/components/ShootDetails/ShootMonitoringCard.vue
+++ b/frontend/src/components/ShootDetails/ShootMonitoringCard.vue
@@ -41,7 +41,7 @@ SPDX-License-Identifier: Apache-2.0
           </v-list-item-title>
         </v-list-item-content>
       </v-list-item>
-      <template v-if="canGetSecrets">
+      <template v-if="canGetMonitoringSecret">
         <v-divider inset></v-divider>
         <cluster-metrics v-if="!metricsNotAvailableText" :shoot-item="shootItem"></cluster-metrics>
         <v-list-item v-else>
@@ -80,8 +80,12 @@ export default {
   mixins: [shootItem],
   computed: {
     ...mapGetters([
-      'canGetSecrets'
+      'canGetSecret'
     ]),
+    canGetMonitoringSecret () {
+      const name = `${this.shootName}.monitoring`
+      return this.canGetSecret(name)
+    },
     metricsNotAvailableText () {
       if (this.isTestingCluster) {
         return 'Cluster Metrics not available for clusters with purpose testing'

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -943,6 +943,11 @@ const getters = {
   canGetSecrets (state) {
     return canI(state.subjectRules, 'list', '', 'secrets')
   },
+  canGetSecret (state) {
+    return name => {
+      return canI(state.subjectRules, 'get', '', 'secrets', name)
+    }
+  },
   canDeleteSecrets (state) {
     return canI(state.subjectRules, 'delete', '', 'secrets')
   },
@@ -1133,10 +1138,7 @@ const actions = {
         }]
       })
       const fetchShootAndShootSeedInfo = async ({ metadata, spec }) => {
-        const promises = []
-        if (store.getters.canGetSecrets) {
-          promises.push(store.dispatch('getShootInfo', metadata))
-        }
+        const promises = [store.dispatch('getShootInfo', metadata)]
         const seedName = spec.seedName
         if (store.getters.isAdmin && !store.getters.isSeedUnreachableByName(seedName)) {
           promises.push(store.dispatch('getShootSeedInfo', metadata))


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR improves the check for showing the monitoring credentials of a shoot cluster.
The minimum required permission is that the user has the `viewer` project role assigned and in addition has the permission to read/get the `<shootName>.monitoring` secret

Example `Role` and `RoleBinding`, that needs to be created
```yaml
---
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: monitoring-viewer
  namespace: garden-my-project
rules:
- apiGroups:
  - ""
  resourceNames:
  - myshoot1.monitoring
  - myshoot2.monitoring
  resources:
  - secrets
  verbs:
  - get
---
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: monitoring-viewer
  namespace: garden-my-project
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: monitoring-viewer
subjects:
- apiGroup: rbac.authorization.k8s.io
  kind: User
  name: user@example.com
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
You can now see the monitoring credentials if you are allowed to read the `<shootName>.monitoring` secret and have at least the project `viewer` role. 
```
