### PR TITLE
Do not auto fix frontend lint errors in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN yarn workspace @gardener-dashboard/request     run lint
 RUN yarn workspace @gardener-dashboard/kube-config run lint
 RUN yarn workspace @gardener-dashboard/kube-client run lint
 RUN yarn workspace @gardener-dashboard/backend     run lint
-RUN yarn workspace @gardener-dashboard/frontend    run lint
+RUN yarn workspace @gardener-dashboard/frontend    run lint --no-fix
 
 # run test in all workspaces
 RUN yarn workspace @gardener-dashboard/logger      run test-coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN yarn workspace @gardener-dashboard/request     run lint
 RUN yarn workspace @gardener-dashboard/kube-config run lint
 RUN yarn workspace @gardener-dashboard/kube-client run lint
 RUN yarn workspace @gardener-dashboard/backend     run lint
-RUN yarn workspace @gardener-dashboard/frontend    run lint --no-fix
+RUN yarn workspace @gardener-dashboard/frontend    run lint
 
 # run test in all workspaces
 RUN yarn workspace @gardener-dashboard/logger      run test-coverage

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,7 @@
     "inspect": "vue-cli-service inspect",
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
-    "lint": "vue-cli-service lint",
+    "lint": "vue-cli-service lint --no-fix",
     "test": "vue-cli-service test:unit",
     "test-coverage": "yarn test --coverage"
   },


### PR DESCRIPTION
**What this PR does / why we need it**:
The Vue CLI plugin `@vue/cli-plugin-eslint` fixes lint errors per default. This means that currently the build step is successful if we have lint errors in the frontend. This kind of errors should lead to build errors in case of e.g. external PRs. With this PR the script `yarn lint` does not auto fix lint error in the frontend. This is also the default in all other workspaces.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
