### PR TITLE
Some changes to CRI Selection

### DIFF
--- a/frontend/src/components/ShootWorkers/ContainerRuntime.vue
+++ b/frontend/src/components/ShootWorkers/ContainerRuntime.vue
@@ -19,14 +19,7 @@ SPDX-License-Identifier: Apache-2.0
       :disabled="immutableCri"
       :hint="criHint"
       persistent-hint
-    >
-      <template v-slot:item="{ item }">
-        <span>{{criItemText(item)}}</span>
-      </template>
-      <template v-slot:selection="{ item }">
-        <span>{{criItemText(item)}}</span>
-      </template>
-    </v-select>
+    ></v-select>
     <v-select
       v-if="ociRuntimeItems.length"
       class="ml-1"
@@ -42,14 +35,7 @@ SPDX-License-Identifier: Apache-2.0
       :disabled="immutableCri"
       :hint="ociHint"
       persistent-hint
-    >
-      <template v-slot:item="{ item }">
-        <span>{{ociItemText(item)}}</span>
-      </template>
-      <template v-slot:selection="{ item }">
-        <span>{{ociItemText(item)}}</span>
-      </template>
-    </v-select>
+    ></v-select>
   </div>
 </template>
 
@@ -119,15 +105,19 @@ export default {
   computed: {
     containerRuntimeItems () {
       const containerRuntimes = map(this.machineImageCri, 'name')
-      return uniq([...containerRuntimes, DEFAULT_CONTAINER_RUNTIME])
+      const items = uniq([...containerRuntimes, DEFAULT_CONTAINER_RUNTIME])
+      return map(items, item => ({ value: item, text: this.criItemText(item) }))
     },
     ociRuntimeItems () {
+      let items
       if (this.containerRuntime === DEFAULT_CONTAINER_RUNTIME) {
-        return [DEFAULT_OCI_RUNTIME]
+        items = [DEFAULT_OCI_RUNTIME]
+      } else {
+        const containerRuntime = find(this.machineImageCri, ['name', this.containerRuntime])
+        const ociRuntimes = get(containerRuntime, 'containerRuntimes', [])
+        items = map(ociRuntimes, 'type')
       }
-      const containerRuntime = find(this.machineImageCri, ['name', this.containerRuntime])
-      const ociRuntimes = get(containerRuntime, 'containerRuntimes', [])
-      return map(ociRuntimes, 'type')
+      return map(items, item => ({ value: item, text: this.ociItemText(item) }))
     },
     criHint () {
       if (this.immutableCri) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes OCI runtimes multi select style 
Show default runtime (docker) without "default"
Hide OCI Runtimes selection in case there is nothing to select
OCI Runtimes selection is not mandatory 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
