### PR TITLE
Increase terminal  timeout

### DIFF
--- a/backend/lib/services/terminals/index.js
+++ b/backend/lib/services/terminals/index.js
@@ -507,7 +507,7 @@ function readTerminalUntilReady ({ user, namespace, name }) {
   }
   return client['dashboard.gardener.cloud'].terminals
     .watch(namespace, name)
-    .waitFor(isTerminalReady, { timeout: 10 * 1000 })
+    .waitFor(isTerminalReady, { timeout: 60 * 1000 })
 }
 
 async function getOrCreateTerminalSession ({ user, namespace, name, target, body = {} }) {


### PR DESCRIPTION
**What this PR does / why we need it**:
In some cases the terminal-controller-manager takes more time than usual to setup all the required resources and update the terminal resource, e.g. due to heavy load on the host or target cluster or the terminal-controller-manager itself. That's why often times the 10 second timeout is reached and the terminal creation is aborted with an error.
This PR increases the 10 second timeout to wait for the terminal resource to be in a "ready" state to 60 seconds.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user

```
