### PR TITLE
Remove oidc configuration from necessary config (#727)

### DIFF
--- a/backend/lib/config/gardener.js
+++ b/backend/lib/config/gardener.js
@@ -88,12 +88,19 @@ module.exports = {
     this.assignEnvironmentVariables(config, env)
     const requiredConfigurationProperties = [
       'sessionSecret',
-      'apiServerUrl',
-      'oidc.issuer',
-      'oidc.client_id',
-      'oidc.client_secret',
-      'oidc.redirect_uri'
+      'apiServerUrl'
     ]
+
+    // When OIDC is configured, some more configuration is required
+    if (config.oidc) {
+      requiredConfigurationProperties.push(
+        'oidc.issuer',
+        'oidc.client_id',
+        'oidc.client_secret',
+        'oidc.redirect_uri'
+      )
+    }
+
     _.forEach(requiredConfigurationProperties, path => {
       assert.ok(_.get(config, path), `Configuration value '${path}' is required`)
     })


### PR DESCRIPTION
**What this PR does / why we need it**: Removes the OIDC configuration parameters from the list of required configuration variables as OIDC is not strictly required (dashboard can also be used with a bearer token)

**Which issue(s) this PR fixes**:
Fixes #727 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Removed OIDC configuration settings from necessary configuration as the dashboard can also be used with a bearer token
```
