### PR TITLE
Use the AWS IAM policy from g/provider-aws

### DIFF
--- a/frontend/src/components/dialogs/SecretDialogAws.vue
+++ b/frontend/src/components/dialogs/SecretDialogAws.vue
@@ -155,17 +155,6 @@ export default {
             ],
             Effect: 'Allow',
             Resource: '*'
-          },
-          {
-            Effect: 'Allow',
-            Action: [
-              'route53:GetChange',
-              'route53:GetHostedZone',
-              'route53:ListResourceRecordSets',
-              'route53:ChangeResourceRecordSets',
-              'route53:ListHostedZones'
-            ],
-            Resource: '*'
           }
         ]
       }


### PR DESCRIPTION
This is basically the diff between the policy in g/dashboard and g/provider-aws (ref https://github.com/gardener/gardener-extension-provider-aws/blob/v1.22.2/docs/usage-as-end-user.md#permissions).
I think we can remove these permission as they are route53 specific. In general the dns provider can be of any type and these permissions should be rather documented under g/external-dns-management.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
NONE
```
