### PR TITLE
TLS settings update. Support CA environment / cert-manager

### DIFF
--- a/backend/lib/config/gardener.js
+++ b/backend/lib/config/gardener.js
@@ -20,6 +20,7 @@ const environmentVariableDefinitions = {
   OIDC_CLIENT_ID: 'oidc.client_id',
   OIDC_CLIENT_SECRET: 'oidc.client_secret', // pragma: whitelist secret
   OIDC_REDIRECT_URI: 'oidc.redirect_uri',
+  OIDC_CA: 'oidc.ca',
   GITHUB_AUTHENTICATION_USERNAME: 'gitHub.authentication.username',
   GITHUB_AUTHENTICATION_TOKEN: 'gitHub.authentication.token',
   GITHUB_WEBHOOK_SECRET: 'gitHub.webhookSecret', // pragma: whitelist secret

--- a/backend/test/config.spec.js
+++ b/backend/test/config.spec.js
@@ -74,8 +74,7 @@ describe('config', function () {
         OIDC_ISSUER: 'issuer',
         OIDC_CLIENT_ID: 'client_id',
         OIDC_CLIENT_SECRET: 'client_secret', // pragma: whitelist secret
-        OIDC_REDIRECT_URI: 'redirect_uri',
-        OIDC_CA: 'my_ca'
+        OIDC_REDIRECT_URI: 'redirect_uri'
       }
 
       beforeEach(() => {
@@ -84,12 +83,22 @@ describe('config', function () {
 
       it('should return the config in test environment', function () {
         const env = Object.assign({
-          NODE_ENV: 'test'
+          NODE_ENV: 'test',
+          OIDC_CA: 'ca'
         }, requiredEnvironmentVariables)
 
         const config = gardener.loadConfig(undefined, { env })
         const defaults = gardener.getDefaults({ env })
         expect(config).toMatchObject(defaults)
+      })
+
+      it('should return optional environment variables', function () {
+        const env = Object.assign({
+          OIDC_CA: 'ca'
+        }, requiredEnvironmentVariables)
+
+        const config = gardener.loadConfig(undefined, { env })
+        expect(config.oidc.ca).toBe('ca')
       })
 
       it('should return the config in production environment', function () {
@@ -103,7 +112,6 @@ describe('config', function () {
         expect(gardener.readConfig.mock.calls[0]).toEqual([filename])
         expect(config.port).toBe(1234)
         expect(config.logLevel).toBe('warn')
-        expect(config.oidc.ca).toBe('my_ca')
       })
 
       it('should return the config with port and logLevel overridden by environment variables', function () {

--- a/backend/test/config.spec.js
+++ b/backend/test/config.spec.js
@@ -74,7 +74,8 @@ describe('config', function () {
         OIDC_ISSUER: 'issuer',
         OIDC_CLIENT_ID: 'client_id',
         OIDC_CLIENT_SECRET: 'client_secret', // pragma: whitelist secret
-        OIDC_REDIRECT_URI: 'redirect_uri'
+        OIDC_REDIRECT_URI: 'redirect_uri',
+        OIDC_CA: 'my_ca'
       }
 
       beforeEach(() => {
@@ -102,6 +103,7 @@ describe('config', function () {
         expect(gardener.readConfig.mock.calls[0]).toEqual([filename])
         expect(config.port).toBe(1234)
         expect(config.logLevel).toBe('warn')
+        expect(config.oidc.ca).toBe('my_ca')
       })
 
       it('should return the config with port and logLevel overridden by environment variables', function () {

--- a/charts/gardener-dashboard/templates/deployment.yaml
+++ b/charts/gardener-dashboard/templates/deployment.yaml
@@ -105,6 +105,12 @@ spec:
               secretKeyRef:
                 name: gardener-dashboard-oidc
                 key: client_secret
+          {{- if .Values.oidc.caSecret -}}
+          - name: OIDC_CA
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.oidc.caSecret }}
+                key: {{ .Values.oidc.caSecretKey | default "ca.crt" }}
           {{- end }}
           {{- if .Values.gitHub }}
           - name: GITHUB_AUTHENTICATION_USERNAME

--- a/charts/gardener-dashboard/templates/ingress.yaml
+++ b/charts/gardener-dashboard/templates/ingress.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
 {{- if .Values.tls.enabled }}
   tls:
-  - secretName: {{ .Values.tlsSecretName | default "gardener-dashboard-tls" }}
+  - secretName: {{ .Values.tls.secretName | default "gardener-dashboard-tls" }}
     hosts:
     {{- range .Values.hosts }}
     - {{ . }}

--- a/charts/gardener-dashboard/templates/ingress.yaml
+++ b/charts/gardener-dashboard/templates/ingress.yaml
@@ -17,7 +17,7 @@ metadata:
 {{ toYaml . | indent 4 }}
   {{- end }}
 spec:
-{{- if .Values.tls }}
+{{- if .Values.tls.enabled }}
   tls:
   - secretName: {{ .Values.tlsSecretName | default "gardener-dashboard-tls" }}
     hosts:

--- a/charts/gardener-dashboard/templates/secret-tls.yaml
+++ b/charts/gardener-dashboard/templates/secret-tls.yaml
@@ -7,7 +7,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.tlsSecretName | default "gardener-dashboard-tls" }}
+  name: {{ .Values.tls.secretName | default "gardener-dashboard-tls" }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: gardener-dashboard

--- a/charts/gardener-dashboard/templates/secret-tls.yaml
+++ b/charts/gardener-dashboard/templates/secret-tls.yaml
@@ -2,7 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if .Values.tls }}
+{{- if .Values.tls.enabled }}
+{{- if and .Values.tls.crt .Values.tls.key -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -17,6 +18,7 @@ type: kubernetes.io/tls
 data:
   tls.crt: {{ required ".Values.tls.crt is required" (b64enc .Values.tls.crt) }}
   tls.key: {{ required ".Values.tls.key is required" (b64enc .Values.tls.key) }}
+{{- end }}
 {{- end }}
 {{- if .Values.terminal }}
 {{- if .Values.terminal.bootstrap }}

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -42,6 +42,7 @@ ingress:
     kubernetes.io/ingress.class: nginx
 tls:
   enabled: true
+  # secretName: gardener-dashboard-tls
   crt: |
     -----BEGIN CERTIFICATE-----
     Li4u

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -41,6 +41,7 @@ ingress:
     nginx.ingress.kubernetes.io/use-port-in-redirects: "true"
     kubernetes.io/ingress.class: nginx
 tls:
+  enabled: true
   crt: |
     -----BEGIN CERTIFICATE-----
     Li4u

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -65,6 +65,11 @@ oidc:
   clientSecret: ~
   # redirectUri is the endpoint receiving the OTAC from the OpenID provider after successful login
   redirectUri: https://dashboard.ingress.example.org/auth/callback
+  # ca as a string to use
+  # ca:
+  # ca as a secret to use
+  # caSecret:
+  # caSecretKey: ca.crt
   # configuration for kubeconfig download required by kubelogin
   # public:
   #  # clientId is the identifier of the public oidc client use by kubelogin


### PR DESCRIPTION
**What this PR does / why we need it**:

Allows CA to be passed by a secret (environment variable).
This is very useful for test environments where the certificates are managed by cert-manager.
Smaller cleanup: rename tlsSecretName to tls.secretName (I guess it is not used, at least was not documented, but in theory a breaking change in helm charts.)
Add a proper tls.enabled flag to enable/disable tls
Allows to enable tls but not provide a key/cert (using cert-manager)


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
- category:       breaking
- category: feature
```
