### PR TITLE
[master] Support http response content compression

### DIFF
--- a/packages/request/__tests__/acceptance.test.js
+++ b/packages/request/__tests__/acceptance.test.js
@@ -19,7 +19,8 @@ const {
   HTTP2_HEADER_PATH,
   HTTP2_HEADER_STATUS,
   HTTP2_HEADER_CONTENT_TYPE,
-  HTTP2_HEADER_CONTENT_LENGTH
+  HTTP2_HEADER_CONTENT_LENGTH,
+  HTTP2_HEADER_ACCEPT_ENCODING
 } = http2.constants
 
 jest.useFakeTimers()
@@ -172,7 +173,10 @@ describe('Acceptance Tests', function () {
         }
         const url = new URL(headers[HTTP2_HEADER_SCHEME] + '://' + headers[HTTP2_HEADER_AUTHORITY] + headers[HTTP2_HEADER_PATH])
         const body = {
-          headers,
+          headers: {
+            ...headers,
+            [HTTP2_HEADER_ACCEPT_ENCODING]: 'gzip, deflate, br'
+          },
           body: ''
         }
         const response = await client.fetch('echo')
@@ -180,7 +184,7 @@ describe('Acceptance Tests', function () {
         expect(response.redirected).toBe(false)
         expect(response.request.options).toEqual({
           body: undefined,
-          headers,
+          headers: body.headers,
           method,
           url
         })
@@ -195,10 +199,6 @@ describe('Acceptance Tests', function () {
         const statusCode = 418
         const statusMessage = http.STATUS_CODES[statusCode]
         const body = statusMessage
-        const headers = {
-          [HTTP2_HEADER_CONTENT_LENGTH]: body.length.toString(),
-          [HTTP2_HEADER_CONTENT_TYPE]: 'text/plain'
-        }
         expect.assertions(2)
         try {
           await client.request('status/418')
@@ -208,7 +208,10 @@ describe('Acceptance Tests', function () {
           expect(err).toMatchObject({
             statusCode,
             statusMessage,
-            headers,
+            headers: {
+              [HTTP2_HEADER_CONTENT_LENGTH]: body.length.toString(),
+              [HTTP2_HEADER_CONTENT_TYPE]: 'text/plain'
+            },
             body
           })
         }
@@ -222,7 +225,8 @@ describe('Acceptance Tests', function () {
             [HTTP2_HEADER_AUTHORITY]: server.options.hostname + ':' + server.options.port,
             [HTTP2_HEADER_METHOD]: method,
             [HTTP2_HEADER_PATH]: '/echo',
-            [HTTP2_HEADER_SCHEME]: 'https'
+            [HTTP2_HEADER_SCHEME]: 'https',
+            [HTTP2_HEADER_ACCEPT_ENCODING]: 'gzip, deflate, br'
           }
         })
       })
@@ -240,6 +244,7 @@ describe('Acceptance Tests', function () {
             [HTTP2_HEADER_METHOD]: method,
             [HTTP2_HEADER_PATH]: '/echo',
             [HTTP2_HEADER_SCHEME]: 'https',
+            [HTTP2_HEADER_ACCEPT_ENCODING]: 'gzip, deflate, br',
             'x-requested-with': 'XmlHttpRequest',
             [HTTP2_HEADER_CONTENT_TYPE]: 'application/json'
           }

--- a/packages/request/__tests__/client.test.js
+++ b/packages/request/__tests__/client.test.js
@@ -7,6 +7,7 @@
 'use strict'
 
 const http2 = require('http2')
+const zlib = require('zlib')
 const { globalLogger: logger } = require('@gardener-dashboard/logger')
 const { Client, extend } = require('../lib')
 const {
@@ -250,6 +251,26 @@ describe('Client', () => {
     it('should create a http client', () => {
       const client = extend({ prefixUrl })
       expect(client).toBeInstanceOf(Client)
+    })
+  })
+
+  describe('#createDecompressor', () => {
+    it('should create a decompressor', () => {
+      expect(Client.createDecompressor('br')).toBeInstanceOf(zlib.BrotliDecompress)
+      expect(Client.createDecompressor('gzip')).toBeInstanceOf(zlib.Gunzip)
+      expect(Client.createDecompressor('deflate')).toBeInstanceOf(zlib.Inflate)
+      expect(Client.createDecompressor('foo')).toBeUndefined()
+    })
+  })
+
+  describe('#transformFactory', () => {
+    it('should create a transform function', () => {
+      const data = 'foo'
+      expect(Client.transformFactory('text')(data)).toBe(data)
+      expect(Client.transformFactory('json')(JSON.stringify(data))).toBe(data)
+      const buffer = Client.transformFactory(false)(data)
+      expect(Buffer.isBuffer(buffer)).toBe(true)
+      expect(buffer.toString('utf8')).toBe(data)
     })
   })
 })

--- a/packages/request/__tests__/client.test.js
+++ b/packages/request/__tests__/client.test.js
@@ -16,6 +16,7 @@ const {
   HTTP2_HEADER_PATH,
   HTTP2_HEADER_CONTENT_TYPE,
   HTTP2_HEADER_CONTENT_LENGTH,
+  HTTP2_HEADER_ACCEPT_ENCODING,
   HTTP2_METHOD_GET,
   HTTP2_METHOD_POST,
   HTTP2_HEADER_STATUS
@@ -51,6 +52,7 @@ describe('Client', () => {
       async getHeaders () {
         return this.mockHeaders()
       },
+      setEncoding: jest.fn(),
       async * [Symbol.asyncIterator] () {
         yield Buffer.from('{')
         let separator
@@ -123,6 +125,7 @@ describe('Client', () => {
       [HTTP2_HEADER_AUTHORITY]: '127.0.0.1:31415',
       [HTTP2_HEADER_METHOD]: HTTP2_METHOD_GET,
       [HTTP2_HEADER_PATH]: '/test',
+      [HTTP2_HEADER_ACCEPT_ENCODING]: 'gzip, deflate, br',
       'x-request-id': xRequestId
     }
 

--- a/packages/request/lib/Client.js
+++ b/packages/request/lib/Client.js
@@ -9,11 +9,13 @@
 const { join } = require('path')
 const http = require('http')
 const http2 = require('http2')
+const zlib = require('zlib')
 const typeis = require('type-is')
 const { pick } = require('lodash')
 const { globalLogger: logger } = require('@gardener-dashboard/logger')
 const { createHttpError } = require('./errors')
 const { globalAgent } = require('./Agent')
+const { pipeline } = require('stream')
 
 const {
   HTTP2_HEADER_STATUS,
@@ -23,7 +25,9 @@ const {
   HTTP2_HEADER_PATH,
   HTTP2_HEADER_CONTENT_TYPE,
   HTTP2_HEADER_CONTENT_LENGTH,
-  HTTP2_METHOD_GET
+  HTTP2_METHOD_GET,
+  HTTP2_HEADER_ACCEPT_ENCODING,
+  HTTP2_HEADER_CONTENT_ENCODING
 } = http2.constants
 
 const EOL = '\n'
@@ -84,7 +88,8 @@ class Client {
         [HTTP2_HEADER_SCHEME]: url.protocol.replace(/:$/, ''),
         [HTTP2_HEADER_AUTHORITY]: url.host,
         [HTTP2_HEADER_METHOD]: method.toUpperCase(),
-        [HTTP2_HEADER_PATH]: url.pathname + url.search
+        [HTTP2_HEADER_PATH]: url.pathname + url.search,
+        [HTTP2_HEADER_ACCEPT_ENCODING]: 'gzip, deflate, br'
       },
       normalizeHeaders(this.defaults.options.headers),
       normalizeHeaders(headers)
@@ -120,9 +125,11 @@ class Client {
     stream.end()
 
     const { responseType } = this.defaults.options
-    const { transformFactory } = this.constructor
+    const { createDecompressor, concat, transformFactory } = this.constructor
 
     headers = await stream.getHeaders()
+    const decompressor = createDecompressor(headers[HTTP2_HEADER_CONTENT_ENCODING])
+
     return {
       request: { options: requestOptions },
       headers,
@@ -150,24 +157,46 @@ class Client {
       destroy (error) {
         stream.destroy(error)
       },
-      async body () {
-        let data = ''
-        for await (const chunk of stream) {
-          data += chunk
+      body () {
+        const streams = [
+          stream,
+          async source => {
+            switch (this.type) {
+              case 'text':
+                return concat(source)
+              case 'json':
+                return JSON.parse(await concat(source))
+              default:
+                return Buffer.from(concat(source), 'utf8')
+            }
+          }
+        ]
+        if (decompressor) {
+          streams.splice(1, 0, decompressor)
         }
-        switch (this.type) {
-          case 'text':
-            return data.toString('utf8')
-          case 'json':
-            return JSON.parse(data)
-          default:
-            return data
-        }
+        return new Promise((resolve, reject) => {
+          pipeline(streams, (err, body) => {
+            if (err) {
+              reject(err)
+            } else {
+              resolve(body)
+            }
+          })
+        })
       },
       async * [Symbol.asyncIterator] () {
         let data = ''
         const transform = transformFactory(this.type)
-        for await (const chunk of stream) {
+        let readable = stream
+        if (decompressor) {
+          readable = pipeline(stream, decompressor, err => {
+            if (err) {
+              logger.debug('Stream decompress pipeline error: %s', err.message)
+            }
+          })
+        }
+        readable.setEncoding('utf8')
+        for await (const chunk of readable) {
           data += chunk
           let index
           while ((index = data.indexOf(EOL)) !== -1) {
@@ -240,7 +269,7 @@ class Client {
   static transformFactory (type) {
     switch (type) {
       case 'text':
-        return data => data.toString('utf8')
+        return data => data
       case 'json':
         return data => {
           try {
@@ -250,7 +279,27 @@ class Client {
           }
         }
       default:
-        return data => data
+        return data => Buffer.from(data, 'utf8')
+    }
+  }
+
+  static async concat (source) {
+    let data = ''
+    source.setEncoding('utf8')
+    for await (const chunk of source) {
+      data += chunk
+    }
+    return data
+  }
+
+  static createDecompressor (contentEncoding) {
+    switch (contentEncoding) {
+      case 'br':
+        return zlib.createBrotliDecompress()
+      case 'gzip':
+        return zlib.createGunzip()
+      case 'deflate':
+        return zlib.createInflate()
     }
   }
 

--- a/packages/request/lib/SessionPool.js
+++ b/packages/request/lib/SessionPool.js
@@ -199,6 +199,7 @@ class SessionPool {
     const { origin, hostname } = this.id
     const options = omit(this.options, ['connectTimeout', 'keepAliveTimeout', 'pingInterval'])
     Object.assign(options, {
+      maxSessionMemory: 20,
       servername: !net.isIP(hostname) ? hostname : '',
       session: this.tlsSession
     })

--- a/packages/request/package.json
+++ b/packages/request/package.json
@@ -79,10 +79,10 @@
     ],
     "coverageThreshold": {
       "global": {
-        "branches": 79,
-        "functions": 94,
-        "lines": 93,
-        "statements": 93
+        "branches": 85,
+        "functions": 97,
+        "lines": 95,
+        "statements": 95
       }
     },
     "setupFilesAfterEnv": [

--- a/packages/request/package.json
+++ b/packages/request/package.json
@@ -79,10 +79,10 @@
     ],
     "coverageThreshold": {
       "global": {
-        "branches": 84,
-        "functions": 95,
-        "lines": 95,
-        "statements": 95
+        "branches": 79,
+        "functions": 94,
+        "lines": 93,
+        "statements": 93
       }
     },
     "setupFilesAfterEnv": [


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR the http/2 request library supports content compression. This can improve the performance for large responses by a factor of 10. This regression has been introduced with release 1.50.0 and has been fixed with patch 1.50.2

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
