### PR TITLE
Fixed `shoot-content` renaming

### DIFF
--- a/frontend/src/views/NewShootEditor.vue
+++ b/frontend/src/views/NewShootEditor.vue
@@ -10,7 +10,7 @@ SPDX-License-Identifier: Apache-2.0
       alert-banner-identifier="newShootEditorWarning"
       :error-message.sync="errorMessage"
       :detailed-error-message.sync="detailedErrorMessage"
-      :shoot-content="newShootResource"
+      :shoot-item="newShootResource"
       ref="shootEditor"
       v-on="$shootEditor.hooks"
     >


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a bug that was introduced with PR #1041. The property `shoot-content` has been renamed to `shoot-item`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
