### PR TITLE
Self-contained shoot-item mixin

### DIFF
--- a/frontend/src/components/ClusterMetrics.vue
+++ b/frontend/src/components/ClusterMetrics.vue
@@ -62,12 +62,6 @@ export default {
     UsernamePassword,
     LinkListTile
   },
-  props: {
-    shootItem: {
-      type: Object,
-      required: true
-    }
-  },
   mixins: [shootItem],
   computed: {
     ...mapGetters([

--- a/frontend/src/components/DeleteCluster.vue
+++ b/frontend/src/components/DeleteCluster.vue
@@ -57,9 +57,6 @@ export default {
     AccountAvatar
   },
   props: {
-    shootItem: {
-      type: Object
-    },
     small: {
       type: Boolean,
       default: false

--- a/frontend/src/components/PurposeConfiguration.vue
+++ b/frontend/src/components/PurposeConfiguration.vue
@@ -44,13 +44,9 @@ export default {
     ActionButtonDialog,
     Purpose
   },
-  props: {
-    shootItem: {
-      type: Object
-    }
-  },
   mixins: [
-    shootItem, asyncRef('purpose')
+    shootItem,
+    asyncRef('purpose')
   ],
   data () {
     return {

--- a/frontend/src/components/ReconcileStart.vue
+++ b/frontend/src/components/ReconcileStart.vue
@@ -40,9 +40,6 @@ export default {
     ActionButtonDialog
   },
   props: {
-    shootItem: {
-      type: Object
-    },
     text: {
       type: Boolean
     }

--- a/frontend/src/components/RetryOperation.vue
+++ b/frontend/src/components/RetryOperation.vue
@@ -23,11 +23,6 @@ import { addShootAnnotation } from '@/utils/api'
 import { shootItem } from '@/mixins/shootItem'
 
 export default {
-  props: {
-    shootItem: {
-      type: Object
-    }
-  },
   data () {
     return {
       retryingOperation: false

--- a/frontend/src/components/RotateKubeconfigStart.vue
+++ b/frontend/src/components/RotateKubeconfigStart.vue
@@ -44,9 +44,6 @@ export default {
     ActionButtonDialog
   },
   props: {
-    shootItem: {
-      type: Object
-    },
     text: {
       type: Boolean
     }

--- a/frontend/src/components/ShootAccessRestrictions/AccessRestrictionsConfiguration.vue
+++ b/frontend/src/components/ShootAccessRestrictions/AccessRestrictionsConfiguration.vue
@@ -38,11 +38,6 @@ export default {
     ActionButtonDialog,
     AccessRestrictions
   },
-  props: {
-    shootItem: {
-      type: Object
-    }
-  },
   mixins: [shootItem],
   computed: {
     ...mapGetters([

--- a/frontend/src/components/ShootAddons/AddonConfiguration.vue
+++ b/frontend/src/components/ShootAddons/AddonConfiguration.vue
@@ -37,11 +37,6 @@ export default {
     ActionButtonDialog,
     ManageShootAddons
   },
-  props: {
-    shootItem: {
-      type: Object
-    }
-  },
   mixins: [shootItem],
   methods: {
     async onConfigurationDialogOpened () {

--- a/frontend/src/components/ShootDetails/GardenctlCommands.vue
+++ b/frontend/src/components/ShootDetails/GardenctlCommands.vue
@@ -56,11 +56,6 @@ export default {
     CopyBtn,
     CodeBlock
   },
-  props: {
-    shootItem: {
-      type: Object
-    }
-  },
   mixins: [shootItem],
   data () {
     return {

--- a/frontend/src/components/ShootDetails/ShootAccessCard.vue
+++ b/frontend/src/components/ShootDetails/ShootAccessCard.vue
@@ -162,9 +162,6 @@ export default {
     TerminalShortcutsTile
   },
   props: {
-    shootItem: {
-      type: Object
-    },
     hideTerminalShortcuts: {
       type: Boolean,
       default: false

--- a/frontend/src/components/ShootDetails/ShootDetails.vue
+++ b/frontend/src/components/ShootDetails/ShootDetails.vue
@@ -60,11 +60,6 @@ export default {
     ShootExternalToolsCard
   },
   mixins: [shootItem],
-  props: {
-    shootItem: {
-      type: Object
-    }
-  },
   computed: {
     ...mapGetters([
       'ticketsByNamespaceAndName',

--- a/frontend/src/components/ShootDetails/ShootDetailsCard.vue
+++ b/frontend/src/components/ShootDetails/ShootDetailsCard.vue
@@ -229,11 +229,6 @@ export default {
     ShootMessages,
     CopyBtn
   },
-  props: {
-    shootItem: {
-      type: Object
-    }
-  },
   mixins: [shootItem],
   computed: {
     ...mapState([

--- a/frontend/src/components/ShootDetails/ShootExternalToolsCard.vue
+++ b/frontend/src/components/ShootDetails/ShootExternalToolsCard.vue
@@ -10,11 +10,11 @@ SPDX-License-Identifier: Apache-2.0
       <v-toolbar-title class="text-subtitle-1">External Tools</v-toolbar-title>
     </v-toolbar>
     <v-list>
-      <template v-for="({ title, url, icon = 'link' }, index) in items">
+      <template v-for="({ title, url, icon }, index) in items">
         <v-divider v-if="index" :key="index" inset class="my-2"></v-divider>
         <v-list-item :key="title">
           <v-list-item-icon>
-            <v-icon color="primary">{{icon}}</v-icon>
+            <v-icon color="primary">{{icon || 'link'}}</v-icon>
           </v-list-item-icon>
           <v-list-item-content>
             <v-list-item-subtitle>{{title}}</v-list-item-subtitle>
@@ -42,11 +42,6 @@ export default {
     ExternalLink
   },
   mixins: [shootItem],
-  props: {
-    shootItem: {
-      type: Object
-    }
-  },
   computed: {
     ...mapState([
       'cfg'

--- a/frontend/src/components/ShootDetails/ShootInfrastructureCard.vue
+++ b/frontend/src/components/ShootDetails/ShootInfrastructureCard.vue
@@ -152,11 +152,6 @@ export default {
     ShootSeedName,
     Vendor
   },
-  props: {
-    shootItem: {
-      type: Object
-    }
-  },
   mixins: [shootItem],
   computed: {
     ...mapGetters([

--- a/frontend/src/components/ShootDetails/ShootLifecycleCard.vue
+++ b/frontend/src/components/ShootDetails/ShootLifecycleCard.vue
@@ -124,11 +124,6 @@ export default {
     RotateKubeconfigStart,
     ShootMessages
   },
-  props: {
-    shootItem: {
-      type: Object
-    }
-  },
   mixins: [shootItem],
   computed: {
     ...mapGetters([

--- a/frontend/src/components/ShootDetails/ShootMonitoringCard.vue
+++ b/frontend/src/components/ShootDetails/ShootMonitoringCard.vue
@@ -69,11 +69,6 @@ export default {
     StatusTags,
     ClusterMetrics
   },
-  props: {
-    shootItem: {
-      type: Object
-    }
-  },
   mixins: [shootItem],
   computed: {
     metricsNotAvailableText () {

--- a/frontend/src/components/ShootDetails/TerminalShortcutsTile.vue
+++ b/frontend/src/components/ShootDetails/TerminalShortcutsTile.vue
@@ -64,9 +64,6 @@ import includes from 'lodash/includes'
 export default {
   mixins: [shootItem],
   props: {
-    shootItem: {
-      type: Object
-    },
     popperBoundariesSelector: {
       type: String
     }

--- a/frontend/src/components/ShootEditor.vue
+++ b/frontend/src/components/ShootEditor.vue
@@ -166,9 +166,6 @@ export default {
     alertBannerIdentifier: {
       type: String
     },
-    shootContent: {
-      type: Object
-    },
     errorMessage: {
       type: String
     },
@@ -217,7 +214,7 @@ export default {
       'canPatchShoots'
     ]),
     value () {
-      let data = cloneDeep(this.shootContent)
+      let data = cloneDeep(this.shootItem)
       if (data) {
         data = pick(data, ['kind', 'apiVersion', 'metadata', 'spec', 'status'])
         if (!this.showManagedFields) {
@@ -226,9 +223,6 @@ export default {
         return data
       }
       return undefined
-    },
-    shootItem () { // needed for mixin
-      return this.shootContent
     },
     containerStyles () {
       return {

--- a/frontend/src/components/ShootHibernation/ChangeHibernation.vue
+++ b/frontend/src/components/ShootHibernation/ChangeHibernation.vue
@@ -40,9 +40,6 @@ export default {
     ActionButtonDialog
   },
   props: {
-    shootItem: {
-      type: Object
-    },
     text: {
       type: Boolean
     }

--- a/frontend/src/components/ShootHibernation/HibernationConfiguration.vue
+++ b/frontend/src/components/ShootHibernation/HibernationConfiguration.vue
@@ -42,11 +42,6 @@ export default {
     ActionButtonDialog,
     ManageHibernationSchedule
   },
-  props: {
-    shootItem: {
-      type: Object
-    }
-  },
   mixins: [
     shootItem,
     asyncRef('hibernationSchedule')

--- a/frontend/src/components/ShootListRow.vue
+++ b/frontend/src/components/ShootListRow.vue
@@ -187,10 +187,6 @@ export default {
     AutoHide
   },
   props: {
-    shootItem: {
-      type: Object,
-      required: true
-    },
     visibleHeaders: {
       type: Array,
       required: true

--- a/frontend/src/components/ShootMaintenance/MaintenanceConfiguration.vue
+++ b/frontend/src/components/ShootMaintenance/MaintenanceConfiguration.vue
@@ -45,11 +45,6 @@ export default {
     MaintenanceComponents,
     MaintenanceTime
   },
-  props: {
-    shootItem: {
-      type: Object
-    }
-  },
   mixins: [shootItem],
   data () {
     return {

--- a/frontend/src/components/ShootMaintenance/MaintenanceStart.vue
+++ b/frontend/src/components/ShootMaintenance/MaintenanceStart.vue
@@ -45,9 +45,6 @@ export default {
     MaintenanceComponents
   },
   props: {
-    shootItem: {
-      type: Object
-    },
     text: {
       type: Boolean
     }

--- a/frontend/src/components/ShootMessages/ShootMessages.vue
+++ b/frontend/src/components/ShootMessages/ShootMessages.vue
@@ -68,9 +68,6 @@ export default {
     ConstraintMessage
   },
   props: {
-    shootItem: {
-      type: Object
-    },
     small: {
       type: Boolean,
       default: false
@@ -164,7 +161,7 @@ export default {
             purposeText: this.shootPurpose || '',
             shootName: this.shootName || '',
             shootNamespace: this.shootNamespace || '',
-            showNavigationLink: this.canPatchShoots
+            showNavigationLink: this.canPatchShoots && !isEmpty(this.shootName) && !isEmpty(this.shootNamespace)
           }
         }
       }]

--- a/frontend/src/components/ShootSeedName.vue
+++ b/frontend/src/components/ShootSeedName.vue
@@ -24,11 +24,6 @@ SPDX-License-Identifier: Apache-2.0
 import { shootItem } from '@/mixins/shootItem'
 
 export default {
-  props: {
-    shootItem: {
-      type: Object
-    }
-  },
   mixins: [shootItem]
 }
 </script>

--- a/frontend/src/components/ShootStatus.vue
+++ b/frontend/src/components/ShootStatus.vue
@@ -78,9 +78,6 @@ export default {
     ShootMessageDetails
   },
   props: {
-    shootItem: {
-      type: Object
-    },
     popperKey: {
       type: String,
       required: true

--- a/frontend/src/components/ShootVersion/ShootVersion.vue
+++ b/frontend/src/components/ShootVersion/ShootVersion.vue
@@ -103,9 +103,6 @@ export default {
     GDialog
   },
   props: {
-    shootItem: {
-      type: Object
-    },
     chip: {
       type: Boolean
     }

--- a/frontend/src/components/ShootWorkers/WorkerConfiguration.vue
+++ b/frontend/src/components/ShootWorkers/WorkerConfiguration.vue
@@ -42,11 +42,6 @@ export default {
     ActionButtonDialog,
     ManageWorkers
   },
-  props: {
-    shootItem: {
-      type: Object
-    }
-  },
   data () {
     return {
       workersValid: false,

--- a/frontend/src/components/StatusTags.vue
+++ b/frontend/src/components/StatusTags.vue
@@ -29,9 +29,6 @@ export default {
     StatusTag
   },
   props: {
-    shootItem: {
-      type: Object
-    },
     popperPlacement: {
       type: String
     }

--- a/frontend/src/components/TerminalListTile.vue
+++ b/frontend/src/components/TerminalListTile.vue
@@ -34,9 +34,6 @@ import { shootItem } from '@/mixins/shootItem'
 export default {
   mixins: [shootItem],
   props: {
-    shootItem: {
-      type: Object
-    },
     target: {
       type: String
     },

--- a/frontend/src/components/TerminalShortcut.vue
+++ b/frontend/src/components/TerminalShortcut.vue
@@ -78,10 +78,6 @@ import CodeBlock from '@/components/CodeBlock'
 
 export default {
   props: {
-    shootItem: {
-      type: Object,
-      required: false
-    },
     shortcut: {
       type: Object,
       required: true

--- a/frontend/src/components/TerminalSplitpanes.vue
+++ b/frontend/src/components/TerminalSplitpanes.vue
@@ -30,8 +30,7 @@ SPDX-License-Identifier: Apache-2.0
     </g-splitpane>
     <create-terminal-session-dialog
       ref="newTerminal"
-      :name="name"
-      :namespace="namespace"
+      :shoot-item="shootItem"
     ></create-terminal-session-dialog>
   </div>
 </template>
@@ -88,8 +87,15 @@ export default {
     ...mapGetters([
       'focusedElementId',
       'hasControlPlaneTerminalAccess',
-      'hasShootTerminalAccess'
+      'hasShootTerminalAccess',
+      'shootByNamespaceAndName'
     ]),
+    shootItem () {
+      return this.shootByNamespaceAndName({
+        namespace: this.namespace,
+        name: this.name
+      })
+    },
     terminalCoordinates () {
       const coordinates = {
         name: this.name,

--- a/frontend/src/components/TerminalSplitpanes.vue
+++ b/frontend/src/components/TerminalSplitpanes.vue
@@ -30,7 +30,8 @@ SPDX-License-Identifier: Apache-2.0
     </g-splitpane>
     <create-terminal-session-dialog
       ref="newTerminal"
-      :shoot-item="shootItem"
+      :name="name"
+      :namespace="namespace"
     ></create-terminal-session-dialog>
   </div>
 </template>
@@ -87,15 +88,8 @@ export default {
     ...mapGetters([
       'focusedElementId',
       'hasControlPlaneTerminalAccess',
-      'hasShootTerminalAccess',
-      'shootByNamespaceAndName'
+      'hasShootTerminalAccess'
     ]),
-    shootItem () {
-      return this.shootByNamespaceAndName({
-        namespace: this.namespace,
-        name: this.name
-      })
-    },
     terminalCoordinates () {
       const coordinates = {
         name: this.name,

--- a/frontend/src/components/TerminalTarget.vue
+++ b/frontend/src/components/TerminalTarget.vue
@@ -58,7 +58,10 @@ SPDX-License-Identifier: Apache-2.0
 
 <script>
 import { mapGetters } from 'vuex'
-import { shootItem } from '@/mixins/shootItem'
+
+import get from 'lodash/get'
+
+import { isShootStatusHibernated } from '@/utils'
 
 export default {
   props: {
@@ -69,7 +72,6 @@ export default {
       type: Object
     }
   },
-  mixins: [shootItem],
   computed: {
     ...mapGetters([
       'hasControlPlaneTerminalAccess',
@@ -77,6 +79,12 @@ export default {
       'hasGardenTerminalAccess',
       'isAdmin'
     ]),
+    shootName () {
+      return get(this.shootItem, 'metadata.name')
+    },
+    isShootStatusHibernated () {
+      return isShootStatusHibernated(get(this.shootItem, 'status'))
+    },
     selectedTarget: {
       get () {
         return this.value

--- a/frontend/src/components/TicketsCard.vue
+++ b/frontend/src/components/TicketsCard.vue
@@ -50,10 +50,6 @@ export default {
   props: {
     tickets: {
       type: Array
-    },
-    shootItem: {
-      type: Object,
-      required: true
     }
   },
   mixins: [shootItem],

--- a/frontend/src/components/dialogs/ActionButtonDialog.vue
+++ b/frontend/src/components/dialogs/ActionButtonDialog.vue
@@ -68,9 +68,6 @@ export default {
     }
   },
   props: {
-    shootItem: {
-      type: Object
-    },
     icon: {
       type: String,
       default: 'mdi-cog-outline'

--- a/frontend/src/mixins/shootItem.js
+++ b/frontend/src/mixins/shootItem.js
@@ -22,6 +22,12 @@ import {
 } from '@/utils'
 
 export const shootItem = {
+  props: {
+    shootItem: {
+      type: Object,
+      required: true
+    }
+  },
   computed: {
     ...mapGetters([
       'selectedAccessRestrictionsForShootByCloudProfileNameAndRegion',

--- a/frontend/src/views/ShootItem.vue
+++ b/frontend/src/views/ShootItem.vue
@@ -31,8 +31,6 @@ import TerminalSplitpanes from '@/components/TerminalSplitpanes'
 
 import { PositionEnum } from '@/lib/g-symbol-tree'
 
-import { shootItem } from '@/mixins/shootItem'
-
 export default {
   name: 'shoot-item',
   components: {
@@ -40,16 +38,18 @@ export default {
     TerminalSplitpanes,
     PositionalDropzone
   },
-  mixins: [shootItem],
   computed: {
     ...mapGetters([
       'shootByNamespaceAndName'
     ]),
-    value () {
-      return this.shootByNamespaceAndName(this.$route.params)
+    shootName () {
+      return get(this.$route.params, 'name')
+    },
+    shootNamespace () {
+      return get(this.$route.params, 'namespace')
     },
     shootItem () {
-      return get(this, 'value', {})
+      return this.shootByNamespaceAndName(this.$route.params) || {}
     }
   },
   methods: {

--- a/frontend/src/views/ShootItemEditor.vue
+++ b/frontend/src/views/ShootItemEditor.vue
@@ -10,7 +10,7 @@ SPDX-License-Identifier: Apache-2.0
       alert-banner-identifier="shootEditorWarning"
       :error-message.sync="errorMessage"
       :detailed-error-message.sync="detailedErrorMessage"
-      :shoot-content="shootContent"
+      :shoot-item="shootItem"
       :extra-keys="extraKeys"
       @clean="onClean"
       @conflict-path="onConflictPath"
@@ -31,7 +31,7 @@ SPDX-License-Identifier: Apache-2.0
 
 <script>
 import ConfirmDialog from '@/components/dialogs/ConfirmDialog'
-import { mapGetters, mapState } from 'vuex'
+import { mapState, mapGetters } from 'vuex'
 import { replaceShoot } from '@/utils/api'
 
 import asyncRef from '@/mixins/asyncRef'
@@ -76,7 +76,7 @@ export default {
     ...mapGetters([
       'shootByNamespaceAndName'
     ]),
-    shootContent () {
+    shootItem () {
       return this.shootByNamespaceAndName(this.$route.params)
     }
   },
@@ -107,7 +107,7 @@ export default {
         const paths = ['spec', 'metadata.labels', 'metadata.annotations']
         const shootResource = await this.getShootResource()
         const data = pick(shootResource, paths)
-        const { metadata: { namespace, name } } = this.shootContent
+        const { metadata: { namespace, name } } = this.shootItem
         const { data: value } = await replaceShoot({ namespace, name, data })
         await this.$shootEditor.dispatch('update', value)
 

--- a/frontend/src/views/ShootItemTerminal.vue
+++ b/frontend/src/views/ShootItemTerminal.vue
@@ -18,16 +18,12 @@ SPDX-License-Identifier: Apache-2.0
 <script>
 import get from 'lodash/get'
 import TerminalSplitpanes from '@/components/TerminalSplitpanes'
-import { mapGetters } from 'vuex'
 
 export default {
   components: {
     TerminalSplitpanes
   },
   computed: {
-    ...mapGetters([
-      'shootByNamespaceAndName'
-    ]),
     name () {
       return get(this.$route.params, 'name')
     },

--- a/frontend/src/views/ShootList.vue
+++ b/frontend/src/views/ShootList.vue
@@ -228,7 +228,6 @@ export default {
   computed: {
     ...mapGetters({
       mappedItems: 'shootList',
-      item: 'shootByNamespaceAndName',
       selectedItem: 'selectedShoot',
       isAdmin: 'isAdmin',
       getShootListFilters: 'getShootListFilters',


### PR DESCRIPTION
**What this PR does / why we need it**:
The `shoot-item` mixin requires that the component that declares the mixin has a property with the name `shootItem`. This property should be defined in the mixin itself. This PR moves the `shootItem` property definition from the components into the mixin.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
