### PR TITLE
Added Info / About Dialog

### DIFF
--- a/.ci/bump_version
+++ b/.ci/bump_version
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.ci/check
+++ b/.ci/check
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -14,7 +14,7 @@ fi
 
 cd "${SOURCE_PATH}"
 
-# Abort with an error exit code if 
+# Abort with an error exit code if
 # the lockfile was to be modified or
 # the cache folder was to be modified or
 # the checksums of the packages are not consistent

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -22,10 +22,10 @@ RUN yarn workspaces foreach --all run test-coverage
 # bump backend and frontend version
 RUN yarn workspaces foreach --include "*/(frontend|backend)" version "$(cat VERSION)"
 
-# run backend production install 
+# run backend production install
 RUN yarn workspace @gardener-dashboard/backend prod-install --pack /usr/src/build
 
-# run frontend build 
+# run frontend build
 RUN yarn workspace @gardener-dashboard/frontend run build
 
 # copy files to production directory

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/backend/__fixtures__/auth.js
+++ b/backend/__fixtures__/auth.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/__fixtures__/cloudprofiles.js
+++ b/backend/__fixtures__/cloudprofiles.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/__fixtures__/config.js
+++ b/backend/__fixtures__/config.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/__fixtures__/controllerregistrations.js
+++ b/backend/__fixtures__/controllerregistrations.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/__fixtures__/github.js
+++ b/backend/__fixtures__/github.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/__fixtures__/helper.js
+++ b/backend/__fixtures__/helper.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/__fixtures__/index.js
+++ b/backend/__fixtures__/index.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/__fixtures__/kube.js
+++ b/backend/__fixtures__/kube.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/__fixtures__/nodes.js
+++ b/backend/__fixtures__/nodes.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/__fixtures__/projects.js
+++ b/backend/__fixtures__/projects.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/__fixtures__/quotas.js
+++ b/backend/__fixtures__/quotas.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/__fixtures__/secretbindings.js
+++ b/backend/__fixtures__/secretbindings.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/__fixtures__/secrets.js
+++ b/backend/__fixtures__/secrets.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/__fixtures__/seeds.js
+++ b/backend/__fixtures__/seeds.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/__fixtures__/shoots.js
+++ b/backend/__fixtures__/shoots.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/__fixtures__/terminals.js
+++ b/backend/__fixtures__/terminals.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/__mocks__/@gardener-dashboard/kube-client.js
+++ b/backend/__mocks__/@gardener-dashboard/kube-client.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/__mocks__/@gardener-dashboard/logger.js
+++ b/backend/__mocks__/@gardener-dashboard/logger.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/__mocks__/@gardener-dashboard/request.js
+++ b/backend/__mocks__/@gardener-dashboard/request.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/__mocks__/@octokit/rest.js
+++ b/backend/__mocks__/@octokit/rest.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/__mocks__/openid-client.js
+++ b/backend/__mocks__/openid-client.js
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/jest.setup.js
+++ b/backend/jest.setup.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/api.js
+++ b/backend/lib/api.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/app.js
+++ b/backend/lib/app.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/auth.js
+++ b/backend/lib/auth.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/cache/index.js
+++ b/backend/lib/cache/index.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/cache/tickets.js
+++ b/backend/lib/cache/tickets.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/config/gardener.js
+++ b/backend/lib/config/gardener.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/config/index.js
+++ b/backend/lib/config/index.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/github/index.js
+++ b/backend/lib/github/index.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/github/octokit.js
+++ b/backend/lib/github/octokit.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/github/webhook.js
+++ b/backend/lib/github/webhook.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/healthz/index.js
+++ b/backend/lib/healthz/index.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/io.js
+++ b/backend/lib/io.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/logger/index.js
+++ b/backend/lib/logger/index.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/markdown.js
+++ b/backend/lib/markdown.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/middleware.js
+++ b/backend/lib/middleware.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/openapi/index.js
+++ b/backend/lib/openapi/index.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/routes/cloudprofiles.js
+++ b/backend/lib/routes/cloudprofiles.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/routes/gardenerExtensions.js
+++ b/backend/lib/routes/gardenerExtensions.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/routes/index.js
+++ b/backend/lib/routes/index.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/routes/info.js
+++ b/backend/lib/routes/info.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/routes/infrastructureSecrets.js
+++ b/backend/lib/routes/infrastructureSecrets.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/routes/members.js
+++ b/backend/lib/routes/members.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/routes/namespaces.js
+++ b/backend/lib/routes/namespaces.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/routes/networkingTypes.js
+++ b/backend/lib/routes/networkingTypes.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/routes/seeds.js
+++ b/backend/lib/routes/seeds.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/routes/shoots.js
+++ b/backend/lib/routes/shoots.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/routes/terminals.js
+++ b/backend/lib/routes/terminals.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/routes/user.js
+++ b/backend/lib/routes/user.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/security/constants.js
+++ b/backend/lib/security/constants.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/security/index.js
+++ b/backend/lib/security/index.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/security/jose.js
+++ b/backend/lib/security/jose.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/server.js
+++ b/backend/lib/server.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/services/authentication.js
+++ b/backend/lib/services/authentication.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/services/authorization.js
+++ b/backend/lib/services/authorization.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/services/cloudprofiles.js
+++ b/backend/lib/services/cloudprofiles.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/services/controllerregistrations.js
+++ b/backend/lib/services/controllerregistrations.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/services/index.js
+++ b/backend/lib/services/index.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/services/infrastructureSecrets.js
+++ b/backend/lib/services/infrastructureSecrets.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/services/members/Member.js
+++ b/backend/lib/services/members/Member.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/services/members/MemberManager.js
+++ b/backend/lib/services/members/MemberManager.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/services/members/SubjectList.js
+++ b/backend/lib/services/members/SubjectList.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/services/members/SubjectListItem.js
+++ b/backend/lib/services/members/SubjectListItem.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/services/members/index.js
+++ b/backend/lib/services/members/index.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/services/projects.js
+++ b/backend/lib/services/projects.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/services/seeds.js
+++ b/backend/lib/services/seeds.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/services/shoots.js
+++ b/backend/lib/services/shoots.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/services/terminals/index.js
+++ b/backend/lib/services/terminals/index.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/services/terminals/terminalBootstrap.js
+++ b/backend/lib/services/terminals/terminalBootstrap.js
@@ -1,6 +1,6 @@
 
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/services/terminals/terminalResources.js
+++ b/backend/lib/services/terminals/terminalResources.js
@@ -1,6 +1,6 @@
 
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/services/terminals/utils.js
+++ b/backend/lib/services/terminals/utils.js
@@ -1,6 +1,6 @@
 
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/services/tickets.js
+++ b/backend/lib/services/tickets.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/utils/batchEmitter.js
+++ b/backend/lib/utils/batchEmitter.js
@@ -1,6 +1,6 @@
 
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/utils/index.js
+++ b/backend/lib/utils/index.js
@@ -1,6 +1,6 @@
 
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/watches/common.js
+++ b/backend/lib/watches/common.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/watches/index.js
+++ b/backend/lib/watches/index.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/watches/seeds.js
+++ b/backend/lib/watches/seeds.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/watches/shoots.js
+++ b/backend/lib/watches/shoots.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/lib/watches/tickets.js
+++ b/backend/lib/watches/tickets.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/test/acceptance/api.cloudprofiles.spec.js
+++ b/backend/test/acceptance/api.cloudprofiles.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/test/acceptance/api.controllerregistrations.spec.js
+++ b/backend/test/acceptance/api.controllerregistrations.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/test/acceptance/api.info.spec.js
+++ b/backend/test/acceptance/api.info.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/test/acceptance/api.infrastructureSecrets.spec.js
+++ b/backend/test/acceptance/api.infrastructureSecrets.spec.js
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/backend/test/acceptance/api.members.spec.js
+++ b/backend/test/acceptance/api.members.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/test/acceptance/api.projects.spec.js
+++ b/backend/test/acceptance/api.projects.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/test/acceptance/api.seeds.spec.js
+++ b/backend/test/acceptance/api.seeds.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/test/acceptance/api.shoots.spec.js
+++ b/backend/test/acceptance/api.shoots.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/test/acceptance/api.terminals.spec.js
+++ b/backend/test/acceptance/api.terminals.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/test/acceptance/api.user.spec.js
+++ b/backend/test/acceptance/api.user.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/test/acceptance/auth.spec.js
+++ b/backend/test/acceptance/auth.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/test/acceptance/config.spec.js
+++ b/backend/test/acceptance/config.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/test/acceptance/healthz.spec.js
+++ b/backend/test/acceptance/healthz.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/test/acceptance/io.spec.js
+++ b/backend/test/acceptance/io.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/test/acceptance/openapi.spec.js
+++ b/backend/test/acceptance/openapi.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/test/acceptance/security.spec.js
+++ b/backend/test/acceptance/security.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/test/acceptance/webhook.spec.js
+++ b/backend/test/acceptance/webhook.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/test/cache.spec.js
+++ b/backend/test/cache.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/test/cache.tickets.spec.js
+++ b/backend/test/cache.tickets.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/test/config.spec.js
+++ b/backend/test/config.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/test/docker.spec.js
+++ b/backend/test/docker.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/test/healthz.spec.js
+++ b/backend/test/healthz.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/test/server.spec.js
+++ b/backend/test/server.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/test/services.members.spec.js
+++ b/backend/test/services.members.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/test/services.projects.spec.js
+++ b/backend/test/services.projects.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/test/services.shoots.spec.js
+++ b/backend/test/services.shoots.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/test/services.terminals.spec.js
+++ b/backend/test/services.terminals.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/test/services.tickets.spec.js
+++ b/backend/test/services.tickets.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/test/utils.spec.js
+++ b/backend/test/utils.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/backend/test/watches.spec.js
+++ b/backend/test/watches.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/charts/__tests__/gardener-dashboard.spec.js
+++ b/charts/__tests__/gardener-dashboard.spec.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/charts/gardener-dashboard/Chart.yaml
+++ b/charts/gardener-dashboard/Chart.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/charts/gardener-dashboard/templates/configmap.yaml
+++ b/charts/gardener-dashboard/templates/configmap.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/charts/gardener-dashboard/templates/deployment.yaml
+++ b/charts/gardener-dashboard/templates/deployment.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/charts/gardener-dashboard/templates/ingress.yaml
+++ b/charts/gardener-dashboard/templates/ingress.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/charts/gardener-dashboard/templates/rbac.yaml
+++ b/charts/gardener-dashboard/templates/rbac.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/charts/gardener-dashboard/templates/secret-github.yaml
+++ b/charts/gardener-dashboard/templates/secret-github.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/charts/gardener-dashboard/templates/secret-kubeconfig.yaml
+++ b/charts/gardener-dashboard/templates/secret-kubeconfig.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/charts/gardener-dashboard/templates/secret-oidc.yaml
+++ b/charts/gardener-dashboard/templates/secret-oidc.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/charts/gardener-dashboard/templates/secret-sessionSecret.yaml
+++ b/charts/gardener-dashboard/templates/secret-sessionSecret.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/charts/gardener-dashboard/templates/secret-tls.yaml
+++ b/charts/gardener-dashboard/templates/secret-tls.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/charts/gardener-dashboard/templates/service.yaml
+++ b/charts/gardener-dashboard/templates/service.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/charts/gardener-dashboard/templates/serviceaccount.yaml
+++ b/charts/gardener-dashboard/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/charts/identity/Chart.yaml
+++ b/charts/identity/Chart.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/charts/identity/templates/configmap.yaml
+++ b/charts/identity/templates/configmap.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/charts/identity/templates/deployment.yaml
+++ b/charts/identity/templates/deployment.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/charts/identity/templates/ingress.yaml
+++ b/charts/identity/templates/ingress.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/charts/identity/templates/rbac.yaml
+++ b/charts/identity/templates/rbac.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/charts/identity/templates/secret-kubeconfig.yaml
+++ b/charts/identity/templates/secret-kubeconfig.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/charts/identity/templates/secret.yaml
+++ b/charts/identity/templates/secret.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/charts/identity/templates/service.yaml
+++ b/charts/identity/templates/service.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/charts/identity/templates/serviceaccount.yaml
+++ b/charts/identity/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/charts/identity/values.yaml
+++ b/charts/identity/values.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/charts/jest.setup.js
+++ b/charts/jest.setup.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/frontend/babel.config.js
+++ b/frontend/babel.config.js
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->
@@ -10,7 +10,7 @@ SPDX-License-Identifier: Apache-2.0
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
-    
+
     <link rel="icon" type="image/png" href="<%= BASE_URL %>static/favicon-16x16.png" sizes="16x16" />
     <link rel="icon" type="image/png" href="<%= BASE_URL %>static/favicon-32x32.png" sizes="32x32" />
     <link rel="icon" type="image/png" href="<%= BASE_URL %>static/favicon-96x96.png" sizes="96x96" />

--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/components/AccountAvatar.vue
+++ b/frontend/src/components/AccountAvatar.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/AnsiText.vue
+++ b/frontend/src/components/AnsiText.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/Breadcrumb.vue
+++ b/frontend/src/components/Breadcrumb.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/CloudProfile.vue
+++ b/frontend/src/components/CloudProfile.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ClusterMetrics.vue
+++ b/frontend/src/components/ClusterMetrics.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/CodeBlock.vue
+++ b/frontend/src/components/CodeBlock.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ConstraintWarning.vue
+++ b/frontend/src/components/ConstraintWarning.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/CopyBtn.vue
+++ b/frontend/src/components/CopyBtn.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/DeleteCluster.vue
+++ b/frontend/src/components/DeleteCluster.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/DisabledSecret.vue
+++ b/frontend/src/components/DisabledSecret.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/DragNDroppableComponent.vue
+++ b/frontend/src/components/DragNDroppableComponent.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/ExternalLink.vue
+++ b/frontend/src/components/ExternalLink.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/GAlert.vue
+++ b/frontend/src/components/GAlert.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/GError.vue
+++ b/frontend/src/components/GError.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/GMessage.vue
+++ b/frontend/src/components/GMessage.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/GPopper.vue
+++ b/frontend/src/components/GPopper.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/GSnotify.vue
+++ b/frontend/src/components/GSnotify.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/GSplitpane.vue
+++ b/frontend/src/components/GSplitpane.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/GTerminal.vue
+++ b/frontend/src/components/GTerminal.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/HintColorizer.vue
+++ b/frontend/src/components/HintColorizer.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/LinkListTile.vue
+++ b/frontend/src/components/LinkListTile.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/Loading.vue
+++ b/frontend/src/components/Loading.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/MainContent.vue
+++ b/frontend/src/components/MainContent.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/MainNavigation.vue
+++ b/frontend/src/components/MainNavigation.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/MainToolbar.vue
+++ b/frontend/src/components/MainToolbar.vue
@@ -34,7 +34,7 @@ SPDX-License-Identifier: Apache-2.0
           </v-card-title>
           <v-divider></v-divider>
           <v-card-actions class="px-3">
-            <v-btn block text color="primary" class="justify-start" @click="showInfoDialog" title="About">
+            <v-btn block text color="primary" class="justify-start" @click="infoDialog=true" title="About">
               <v-icon color="primary" class="mr-3">mdi-information-outline</v-icon>
               About
             </v-btn>
@@ -124,7 +124,7 @@ SPDX-License-Identifier: Apache-2.0
         </v-tab>
       </v-tabs>
     </template>
-    <info-dialog ref="infoDialog"></info-dialog>
+    <info-dialog v-model="infoDialog" @dialog-closed="infoDialog=false"></info-dialog>
   </v-app-bar>
 </template>
 
@@ -143,7 +143,8 @@ export default {
   data () {
     return {
       menu: false,
-      help: false
+      help: false,
+      infoDialog: false
     }
   },
   methods: {
@@ -154,11 +155,6 @@ export default {
     ]),
     handleLogout () {
       this.$auth.signout()
-    },
-    showInfoDialog () {
-      this.$refs.infoDialog.showDialog()
-      this.$refs.infoDialog.fetchVersions()
-      this.$refs.infoDialog.fetchExtensions()
     }
   },
   computed: {

--- a/frontend/src/components/MainToolbar.vue
+++ b/frontend/src/components/MainToolbar.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->
@@ -30,16 +30,17 @@ SPDX-License-Identifier: Apache-2.0
         </template>
         <v-card tile width="300px">
           <v-card-title primary-title>
-            <div class="content">
-              <div class="title mb-2">Gardener</div>
-              <v-progress-circular size="18" indeterminate v-if="!dashboardVersion"></v-progress-circular>
-              <div class="caption" v-if="!!gardenerVersion">API version {{gardenerVersion}}</div>
-              <div class="caption" v-if="!!dashboardVersion">Dashboard version {{dashboardVersion}}</div>
-            </div>
+            <div class="content title mb-2">Gardener</div>
           </v-card-title>
           <v-divider></v-divider>
+          <v-card-actions class="px-3">
+            <v-btn block text color="primary" class="justify-start" @click="showInfoDialog" title="About">
+              <v-icon color="primary" class="mr-3">mdi-information-outline</v-icon>
+              About
+            </v-btn>
+          </v-card-actions>
           <template v-for="(item, index) in helpMenuItems">
-            <v-divider v-if="index !== 0" :key="`d-${index}`"></v-divider>
+            <v-divider :key="`d-${index}`"></v-divider>
             <v-card-actions :key="index" class="px-3">
               <v-btn block text color="primary" class="justify-start" :href="item.url" :target="helpTarget(item)" :title="item.title">
                 <v-icon color="primary" class="mr-3">{{item.icon}}</v-icon>
@@ -123,6 +124,7 @@ SPDX-License-Identifier: Apache-2.0
         </v-tab>
       </v-tabs>
     </template>
+    <info-dialog ref="infoDialog"></info-dialog>
   </v-app-bar>
 </template>
 
@@ -130,19 +132,18 @@ SPDX-License-Identifier: Apache-2.0
 import { mapState, mapGetters, mapActions } from 'vuex'
 import get from 'lodash/get'
 import Breadcrumb from '@/components/Breadcrumb'
-import { getInfo } from '@/utils/api'
+import InfoDialog from '@/components/dialogs/InfoDialog'
 
 export default {
   name: 'toolbar-background',
   components: {
-    Breadcrumb
+    Breadcrumb,
+    InfoDialog
   },
   data () {
     return {
       menu: false,
-      help: false,
-      gardenerVersion: undefined,
-      dashboardVersion: undefined
+      help: false
     }
   },
   methods: {
@@ -153,6 +154,11 @@ export default {
     ]),
     handleLogout () {
       this.$auth.signout()
+    },
+    showInfoDialog () {
+      this.$refs.infoDialog.showDialog()
+      this.$refs.infoDialog.fetchVersions()
+      this.$refs.infoDialog.fetchExtensions()
     }
   },
   computed: {
@@ -203,30 +209,6 @@ export default {
       },
       set (value) {
         this.setDarkMode(value)
-      }
-    }
-  },
-  watch: {
-    async help (value) {
-      if (value && !this.dashboardVersion) {
-        try {
-          const {
-            data: {
-              gardenerVersion,
-              version
-            } = {}
-          } = await getInfo()
-          if (gardenerVersion) {
-            this.gardenerVersion = gardenerVersion.gitVersion
-          }
-          if (version) {
-            this.dashboardVersion = `${version}`
-          }
-        } catch (err) {
-          this.setError({
-            message: `Failed to fetch version information. ${err.message}`
-          })
-        }
       }
     }
   }

--- a/frontend/src/components/MemberAccountRoles.vue
+++ b/frontend/src/components/MemberAccountRoles.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/NewShoot/NewShootDetails.vue
+++ b/frontend/src/components/NewShoot/NewShootDetails.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/NewShoot/NewShootInfrastructureDetails.vue
+++ b/frontend/src/components/NewShoot/NewShootInfrastructureDetails.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/NewShoot/NewShootSelectInfrastructure.vue
+++ b/frontend/src/components/NewShoot/NewShootSelectInfrastructure.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/PageHeader.vue
+++ b/frontend/src/components/PageHeader.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/PositionalDropzone.vue
+++ b/frontend/src/components/PositionalDropzone.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/ProjectServiceAccountRow.vue
+++ b/frontend/src/components/ProjectServiceAccountRow.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/ProjectUserRow.vue
+++ b/frontend/src/components/ProjectUserRow.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/Purpose.vue
+++ b/frontend/src/components/Purpose.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/PurposeConfiguration.vue
+++ b/frontend/src/components/PurposeConfiguration.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/PurposeTag.vue
+++ b/frontend/src/components/PurposeTag.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ReconcileStart.vue
+++ b/frontend/src/components/ReconcileStart.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/RetryOperation.vue
+++ b/frontend/src/components/RetryOperation.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/RotateKubeconfigStart.vue
+++ b/frontend/src/components/RotateKubeconfigStart.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/Secret.vue
+++ b/frontend/src/components/Secret.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/SecretRow.vue
+++ b/frontend/src/components/SecretRow.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/SelfTerminationWarning.vue
+++ b/frontend/src/components/SelfTerminationWarning.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootAccessRestrictions/AccessRestrictionChips.vue
+++ b/frontend/src/components/ShootAccessRestrictions/AccessRestrictionChips.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootAccessRestrictions/AccessRestrictions.vue
+++ b/frontend/src/components/ShootAccessRestrictions/AccessRestrictions.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootAccessRestrictions/AccessRestrictionsConfiguration.vue
+++ b/frontend/src/components/ShootAccessRestrictions/AccessRestrictionsConfiguration.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootAddons/AddonConfiguration.vue
+++ b/frontend/src/components/ShootAddons/AddonConfiguration.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootAddons/ManageAddons.vue
+++ b/frontend/src/components/ShootAddons/ManageAddons.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootCustomField.vue
+++ b/frontend/src/components/ShootCustomField.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootDetails/CustomFieldsCard.vue
+++ b/frontend/src/components/ShootDetails/CustomFieldsCard.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootDetails/GardenctlCommands.vue
+++ b/frontend/src/components/ShootDetails/GardenctlCommands.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootDetails/LbClass.vue
+++ b/frontend/src/components/ShootDetails/LbClass.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootDetails/ShootAccessCard.vue
+++ b/frontend/src/components/ShootDetails/ShootAccessCard.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootDetails/ShootDetails.vue
+++ b/frontend/src/components/ShootDetails/ShootDetails.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/ShootDetails/ShootDetailsCard.vue
+++ b/frontend/src/components/ShootDetails/ShootDetailsCard.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootDetails/ShootExternalToolsCard.vue
+++ b/frontend/src/components/ShootDetails/ShootExternalToolsCard.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootDetails/ShootInfrastructureCard.vue
+++ b/frontend/src/components/ShootDetails/ShootInfrastructureCard.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootDetails/ShootLifecycleCard.vue
+++ b/frontend/src/components/ShootDetails/ShootLifecycleCard.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootDetails/ShootMonitoringCard.vue
+++ b/frontend/src/components/ShootDetails/ShootMonitoringCard.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootDetails/TerminalShortcutsTile.vue
+++ b/frontend/src/components/ShootDetails/TerminalShortcutsTile.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootEditor.vue
+++ b/frontend/src/components/ShootEditor.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/ShootHibernation/ChangeHibernation.vue
+++ b/frontend/src/components/ShootHibernation/ChangeHibernation.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootHibernation/HibernationConfiguration.vue
+++ b/frontend/src/components/ShootHibernation/HibernationConfiguration.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootHibernation/HibernationScheduleEvent.vue
+++ b/frontend/src/components/ShootHibernation/HibernationScheduleEvent.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootHibernation/HibernationScheduleWarning.vue
+++ b/frontend/src/components/ShootHibernation/HibernationScheduleWarning.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootHibernation/ManageHibernationSchedule.vue
+++ b/frontend/src/components/ShootHibernation/ManageHibernationSchedule.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootListRow.vue
+++ b/frontend/src/components/ShootListRow.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootListRowActions.vue
+++ b/frontend/src/components/ShootListRowActions.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootMaintenance/MaintenanceComponents.vue
+++ b/frontend/src/components/ShootMaintenance/MaintenanceComponents.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootMaintenance/MaintenanceConfiguration.vue
+++ b/frontend/src/components/ShootMaintenance/MaintenanceConfiguration.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootMaintenance/MaintenanceStart.vue
+++ b/frontend/src/components/ShootMaintenance/MaintenanceStart.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootMaintenance/MaintenanceTime.vue
+++ b/frontend/src/components/ShootMaintenance/MaintenanceTime.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootMessageDetails.vue
+++ b/frontend/src/components/ShootMessageDetails.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootSeedName.vue
+++ b/frontend/src/components/ShootSeedName.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootStatus.vue
+++ b/frontend/src/components/ShootStatus.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootTickets/Ticket.vue
+++ b/frontend/src/components/ShootTickets/Ticket.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootTickets/TicketComment.vue
+++ b/frontend/src/components/ShootTickets/TicketComment.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootTickets/TicketLabel.vue
+++ b/frontend/src/components/ShootTickets/TicketLabel.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootVersion/ShootVersion.vue
+++ b/frontend/src/components/ShootVersion/ShootVersion.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootVersion/ShootVersionUpdate.vue
+++ b/frontend/src/components/ShootVersion/ShootVersionUpdate.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootWorkers/MachineImage.vue
+++ b/frontend/src/components/ShootWorkers/MachineImage.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootWorkers/MachineType.vue
+++ b/frontend/src/components/ShootWorkers/MachineType.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootWorkers/ManageWorkers.vue
+++ b/frontend/src/components/ShootWorkers/ManageWorkers.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootWorkers/VolumeSizeInput.vue
+++ b/frontend/src/components/ShootWorkers/VolumeSizeInput.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootWorkers/VolumeType.vue
+++ b/frontend/src/components/ShootWorkers/VolumeType.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootWorkers/WorkerConfiguration.vue
+++ b/frontend/src/components/ShootWorkers/WorkerConfiguration.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootWorkers/WorkerGroup.vue
+++ b/frontend/src/components/ShootWorkers/WorkerGroup.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/ShootWorkers/WorkerInputGeneric.vue
+++ b/frontend/src/components/ShootWorkers/WorkerInputGeneric.vue
@@ -1,6 +1,6 @@
 
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/StaleProjectWarning.vue
+++ b/frontend/src/components/StaleProjectWarning.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/StatusTag.vue
+++ b/frontend/src/components/StatusTag.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/StatusTags.vue
+++ b/frontend/src/components/StatusTags.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/TableColumnSelection.vue
+++ b/frontend/src/components/TableColumnSelection.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/TerminalListTile.vue
+++ b/frontend/src/components/TerminalListTile.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/TerminalSettings.vue
+++ b/frontend/src/components/TerminalSettings.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/TerminalShortcut.vue
+++ b/frontend/src/components/TerminalShortcut.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/TerminalShortcuts.vue
+++ b/frontend/src/components/TerminalShortcuts.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/TerminalSplitpanes.vue
+++ b/frontend/src/components/TerminalSplitpanes.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/TerminalTarget.vue
+++ b/frontend/src/components/TerminalTarget.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/TicketsCard.vue
+++ b/frontend/src/components/TicketsCard.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/TimeString.vue
+++ b/frontend/src/components/TimeString.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/UsernamePasswordListTile.vue
+++ b/frontend/src/components/UsernamePasswordListTile.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/Vendor.vue
+++ b/frontend/src/components/Vendor.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/VendorIcon.vue
+++ b/frontend/src/components/VendorIcon.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/VersionExpirationWarning.vue
+++ b/frontend/src/components/VersionExpirationWarning.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/WildcardSelect.vue
+++ b/frontend/src/components/WildcardSelect.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/dialogs/ActionButtonDialog.vue
+++ b/frontend/src/components/dialogs/ActionButtonDialog.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/dialogs/ConfirmDialog.vue
+++ b/frontend/src/components/dialogs/ConfirmDialog.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/dialogs/CreateTerminalSessionDialog.vue
+++ b/frontend/src/components/dialogs/CreateTerminalSessionDialog.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/dialogs/GDialog.vue
+++ b/frontend/src/components/dialogs/GDialog.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->
@@ -40,7 +40,7 @@ SPDX-License-Identifier: Apache-2.0
       </v-alert>
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn text @click="resolveAction(false)">{{cancelButtonText}}</v-btn>
+        <v-btn text @click="resolveAction(false)" v-if="cancelButtonText.length">{{cancelButtonText}}</v-btn>
         <v-btn text @click="resolveAction(true)" :disabled="!valid" :class="textColorClass">{{confirmButtonText}}</v-btn>
       </v-card-actions>
     </v-card>

--- a/frontend/src/components/dialogs/GDialog.vue
+++ b/frontend/src/components/dialogs/GDialog.vue
@@ -219,6 +219,7 @@ export default {
         this.resolve = undefined
         resolve(value)
       }
+      this.$emit('dialog-closed', value)
       this.visible = false
     },
     showScrollBar (retryCount = 0) {

--- a/frontend/src/components/dialogs/InfoDialog.vue
+++ b/frontend/src/components/dialogs/InfoDialog.vue
@@ -10,47 +10,31 @@ SPDX-License-Identifier: Apache-2.0
     confirm-button-text="Ok"
     cancel-button-text=""
     maxWidth="600"
+    @dialog-closed="onDialogClosed()"
     >
     <template v-slot:caption>About Gardener Dashboard</template>
     <template v-slot:message>
       <div class="d-flex flex-row align-center mt-3">
         <img src="../../assets/logo.svg" class="logo mr-3">
         <div>
-          <h1 class="mb-1">Gardener Dashboard</h1>
-          <h2>Web-based GUI for the Gardener.</h2>
+          <h2 class="mb-1">Gardener Dashboard</h2>
         </div>
       </div>
       <v-divider class="my-3"></v-divider>
       <div class="grey--text text--darken-1">
         <div class="font-weight-bold">Version Information</div>
-        <div v-if="!retrievedVersions"><v-progress-circular size="12" width="1" class="mr-1" indeterminate ></v-progress-circular>Retrieving versions...</div>
         <div v-if="!!dashboardVersion">Dashboard version {{dashboardVersion}}</div>
         <div v-if="!!gardenerVersion">API version {{gardenerVersion}}</div>
-        <div v-if="!retrievedExtensions"><v-progress-circular size="12" width="1" class="mr-1" indeterminate ></v-progress-circular>Retrieving extensions...</div>
-        <v-expansion-panels v-else-if="gardenerExtensionsList.length && isAdmin" flat>
-          <v-expansion-panel class="grey--text text--darken-1">
-            <v-expansion-panel-header class="text-body-2 pa-0">
-              {{gardenerExtensionsList.length}} deployed Extensions
-            </v-expansion-panel-header>
-            <v-expansion-panel-content>
-              <div
-              v-for="extension in gardenerExtensionsList"
-              :key="extension.id"
-              class="extension-item">
-                <span class="font-weight-bold">{{extension.name}}</span>
-                <span v-if="!!extension.version"> | Version: {{extension.version}}</span>
-                <span v-if="!!extension.kind"> | Kind: {{extension.kind}}</span>
-              </div>
-            </v-expansion-panel-content>
-          </v-expansion-panel>
-        </v-expansion-panels>
-      </div>
-      <v-divider class="my-3"></v-divider>
-      <div class="grey--text">
-        <span class="font-weight-bold">Gardener Dashboard</span><br />
-        Copyright 2021 SAP SE or an SAP affiliate company and Gardener contributors<br />
-        Github Project: <a href="https://github.com/gardener/dashboard" target="_blank">github.com/gardener/dashboard <v-icon style="font-size:80%">mdi-open-in-new</v-icon></a><br />
-        License: <a href="https://github.com/gardener/dashboard/blob/master/LICENSES/Apache-2.0.txt" target="_blank">Apache License Version 2.0 <v-icon style="font-size:80%">mdi-open-in-new</v-icon></a>
+        <v-divider v-if="gardenerExtensionsList.length" class="my-3"></v-divider>
+        <div v-if="gardenerExtensionsList.length" class="font-weight-bold">{{gardenerExtensionsList.length}} deployed Extensions</div>
+        <div
+        v-for="extension in gardenerExtensionsList"
+        :key="extension.id"
+        class="extension-item">
+          <span>{{extension.name}}</span>
+          <span v-if="!!extension.version"> {{extension.version}}</span>
+          <span v-if="!!extension.kind"> (Kind: {{extension.kind}})</span>
+        </div>
       </div>
     </template>
   </g-dialog>
@@ -66,12 +50,15 @@ export default {
   components: {
     GDialog
   },
+  props: {
+    value: {
+      type: Boolean
+    }
+  },
   data () {
     return {
       gardenerVersion: undefined,
-      dashboardVersion: undefined,
-      retrievedVersions: false,
-      retrievedExtensions: false
+      dashboardVersion: undefined
     }
   },
   computed: {
@@ -86,9 +73,6 @@ export default {
       'fetchGardenerExtensions',
       'setError'
     ]),
-    showDialog () {
-      this.$refs.gDialog.showDialog()
-    },
     async fetchVersions () {
       try {
         const {
@@ -108,11 +92,21 @@ export default {
           message: `Failed to fetch version information. ${err.message}`
         })
       }
-      this.retrievedVersions = true
     },
     async fetchExtensions () {
       await this.fetchGardenerExtensions()
-      this.retrievedExtensions = true
+    },
+    onDialogClosed () {
+      this.$emit('dialog-closed')
+    }
+  },
+  watch: {
+    value (value) {
+      if (value) {
+        this.$refs.gDialog.showDialog()
+        this.fetchVersions()
+        this.fetchExtensions()
+      }
     }
   }
 }

--- a/frontend/src/components/dialogs/InfoDialog.vue
+++ b/frontend/src/components/dialogs/InfoDialog.vue
@@ -1,0 +1,126 @@
+<!--
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+ -->
+
+ <template>
+  <g-dialog
+    ref="gDialog"
+    confirm-button-text="Ok"
+    cancel-button-text=""
+    maxWidth="600"
+    >
+    <template v-slot:caption>About Gardener Dashboard</template>
+    <template v-slot:message>
+      <div class="d-flex flex-row align-center mt-3">
+        <img src="../../assets/logo.svg" class="logo mr-3">
+        <div>
+          <h1 class="mb-1">Gardener Dashboard</h1>
+          <h2>Web-based GUI for the Gardener.</h2>
+        </div>
+      </div>
+      <v-divider class="my-3"></v-divider>
+      <div class="grey--text text--darken-1">
+        <div class="font-weight-bold">Version Information</div>
+        <div v-if="!retrievedVersions"><v-progress-circular size="12" width="1" class="mr-1" indeterminate ></v-progress-circular>Retrieving versions...</div>
+        <div v-if="!!dashboardVersion">Dashboard version {{dashboardVersion}}</div>
+        <div v-if="!!gardenerVersion">API version {{gardenerVersion}}</div>
+        <div v-if="!retrievedExtensions"><v-progress-circular size="12" width="1" class="mr-1" indeterminate ></v-progress-circular>Retrieving extensions...</div>
+        <v-expansion-panels v-else-if="gardenerExtensionsList.length && isAdmin" flat>
+          <v-expansion-panel class="grey--text text--darken-1">
+            <v-expansion-panel-header class="text-body-2 pa-0">
+              {{gardenerExtensionsList.length}} deployed Extensions
+            </v-expansion-panel-header>
+            <v-expansion-panel-content>
+              <div
+              v-for="extension in gardenerExtensionsList"
+              :key="extension.id"
+              class="extension-item">
+                <span class="font-weight-bold">{{extension.name}}</span>
+                <span v-if="!!extension.version"> | Version: {{extension.version}}</span>
+                <span v-if="!!extension.kind"> | Kind: {{extension.kind}}</span>
+              </div>
+            </v-expansion-panel-content>
+          </v-expansion-panel>
+        </v-expansion-panels>
+      </div>
+      <v-divider class="my-3"></v-divider>
+      <div class="grey--text">
+        <span class="font-weight-bold">Gardener Dashboard</span><br />
+        Copyright 2021 SAP SE or an SAP affiliate company and Gardener contributors<br />
+        Github Project: <a href="https://github.com/gardener/dashboard" target="_blank">github.com/gardener/dashboard <v-icon style="font-size:80%">mdi-open-in-new</v-icon></a><br />
+        License: <a href="https://github.com/gardener/dashboard/blob/master/LICENSES/Apache-2.0.txt" target="_blank">Apache License Version 2.0 <v-icon style="font-size:80%">mdi-open-in-new</v-icon></a>
+      </div>
+    </template>
+  </g-dialog>
+</template>
+
+<script>
+import { mapGetters, mapActions } from 'vuex'
+import GDialog from '@/components/dialogs/GDialog'
+import { getInfo } from '@/utils/api'
+
+export default {
+  name: 'info-dialog',
+  components: {
+    GDialog
+  },
+  data () {
+    return {
+      gardenerVersion: undefined,
+      dashboardVersion: undefined,
+      retrievedVersions: false,
+      retrievedExtensions: false
+    }
+  },
+  computed: {
+    ...mapGetters([
+      'isAdmin',
+      'gardenerExtensionsList'
+    ])
+  },
+
+  methods: {
+    ...mapActions([
+      'fetchGardenerExtensions',
+      'setError'
+    ]),
+    showDialog () {
+      this.$refs.gDialog.showDialog()
+    },
+    async fetchVersions () {
+      try {
+        const {
+          data: {
+            gardenerVersion,
+            version
+          } = {}
+        } = await getInfo()
+        if (gardenerVersion) {
+          this.gardenerVersion = gardenerVersion.gitVersion
+        }
+        if (version) {
+          this.dashboardVersion = `${version}`
+        }
+      } catch (err) {
+        this.setError({
+          message: `Failed to fetch version information. ${err.message}`
+        })
+      }
+      this.retrievedVersions = true
+    },
+    async fetchExtensions () {
+      await this.fetchGardenerExtensions()
+      this.retrievedExtensions = true
+    }
+  }
+}
+
+</script>
+
+<style lang="scss" scoped>
+  .logo {
+    height: 50px;
+  }
+</style>

--- a/frontend/src/components/dialogs/InfoDialog.vue
+++ b/frontend/src/components/dialogs/InfoDialog.vue
@@ -94,7 +94,9 @@ export default {
       }
     },
     async fetchExtensions () {
-      await this.fetchGardenerExtensions()
+      if (this.isAdmin) {
+        await this.fetchGardenerExtensions()
+      }
     },
     onDialogClosed () {
       this.$emit('dialog-closed')

--- a/frontend/src/components/dialogs/InfoDialog.vue
+++ b/frontend/src/components/dialogs/InfoDialog.vue
@@ -12,7 +12,7 @@ SPDX-License-Identifier: Apache-2.0
     maxWidth="600"
     @dialog-closed="onDialogClosed()"
     >
-    <template v-slot:caption>About Gardener Dashboard</template>
+    <template v-slot:caption>About</template>
     <template v-slot:message>
       <div class="d-flex flex-row align-center mt-3">
         <img src="../../assets/logo.svg" class="logo mr-3">
@@ -23,10 +23,10 @@ SPDX-License-Identifier: Apache-2.0
       <v-divider class="my-3"></v-divider>
       <div class="grey--text text--darken-1">
         <div class="font-weight-bold">Version Information</div>
-        <div v-if="!!dashboardVersion">Dashboard version {{dashboardVersion}}</div>
-        <div v-if="!!gardenerVersion">API version {{gardenerVersion}}</div>
+        <div v-if="!!dashboardVersion">Dashboard {{dashboardVersion}}</div>
+        <div v-if="!!gardenerVersion">API {{gardenerVersion}}</div>
         <v-divider v-if="gardenerExtensionsList.length" class="my-3"></v-divider>
-        <div v-if="gardenerExtensionsList.length" class="font-weight-bold">{{gardenerExtensionsList.length}} deployed Extensions</div>
+        <div v-if="gardenerExtensionsList.length" class="font-weight-bold">Extensions ({{gardenerExtensionsList.length}} deployed)</div>
         <div
         v-for="extension in gardenerExtensionsList"
         :key="extension.id"

--- a/frontend/src/components/dialogs/MemberDialog.vue
+++ b/frontend/src/components/dialogs/MemberDialog.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/dialogs/MemberHelpDialog.vue
+++ b/frontend/src/components/dialogs/MemberHelpDialog.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/dialogs/ProjectDialog.vue
+++ b/frontend/src/components/dialogs/ProjectDialog.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/dialogs/SecretDialog.vue
+++ b/frontend/src/components/dialogs/SecretDialog.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/dialogs/SecretDialogAlicloud.vue
+++ b/frontend/src/components/dialogs/SecretDialogAlicloud.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/dialogs/SecretDialogAlicloudHelp.vue
+++ b/frontend/src/components/dialogs/SecretDialogAlicloudHelp.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/dialogs/SecretDialogAws.vue
+++ b/frontend/src/components/dialogs/SecretDialogAws.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/dialogs/SecretDialogAwsHelp.vue
+++ b/frontend/src/components/dialogs/SecretDialogAwsHelp.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/dialogs/SecretDialogAzure.vue
+++ b/frontend/src/components/dialogs/SecretDialogAzure.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/dialogs/SecretDialogAzureHelp.vue
+++ b/frontend/src/components/dialogs/SecretDialogAzureHelp.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/dialogs/SecretDialogDelete.vue
+++ b/frontend/src/components/dialogs/SecretDialogDelete.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/dialogs/SecretDialogGcp.vue
+++ b/frontend/src/components/dialogs/SecretDialogGcp.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/dialogs/SecretDialogGcpHelp.vue
+++ b/frontend/src/components/dialogs/SecretDialogGcpHelp.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/dialogs/SecretDialogHelp.vue
+++ b/frontend/src/components/dialogs/SecretDialogHelp.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/dialogs/SecretDialogMetal.vue
+++ b/frontend/src/components/dialogs/SecretDialogMetal.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/dialogs/SecretDialogMetalHelp.vue
+++ b/frontend/src/components/dialogs/SecretDialogMetalHelp.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/dialogs/SecretDialogOpenstack.vue
+++ b/frontend/src/components/dialogs/SecretDialogOpenstack.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/dialogs/SecretDialogOpenstackHelp.vue
+++ b/frontend/src/components/dialogs/SecretDialogOpenstackHelp.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/dialogs/SecretDialogVSphere.vue
+++ b/frontend/src/components/dialogs/SecretDialogVSphere.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/dialogs/SecretDialogVSphereHelp.vue
+++ b/frontend/src/components/dialogs/SecretDialogVSphereHelp.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/dialogs/SecretDialogWrapper.vue
+++ b/frontend/src/components/dialogs/SecretDialogWrapper.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/dialogs/TerminalSettingsDialog.vue
+++ b/frontend/src/components/dialogs/TerminalSettingsDialog.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/dialogs/UnverifiedTerminalShortcutsDialog.vue
+++ b/frontend/src/components/dialogs/UnverifiedTerminalShortcutsDialog.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/dialogs/WebterminalServiceAccountDialog.vue
+++ b/frontend/src/components/dialogs/WebterminalServiceAccountDialog.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/editable/EditableAccount.vue
+++ b/frontend/src/components/editable/EditableAccount.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/editable/EditableText.vue
+++ b/frontend/src/components/editable/EditableText.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/editable/ErrorMessage.vue
+++ b/frontend/src/components/editable/ErrorMessage.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/components/icons/CertifiedKubernetes.vue
+++ b/frontend/src/components/icons/CertifiedKubernetes.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/icons/Connected.vue
+++ b/frontend/src/components/icons/Connected.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/icons/Disconnected.vue
+++ b/frontend/src/components/icons/Disconnected.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/icons/IconBase.vue
+++ b/frontend/src/components/icons/IconBase.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/icons/SplitHorizontally.vue
+++ b/frontend/src/components/icons/SplitHorizontally.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/icons/SplitVertically.vue
+++ b/frontend/src/components/icons/SplitVertically.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/icons/TerminalShortcutIcon.vue
+++ b/frontend/src/components/icons/TerminalShortcutIcon.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/messages/DeleteServiceAccount.vue
+++ b/frontend/src/components/messages/DeleteServiceAccount.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/messages/RemoveProjectMember.vue
+++ b/frontend/src/components/messages/RemoveProjectMember.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/components/messages/RotateServiceAccountSecret.vue
+++ b/frontend/src/components/messages/RotateServiceAccountSecret.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/frontend/src/lib/g-draggable.js
+++ b/frontend/src/lib/g-draggable.js
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/frontend/src/lib/g-symbol-tree.js
+++ b/frontend/src/lib/g-symbol-tree.js
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/frontend/src/lib/terminal.js
+++ b/frontend/src/lib/terminal.js
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/frontend/src/lib/xterm-addon-focus.js
+++ b/frontend/src/lib/xterm-addon-focus.js
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/frontend/src/lib/xterm-addon-k8s-attach.js
+++ b/frontend/src/lib/xterm-addon-k8s-attach.js
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/frontend/src/main.dev.js
+++ b/frontend/src/main.dev.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/mixins/asyncRef.js
+++ b/frontend/src/mixins/asyncRef.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/mixins/shootItem.js
+++ b/frontend/src/mixins/shootItem.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/plugins/auth.js
+++ b/frontend/src/plugins/auth.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/plugins/bus.js
+++ b/frontend/src/plugins/bus.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/plugins/cookie.js
+++ b/frontend/src/plugins/cookie.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/plugins/index.js
+++ b/frontend/src/plugins/index.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/plugins/shortkey.js
+++ b/frontend/src/plugins/shortkey.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/plugins/snotify.js
+++ b/frontend/src/plugins/snotify.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/plugins/storage.js
+++ b/frontend/src/plugins/storage.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/plugins/styles.js
+++ b/frontend/src/plugins/styles.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/plugins/utils.js
+++ b/frontend/src/plugins/utils.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/plugins/vuelidate.js
+++ b/frontend/src/plugins/vuelidate.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/plugins/vuetify.dev.js
+++ b/frontend/src/plugins/vuetify.dev.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/plugins/vuetify.js
+++ b/frontend/src/plugins/vuetify.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/plugins/vuetify.theme.js
+++ b/frontend/src/plugins/vuetify.theme.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/plugins/yaml.js
+++ b/frontend/src/plugins/yaml.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/router/breadcrumbs.js
+++ b/frontend/src/router/breadcrumbs.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/router/guards.js
+++ b/frontend/src/router/guards.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/router/routes.js
+++ b/frontend/src/router/routes.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/router/tabs.js
+++ b/frontend/src/router/tabs.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/sass/main.scss
+++ b/frontend/src/sass/main.scss
@@ -1,5 +1,5 @@
 /*
- *  SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+ *  SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
  *
  *  SPDX-License-Identifier: Apache-2.0
  */

--- a/frontend/src/sass/variables.scss
+++ b/frontend/src/sass/variables.scss
@@ -1,5 +1,5 @@
 /*
- *  SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+ *  SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
  *
  *  SPDX-License-Identifier: Apache-2.0
  */

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -340,7 +340,7 @@ const getters = {
       return sortBy(filteredCloudProfiles, 'metadata.name')
     }
   },
-  gardenerExtensionsist (state) {
+  gardenerExtensionsList (state) {
     return state.gardenerExtensions.all
   },
   networkingTypeList (state, getters) {

--- a/frontend/src/store/modules/cloudProfiles.js
+++ b/frontend/src/store/modules/cloudProfiles.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/store/modules/draggable.js
+++ b/frontend/src/store/modules/draggable.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/store/modules/gardenerExtensions.js
+++ b/frontend/src/store/modules/gardenerExtensions.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/store/modules/infrastructureSecrets.js
+++ b/frontend/src/store/modules/infrastructureSecrets.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/store/modules/members.js
+++ b/frontend/src/store/modules/members.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/store/modules/networkingTypes.js
+++ b/frontend/src/store/modules/networkingTypes.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/store/modules/projects.js
+++ b/frontend/src/store/modules/projects.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/store/modules/seeds.js
+++ b/frontend/src/store/modules/seeds.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/store/modules/shoots/getters.js
+++ b/frontend/src/store/modules/shoots/getters.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/store/modules/shoots/helper.js
+++ b/frontend/src/store/modules/shoots/helper.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/store/modules/shoots/index.js
+++ b/frontend/src/store/modules/shoots/index.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/store/modules/tickets.js
+++ b/frontend/src/store/modules/tickets.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/utils/Emitter.js
+++ b/frontend/src/utils/Emitter.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/utils/ThrottledEmitter.js
+++ b/frontend/src/utils/ThrottledEmitter.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/utils/auth.js
+++ b/frontend/src/utils/auth.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/utils/createShoot.js
+++ b/frontend/src/utils/createShoot.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -54,7 +54,6 @@ export function getSpecTemplate (infrastructureKind) {
       return {
         provider: getProviderTemplate(infrastructureKind),
         networking: {
-          type: 'calico', // TODO: read nework extension list, see https://github.com/gardener/dashboard/issues/452
           nodes: defaultWorkerCIDR
         }
       }

--- a/frontend/src/utils/error.js
+++ b/frontend/src/utils/error.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/utils/errorCodes.js
+++ b/frontend/src/utils/errorCodes.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/utils/hibernationSchedule.js
+++ b/frontend/src/utils/hibernationSchedule.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/utils/shootEditorCompletions.js
+++ b/frontend/src/utils/shootEditorCompletions.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/utils/validators.js
+++ b/frontend/src/utils/validators.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/views/Account.vue
+++ b/frontend/src/views/Account.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/views/Administration.vue
+++ b/frontend/src/views/Administration.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/views/Default.vue
+++ b/frontend/src/views/Default.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/views/Error.vue
+++ b/frontend/src/views/Error.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/views/Members.vue
+++ b/frontend/src/views/Members.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/views/NewShoot.vue
+++ b/frontend/src/views/NewShoot.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/views/NewShootEditor.vue
+++ b/frontend/src/views/NewShootEditor.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/views/NotFound.vue
+++ b/frontend/src/views/NotFound.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/views/ProjectError.vue
+++ b/frontend/src/views/ProjectError.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/views/ProjectPlaceholder.vue
+++ b/frontend/src/views/ProjectPlaceholder.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/views/Secrets.vue
+++ b/frontend/src/views/Secrets.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/views/ShootItem.vue
+++ b/frontend/src/views/ShootItem.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/views/ShootItemEditor.vue
+++ b/frontend/src/views/ShootItemEditor.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/views/ShootItemError.vue
+++ b/frontend/src/views/ShootItemError.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/views/ShootItemLoading.vue
+++ b/frontend/src/views/ShootItemLoading.vue
@@ -1,5 +1,5 @@
    <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/views/ShootItemPlaceholder.vue
+++ b/frontend/src/views/ShootItemPlaceholder.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/views/ShootItemTerminal.vue
+++ b/frontend/src/views/ShootItemTerminal.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/src/views/ShootList.vue
+++ b/frontend/src/views/ShootList.vue
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
  -->

--- a/frontend/tests/unit/CodeBlock.spec.js
+++ b/frontend/tests/unit/CodeBlock.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/tests/unit/CopyBtn.spec.js
+++ b/frontend/tests/unit/CopyBtn.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/tests/unit/GPopper.spec.js
+++ b/frontend/tests/unit/GPopper.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/tests/unit/HintColorizer.spec.js
+++ b/frontend/tests/unit/HintColorizer.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/tests/unit/MainNavigation.spec.js
+++ b/frontend/tests/unit/MainNavigation.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/tests/unit/NewShootDetails.spec.js
+++ b/frontend/tests/unit/NewShootDetails.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/tests/unit/StatusTag.spec.js
+++ b/frontend/tests/unit/StatusTag.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/tests/unit/WildcardSelect.spec.js
+++ b/frontend/tests/unit/WildcardSelect.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/tests/unit/lib.g-symbol-tree.spec.js
+++ b/frontend/tests/unit/lib.g-symbol-tree.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/tests/unit/store.index.spec.js
+++ b/frontend/tests/unit/store.index.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/tests/unit/store.shoots.spec.js
+++ b/frontend/tests/unit/store.shoots.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/tests/unit/utils.createShoot.spec.js
+++ b/frontend/tests/unit/utils.createShoot.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/tests/unit/utils.hibernationSchedule.spec.js
+++ b/frontend/tests/unit/utils.hibernationSchedule.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/tests/unit/utils.shootEditorCompletions.spec.js
+++ b/frontend/tests/unit/utils.shootEditorCompletions.spec.js
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/frontend/tests/unit/utils.spec.js
+++ b/frontend/tests/unit/utils.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/tests/unit/utils.validators.spec.js
+++ b/frontend/tests/unit/utils.validators.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/packages/kube-client/__tests__/api-errors.test.js
+++ b/packages/kube-client/__tests__/api-errors.test.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/packages/kube-client/__tests__/cache.test.js
+++ b/packages/kube-client/__tests__/cache.test.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/packages/kube-client/__tests__/client.test.js
+++ b/packages/kube-client/__tests__/client.test.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/packages/kube-client/__tests__/debug.test.js
+++ b/packages/kube-client/__tests__/debug.test.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/packages/kube-client/__tests__/http-client.test.js
+++ b/packages/kube-client/__tests__/http-client.test.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/packages/kube-client/__tests__/mixins.test.js
+++ b/packages/kube-client/__tests__/mixins.test.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/packages/kube-client/__tests__/nonResourceEndpoints.test.js
+++ b/packages/kube-client/__tests__/nonResourceEndpoints.test.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/packages/kube-client/__tests__/watch-builder.test.js
+++ b/packages/kube-client/__tests__/watch-builder.test.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/packages/kube-client/lib/ApiErrors.js
+++ b/packages/kube-client/lib/ApiErrors.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/packages/kube-client/lib/Client.js
+++ b/packages/kube-client/lib/Client.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/packages/kube-client/lib/HttpClient.js
+++ b/packages/kube-client/lib/HttpClient.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/packages/kube-client/lib/WatchBuilder.js
+++ b/packages/kube-client/lib/WatchBuilder.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/packages/kube-client/lib/cache/ListPager.js
+++ b/packages/kube-client/lib/cache/ListPager.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/packages/kube-client/lib/cache/Reflector.js
+++ b/packages/kube-client/lib/cache/Reflector.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/packages/kube-client/lib/cache/Store.js
+++ b/packages/kube-client/lib/cache/Store.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/packages/kube-client/lib/cache/index.js
+++ b/packages/kube-client/lib/cache/index.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/packages/kube-client/lib/debug.js
+++ b/packages/kube-client/lib/debug.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/packages/kube-client/lib/groups.js
+++ b/packages/kube-client/lib/groups.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/packages/kube-client/lib/index.js
+++ b/packages/kube-client/lib/index.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/packages/kube-client/lib/mixins.js
+++ b/packages/kube-client/lib/mixins.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/packages/kube-client/lib/nonResourceEndpoints/Healthz.js
+++ b/packages/kube-client/lib/nonResourceEndpoints/Healthz.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/packages/kube-client/lib/nonResourceEndpoints/OpenAPI.js
+++ b/packages/kube-client/lib/nonResourceEndpoints/OpenAPI.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/packages/kube-client/lib/nonResourceEndpoints/index.js
+++ b/packages/kube-client/lib/nonResourceEndpoints/index.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/packages/kube-client/lib/resources/APIRegistration.js
+++ b/packages/kube-client/lib/resources/APIRegistration.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/packages/kube-client/lib/resources/Authentication.js
+++ b/packages/kube-client/lib/resources/Authentication.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/packages/kube-client/lib/resources/Authorization.js
+++ b/packages/kube-client/lib/resources/Authorization.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/packages/kube-client/lib/resources/Core.js
+++ b/packages/kube-client/lib/resources/Core.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/packages/kube-client/lib/resources/Extensions.js
+++ b/packages/kube-client/lib/resources/Extensions.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/packages/kube-client/lib/resources/GardenerCore.js
+++ b/packages/kube-client/lib/resources/GardenerCore.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/packages/kube-client/lib/resources/GardenerDashboard.js
+++ b/packages/kube-client/lib/resources/GardenerDashboard.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/packages/kube-client/lib/resources/index.js
+++ b/packages/kube-client/lib/resources/index.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/packages/kube-client/lib/symbols.js
+++ b/packages/kube-client/lib/symbols.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/packages/kube-client/lib/util.js
+++ b/packages/kube-client/lib/util.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/packages/kube-config/__tests__/kube-config.test.js
+++ b/packages/kube-config/__tests__/kube-config.test.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/packages/kube-config/lib/index.js
+++ b/packages/kube-config/lib/index.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/packages/logger/__tests__/logger.test.js
+++ b/packages/logger/__tests__/logger.test.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/packages/logger/lib/Logger.js
+++ b/packages/logger/lib/Logger.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/packages/logger/lib/index.js
+++ b/packages/logger/lib/index.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/packages/request/__tests__/request.test.js
+++ b/packages/request/__tests__/request.test.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/packages/request/lib/HttpClient.js
+++ b/packages/request/lib/HttpClient.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/packages/request/lib/index.js
+++ b/packages/request/lib/index.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/scripts/git-version
+++ b/scripts/git-version
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 #


### PR DESCRIPTION
**What this PR does / why we need it**:
- Added Info dialog to show Dashboard and Gardener Versions and a list of deployed extensions
- Replaced Copyright Year with 2021

<img width="307" alt="Screenshot 2021-02-18 at 17 15 10" src="https://user-images.githubusercontent.com/35373687/108387336-c9c1e180-720d-11eb-9308-57c0d1548d9c.png">
<img width="592" alt="Screenshot 2021-02-21 at 12 23 11" src="https://user-images.githubusercontent.com/35373687/108623478-99fa2000-743f-11eb-866e-31285aa8b428.png">

**Which issue(s) this PR fixes**:
Fixes #452 Fixes #498

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Moved Dashboard and Gardener version information to a dedicated dialog
```
```feature operator
Operators with admin role can now view a list of the deployed extensions for the Gardener landscape that the Dashboard is connected to
```
