### PR TITLE
Keep frontend host during the OIDC login process

### DIFF
--- a/backend/__fixtures__/config.js
+++ b/backend/__fixtures__/config.js
@@ -37,7 +37,9 @@ const defaultConfig = {
     ca,
     client_id: 'dashboard',
     client_secret: toHex('dashboard-secret'),
-    redirect_uri: 'http://localhost:8080/auth/callback',
+    redirect_uris: [
+      'http://localhost:8080/auth/callback'
+    ],
     scope: 'openid email profile groups audience:server:client_id:dashboard audience:server:client_id:kube-kubectl',
     clockTolerance: 42,
     public: {
@@ -123,7 +125,7 @@ configMap.set('/etc/gardener/3/config.yaml', {
 
 configMap.set('/etc/gardener/4/config.yaml', {
   oidc: {
-    ca
+    ...defaultConfig.oidc
   }
 })
 

--- a/backend/lib/config/gardener.js
+++ b/backend/lib/config/gardener.js
@@ -19,7 +19,6 @@ const environmentVariableDefinitions = {
   OIDC_ISSUER: 'oidc.issuer',
   OIDC_CLIENT_ID: 'oidc.client_id',
   OIDC_CLIENT_SECRET: 'oidc.client_secret', // pragma: whitelist secret
-  OIDC_REDIRECT_URI: 'oidc.redirect_uri',
   OIDC_CA: 'oidc.ca',
   GITHUB_AUTHENTICATION_USERNAME: 'gitHub.authentication.username',
   GITHUB_AUTHENTICATION_TOKEN: 'gitHub.authentication.token',
@@ -94,11 +93,16 @@ module.exports = {
 
     // When OIDC is configured, some more configuration is required
     if (config.oidc) {
+      const redirectUri = _.get(config, 'oidc.redirect_uri')
+      const redirectUris = _.get(config, 'oidc.redirect_uris')
+      if (redirectUri && _.isEmpty(redirectUris)) {
+        _.set(config, 'oidc.redirect_uris', [redirectUri])
+      }
       requiredConfigurationProperties.push(
         'oidc.issuer',
         'oidc.client_id',
         'oidc.client_secret',
-        'oidc.redirect_uri'
+        'oidc.redirect_uris'
       )
     }
 

--- a/backend/lib/security/index.js
+++ b/backend/lib/security/index.js
@@ -112,10 +112,13 @@ async function authorizationUrl (req, res) {
   if (redirectUrl) {
     try {
       const url = new URL(redirectUrl)
-      // update host of redirectUri for OIDC redirection
+      // update origin of redirectUri for OIDC redirection
+      if (process.env.NODE_ENV !== 'production') {
+        actualRedirectUri.protocol = url.protocol
+      }
       actualRedirectUri.host = url.host
       // set redirectPath for frontend redirection
-      query.redirectPath = url.path
+      query.redirectPath = url.pathname + url.search
     } catch (err) {
       logger.warn('Received invalid redirectUrl query parameter value: "%s"', redirectUrl)
     }

--- a/backend/package.json
+++ b/backend/package.json
@@ -141,10 +141,10 @@
     ],
     "coverageThreshold": {
       "global": {
-        "branches": 62,
-        "functions": 90,
-        "lines": 87,
-        "statements": 87
+        "branches": 64,
+        "functions": 93,
+        "lines": 88,
+        "statements": 88
       }
     },
     "setupFilesAfterEnv": [

--- a/backend/test/acceptance/auth.spec.js
+++ b/backend/test/acceptance/auth.spec.js
@@ -6,7 +6,7 @@
 
 'use strict'
 
-const { pick } = require('lodash')
+const { pick, head } = require('lodash')
 const assert = require('assert').strict
 const setCookieParser = require('set-cookie-parser')
 const { mockRequest } = require('@gardener-dashboard/request')
@@ -15,7 +15,8 @@ const security = require('../../lib/security')
 const {
   COOKIE_HEADER_PAYLOAD,
   COOKIE_SIGNATURE,
-  COOKIE_TOKEN
+  COOKIE_TOKEN,
+  decodeState
 } = security
 
 const ZERO_DATE = new Date(0)
@@ -26,16 +27,21 @@ class Client {
     user,
     issuer,
     client_id: clientId,
-    client_secret: clientSecret
+    client_secret: clientSecret,
+    redirect_uris: redirectUris,
+    response_types: responseTypes
   }) {
     this.user = user
     this.issuer = issuer
     this.clientId = clientId
     this.clientSecret = clientSecret
+    this.redirectUris = redirectUris
+    this.responseTypes = responseTypes
   }
 
   authorizationUrl ({
     redirect_uri: redirectUri,
+    state,
     scope
   }) {
     const url = new URL(this.issuer)
@@ -43,8 +49,9 @@ class Client {
     const params = url.searchParams
     params.append('client_id', this.clientId)
     params.append('redirect_uri', redirectUri)
+    params.append('state', state)
     params.append('scope', scope)
-    params.append('response_type', 'code')
+    params.append('response_type', head(this.responseTypes))
     return url.toString()
   }
 
@@ -84,7 +91,10 @@ describe('auth', function () {
     getIssuerClientStub = jest.spyOn(security, 'getIssuerClient').mockResolvedValue(client)
   })
 
-  it('should redirect to authorization url', async function () {
+  it('should redirect to authorization url without frontend redirectUrl', async function () {
+    const redirectPath = '/'
+    const redirectUri = head(oidc.redirect_uris)
+
     const res = await agent
       .get('/auth')
       .redirects(0)
@@ -93,8 +103,34 @@ describe('auth', function () {
     expect(getIssuerClientStub).toBeCalledTimes(1)
     const url = new URL(res.headers.location)
     expect(url.searchParams.get('client_id')).toBe(oidc.client_id)
-    expect(url.searchParams.get('redirect_uri')).toBe(oidc.redirect_uri)
+    expect(url.searchParams.get('redirect_uri')).toBe(redirectUri)
     expect(url.searchParams.get('scope')).toBe(oidc.scope)
+    const state = url.searchParams.get('state')
+    expect(decodeState(state)).toEqual({
+      redirectPath,
+      redirectUri
+    })
+  })
+
+  it('should redirect to authorization url with frontend redirectUrl', async function () {
+    const redirectPath = '/namespace/garden-foo/administration'
+    const redirectUri = head(oidc.redirect_uris)
+    const redirectUrl = new URL(redirectPath, redirectUri).toString()
+
+    const res = await agent
+      .get('/auth')
+      .query({ redirectUrl })
+      .redirects(0)
+      .expect(302)
+
+    expect(getIssuerClientStub).toBeCalledTimes(1)
+    const url = new URL(res.headers.location)
+    expect(url.searchParams.get('redirect_uri')).toBe(redirectUri)
+    const state = url.searchParams.get('state')
+    expect(decodeState(state)).toEqual({
+      redirectPath,
+      redirectUri
+    })
   })
 
   it('should fail to redirect to authorization url', async function () {

--- a/backend/test/acceptance/auth.spec.js
+++ b/backend/test/acceptance/auth.spec.js
@@ -94,6 +94,7 @@ describe('auth', function () {
   it('should redirect to authorization url without frontend redirectUrl', async function () {
     const redirectPath = '/'
     const redirectUri = head(oidc.redirect_uris)
+    const redirectOrigin = new URL(redirectUri).origin
 
     const res = await agent
       .get('/auth')
@@ -108,13 +109,14 @@ describe('auth', function () {
     const state = url.searchParams.get('state')
     expect(decodeState(state)).toEqual({
       redirectPath,
-      redirectUri
+      redirectOrigin
     })
   })
 
   it('should redirect to authorization url with frontend redirectUrl', async function () {
     const redirectPath = '/namespace/garden-foo/administration'
     const redirectUri = head(oidc.redirect_uris)
+    const redirectOrigin = new URL(redirectUri).origin
     const redirectUrl = new URL(redirectPath, redirectUri).toString()
 
     const res = await agent
@@ -129,7 +131,7 @@ describe('auth', function () {
     const state = url.searchParams.get('state')
     expect(decodeState(state)).toEqual({
       redirectPath,
-      redirectUri
+      redirectOrigin
     })
   })
 

--- a/backend/test/config.spec.js
+++ b/backend/test/config.spec.js
@@ -68,13 +68,9 @@ describe('config', function () {
     })
 
     describe('#loadConfig', function () {
-      const requiredEnvironmentVariables = {
+      const environmentVariables = {
         API_SERVER_URL: 'apiServerUrl',
-        SESSION_SECRET: 'secret', // pragma: whitelist secret
-        OIDC_ISSUER: 'issuer',
-        OIDC_CLIENT_ID: 'client_id',
-        OIDC_CLIENT_SECRET: 'client_secret', // pragma: whitelist secret
-        OIDC_REDIRECT_URI: 'redirect_uri'
+        SESSION_SECRET: 'secret'
       }
 
       beforeEach(() => {
@@ -84,7 +80,7 @@ describe('config', function () {
       it('should return the config in test environment', function () {
         const env = Object.assign({
           NODE_ENV: 'test'
-        }, requiredEnvironmentVariables)
+        }, environmentVariables)
 
         const config = gardener.loadConfig(undefined, { env })
         const defaults = gardener.getDefaults({ env })
@@ -94,7 +90,7 @@ describe('config', function () {
       it('should return the config in production environment', function () {
         const env = Object.assign({
           NODE_ENV: 'production'
-        }, requiredEnvironmentVariables)
+        }, environmentVariables)
 
         const filename = '/etc/gardener/1/config.yaml'
         const config = gardener.loadConfig(filename, { env })
@@ -109,7 +105,7 @@ describe('config', function () {
           NODE_ENV: 'production',
           PORT: '3456',
           LOG_LEVEL: 'error'
-        }, requiredEnvironmentVariables)
+        }, environmentVariables)
 
         const filename = '/etc/gardener/2/config.yaml'
         const config = gardener.loadConfig(filename, { env })
@@ -122,7 +118,7 @@ describe('config', function () {
       it('should return the config in development environment', function () {
         const env = Object.assign({
           NODE_ENV: 'development'
-        }, requiredEnvironmentVariables)
+        }, environmentVariables)
 
         const filename = '/etc/gardener/3/config.yaml'
         const config = gardener.loadConfig(filename, { env })
@@ -134,11 +130,15 @@ describe('config', function () {
 
       it('should return the config with oidc.ca overridden by environment variables', function () {
         const env = Object.assign({
+          OIDC_CLIENT_ID: 'client_id',
+          OIDC_CLIENT_SECRET: 'client_secret',
           OIDC_CA: 'ca'
-        }, requiredEnvironmentVariables)
+        }, environmentVariables)
 
         const filename = '/etc/gardener/4/config.yaml'
         const config = gardener.loadConfig(filename, { env })
+        expect(config.oidc.client_id).toBe('client_id')
+        expect(config.oidc.client_secret).toBe('client_secret')
         expect(config.oidc.ca).toBe('ca')
       })
     })

--- a/charts/__fixtures__/gardener-dashboard.js
+++ b/charts/__fixtures__/gardener-dashboard.js
@@ -21,7 +21,8 @@ const defaults = {
       'kubernetes.io/ingress.class': 'nginx'
     },
     hosts: [
-      'gardener.garden.example.org'
+      'dashboard.garden.example.org',
+      'dashboard.ingress.garden.example.org'
     ],
     tls: {
       secretName: 'default-gardener-dashboard-tls'
@@ -64,7 +65,6 @@ const defaults = {
     issuerUrl: 'https://identity.garden.example.org',
     clientId: 'dashboard',
     clientSecret: 'dashboardSecret',
-    redirectUri: 'https://gardener.garden.example.org/auth/callback',
     ca: getCertificate('...')
   },
   frontendConfig: {

--- a/charts/__fixtures__/identity.js
+++ b/charts/__fixtures__/identity.js
@@ -7,7 +7,13 @@
 'use strict'
 
 const releaseName = 'identity'
-const defaults = {}
+const defaults = {
+  dashboardOrigins: [
+    'https://dashboard.garden.example.org',
+    'https://dashboard.ingress.garden.example.org',
+    'http://localhost:8080'
+  ]
+}
 
 module.exports = {
   releaseName,

--- a/charts/__tests__/gardener-dashboard/__snapshots__/configmap.spec.js.snap
+++ b/charts/__tests__/gardener-dashboard/__snapshots__/configmap.spec.js.snap
@@ -108,7 +108,10 @@ Li4u
       "clientId": "kube-kubectl",
       "clientSecret": "kube-kubectl-secret",
     },
-    "redirect_uri": "https://gardener.garden.example.org/auth/callback",
+    "redirect_uris": Array [
+      "https://dashboard.garden.example.org/auth/callback",
+      "https://dashboard.ingress.garden.example.org/auth/callback",
+    ],
     "rejectUnauthorized": true,
     "scope": "openid email profile groups audience:server:client_id:dashboard audience:server:client_id:kube-kubectl",
   },
@@ -192,7 +195,10 @@ Object {
 Li4u
 -----END CERTIFICATE-----",
     "issuer": "https://identity.garden.example.org",
-    "redirect_uri": "https://gardener.garden.example.org/auth/callback",
+    "redirect_uris": Array [
+      "https://dashboard.garden.example.org/auth/callback",
+      "https://dashboard.ingress.garden.example.org/auth/callback",
+    ],
     "rejectUnauthorized": true,
     "scope": "openid email profile groups audience:server:client_id:dashboard audience:server:client_id:kube-kubectl",
   },

--- a/charts/__tests__/gardener-dashboard/__snapshots__/ingress.spec.js.snap
+++ b/charts/__tests__/gardener-dashboard/__snapshots__/ingress.spec.js.snap
@@ -22,7 +22,22 @@ Object {
   "spec": Object {
     "rules": Array [
       Object {
-        "host": "gardener.garden.example.org",
+        "host": "dashboard.garden.example.org",
+        "http": Object {
+          "paths": Array [
+            Object {
+              "backend": Object {
+                "serviceName": "gardener-dashboard-service",
+                "servicePort": 8080,
+              },
+              "path": "/",
+              "pathType": "Prefix",
+            },
+          ],
+        },
+      },
+      Object {
+        "host": "dashboard.ingress.garden.example.org",
         "http": Object {
           "paths": Array [
             Object {
@@ -40,7 +55,8 @@ Object {
     "tls": Array [
       Object {
         "hosts": Array [
-          "gardener.garden.example.org",
+          "dashboard.garden.example.org",
+          "dashboard.ingress.garden.example.org",
         ],
         "secretName": "other-gardener-dashboard-tls",
       },

--- a/charts/__tests__/gardener-dashboard/configmap-assets.spec.js
+++ b/charts/__tests__/gardener-dashboard/configmap-assets.spec.js
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 //
 // SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //

--- a/charts/__tests__/gardener-dashboard/configmap.spec.js
+++ b/charts/__tests__/gardener-dashboard/configmap.spec.js
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 //
 // SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //

--- a/charts/__tests__/gardener-dashboard/deployment.spec.js
+++ b/charts/__tests__/gardener-dashboard/deployment.spec.js
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 //
 // SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //

--- a/charts/__tests__/gardener-dashboard/ingress.spec.js
+++ b/charts/__tests__/gardener-dashboard/ingress.spec.js
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 //
 // SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //

--- a/charts/__tests__/gardener-dashboard/ingress.spec.js
+++ b/charts/__tests__/gardener-dashboard/ingress.spec.js
@@ -7,7 +7,13 @@
 'use strict'
 
 const { basename } = require('path')
-const { helm, helper } = fixtures
+const {
+  helm,
+  helper,
+  'gardener-dashboard': {
+    defaults
+  }
+} = fixtures
 const { getPrivateKey, getCertificate } = helper
 
 const chart = basename(__dirname)
@@ -62,7 +68,7 @@ describe('gardener-dashboard', function () {
       expect(ingress.spec.tls).toHaveLength(1)
       expect(ingress.spec.tls[0]).toEqual({
         secretName: tlsSecretName,
-        hosts: ['gardener.garden.example.org']
+        hosts: defaults.ingress.hosts
       })
 
       expect(tlsSecret).toBeFalsy()

--- a/charts/__tests__/gardener-dashboard/rbac.spec.js
+++ b/charts/__tests__/gardener-dashboard/rbac.spec.js
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 //
 // SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //

--- a/charts/__tests__/gardener-dashboard/secrets.spec.js
+++ b/charts/__tests__/gardener-dashboard/secrets.spec.js
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 //
 // SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //

--- a/charts/__tests__/gardener-dashboard/service.spec.js
+++ b/charts/__tests__/gardener-dashboard/service.spec.js
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 //
 // SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //

--- a/charts/__tests__/gardener-dashboard/serviceaccount.spec.js
+++ b/charts/__tests__/gardener-dashboard/serviceaccount.spec.js
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 //
 // SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //

--- a/charts/__tests__/gardener-dashboard/vpa.spec.js
+++ b/charts/__tests__/gardener-dashboard/vpa.spec.js
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 //
 // SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 //

--- a/charts/__tests__/identity/__snapshots__/configmap.spec.js.snap
+++ b/charts/__tests__/identity/__snapshots__/configmap.spec.js.snap
@@ -1,0 +1,81 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`identity configmap should render the template w/ defaults values 1`] = `
+Object {
+  "apiVersion": "v1",
+  "kind": "ConfigMap",
+  "metadata": Object {
+    "name": "identity-configmap",
+    "namespace": "garden",
+  },
+}
+`;
+
+exports[`identity configmap should render the template w/ defaults values 2`] = `
+Object {
+  "connectors": Array [
+    Object {
+      "config": Object {
+        "caData": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCkxpNHUKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ==",
+        "emailAttr": "email",
+        "entityIssuer": "identity.ingress.example.org",
+        "groupsAttr": "groups",
+        "nameIDPolicyFormat": "unspecified",
+        "redirectURI": "https://identity.ingress.example.org/callback",
+        "ssoIssuer": "saml.example.org",
+        "ssoURL": "https://saml.example.org/sso",
+        "usernameAttr": "name",
+      },
+      "id": "saml",
+      "name": "SAML",
+      "type": "saml",
+    },
+  ],
+  "enablePasswordDB": false,
+  "issuer": "https://identity.ingress.example.org",
+  "oauth2": Object {
+    "responseTypes": Array [
+      "token",
+      "code",
+      "id_token",
+    ],
+    "skipApprovalScreen": true,
+  },
+  "staticClients": Array [
+    Object {
+      "id": "dashboard",
+      "name": "Gardener Dashboard",
+      "redirectURIs": Array [
+        "https://dashboard.garden.example.org/auth/callback",
+        "https://dashboard.ingress.garden.example.org/auth/callback",
+        "http://localhost:8080/auth/callback",
+      ],
+      "secret": "sHq4vLoiQcIWbO3h",
+    },
+    Object {
+      "id": "kube-kubectl",
+      "name": "Kubectl",
+      "public": true,
+      "secret": "if6ji0dTFE4rQfj8",
+      "trustedPeers": Array [
+        "dashboard",
+      ],
+    },
+  ],
+  "staticPasswords": Array [],
+  "storage": Object {
+    "config": Object {
+      "inCluster": true,
+    },
+    "type": "kubernetes",
+  },
+  "web": Object {
+    "allowedOrigins": Array [
+      "https://dashboard.garden.example.org",
+      "https://dashboard.ingress.garden.example.org",
+      "http://localhost:8080",
+    ],
+    "http": "0.0.0.0:5556",
+  },
+}
+`;

--- a/charts/__tests__/identity/configmap.spec.js
+++ b/charts/__tests__/identity/configmap.spec.js
@@ -1,0 +1,37 @@
+//
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+'use strict'
+
+const yaml = require('js-yaml')
+const { omit } = require('lodash')
+const { basename } = require('path')
+const { helm } = fixtures
+
+const chart = basename(__dirname)
+const renderTemplates = (templates, values) => helm.renderChartTemplates(chart, templates, values)
+
+describe('identity', function () {
+  describe('configmap', function () {
+    let templates
+
+    beforeEach(() => {
+      templates = [
+        'configmap'
+      ]
+    })
+
+    it('should render the template w/ defaults values', async function () {
+      const documents = await renderTemplates(templates, {})
+      expect(documents).toHaveLength(1)
+      const [configMap] = documents
+      expect(omit(configMap, ['data'])).toMatchSnapshot()
+      expect(Object.keys(configMap.data)).toEqual(['config.yaml'])
+      const config = yaml.safeLoad(configMap.data['config.yaml'])
+      expect(config).toMatchSnapshot()
+    })
+  })
+})

--- a/charts/gardener-dashboard/templates/configmap.yaml
+++ b/charts/gardener-dashboard/templates/configmap.yaml
@@ -50,7 +50,11 @@ data:
     {{- if .Values.oidc }}
     oidc:
       issuer: {{ required ".Values.oidc.issuerUrl is required" .Values.oidc.issuerUrl }}
-      redirect_uri: {{ required ".Values.oidc.redirectUri is required" .Values.oidc.redirectUri }}
+      redirect_uris:
+      {{- $protocol := ternary "http" "https" ( empty .Values.ingress.tls ) }}
+      {{- range .Values.ingress.hosts }}
+      - "{{ $protocol }}://{{ . }}/auth/callback"
+      {{- end }}
       {{- if .Values.oidc.scope }}
       scope: {{ .Values.oidc.scope }}
       {{- else }}

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -84,8 +84,6 @@ oidc:
   # caSecretKeyRef:
   #   name: oidc-ca-secret-name
   #   key: ca.crt
-  # # redirectUri is the endpoint receiving the OTAC from the OpenID provider after successful login
-  # redirectUri: https://dashboard.ingress.example.org/auth/callback
   # # configuration for kubeconfig download required by kubelogin
   # public:
   #  # clientId is the identifier of the public oidc client use by kubelogin

--- a/charts/identity/templates/configmap.yaml
+++ b/charts/identity/templates/configmap.yaml
@@ -35,7 +35,6 @@ data:
       redirectURIs:
       {{- range .Values.dashboardOrigins }}
         - "{{ . }}/auth/callback"
-        - "{{ . }}/callback"
       {{- end }}
       name: Gardener Dashboard
       secret: {{ .Values.dashboardClientSecret }}

--- a/charts/jest.setup.js
+++ b/charts/jest.setup.js
@@ -17,7 +17,7 @@ beforeAll(function () {
 
 afterAll(function () {
   const dirname = process.env.HELM_VALUES_DIRNAME
-  fs.rmdirSync(dirname, {
+  fs.rmSync(dirname, {
     maxRetries: 100,
     recursive: true
   })

--- a/frontend/src/utils/auth.js
+++ b/frontend/src/utils/auth.js
@@ -31,19 +31,17 @@ export class UserManager {
 
   signout (err) {
     this.removeUser()
-    let path = '/auth/logout'
+    const url = new URL('/auth/logout', this.origin)
     if (err) {
-      path += `?error[message]=${encodeURIComponent(err.message)}`
+      url.searchParams.set('error[message]', err.message)
     }
-    window.location = this.origin + path
+    window.location = url
   }
 
-  signinWithOidc (redirectPath) {
-    let path = '/auth'
-    if (redirectPath) {
-      path += `?redirectPath=${encodeURIComponent(redirectPath)}`
-    }
-    window.location = this.origin + path
+  signinWithOidc (redirectPath = '/') {
+    const url = new URL('/auth', this.origin)
+    url.searchParams.set('redirectUrl', new URL(redirectPath, this.origin))
+    window.location = url
   }
 
   signinWithToken (token) {

--- a/frontend/src/utils/auth.js
+++ b/frontend/src/utils/auth.js
@@ -40,7 +40,8 @@ export class UserManager {
 
   signinWithOidc (redirectPath = '/') {
     const url = new URL('/auth', this.origin)
-    url.searchParams.set('redirectUrl', new URL(redirectPath, this.origin))
+    const redirectUrl = new URL(redirectPath, this.origin)
+    url.searchParams.set('redirectUrl', redirectUrl)
     window.location = url
   }
 

--- a/frontend/src/utils/auth.js
+++ b/frontend/src/utils/auth.js
@@ -35,13 +35,17 @@ export class UserManager {
     if (err) {
       url.searchParams.set('error[message]', err.message)
     }
-    window.location = url
+    this.redirect(url)
   }
 
   signinWithOidc (redirectPath = '/') {
     const url = new URL('/auth', this.origin)
     const redirectUrl = new URL(redirectPath, this.origin)
     url.searchParams.set('redirectUrl', redirectUrl)
+    this.redirect(url)
+  }
+
+  redirect (url) {
     window.location = url
   }
 

--- a/frontend/tests/unit/utils.auth.spec.js
+++ b/frontend/tests/unit/utils.auth.spec.js
@@ -1,0 +1,42 @@
+//
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import { UserManager } from '@/utils/auth'
+
+describe('utils', () => {
+  describe('auth', () => {
+    const origin = 'https://localhost:8443'
+    let auth
+
+    beforeEach(() => {
+      auth = new UserManager()
+      auth.origin = 'https://localhost:8443'
+      auth.redirect = jest.fn()
+    })
+
+    describe('#signinWithOidc', () => {
+      it('should redirect to the home view', () => {
+        auth.signinWithOidc()
+        expect(auth.redirect).toBeCalledTimes(1)
+        const url = new URL('/auth', origin)
+        url.searchParams.set('redirectUrl', new URL('/', origin))
+        expect(auth.redirect).toBeCalledTimes(1)
+        expect(auth.redirect.mock.calls[0]).toHaveLength(1)
+        expect(auth.redirect.mock.calls[0][0].href).toEqual(url.href)
+      })
+
+      it('should redirect to the admin view', () => {
+        auth.signinWithOidc()
+        expect(auth.redirect).toBeCalledTimes(1)
+        const url = new URL('/auth', origin)
+        url.searchParams.set('redirectUrl', new URL('/namespace/garden-foo/admin', origin))
+        expect(auth.redirect).toBeCalledTimes(1)
+        expect(auth.redirect.mock.calls[0]).toHaveLength(1)
+        expect(auth.redirect.mock.calls[0][0].href).toEqual(url.href)
+      })
+    })
+  })
+})

--- a/frontend/tests/unit/utils.auth.spec.js
+++ b/frontend/tests/unit/utils.auth.spec.js
@@ -11,6 +11,12 @@ describe('utils', () => {
     const origin = 'https://localhost:8443'
     let auth
 
+    function createRedirectUrl (redirectPath) {
+      const url = new URL('/auth', origin)
+      url.searchParams.set('redirectUrl', new URL(redirectPath, origin))
+      return url
+    }
+
     beforeEach(() => {
       auth = new UserManager()
       auth.origin = 'https://localhost:8443'
@@ -19,23 +25,19 @@ describe('utils', () => {
 
     describe('#signinWithOidc', () => {
       it('should redirect to the home view', () => {
+        const redirectPath = '/'
         auth.signinWithOidc()
         expect(auth.redirect).toBeCalledTimes(1)
-        const url = new URL('/auth', origin)
-        url.searchParams.set('redirectUrl', new URL('/', origin))
-        expect(auth.redirect).toBeCalledTimes(1)
         expect(auth.redirect.mock.calls[0]).toHaveLength(1)
-        expect(auth.redirect.mock.calls[0][0].href).toEqual(url.href)
+        expect(auth.redirect.mock.calls[0][0].href).toBe(createRedirectUrl(redirectPath).href)
       })
 
       it('should redirect to the admin view', () => {
-        auth.signinWithOidc()
-        expect(auth.redirect).toBeCalledTimes(1)
-        const url = new URL('/auth', origin)
-        url.searchParams.set('redirectUrl', new URL('/namespace/garden-foo/admin', origin))
+        const redirectPath = '/namespace/garden-foo/admin'
+        auth.signinWithOidc(redirectPath)
         expect(auth.redirect).toBeCalledTimes(1)
         expect(auth.redirect.mock.calls[0]).toHaveLength(1)
-        expect(auth.redirect.mock.calls[0][0].href).toEqual(url.href)
+        expect(auth.redirect.mock.calls[0][0].href).toBe(createRedirectUrl(redirectPath).href)
       })
     })
   })


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds full support for all hostnames configured in the dashboard ingress. This means that all hostnames are valid OIDC redirect URIs. The configuration property `.Values.oidc.redirectUri` is no longer used and has been removed. The list of valid OIDC redirect URIs is determined based on the ingress configuration.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Preserve the initial URL hostname during the OIDC login process 
```

```doc operator
Please note the following changes in the `values.yaml` file of the `gardener-dashboard` helm chart:
- The configuration property `.Values.oidc.redirectUri` is no longer used and has been removed. Instead, the list of valid OIDC redirect URIs is determined based on the ingress hosts `.Values.ingress.hosts`. If tls `.Values.ingress.tls` is active the redirect URI scheme is assumed to be `https` for all hosts.
```