### PR TITLE
Added OIDC kubeconfig to access plane in shoot detail

### DIFF
--- a/backend/__fixtures__/shoots.js
+++ b/backend/__fixtures__/shoots.js
@@ -67,7 +67,11 @@ function getShoot ({
   secretBindingName = 'foo-secret',
   seed = 'infra1-seed',
   hibernation = { enabled: false },
-  kubernetesVersion = '1.16.0'
+  kubernetesVersion = '1.16.0',
+  clientId,
+  secret,
+  issuerURL,
+  extraConfig = {}
 }) {
   uid = uid || `${namespace}--${name}`
   const shoot = {
@@ -87,7 +91,17 @@ function getShoot ({
       },
       seedName: seed,
       kubernetes: {
-        version: kubernetesVersion
+        version: kubernetesVersion,
+        kubeAPIServer: {
+          oidcConfig: {
+            clientAuthentication: {
+              secret,
+              extraConfig
+            },
+            clientId,
+            issuerURL
+          }
+        }
       },
       purpose
     },

--- a/backend/lib/routes/shoots.js
+++ b/backend/lib/routes/shoots.js
@@ -194,3 +194,15 @@ router.route('/:name/spec/purpose')
       next(err)
     }
   })
+
+router.route('/:name/oidckubeconfig')
+  .get(async (req, res, next) => {
+    try {
+      const user = req.user
+      const namespace = req.params.namespace
+      const name = req.params.name
+      res.send(await shoots.oidcKubeconfig({ user, namespace, name }))
+    } catch (err) {
+      next(err)
+    }
+  })

--- a/frontend/src/mixins/shootItem.js
+++ b/frontend/src/mixins/shootItem.js
@@ -5,6 +5,7 @@
 //
 
 import get from 'lodash/get'
+import isEmpty from 'lodash/isEmpty'
 import uniq from 'lodash/uniq'
 import flatMap from 'lodash/flatMap'
 import cloneDeep from 'lodash/cloneDeep'
@@ -100,6 +101,10 @@ export const shootItem = {
     },
     shootK8sVersion () {
       return get(this.shootSpec, 'kubernetes.version')
+    },
+    shootHasOidcConfig () {
+      const oidcConfig = get(this.shootSpec, 'kubernetes.kubeAPIServer.oidcConfig', {})
+      return !isEmpty(oidcConfig)
     },
     shootCloudProfileName () {
       return this.shootSpec.cloudProfileName

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -58,6 +58,8 @@ export default function createRouter (store) {
 
   /* router error */
   router.onError(err => {
+    // eslint-disable-next-line no-console
+    console.info(JSON.stringify(err))
     console.error('Router error:', err)
     store.commit('SET_LOADING', false)
     store.commit('SET_ALERT', { type: 'error', message: err.message })

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -20,7 +20,7 @@ import {
   isHtmlColorCode
 } from '@/utils'
 import { hash } from '@/utils/crypto'
-import { getSubjectRules, getKubeconfigData, listProjectTerminalShortcuts } from '@/utils/api'
+import { getSubjectRules, getKubeconfigData, getShootOidcKubeconfig, listProjectTerminalShortcuts } from '@/utils/api'
 import reduce from 'lodash/reduce'
 import map from 'lodash/map'
 import mapKeys from 'lodash/mapKeys'
@@ -87,6 +87,7 @@ if (debug) {
 const state = {
   cfg: null,
   kubeconfigData: null,
+  oidcKubeconfigData: null,
   ready: false,
   namespace: null,
   subjectRules: { // selfSubjectRules for state.namespace
@@ -1341,6 +1342,10 @@ const actions = {
     const { data } = await getKubeconfigData()
     commit('SET_KUBECONFIG_DATA', data)
   },
+  async fetchOidcKubeconfigData ({ commit }, { name, namespace }) {
+    const { data } = await getShootOidcKubeconfig({ namespace: namespace, name: name })
+    commit('SET_OIDCKUBECONFIG_DATA', data)
+  },
   async ensureProjectTerminalShortcutsLoaded ({ commit, dispatch, state }) {
     const { namespace, projectTerminalShortcuts } = state
     if (!projectTerminalShortcuts || projectTerminalShortcuts.namespace !== namespace) {
@@ -1441,6 +1446,9 @@ const mutations = {
   },
   SET_KUBECONFIG_DATA (state, value) {
     state.kubeconfigData = value
+  },
+  SET_OIDCKUBECONFIG_DATA (state, value) {
+    state.oidcKubeconfigData = value
   },
   SET_PROJECT_TERMINAL_SHORTCUTS (state, value) {
     state.projectTerminalShortcuts = value

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -121,6 +121,12 @@ export function getShootInfo ({ namespace, name }) {
   return getResource(`/api/namespaces/${namespace}/shoots/${name}/info`)
 }
 
+export function getShootOidcKubeconfig ({ namespace, name }) {
+  namespace = encodeURIComponent(namespace)
+  name = encodeURIComponent(name)
+  return getResource(`/api/namespaces/${namespace}/shoots/${name}/oidckubeconfig`)
+}
+
 export function getShootSeedInfo ({ namespace, name }) {
   namespace = encodeURIComponent(namespace)
   name = encodeURIComponent(name)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds UI to display OIDC kubeconfig in Access plane in Shoot detail if oidc is configured for that Shoot.

**Which issue(s) this PR fixes**:
Fixes #999

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. NONE
Format of block header: <category> <target_group>
Possible values:
- category:feature
- target_group:   user
-->
```bugfix user

```
<img width="621" alt="Screenshot of added UI" src="https://user-images.githubusercontent.com/4294656/115235251-455ee280-a11a-11eb-8845-5c1e88cd1cb3.png">
