### PR TITLE
Add configurable hints for machine image vendors

### DIFF
--- a/backend/lib/middleware.js
+++ b/backend/lib/middleware.js
@@ -11,6 +11,7 @@ const logger = require('./logger')
 const markdown = require('./markdown')
 const { NotFound, InternalServerError, isHttpError } = require('http-errors')
 const { STATUS_CODES } = require('http')
+const { CLIEngine } = require('eslint')
 
 function frontendConfig (config) {
   const converter = markdown.createConverter()
@@ -28,7 +29,8 @@ function frontendConfig (config) {
     addonDefinition = {},
     accessRestriction: {
       items = []
-    } = {}
+    } = {},
+    vendorHints = []
   } = frontendConfig
 
   convertAndSanitize(alert, 'message')
@@ -52,6 +54,10 @@ function frontendConfig (config) {
       convertAndSanitize(display, 'description')
       convertAndSanitize(input, 'description')
     }
+  }
+
+  for (const vendorHint of vendorHints) {
+    convertAndSanitize(vendorHint, 'hintMessage')
   }
 
   return (req, res, next) => {

--- a/backend/lib/middleware.js
+++ b/backend/lib/middleware.js
@@ -56,7 +56,7 @@ function frontendConfig (config) {
   }
 
   for (const vendorHint of vendorHints) {
-    convertAndSanitize(vendorHint, 'hintMessage')
+    convertAndSanitize(vendorHint, 'message')
   }
 
   return (req, res, next) => {

--- a/backend/lib/middleware.js
+++ b/backend/lib/middleware.js
@@ -11,7 +11,6 @@ const logger = require('./logger')
 const markdown = require('./markdown')
 const { NotFound, InternalServerError, isHttpError } = require('http-errors')
 const { STATUS_CODES } = require('http')
-const { CLIEngine } = require('eslint')
 
 function frontendConfig (config) {
   const converter = markdown.createConverter()

--- a/charts/__fixtures__/helm.js
+++ b/charts/__fixtures__/helm.js
@@ -31,7 +31,7 @@ async function renderChartTemplates (chart, templates, values) {
   try {
     fs.writeFileSync(filename, yaml.safeDump(values, { skipInvalid: true }))
     const cmd = [
-      '/usr/local/bin/helm',
+      'helm',
       'template',
       name,
       '-n',

--- a/charts/__tests__/gardener-dashboard/__snapshots__/configmap.spec.js.snap
+++ b/charts/__tests__/gardener-dashboard/__snapshots__/configmap.spec.js.snap
@@ -346,18 +346,18 @@ Object {
   "frontend": Object {
     "vendorHints": Array [
       Object {
-        "hintMessage": "[foo](https://bar.baz)",
-        "hintType": "warning",
-        "vendorNames": Array [
+        "matchNames": Array [
           "foo",
           "bar",
         ],
+        "message": "[foo](https://bar.baz)",
+        "severity": "warning",
       },
       Object {
-        "hintMessage": "other message",
-        "vendorNames": Array [
+        "matchNames": Array [
           "fooz",
         ],
+        "message": "other message",
       },
     ],
   },

--- a/charts/__tests__/gardener-dashboard/__snapshots__/configmap.spec.js.snap
+++ b/charts/__tests__/gardener-dashboard/__snapshots__/configmap.spec.js.snap
@@ -346,7 +346,7 @@ Object {
   "frontend": Object {
     "vendorHints": Array [
       Object {
-        "hintMessage": "hint message",
+        "hintMessage": "[foo](https://bar.baz)",
         "hintType": "warning",
         "vendorNames": Array [
           "foo",

--- a/charts/__tests__/gardener-dashboard/__snapshots__/configmap.spec.js.snap
+++ b/charts/__tests__/gardener-dashboard/__snapshots__/configmap.spec.js.snap
@@ -340,3 +340,26 @@ Object {
   },
 }
 `;
+
+exports[`gardener-dashboard configmap vendorHints should render the template 1`] = `
+Object {
+  "frontend": Object {
+    "vendorHints": Array [
+      Object {
+        "hintMessage": "hint message",
+        "hintType": "warning",
+        "vendorNames": Array [
+          "foo",
+          "bar",
+        ],
+      },
+      Object {
+        "hintMessage": "other message",
+        "vendorNames": Array [
+          "fooz",
+        ],
+      },
+    ],
+  },
+}
+`;

--- a/charts/__tests__/gardener-dashboard/configmap.spec.js
+++ b/charts/__tests__/gardener-dashboard/configmap.spec.js
@@ -304,5 +304,36 @@ describe('gardener-dashboard', function () {
         expect(pick(config, ['frontend.themes'])).toMatchSnapshot()
       })
     })
+
+    describe('vendorHints', function () {
+      it('should render the template', async function () {
+        const values = {
+          frontendConfig: {
+            vendorHints: [
+              {
+                vendorNames: [
+                  'foo',
+                  'bar'
+                ],
+                hintMessage: 'hint message',
+                hintType: 'warning'
+              },
+              {
+                vendorNames: [
+                  'fooz'
+                ],
+                hintMessage: 'other message'
+              }
+            ]
+          }
+        }
+
+        const documents = await renderTemplates(templates, values)
+        expect(documents).toHaveLength(1)
+        const [configMap] = documents
+        const config = yaml.safeLoad(configMap.data['config.yaml'])
+        expect(pick(config, ['frontend.vendorHints'])).toMatchSnapshot()
+      })
+    })
   })
 })

--- a/charts/__tests__/gardener-dashboard/configmap.spec.js
+++ b/charts/__tests__/gardener-dashboard/configmap.spec.js
@@ -311,18 +311,18 @@ describe('gardener-dashboard', function () {
           frontendConfig: {
             vendorHints: [
               {
-                vendorNames: [
+                matchNames: [
                   'foo',
                   'bar'
                 ],
-                hintMessage: '[foo](https://bar.baz)',
-                hintType: 'warning'
+                message: '[foo](https://bar.baz)',
+                severity: 'warning'
               },
               {
-                vendorNames: [
+                matchNames: [
                   'fooz'
                 ],
-                hintMessage: 'other message'
+                message: 'other message'
               }
             ]
           }

--- a/charts/__tests__/gardener-dashboard/configmap.spec.js
+++ b/charts/__tests__/gardener-dashboard/configmap.spec.js
@@ -315,7 +315,7 @@ describe('gardener-dashboard', function () {
                   'foo',
                   'bar'
                 ],
-                hintMessage: 'hint message',
+                hintMessage: '[foo](https://bar.baz)',
                 hintType: 'warning'
               },
               {

--- a/charts/gardener-dashboard/templates/configmap.yaml
+++ b/charts/gardener-dashboard/templates/configmap.yaml
@@ -301,3 +301,16 @@ data:
           {{- end }}
         {{- end }}
       {{- end }}
+      {{- if .Values.frontendConfig.vendorHints }}
+      vendorHints:
+        {{- range .Values.frontendConfig.vendorHints }}
+        - vendorNames:
+            {{- range .vendorNames }}
+            - {{ . }}
+            {{- end }}
+          hintMessage: {{ .hintMessage }}
+          {{- if .hintType }}
+          hintType: {{ .hintType }}
+          {{- end }}
+        {{- end }}
+      {{- end }}

--- a/charts/gardener-dashboard/templates/configmap.yaml
+++ b/charts/gardener-dashboard/templates/configmap.yaml
@@ -304,13 +304,10 @@ data:
       {{- if .Values.frontendConfig.vendorHints }}
       vendorHints:
         {{- range .Values.frontendConfig.vendorHints }}
-        - vendorNames:
-            {{- range .vendorNames }}
-            - {{ . }}
-            {{- end }}
-          hintMessage: {{ quote .hintMessage }}
-          {{- if .hintType }}
-          hintType: {{ .hintType }}
+        - matchNames: {{ toJson .matchNames }}
+          message: {{ quote .message }}
+          {{- if .severity }}
+          severity: {{ .severity }}
           {{- end }}
         {{- end }}
       {{- end }}

--- a/charts/gardener-dashboard/templates/configmap.yaml
+++ b/charts/gardener-dashboard/templates/configmap.yaml
@@ -308,7 +308,7 @@ data:
             {{- range .vendorNames }}
             - {{ . }}
             {{- end }}
-          hintMessage: {{ .hintMessage }}
+          hintMessage: {{ quote .hintMessage }}
           {{- if .hintType }}
           hintType: {{ .hintType }}
           {{- end }}

--- a/frontend/src/components/MultiMessage.vue
+++ b/frontend/src/components/MultiMessage.vue
@@ -28,12 +28,10 @@ export default {
         const obj = JSON.parse(this.message)
         const hints = Array.isArray(obj) ? obj : [obj]
 
-        return map(hints, ({ type, hint, severity }) => {
-          return {
-            type,
-            hint,
-            className: severity ? `${severity}--text` : undefined
-          }
+        const severities = ['info', 'success', 'warning', 'error']
+        return map(hints, ({ severity, ...rest }) => {
+          const className = severities.includes(severity) ? `${severity}--text` : ''
+          return { ...rest, className }
         })
       } catch (err) {
         return [

--- a/frontend/src/components/MultiMessage.vue
+++ b/frontend/src/components/MultiMessage.vue
@@ -1,0 +1,49 @@
+<!--
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+<template>
+  <div class="wrapper">
+    <template v-for="({ type, hint, className }, index) in hints">
+      <div v-if="type === 'html'" v-html="hint" :class="className" :key="index" />
+      <div v-else v-text="hint" :class="className" :key="index" />
+    </template>
+  </div>
+</template>
+
+<script>
+import map from 'lodash/map'
+
+export default {
+  props: {
+    message: {
+      type: String
+    }
+  },
+  computed: {
+    hints () {
+      try {
+        const obj = JSON.parse(this.message)
+        const hints = Array.isArray(obj) ? obj : [obj]
+
+        return map(hints, ({ type, hint, severity }) => {
+          return {
+            type,
+            hint,
+            className: severity ? `${severity}--text` : undefined
+          }
+        })
+      } catch (err) {
+        return [
+          {
+            type: 'text',
+            hint: this.message
+          }
+        ]
+      }
+    }
+  }
+}
+</script>

--- a/frontend/src/components/ShootWorkers/MachineImage.vue
+++ b/frontend/src/components/ShootWorkers/MachineImage.vue
@@ -111,8 +111,8 @@ export default {
       if (this.machineImage.vendorHint) {
         hints.push({
           type: 'html',
-          hint: transformHtml(this.machineImage.vendorHint.hintMessage),
-          severity: 'warning'
+          hint: transformHtml(this.machineImage.vendorHint.message),
+          severity: this.machineImage.vendorHint.severity
         })
       }
       if (this.machineImage.expirationDate) {

--- a/frontend/src/components/ShootWorkers/MachineImage.vue
+++ b/frontend/src/components/ShootWorkers/MachineImage.vue
@@ -4,7 +4,7 @@ SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener con
 SPDX-License-Identifier: Apache-2.0
 -->
 <template>
-  <hint-colorizer hint-color="warning">
+  <hint-colorizer :hint-color="hintColor">
     <v-select
       color="primary"
       item-color="primary"
@@ -107,8 +107,8 @@ export default {
     },
     hint () {
       const hintText = []
-      if (this.machineImage.needsLicense) {
-        hintText.push('The OS image selected requires a license and a contract for full enterprise support. By continuing you are confirming that you have a valid license and you have signed an enterprise support contract.')
+      if (this.machineImage.vendorHint) {
+        hintText.push(this.machineImage.vendorHint.hintMessage)
       }
       if (this.machineImage.expirationDate) {
         hintText.push(`Image version expires on: ${this.machineImage.expirationDateString}. Image update will be enforced after that date.`)
@@ -120,6 +120,17 @@ export default {
         hintText.push('Preview versions have not yet undergone thorough testing. There is a higher probability of undiscovered issues and are therefore not recommended for production usage')
       }
       return join(hintText, ' / ')
+    },
+    hintColor () {
+      if (this.machineImage.expirationDate ||
+         (this.updateOSMaintenance && this.selectedImageIsNotLatest) ||
+         this.machineImage.isPreview) {
+        return 'warning'
+      }
+      if (this.machineImage.vendorHint) {
+        return this.machineImage.vendorHint.hintType
+      }
+      return undefined
     },
     selectedImageIsNotLatest () {
       return selectedImageIsNotLatest(this.machineImage, this.machineImages)

--- a/frontend/src/components/ShootWorkers/MachineImage.vue
+++ b/frontend/src/components/ShootWorkers/MachineImage.vue
@@ -36,6 +36,9 @@ SPDX-License-Identifier: Apache-2.0
          {{item.name}} [{{item.version}}]
         </span>
       </template>
+      <template v-slot:message="{ message }">
+        <div v-html="message"></div>
+      </template>
     </v-select>
   </hint-colorizer>
 </template>
@@ -44,7 +47,7 @@ SPDX-License-Identifier: Apache-2.0
 import VendorIcon from '@/components/VendorIcon'
 import HintColorizer from '@/components/HintColorizer'
 import { required } from 'vuelidate/lib/validators'
-import { getValidationErrors, selectedImageIsNotLatest } from '@/utils'
+import { getValidationErrors, selectedImageIsNotLatest, transformHtml } from '@/utils'
 import includes from 'lodash/includes'
 import map from 'lodash/map'
 import pick from 'lodash/pick'
@@ -108,7 +111,7 @@ export default {
     hint () {
       const hintText = []
       if (this.machineImage.vendorHint) {
-        hintText.push(this.machineImage.vendorHint.hintMessage)
+        hintText.push(transformHtml(this.machineImage.vendorHint.hintMessage))
       }
       if (this.machineImage.expirationDate) {
         hintText.push(`Image version expires on: ${this.machineImage.expirationDateString}. Image update will be enforced after that date.`)
@@ -119,7 +122,7 @@ export default {
       if (this.machineImage.isPreview) {
         hintText.push('Preview versions have not yet undergone thorough testing. There is a higher probability of undiscovered issues and are therefore not recommended for production usage')
       }
-      return join(hintText, ' / ')
+      return join(hintText, '<br />')
     },
     hintColor () {
       if (this.machineImage.expirationDate ||

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -180,7 +180,7 @@ const vendorNameFromImageName = imageName => {
 }
 
 const findVendorHint = (vendorHints, vendorName) => {
-  return find(vendorHints, hint => includes(hint.vendorNames, vendorName))
+  return find(vendorHints, hint => includes(hint.matchNames, vendorName))
 }
 
 const matchesPropertyOrEmpty = (path, srcValue) => {

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -179,9 +179,8 @@ const vendorNameFromImageName = imageName => {
   return undefined
 }
 
-const vendorHint = (state, vendorName) => {
-  const hints = get(state.cfg, 'vendorHints')
-  return find(hints, hint => includes(hint.vendorNames, vendorName))
+const findVendorHint = (vendorHints, vendorName) => {
+  return find(vendorHints, hint => includes(hint.vendorNames, vendorName))
 }
 
 const matchesPropertyOrEmpty = (path, srcValue) => {
@@ -465,7 +464,7 @@ const getters = {
             expirationDate,
             vendorName,
             icon: vendorName,
-            vendorHint: vendorHint(state, vendorName)
+            vendorHint: findVendorHint(state.cfg.vendorHints, vendorName)
           })
         })
       }

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -453,6 +453,7 @@ const getters = {
 
         const name = machineImage.name
         const vendorName = vendorNameFromImageName(machineImage.name)
+        const vendorHint = findVendorHint(state.cfg.vendorHints, vendorName)
 
         return map(versions, ({ version, expirationDate, cri, classification }) => {
           return decorateClassificationObject({
@@ -464,7 +465,7 @@ const getters = {
             expirationDate,
             vendorName,
             icon: vendorName,
-            vendorHint: findVendorHint(state.cfg.vendorHints, vendorName)
+            vendorHint
           })
         })
       }

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -179,8 +179,9 @@ const vendorNameFromImageName = imageName => {
   return undefined
 }
 
-const vendorNeedsLicense = vendorName => {
-  return vendorName === 'suse-jeos' || vendorName === 'suse-chost'
+const vendorHint = (state, vendorName) => {
+  const hints = get(state.cfg, 'vendorHints')
+  return find(hints, hint => includes(hint.vendorNames, vendorName))
 }
 
 const matchesPropertyOrEmpty = (path, srcValue) => {
@@ -456,7 +457,7 @@ const getters = {
             expirationDateString: getDateFormatted(expirationDate),
             vendorName,
             icon: vendorName,
-            needsLicense: vendorNeedsLicense(vendorName)
+            vendorHint: vendorHint(state, vendorName)
           }
         })
       }

--- a/frontend/tests/unit/store.index.spec.js
+++ b/frontend/tests/unit/store.index.spec.js
@@ -89,7 +89,7 @@ describe('Store', () => {
     expect(suseImage.expirationDateString).toBeDefined()
     expect(suseImage.vendorName).toBe('suse-chost')
     expect(suseImage.icon).toBe('suse-chost')
-    expect(suseImage.vendorHint).toBe(storeState.cfg.vendorHints[0])
+    expect(suseImage.vendorHint).toEqual(storeState.cfg.vendorHints[0])
     expect(suseImage.classification).toBe('supported')
     expect(suseImage.isSupported).toBe(true)
     expect(suseImage.isDeprecated).toBe(false)
@@ -101,7 +101,7 @@ describe('Store', () => {
     expect(suseImage2.isPreview).toBe(true)
 
     const fooImage = find(dashboardMachineImages, { name: 'foo', version: '1.2.3' })
-    expect(fooImage.vendorHint).toBe(undefined)
+    expect(fooImage.vendorHint).toBeUndefined()
     expect(fooImage.isSupported).toBe(true)
   })
 

--- a/frontend/tests/unit/store.index.spec.js
+++ b/frontend/tests/unit/store.index.spec.js
@@ -58,7 +58,22 @@ describe('Store', () => {
       }
     }
 
-    const dashboardMachineImages = getters.machineImagesByCloudProfileName({}, storeGetters)('foo')
+    const storeState = {
+      cfg: {
+        vendorHints: [
+          {
+            vendorNames: [
+              'suse-jeos',
+              'suse-chost'
+            ],
+            hintMessage: 'test',
+            hintType: 'warning'
+          }
+        ]
+      }
+    }
+
+    const dashboardMachineImages = getters.machineImagesByCloudProfileName(storeState, storeGetters)('foo')
     expect(dashboardMachineImages).toHaveLength(5)
 
     const expiredImage = find(dashboardMachineImages, { name: 'suse-chost', version: '15.1.20191127' })
@@ -72,7 +87,7 @@ describe('Store', () => {
     expect(suseImage.expirationDateString).toBeDefined()
     expect(suseImage.vendorName).toBe('suse-chost')
     expect(suseImage.icon).toBe('suse-chost')
-    expect(suseImage.needsLicense).toBe(true)
+    expect(suseImage.vendorHint).toBe(storeState.cfg.vendorHints[0])
     expect(suseImage.classification).toBe('supported')
     expect(suseImage.isSupported).toBe(true)
     expect(suseImage.isDeprecated).toBe(false)
@@ -80,7 +95,7 @@ describe('Store', () => {
     expect(suseImage).toBe(dashboardMachineImages[2]) // check sorting
 
     const fooImage = find(dashboardMachineImages, { name: 'foo', version: '1.2.3' })
-    expect(fooImage.needsLicense).toBe(false)
+    expect(fooImage.vendorHint).toBe(undefined)
     expect(fooImage.isSupported).toBe(false)
   })
 

--- a/frontend/tests/unit/store.index.spec.js
+++ b/frontend/tests/unit/store.index.spec.js
@@ -63,12 +63,12 @@ describe('Store', () => {
       cfg: {
         vendorHints: [
           {
-            vendorNames: [
+            matchNames: [
               'suse-jeos',
               'suse-chost'
             ],
-            hintMessage: 'test',
-            hintType: 'warning'
+            message: 'test',
+            type: 'warning'
           }
         ]
       }


### PR DESCRIPTION
**What this PR does / why we need it**:
Some vendors require additional hints, e.g. to inform the user that an enterprise license is required for usage.
With this PR it is possible to define those hints via the dashboard configuration.

<img width="162" alt="Capture" src="https://user-images.githubusercontent.com/35373687/127617551-72dda480-e52a-4e27-94c2-c192cab31612.PNG">

Example:

```yaml
apiVersion: v1
kind: ConfigMap
data:
  config.yaml: |
    ---
    frontend:
      vendorHints:
        - matchNames:
            - suse-chost
            - suse-jeos
          message: Enterprise license required
          severity: warning
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
It is now possible to add configurable hints for machine image vendors
```
