### PR TITLE
Update the Alicloud RAM policy

### DIFF
--- a/frontend/src/components/dialogs/SecretDialogAlicloud.vue
+++ b/frontend/src/components/dialogs/SecretDialogAlicloud.vue
@@ -135,6 +135,11 @@ export default {
             ],
             Effect: 'Allow',
             Resource: '*'
+          },
+          {
+            Action: 'ros:*',
+            Effect: 'Allow',
+            Resource: '*'
           }
         ],
         Version: '1'


### PR DESCRIPTION
/kind enhancement

https://github.com/gardener/gardener-extension-provider-alicloud/pull/281 updates the Alicloud RAM policy, but this update is not reflected to the policy maintained in the dashboard.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
NONE
```
