### PR TITLE
Removed unused color properties

### DIFF
--- a/frontend/src/components/ShootVersion/ShootVersion.vue
+++ b/frontend/src/components/ShootVersion/ShootVersion.vue
@@ -44,8 +44,6 @@ SPDX-License-Identifier: Apache-2.0
       :confirm-disabled="selectedVersionInvalid"
       :error-message.sync="updateErrorMessage"
       :detailed-error-message.sync="updateDetailedErrorMessage"
-      confirm-color="toolbar-background"
-      default-color="toolbar-background"
       ref="gDialog"
       >
       <template v-slot:caption>Update Cluster</template>

--- a/frontend/src/components/dialogs/ActionButtonDialog.vue
+++ b/frontend/src/components/dialogs/ActionButtonDialog.vue
@@ -40,8 +40,6 @@ SPDX-License-Identifier: Apache-2.0
       :max-height="maxHeight"
       :confirm-value="confirmValue"
       :confirm-message="confirmMessage"
-      :confirm-color="dialogColor"
-      :default-color="dialogColor"
       :disable-confirm-input-focus="disableConfirmInputFocus"
       ref="gDialog"
     >
@@ -116,10 +114,6 @@ export default {
     smallIcon: {
       type: Boolean,
       default: false
-    },
-    dialogColor: {
-      type: String,
-      default: 'toolbar-background'
     },
     disabled: {
       type: Boolean,

--- a/frontend/src/components/dialogs/ConfirmDialog.vue
+++ b/frontend/src/components/dialogs/ConfirmDialog.vue
@@ -10,7 +10,6 @@ SPDX-License-Identifier: Apache-2.0
     :confirm-button-text="confirmButtonText"
     :cancel-button-text="cancelButtonText"
     :max-width="maxWidth"
-    :default-color="dialogColor"
     :confirm-value="confirmValue"
     >
     <template v-slot:caption>{{captionText}}</template>
@@ -34,18 +33,16 @@ export default {
       cancelButtonText: undefined,
       captionText: undefined,
       messageHtml: undefined,
-      dialogColor: undefined,
       maxWidth: undefined,
       confirmValue: undefined
     }
   },
   methods: {
-    waitForConfirmation ({ confirmButtonText, cancelButtonText, captionText, messageHtml, dialogColor, maxWidth, confirmValue } = {}) {
+    waitForConfirmation ({ confirmButtonText, cancelButtonText, captionText, messageHtml, maxWidth, confirmValue } = {}) {
       this.confirmButtonText = confirmButtonText || 'Confirm'
       this.cancelButtonText = cancelButtonText || 'Cancel'
       this.captionText = captionText || 'Confirm'
       this.messageHtml = messageHtml
-      this.dialogColor = dialogColor || 'toolbar-background'
       this.maxWidth = maxWidth || '400'
       this.confirmValue = confirmValue
 

--- a/frontend/src/components/dialogs/CreateTerminalSessionDialog.vue
+++ b/frontend/src/components/dialogs/CreateTerminalSessionDialog.vue
@@ -10,7 +10,6 @@ SPDX-License-Identifier: Apache-2.0
     :confirm-disabled="!valid"
     max-width="750px"
     max-height="100vh"
-    default-color="toolbar-background"
     ref="gDialog"
   >
     <template v-slot:caption>Create Terminal Session</template>

--- a/frontend/src/components/dialogs/GDialog.vue
+++ b/frontend/src/components/dialogs/GDialog.vue
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 <template>
   <v-dialog v-model="visible" scrollable persistent :max-width="maxWidth" @keydown.esc="resolveAction(false)">
     <v-card>
-      <v-toolbar flat :class="titleColorClass">
+      <v-toolbar flat class="toolbar-background toolbar-title--text">
         <v-toolbar-title class="dialog-title align-center justify-start">
           <slot name="caption">
             Confirm Dialog
@@ -42,7 +42,7 @@ SPDX-License-Identifier: Apache-2.0
           dense>
         </v-text-field>
         <v-btn text @click="resolveAction(false)" v-if="cancelButtonText.length">{{cancelButtonText}}</v-btn>
-        <v-btn text @click="resolveAction(true)" :disabled="!valid" :class="textColorClass">{{confirmButtonText}}</v-btn>
+        <v-btn text @click="resolveAction(true)" :disabled="!valid" class="toolbar-background--text">{{confirmButtonText}}</v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>
@@ -76,14 +76,6 @@ export default {
     },
     detailedErrorMessage: {
       type: String
-    },
-    confirmColor: {
-      type: String,
-      default: 'toolbar-background'
-    },
-    defaultColor: {
-      type: String,
-      default: 'toolbar-background'
     },
     confirmButtonText: {
       type: String,
@@ -143,12 +135,6 @@ export default {
         this.$emit('update:detailed-error-message', value)
       }
     },
-    titleColorClass () {
-      return this.confirmValue ? this.titleColorClassForString(this.confirmColor) : this.titleColorClassForString(this.defaultColor)
-    },
-    textColorClass () {
-      return this.confirmValue ? this.textColorClassForString(this.confirmColor) : this.textColorClassForString(this.defaultColor)
-    },
     valid () {
       return !this.confirmDisabled && !this.hasError
     }
@@ -174,26 +160,6 @@ export default {
     },
     showDialog () {
       this.visible = true
-    },
-    titleColorClassForString (titleColorClass) {
-      switch (titleColorClass) {
-        case 'error':
-          return 'error toolbar-title--text'
-        case 'warning':
-          return 'warning toolbar-title--text'
-        default:
-          return 'toolbar-background toolbar-title--text'
-      }
-    },
-    textColorClassForString (textColorClass) {
-      switch (textColorClass) {
-        case 'error':
-          return 'error--text'
-        case 'warning':
-          return 'warning--text'
-        default:
-          return 'primary--text'
-      }
     },
     async resolveAction (value) {
       if (value && !this.valid) {

--- a/frontend/src/components/dialogs/TerminalSettingsDialog.vue
+++ b/frontend/src/components/dialogs/TerminalSettingsDialog.vue
@@ -10,7 +10,6 @@ SPDX-License-Identifier: Apache-2.0
     :confirm-disabled="!validSettings"
     max-width="750px"
     max-height="100vh"
-    default-color="primary"
     ref="gDialog"
     >
     <template v-slot:caption>Change Terminal Settings</template>

--- a/frontend/src/components/dialogs/UnverifiedTerminalShortcutsDialog.vue
+++ b/frontend/src/components/dialogs/UnverifiedTerminalShortcutsDialog.vue
@@ -9,7 +9,6 @@ SPDX-License-Identifier: Apache-2.0
     confirm-button-text="Confirm"
     max-width="750px"
     max-height="100vh"
-    default-color="primary"
     ref="gDialog"
     >
     <template v-slot:caption>Confirm</template>

--- a/frontend/src/components/dialogs/WebterminalServiceAccountDialog.vue
+++ b/frontend/src/components/dialogs/WebterminalServiceAccountDialog.vue
@@ -9,7 +9,6 @@ SPDX-License-Identifier: Apache-2.0
     :confirm-button-text="confirmButtonText"
     max-width="750px"
     max-height="100vh"
-    default-color="primary"
     ref="gDialog"
     >
     <template v-slot:caption>


### PR DESCRIPTION
**What this PR does / why we need it**:
Removed unused color properties from dialogs. We do not need them anymore because we now style all dialogs with toolbar-background color.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
