### PR TITLE
Fix deployment template in helm chart

### DIFF
--- a/charts/gardener-dashboard/templates/deployment.yaml
+++ b/charts/gardener-dashboard/templates/deployment.yaml
@@ -120,11 +120,6 @@ spec:
           {{- end }}
           {{- end }}
           {{- if .Values.gitHub }}
-          - name: GITHUB_AUTHENTICATION_USERNAME
-            valueFrom:
-              secretKeyRef:
-                name: gardener-dashboard-github
-                key: authentication.username
           - name: GITHUB_AUTHENTICATION_TOKEN
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes the environment variable GITHUB_AUTHENTICATION_USERNAME from the deployment template. The referenced secretKey has been deleted with PR #1001

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
