### PR TITLE
Register dashboard doc component

### DIFF
--- a/.docforge/manifest.yaml
+++ b/.docforge/manifest.yaml
@@ -1,0 +1,8 @@
+# The documentation matches the file/folder structure at /docs
+nodesSelector:
+  path: https://github.com/gardener/dashboard/tree/master/docs    
+links:
+  downloads:
+    scope:
+      # all referenced files that reside in dashboard's docs dir are forged into the documentation
+      gardener/dashboard/(blob|raw)/(.*)/docs: ~


### PR DESCRIPTION
**What this PR does / why we need it**:
Registers dashboard as a "documentation" component. Documentation components contribute documentation (md+ supplementary multimedia) sources. 

**Special notes for your reviewer**:
The upcoming components DocHub at the [gardener.cloud](https://gardener.cloud) site, which is replacing the current Gardener-core centric documentation will be one of the publishing channels for the sources contributed by documentation components. Other channels are the landscape deployments and the upcoming Gardener landscaper.

The sources are built into publishable documentation bundles by various automated mechanisms that generally rely on the CICD for orchestration of the process. Commonly, they "recognize" documentation components as such by the availability of a `.docforge/manifest.yaml` resource in the component repository. The manifest  at that path describes the intended documentation structure and the rules to build it. 

Note, that the proposed manifest is fairly minimal. It will replicate the same file/folder structure that you have chosen to organize your `docs` directory and make sure that all referenced resources within the `docs` directory are part of the forged documentation bundle too. There are a number of other options how to evolve this if necessary. Take a look at the [Working with Manifests](https://github.com/gardener/docforge/blob/master/docs/manifests.md) document and the other documents at that location to get the feel of the opportunities.

To present a somewhat coherently structured documentation in multi-component documentation hub, please stick to a role-based top-level sections in your documentation structure as in the [Gardener documentation](https://github.com/gardener/gardener/tree/master/docs) for example, with the **Concepts** and **API Reference** being one notable, but necessary exempt from that rule. 

**Release note**:
```improvement user
NONE
```
/cc @swilen-iwanow 