### PR TITLE
Place custom fields popper right

### DIFF
--- a/frontend/src/components/ShootCustomField.vue
+++ b/frontend/src/components/ShootCustomField.vue
@@ -9,6 +9,7 @@ SPDX-License-Identifier: Apache-2.0
     :title="name"
     :toolbar-color="color"
     :popper-key="`worker_group_${name}`"
+    placement="right"
   >
     <template v-slot:popperRef>
       <v-chip


### PR DESCRIPTION
**What this PR does / why we need it**:
The arrow of the custom fields popper was not pointing on the chip as the popper is so large. Hence I have placed it on the right side
<img width="734" alt="Screenshot 2021-03-04 at 09 36 05" src="https://user-images.githubusercontent.com/5526658/109934658-0fca7b00-7ccd-11eb-9f50-6e0130ff7fb8.png">


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
