### PR TITLE
Fix privileged terminal container bug

### DIFF
--- a/backend/lib/services/terminals/index.js
+++ b/backend/lib/services/terminals/index.js
@@ -375,8 +375,8 @@ function getContainerConfigFromBody ({ container }) {
 }
 
 function getConfigFromBody (body) {
-  const config = _.pick(body, ['node', 'privileged', 'hostPID', 'hostNetwork', 'container'])
-  config.container = _.pick(config.container, ['image', 'command', 'args'])
+  const config = _.pick(body, ['node', 'hostPID', 'hostNetwork', 'container'])
+  config.container = _.pick(config.container, ['image', 'command', 'args', 'privileged'])
   return config
 }
 

--- a/frontend/src/components/GTerminal.vue
+++ b/frontend/src/components/GTerminal.vue
@@ -172,7 +172,7 @@ SPDX-License-Identifier: Apache-2.0
                 <span>{{privilegedModeText}}</span>
               </v-btn>
             </template>
-            <strong>Privileged:</strong> {{terminalSession.privileged}}<br/>
+            <strong>Privileged:</strong> {{terminalSession.container.privileged}}<br/>
             <strong>Host PID:</strong> {{terminalSession.hostPID}}<br/>
             <strong>Host Network:</strong> {{terminalSession.hostNetwork}}
           </v-tooltip>
@@ -268,7 +268,9 @@ export default {
         nodes: []
       },
       selectedConfig: {},
-      terminalSession: {},
+      terminalSession: {
+        container: {}
+      },
       TerminalSession,
       showMenu: false
     }
@@ -311,7 +313,7 @@ export default {
       return this.privilegedMode || false
     },
     privilegedMode () {
-      return this.terminalSession.privileged || this.terminalSession.hostPID || this.terminalSession.hostNetwork
+      return get(this.terminalSession, 'container.privileged') || this.terminalSession.hostPID || this.terminalSession.hostNetwork
     },
     connectionStateText () {
       switch (this.terminalSession.connectionState) {

--- a/frontend/src/components/TerminalSettings.vue
+++ b/frontend/src/components/TerminalSettings.vue
@@ -190,11 +190,11 @@ export default {
 
       const selectedConfig = {
         container: {
-          image: this.selectedContainerImage
+          image: this.selectedContainerImage,
+          privileged: this.selectedPrivilegedMode
         },
         node,
         preferredHost,
-        privileged: this.selectedPrivilegedMode,
         hostPID: this.selectedPrivilegedMode,
         hostNetwork: this.selectedPrivilegedMode
       }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an issue where the field `spec.host.pod.container.privileged` was not set on the `Terminal` resource and hence the `terminal-controller-manager` did not create the terminal container with 

```yaml
securityContext:
  privileged: true
```

**Which issue(s) this PR fixes**:
Fixes #1050 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed an issue where the terminal container was not created with `privileged` set to `true` of the `container`s `securityContext` when enabling the `Privileged` flag on the terminal settings UI
```
