### PR TITLE
Show monitoring credentials for project viewer

### DIFF
--- a/backend/lib/services/shoots.js
+++ b/backend/lib/services/shoots.js
@@ -8,6 +8,7 @@
 
 const { isHttpError } = require('@gardener-dashboard/request')
 const kubeconfig = require('@gardener-dashboard/kube-config')
+const { dashboardClient } = require('@gardener-dashboard/kube-client')
 const utils = require('../utils')
 const { getSeed } = require('../cache')
 const authorization = require('./authorization')
@@ -197,9 +198,9 @@ exports.info = async function ({ user, namespace, name }) {
   const client = user.client
 
   const [
-    shoot,
-    secret
-  ] = await Promise.all([
+    { value: shoot, reason: shootError },
+    { value: secret }
+  ] = await Promise.allSettled([
     read({
       user,
       namespace,
@@ -212,12 +213,15 @@ exports.info = async function ({ user, namespace, name }) {
     })
   ])
 
+  if (shootError) {
+    throw shootError
+  }
+
   const data = {
     canLinkToSeed: false
   }
-  let seed
   if (shoot.spec.seedName) {
-    seed = getSeed(getSeedNameFromShoot(shoot))
+    const seed = getSeed(getSeedNameFromShoot(shoot))
     const prefix = _.replace(shoot.status.technicalID, /^shoot--/, '')
     if (prefix) {
       const ingressDomain = getSeedIngressDomain(seed)
@@ -259,7 +263,14 @@ exports.info = async function ({ user, namespace, name }) {
 
   const isAdmin = await authorization.isAdmin(user)
   if (!isAdmin) {
-    await assignComponentSecrets(client, data, namespace, name)
+    /*
+      We explicitly use the (privileged) dashboardClient here for fetching the monitoring credentials instead of using the user's token
+      as we agreed that also project viewers should be able to see the monitoring credentials.
+      Usually project viewers do not have the permission to read the <shootName>.monitoring credential.
+      Our assumption: if the user can read the shoot resource, the user can be considered as project viewer.
+      This is only a temporary workaround until a Grafana SSO solution is implemented https://github.com/gardener/monitoring/issues/11.
+    */
+    await assignMonitoringSecret(dashboardClient, data, namespace, name)
   }
 
   return data
@@ -288,20 +299,12 @@ exports.seedInfo = async function ({ user, namespace, name }) {
   try {
     const seedClient = await client.createKubeconfigClient(seed.spec.secretRef)
     const seedShootNamespace = shoot.status.technicalID
-    await assignComponentSecrets(seedClient, data, seedShootNamespace)
+    await assignMonitoringSecret(seedClient, data, seedShootNamespace)
   } catch (err) {
     logger.error('Failed to retrieve information using seed core client', err)
   }
 
   return data
-}
-
-function assignComponentSecrets (client, data, namespace, name) {
-  const components = ['monitoring']
-  return Promise.all(components.map(component => {
-    const ingressSecretName = name ? `${name}.${component}` : `${component}-ingress-credentials`
-    return assignComponentSecret(client, data, component, namespace, ingressSecretName)
-  }))
 }
 
 async function getSecret (client, { namespace, name }) {
@@ -311,12 +314,13 @@ async function getSecret (client, { namespace, name }) {
     if (isHttpError(err, 404)) {
       return
     }
-    logger.error('failed to fetch %s secret: %s', name, err) // pragma: whitelist secret
+    logger.error('failed to fetch %s secret: %s', name, err)
     throw err
   }
 }
 
-async function assignComponentSecret (client, data, component, namespace, name) {
+async function assignMonitoringSecret (client, data, namespace, shootName) {
+  const name = shootName ? `${shootName}.monitoring` : 'monitoring-ingress-credentials'
   const secret = await getSecret(client, { namespace, name })
   if (secret) {
     _
@@ -325,9 +329,9 @@ async function assignComponentSecret (client, data, component, namespace, name) 
       .pick('username', 'password')
       .forEach((value, key) => {
         if (key === 'password') {
-          data[`${component}_password`] = decodeBase64(value)
+          data.monitoringPassword = decodeBase64(value)
         } else if (key === 'username') {
-          data[`${component}_username`] = decodeBase64(value)
+          data.monitoringUsername = decodeBase64(value)
         }
       })
       .commit()

--- a/backend/test/acceptance/__snapshots__/api.shoots.spec.js.snap
+++ b/backend/test/acceptance/__snapshots__/api.shoots.spec.js.snap
@@ -884,8 +884,8 @@ Array [
 
 exports[`api shoots should return shoot seed info 2`] = `
 Object {
-  "monitoring_password": "pass-foo-barShoot",
-  "monitoring_username": "user-foo-barShoot",
+  "monitoringPassword": "pass-foo-barShoot",
+  "monitoringUsername": "user-foo-barShoot",
 }
 `;
 

--- a/frontend/src/components/ClusterMetrics.vue
+++ b/frontend/src/components/ClusterMetrics.vue
@@ -86,10 +86,10 @@ export default {
       return get(this.shootItem, 'info.alertmanagerUrl', '')
     },
     username () {
-      return this.isAdmin ? get(this.shootItem, 'seedInfo.monitoring_username', '') : get(this.shootItem, 'info.monitoring_username', '')
+      return this.isAdmin ? get(this.shootItem, 'seedInfo.monitoringUsername', '') : get(this.shootItem, 'info.monitoringUsername', '')
     },
     password () {
-      return this.isAdmin ? get(this.shootItem, 'seedInfo.monitoring_password', '') : get(this.shootItem, 'info.monitoring_password', '')
+      return this.isAdmin ? get(this.shootItem, 'seedInfo.monitoringPassword', '') : get(this.shootItem, 'info.monitoringPassword', '')
     },
     hasAlertmanager () {
       const emailReceivers = get(this.shootItem, 'spec.monitoring.alerting.emailReceivers', [])

--- a/frontend/src/components/ShootDetails/ShootMonitoringCard.vue
+++ b/frontend/src/components/ShootDetails/ShootMonitoringCard.vue
@@ -41,20 +41,18 @@ SPDX-License-Identifier: Apache-2.0
           </v-list-item-title>
         </v-list-item-content>
       </v-list-item>
-      <template v-if="canGetSecrets">
-        <v-divider inset></v-divider>
-        <cluster-metrics v-if="!metricsNotAvailableText" :shoot-item="shootItem"></cluster-metrics>
-        <v-list-item v-else>
-          <v-list-item-icon>
-            <v-icon color="primary">mdi-alert-circle-outline</v-icon>
-          </v-list-item-icon>
-          <v-list-item-content>
-            <v-list-item-title>
-              {{metricsNotAvailableText}}
-            </v-list-item-title>
-          </v-list-item-content>
-        </v-list-item>
-      </template>
+      <v-divider inset></v-divider>
+      <cluster-metrics v-if="!metricsNotAvailableText" :shoot-item="shootItem"></cluster-metrics>
+      <v-list-item v-else>
+        <v-list-item-icon>
+          <v-icon color="primary">mdi-alert-circle-outline</v-icon>
+        </v-list-item-icon>
+        <v-list-item-content>
+          <v-list-item-title>
+            {{metricsNotAvailableText}}
+          </v-list-item-title>
+        </v-list-item-content>
+      </v-list-item>
     </v-list>
   </v-card>
 </template>
@@ -64,7 +62,6 @@ import ShootStatus from '@/components/ShootStatus'
 import StatusTags from '@/components/StatusTags'
 import ClusterMetrics from '@/components/ClusterMetrics'
 import { shootItem } from '@/mixins/shootItem'
-import { mapGetters } from 'vuex'
 
 export default {
   components: {
@@ -79,9 +76,6 @@ export default {
   },
   mixins: [shootItem],
   computed: {
-    ...mapGetters([
-      'canGetSecrets'
-    ]),
     metricsNotAvailableText () {
       if (this.isTestingCluster) {
         return 'Cluster Metrics not available for clusters with purpose testing'

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -1133,10 +1133,7 @@ const actions = {
         }]
       })
       const fetchShootAndShootSeedInfo = async ({ metadata, spec }) => {
-        const promises = []
-        if (store.getters.canGetSecrets) {
-          promises.push(store.dispatch('getShootInfo', metadata))
-        }
+        const promises = [store.dispatch('getShootInfo', metadata)]
         const seedName = spec.seedName
         if (store.getters.isAdmin && !store.getters.isSeedUnreachableByName(seedName)) {
           promises.push(store.dispatch('getShootSeedInfo', metadata))


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will show the monitoring credentials for project viewer.
Project viewer will only be able to see the monitoring credentials using the dashboard and not via the gardener API server with their own user.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This PR will block https://github.com/gardener/dashboard/issues/545 until https://github.com/gardener/monitoring/issues/11 is resolved.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Project members with `viewer` role can now see the monitoring credentials using the gardener dashboard
```
