### PR TITLE
Fixed autoscaler min / max value not showing up in worker description

### DIFF
--- a/frontend/src/components/ShootWorkers/WorkerGroup.vue
+++ b/frontend/src/components/ShootWorkers/WorkerGroup.vue
@@ -85,13 +85,13 @@ export default {
       description.push(this.machineImageDescription)
 
       const { minimum, maximum, maxSurge, zones = [] } = this.workerGroup
-      if (minimum !== undefined && maximum !== undefined) {
+      if (minimum >= 0 && maximum >= 0) {
         description.push({
           title: 'Autoscaler',
           value: `Min. ${minimum} / Max. ${maximum}`
         })
       }
-      if (maxSurge !== undefined) {
+      if (maxSurge >= 0) {
         description.push({
           title: 'Max. Surge',
           value: `${maxSurge}`

--- a/frontend/src/components/ShootWorkers/WorkerGroup.vue
+++ b/frontend/src/components/ShootWorkers/WorkerGroup.vue
@@ -85,13 +85,13 @@ export default {
       description.push(this.machineImageDescription)
 
       const { minimum, maximum, maxSurge, zones = [] } = this.workerGroup
-      if (minimum && maximum) {
+      if (minimum !== undefined && maximum !== undefined) {
         description.push({
           title: 'Autoscaler',
           value: `Min. ${minimum} / Max. ${maximum}`
         })
       }
-      if (maxSurge) {
+      if (maxSurge !== undefined) {
         description.push({
           title: 'Max. Surge',
           value: `${maxSurge}`


### PR DESCRIPTION
Fixed autoscaler min / max  or surge value not showing up in worker description if value is zero

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed: Autoscaler min / max  or surge value not showing up in worker description if one of the values is zero
```
