### PR TITLE
Fix pathType

### DIFF
--- a/charts/gardener-dashboard/templates/ingress.yaml
+++ b/charts/gardener-dashboard/templates/ingress.yaml
@@ -34,5 +34,5 @@ spec:
           serviceName: gardener-dashboard-service
           servicePort: {{ $.Values.servicePort }}
         path: /
-        pathType: prefix
+        pathType: Prefix
   {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the helm chart ingress `pathType`.

**Special notes for your reviewer:**

The release not says „adds“ and not „fixes“ as the PR originally adding it (#982) is not yet part of a release and has no release not itself

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Adds `pathType: Prefix` to the Ingress resource
```