### PR TITLE
Add copy button for shoot name and seed name

### DIFF
--- a/frontend/src/components/ShootListRow.vue
+++ b/frontend/src/components/ShootListRow.vue
@@ -15,9 +15,12 @@ SPDX-License-Identifier: Apache-2.0
       <template v-if="cell.header.value === 'name'">
         <v-row align="center" class="pa-0 ma-0 fill-height flex-nowrap">
           <v-col class="grow pa-0 ma-0">
-            <router-link :to="{ name: 'ShootItem', params: { name: shootName, namespace: shootNamespace } }">
-              {{ shootName }}
-            </router-link>
+            <div class="d-flex align-center justify-start flex-nowrap fill-height">
+              <router-link :to="{ name: 'ShootItem', params: { name: shootName, namespace: shootNamespace } }">
+                {{ shootName }}
+              </router-link>
+              <copy-btn :clipboard-text="shootName"></copy-btn>
+            </div>
           </v-col>
           <v-col class="shrink" >
             <div class="d-flex flew-row" v-if="!isShootMarkedForDeletion">
@@ -48,7 +51,10 @@ SPDX-License-Identifier: Apache-2.0
         <vendor :cloud-provider-kind="shootCloudProviderKind" :region="shootRegion" :zones="shootZones"></vendor>
       </template>
       <template v-if="cell.header.value === 'seed'">
-        <shoot-seed-name :shoot-item="shootItem" />
+        <div class="d-flex align-center justify-start flex-nowrap fill-height">
+          <shoot-seed-name :shoot-item="shootItem" />
+          <copy-btn :clipboard-text="shootSeedName"></copy-btn>
+        </div>
       </template>
       <template v-if="cell.header.value === 'technicalId'">
         <div class="d-flex align-center justify-start flex-nowrap fill-height">

--- a/frontend/src/components/ShootSeedName.vue
+++ b/frontend/src/components/ShootSeedName.vue
@@ -5,20 +5,18 @@ SPDX-License-Identifier: Apache-2.0
 -->
 
 <template>
-  <v-row align="center" class="ma-0">
-    <v-tooltip top :disabled="!isShootLastOperationTypeControlPlaneMigrating">
-      <template v-slot:activator="{ on }">
-        <div v-on="on">
-          <v-progress-circular v-if="isShootLastOperationTypeControlPlaneMigrating" indeterminate size=12 width=2 class="mr-1"></v-progress-circular>
-          <router-link v-if="canLinkToSeed" :to="{ name: 'ShootItem', params: { name: shootSeedName, namespace:'garden' } }">
-            <span>{{shootSeedName}}</span>
-          </router-link>
-          <span v-else>{{shootSeedName}}</span>
-        </div>
-      </template>
-      <span>{{shootLastOperationTypeControlPlaneMigrationMessage}}</span>
-    </v-tooltip>
-  </v-row>
+  <v-tooltip top :disabled="!isShootLastOperationTypeControlPlaneMigrating">
+    <template v-slot:activator="{ on }">
+      <div v-on="on">
+        <v-progress-circular v-if="isShootLastOperationTypeControlPlaneMigrating" indeterminate size=12 width=2 class="mr-1"></v-progress-circular>
+        <router-link v-if="canLinkToSeed" :to="{ name: 'ShootItem', params: { name: shootSeedName, namespace:'garden' } }">
+          <span>{{shootSeedName}}</span>
+        </router-link>
+        <span v-else>{{shootSeedName}}</span>
+      </div>
+    </template>
+    <span>{{shootLastOperationTypeControlPlaneMigrationMessage}}</span>
+  </v-tooltip>
 </template>
 
 <script>


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a copy button for the shoot name and seed name on the cluster list page.

<img width="1549" alt="Screenshot 2021-03-31 at 09 29 38" src="https://user-images.githubusercontent.com/5526658/113107019-b12cea00-9203-11eb-996e-d421b1321241.png">


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
You can now copy the shoot name and seed name from the cluster list page
```
