### PR TITLE
Show copy button only if mouse over parent element

### DIFF
--- a/frontend/src/components/AutoHide.vue
+++ b/frontend/src/components/AutoHide.vue
@@ -1,0 +1,47 @@
+<!--
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+<template>
+  <div class="d-flex align-center justify-start flex-nowrap fill-height auto-hide-wrapper">
+    <div class="auto-hide-slot">
+      <slot v-if="left"></slot>
+    </div>
+    <slot name="activator"></slot>
+    <div class="auto-hide-slot">
+      <slot v-if="right"></slot>
+    </div>
+  </div>
+</template>
+
+<script>
+
+export default {
+  props: {
+    left: {
+      type: Boolean
+    },
+    right: {
+      type: Boolean
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+  .auto-hide-wrapper {
+    &:hover {
+      .auto-hide-slot {
+        opacity: 1;
+        &:after {
+          opacity: 0;
+        }
+      }
+    }
+    .auto-hide-slot {
+      opacity: 0;
+    }
+  }
+</style>

--- a/frontend/src/components/CopyBtn.vue
+++ b/frontend/src/components/CopyBtn.vue
@@ -127,8 +127,8 @@ export default {
   mounted () {
     this.enableCopy()
     if (this.autoHide) {
-      this.$parent.$el.addEventListener('mouseover', e => { this.hidden = true })
-      this.$parent.$el.addEventListener('mouseout', e => { this.hidden = false })
+      this.$parent.$el.addEventListener('mouseover', () => this.hidden = true)
+      this.$parent.$el.addEventListener('mouseout', () => this.hidden = false)
     }
   }
 }

--- a/frontend/src/components/CopyBtn.vue
+++ b/frontend/src/components/CopyBtn.vue
@@ -58,8 +58,7 @@ export default {
       snackbar: false,
       clipboard: undefined,
       copySucceeded: false,
-      timeoutId: undefined,
-      hidden: false
+      timeoutId: undefined
     }
   },
   computed: {

--- a/frontend/src/components/CopyBtn.vue
+++ b/frontend/src/components/CopyBtn.vue
@@ -19,7 +19,7 @@ SPDX-License-Identifier: Apache-2.0
     </v-snackbar>
     <v-tooltip top>
       <template v-slot:activator="{ on }">
-        <v-btn v-on="on" icon ref="copy" :color="btnColor">
+        <v-btn v-on="on" icon ref="copy" :color="btnColor" :class="{ 'hidden': !hidden && autoHide }">
           <v-icon :small="true">{{icon}}</v-icon>
         </v-btn>
       </template>
@@ -51,6 +51,9 @@ export default {
     userFeedback: {
       type: Boolean,
       default: true
+    },
+    autoHide: {
+      type: Boolean
     }
   },
   data () {
@@ -58,7 +61,8 @@ export default {
       snackbar: false,
       clipboard: undefined,
       copySucceeded: false,
-      timeoutId: undefined
+      timeoutId: undefined,
+      hidden: false
     }
   },
   computed: {
@@ -122,6 +126,16 @@ export default {
   },
   mounted () {
     this.enableCopy()
+    if (this.autoHide) {
+      this.$parent.$el.addEventListener('mouseover', e => { this.hidden = true })
+      this.$parent.$el.addEventListener('mouseout', e => { this.hidden = false })
+    }
   }
 }
 </script>
+
+<style lang="scss" scoped>
+  .hidden {
+    opacity: 0;
+  }
+</style>

--- a/frontend/src/components/CopyBtn.vue
+++ b/frontend/src/components/CopyBtn.vue
@@ -127,8 +127,12 @@ export default {
   mounted () {
     this.enableCopy()
     if (this.autoHide) {
-      this.$parent.$el.addEventListener('mouseover', () => this.hidden = true)
-      this.$parent.$el.addEventListener('mouseout', () => this.hidden = false)
+      this.$parent.$el.addEventListener('mouseover', () => {
+        this.hidden = true
+      })
+      this.$parent.$el.addEventListener('mouseout', () => {
+        this.hidden = false
+      })
     }
   }
 }

--- a/frontend/src/components/CopyBtn.vue
+++ b/frontend/src/components/CopyBtn.vue
@@ -19,7 +19,7 @@ SPDX-License-Identifier: Apache-2.0
     </v-snackbar>
     <v-tooltip top>
       <template v-slot:activator="{ on }">
-        <v-btn v-on="on" icon ref="copy" :color="btnColor" :class="{ 'hidden': !hidden && autoHide }">
+        <v-btn v-on="on" icon ref="copy" :color="btnColor">
           <v-icon :small="true">{{icon}}</v-icon>
         </v-btn>
       </template>
@@ -51,9 +51,6 @@ export default {
     userFeedback: {
       type: Boolean,
       default: true
-    },
-    autoHide: {
-      type: Boolean
     }
   },
   data () {
@@ -126,20 +123,6 @@ export default {
   },
   mounted () {
     this.enableCopy()
-    if (this.autoHide) {
-      this.$parent.$el.addEventListener('mouseover', () => {
-        this.hidden = true
-      })
-      this.$parent.$el.addEventListener('mouseout', () => {
-        this.hidden = false
-      })
-    }
   }
 }
 </script>
-
-<style lang="scss" scoped>
-  .hidden {
-    opacity: 0;
-  }
-</style>

--- a/frontend/src/components/ShootListRow.vue
+++ b/frontend/src/components/ShootListRow.vue
@@ -14,14 +14,18 @@ SPDX-License-Identifier: Apache-2.0
       </template>
       <template v-if="cell.header.value === 'name'">
         <v-row align="center" class="pa-0 ma-0 fill-height flex-nowrap">
-          <v-col class="grow pa-0 ma-0">
-            <div class="d-flex align-center justify-start flex-nowrap fill-height">
-              <router-link :to="{ name: 'ShootItem', params: { name: shootName, namespace: shootNamespace } }">
-                {{ shootName }}
-              </router-link>
-              <copy-btn :clipboard-text="shootName" auto-hide></copy-btn>
-            </div>
-          </v-col>
+          <auto-hide right>
+            <template v-slot:activator>
+              <v-col class="grow pa-0 ma-0">
+                <div class="d-flex align-center justify-start flex-nowrap fill-height">
+                  <router-link :to="{ name: 'ShootItem', params: { name: shootName, namespace: shootNamespace } }">
+                    {{ shootName }}
+                  </router-link>
+                </div>
+              </v-col>
+            </template>
+            <copy-btn :clipboard-text="shootName"></copy-btn>
+          </auto-hide>
           <v-col class="shrink" >
             <div class="d-flex flew-row" v-if="!isShootMarkedForDeletion">
               <self-termination-warning :expiration-timestamp="shootExpirationTimestamp" />
@@ -51,16 +55,20 @@ SPDX-License-Identifier: Apache-2.0
         <vendor :cloud-provider-kind="shootCloudProviderKind" :region="shootRegion" :zones="shootZones"></vendor>
       </template>
       <template v-if="cell.header.value === 'seed'">
-        <div class="d-flex align-center justify-start flex-nowrap fill-height">
-          <shoot-seed-name :shoot-item="shootItem" />
-          <copy-btn :clipboard-text="shootSeedName" auto-hide></copy-btn>
-        </div>
+        <auto-hide right>
+          <template v-slot:activator>
+            <shoot-seed-name :shoot-item="shootItem" />
+          </template>
+          <copy-btn :clipboard-text="shootSeedName"></copy-btn>
+        </auto-hide>
       </template>
       <template v-if="cell.header.value === 'technicalId'">
-        <div class="d-flex align-center justify-start flex-nowrap fill-height">
-          <span>{{shootTechnicalId}}</span>
-          <copy-btn :clipboard-text="shootTechnicalId" auto-hide></copy-btn>
-        </div>
+        <auto-hide right>
+          <template v-slot:activator>
+            <span>{{shootTechnicalId}}</span>
+          </template>
+          <copy-btn :clipboard-text="shootTechnicalId"></copy-btn>
+        </auto-hide>
       </template>
       <template v-if="cell.header.value === 'createdBy'">
         <account-avatar :account-name="shootCreatedBy"></account-avatar>
@@ -177,6 +185,7 @@ import ShootSeedName from '@/components/ShootSeedName'
 import VersionExpirationWarning from '@/components/VersionExpirationWarning'
 import ShootListRowActions from '@/components/ShootListRowActions'
 import ConstraintWarning from '@/components/ConstraintWarning'
+import AutoHide from '@/components/AutoHide'
 
 import {
   isTypeDelete,
@@ -203,7 +212,8 @@ export default {
     Vendor,
     VersionExpirationWarning,
     ShootListRowActions,
-    ConstraintWarning
+    ConstraintWarning,
+    AutoHide
   },
   props: {
     shootItem: {

--- a/frontend/src/components/ShootListRow.vue
+++ b/frontend/src/components/ShootListRow.vue
@@ -19,7 +19,7 @@ SPDX-License-Identifier: Apache-2.0
               <router-link :to="{ name: 'ShootItem', params: { name: shootName, namespace: shootNamespace } }">
                 {{ shootName }}
               </router-link>
-              <copy-btn :clipboard-text="shootName"></copy-btn>
+              <copy-btn :clipboard-text="shootName" auto-hide></copy-btn>
             </div>
           </v-col>
           <v-col class="shrink" >
@@ -53,13 +53,13 @@ SPDX-License-Identifier: Apache-2.0
       <template v-if="cell.header.value === 'seed'">
         <div class="d-flex align-center justify-start flex-nowrap fill-height">
           <shoot-seed-name :shoot-item="shootItem" />
-          <copy-btn :clipboard-text="shootSeedName"></copy-btn>
+          <copy-btn :clipboard-text="shootSeedName" auto-hide></copy-btn>
         </div>
       </template>
       <template v-if="cell.header.value === 'technicalId'">
         <div class="d-flex align-center justify-start flex-nowrap fill-height">
           <span>{{shootTechnicalId}}</span>
-          <copy-btn :clipboard-text="shootTechnicalId"></copy-btn>
+          <copy-btn :clipboard-text="shootTechnicalId" auto-hide></copy-btn>
         </div>
       </template>
       <template v-if="cell.header.value === 'createdBy'">

--- a/frontend/src/components/ShootListRow.vue
+++ b/frontend/src/components/ShootListRow.vue
@@ -14,18 +14,16 @@ SPDX-License-Identifier: Apache-2.0
       </template>
       <template v-if="cell.header.value === 'name'">
         <v-row align="center" class="pa-0 ma-0 fill-height flex-nowrap">
-          <auto-hide right>
-            <template v-slot:activator>
-              <v-col class="grow pa-0 ma-0">
-                <div class="d-flex align-center justify-start flex-nowrap fill-height">
-                  <router-link :to="{ name: 'ShootItem', params: { name: shootName, namespace: shootNamespace } }">
-                    {{ shootName }}
-                  </router-link>
-                </div>
-              </v-col>
-            </template>
-            <copy-btn :clipboard-text="shootName"></copy-btn>
-          </auto-hide>
+          <v-col class="grow pa-0 ma-0">
+            <auto-hide right>
+              <template v-slot:activator>
+                <router-link :to="{ name: 'ShootItem', params: { name: shootName, namespace: shootNamespace } }">
+                  {{ shootName }}
+                </router-link>
+              </template>
+              <copy-btn :clipboard-text="shootName"></copy-btn>
+            </auto-hide>
+          </v-col>
           <v-col class="shrink" >
             <div class="d-flex flew-row" v-if="!isShootMarkedForDeletion">
               <self-termination-warning :expiration-timestamp="shootExpirationTimestamp" />


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the posibility to auto hide copy buttons.
This is a first attempt, maybe someone has a better solution?
Note: With the current implementation, `auto-hide` prop must not be dynamic. This could be changed easily but I don't think there is a use case for it right now.

**Which issue(s) this PR fixes**:
Fixes #996 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Cluster List: Show copy button on hover only
```
