### PR TITLE
Fix text color on dark mode

### DIFF
--- a/frontend/src/components/TerminalSettings.vue
+++ b/frontend/src/components/TerminalSettings.vue
@@ -75,7 +75,7 @@ SPDX-License-Identifier: Apache-2.0
           </v-list-item-content>
         </template>
         <template v-slot:selection="{ item }">
-          <span :class="nodeTextColor" class="ml-2">
+          <span :class="{'grey--text': !selectedRunOnShootWorker}" class="ml-2">
             <template v-if="item !== autoSelectNodeItem">
               {{item.data.kubernetesHostname}} [{{item.data.version}}]
             </template>
@@ -177,9 +177,6 @@ export default {
       set (value) {
         this.shootNodesInternal = value
       }
-    },
-    nodeTextColor () {
-      return this.selectedRunOnShootWorker ? 'black--text' : 'grey--text'
     },
     selectedConfig () {
       const node = this.selectedNode === this.autoSelectNodeItem.data.kubernetesHostname


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an issue with the text color on dark mode for the node selection on the terminal configuration component.
<img width="774" alt="Screenshot 2021-06-30 at 14 35 47" src="https://user-images.githubusercontent.com/5526658/123961423-9e67b400-d9b0-11eb-83eb-f911fc80a29f.png">


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
