### PR TITLE
Handle html content correctly in access restrictions 

### DIFF
--- a/backend/lib/middleware.js
+++ b/backend/lib/middleware.js
@@ -42,18 +42,14 @@ function frontendConfig (config) {
       input = {},
       options = []
     } = item
-    convertAndSanitize(display, 'title')
     convertAndSanitize(display, 'description')
-    convertAndSanitize(input, 'title')
     convertAndSanitize(input, 'description')
     for (const option of options) {
       const {
         display = {},
         input = {}
       } = option
-      convertAndSanitize(display, 'title')
       convertAndSanitize(display, 'description')
-      convertAndSanitize(input, 'title')
       convertAndSanitize(input, 'description')
     }
   }

--- a/frontend/src/components/ShootAccessRestrictions/AccessRestrictionChips.vue
+++ b/frontend/src/components/ShootAccessRestrictions/AccessRestrictionChips.vue
@@ -21,7 +21,7 @@ SPDX-License-Identifier: Apache-2.0
             class="mr-2 mb-1"
           >{{title}}</v-chip>
         </template>
-        {{description}}
+        <section v-html="transformHtml(description)"/>
       </v-tooltip>
       <v-tooltip
         v-for="{ key: optionsKey, title, description } in options"
@@ -39,7 +39,7 @@ SPDX-License-Identifier: Apache-2.0
             class="mr-2"
           >{{title}}</v-chip>
         </template>
-        {{description}}
+        <section v-html="transformHtml(description)"/>
       </v-tooltip>
     </v-row>
   </div>
@@ -47,15 +47,26 @@ SPDX-License-Identifier: Apache-2.0
 
 <script>
 
+import { transformHtml } from '@/utils'
+
 export default {
   props: {
     selectedAccessRestrictions: {
       type: Array
+    }
+  },
+  methods: {
+    transformHtml (value) {
+      return transformHtml(value)
     }
   }
 }
 </script>
 
 <style lang="scss" scoped>
-
+  section {
+    ::v-deep > p {
+      margin: 0;
+    }
+  }
 </style>

--- a/frontend/src/components/ShootAccessRestrictions/AccessRestrictions.vue
+++ b/frontend/src/components/ShootAccessRestrictions/AccessRestrictions.vue
@@ -17,8 +17,11 @@ SPDX-License-Identifier: Apache-2.0
             ></v-switch>
           </v-list-item-action>
           <v-list-item-content>
-            <v-list-item-title class="wrap-text" v-html="transformHtml(definition.input.title)"></v-list-item-title>
-            <v-list-item-subtitle v-if="definition.input.description" class="wrap-text" v-html="transformHtml(definition.input.description)"></v-list-item-subtitle>
+            <v-list-item-title class="wrap-text">{{definition.input.title}}</v-list-item-title>
+            <v-list-item-subtitle v-if="definition.input.description"
+              class="wrap-text"
+              v-html="transformHtml(definition.input.description)"
+            />
           </v-list-item-content>
         </v-list-item>
         <template v-if="definition">
@@ -31,8 +34,14 @@ SPDX-License-Identifier: Apache-2.0
               ></v-checkbox>
             </v-list-item-action>
             <v-list-item-content>
-              <v-list-item-title class="wrap-text" :class="textClass(definition)" v-html="transformHtml(optionValue.input.title)"></v-list-item-title>
-              <v-list-item-subtitle v-if="optionValue.input.description" class="wrap-text pt-n3" :class="textClass(definition)" v-html="transformHtml(optionValue.input.description)"></v-list-item-subtitle>
+              <v-list-item-title class="wrap-text" :class="textClass(definition)">
+                {{optionValue.input.title}}
+              </v-list-item-title>
+              <v-list-item-subtitle v-if="optionValue.input.description"
+                class="wrap-text"
+                :class="textClass(definition)"
+                v-html="transformHtml(optionValue.input.description)"
+              />
             </v-list-item-content>
           </v-list-item>
         </template>
@@ -103,8 +112,9 @@ export default {
       return inverted ? !value : value
     },
     textClass (definition) {
-      const enabled = this.enabled(definition)
-      return enabled ? 'text--secondary' : 'text--disabled'
+      return this.enabled(definition)
+        ? 'text--secondary'
+        : 'text--disabled'
     },
     applyTo (shootResource) {
       const definitions = this.definitions || []

--- a/frontend/src/components/ShootAccessRestrictions/AccessRestrictions.vue
+++ b/frontend/src/components/ShootAccessRestrictions/AccessRestrictions.vue
@@ -19,7 +19,7 @@ SPDX-License-Identifier: Apache-2.0
           <v-list-item-content>
             <v-list-item-title class="wrap-text">{{definition.input.title}}</v-list-item-title>
             <v-list-item-subtitle v-if="definition.input.description"
-              class="wrap-text"
+              class="wrap-text pt-1"
               v-html="transformHtml(definition.input.description)"
             />
           </v-list-item-content>
@@ -38,7 +38,7 @@ SPDX-License-Identifier: Apache-2.0
                 {{optionValue.input.title}}
               </v-list-item-title>
               <v-list-item-subtitle v-if="optionValue.input.description"
-                class="wrap-text"
+                class="wrap-text pt-1"
                 :class="textClass(definition)"
                 v-html="transformHtml(optionValue.input.description)"
               />


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR html content in access restrictions input and display components is handled correctly.

**before (description and title as text)**:
<img width="640" src="https://user-images.githubusercontent.com/1574023/108983943-b096b600-768f-11eb-94c6-7f1453329dfd.png">
**after (description as v-html)**:
<img width="640" src="https://user-images.githubusercontent.com/1574023/108984077-d2903880-768f-11eb-801c-f86f9610f7a1.png">
**padding between title and subtitle**:
<img width="640" src="https://user-images.githubusercontent.com/1574023/108984468-3fa3ce00-7690-11eb-825f-eeacd5cfe0fc.png">

**Which issue(s) this PR fixes**:
Fixes #954 

**Special notes for your reviewer**:
I have removed markdown processing for titles in the backend. For all others frontend configuration texts we do also not process titles but only descriptions. I think it is more consistent now. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
HTML content is correctly displayed in access restriction components
```

