### PR TITLE
[hotfix-1.49] Wrong zone field

### DIFF
--- a/frontend/src/utils/createShoot.js
+++ b/frontend/src/utils/createShoot.js
@@ -299,7 +299,6 @@ export function getControlPlaneZone (workers, infrastructureKind, oldControlPlan
   switch (infrastructureKind) {
     case 'gcp':
     case 'openstack':
-    case 'alicloud':
       if (includes(workerZones, oldControlPlaneZone)) {
         return oldControlPlaneZone
       }


### PR DESCRIPTION
/kind bug

Currently creating a new alicloud Shoot from the dashboard, the dashboard wrongly sets the `.spec.provider.controlPlaneConfig.zone` for alicloud Shoots. The corresponding zone field was removed ~1y ago with https://github.com/gardener/gardener-extension-provider-alicloud/pull/64.
Setting unknown fields causes problem with the strict decoding that provider extensions now enforce.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
An issue causing the dashboard to set the `.spec.provider.controlPlaneConfig.zone` field for newly created alicloud Shoots is now resolved. The corresponding ControlPlaneConfig field is invalid as it was removed with https://github.com/gardener/gardener-extension-provider-alicloud/pull/64.
```
