### PR TITLE
Fix chart for sla config

### DIFF
--- a/charts/__tests__/gardener-dashboard/__snapshots__/configmap.spec.js.snap
+++ b/charts/__tests__/gardener-dashboard/__snapshots__/configmap.spec.js.snap
@@ -285,6 +285,17 @@ Object {
 }
 `;
 
+exports[`gardener-dashboard configmap themes should render the template with sla description markdown hyperlink 1`] = `
+Object {
+  "frontend": Object {
+    "sla": Object {
+      "description": "[foo](https://bar.baz)",
+      "title": "SLA title",
+    },
+  },
+}
+`;
+
 exports[`gardener-dashboard configmap tickets should render the template 1`] = `
 Object {
   "frontend": Object {

--- a/charts/__tests__/gardener-dashboard/configmap.spec.js
+++ b/charts/__tests__/gardener-dashboard/configmap.spec.js
@@ -303,6 +303,22 @@ describe('gardener-dashboard', function () {
         const config = yaml.safeLoad(configMap.data['config.yaml'])
         expect(pick(config, ['frontend.themes'])).toMatchSnapshot()
       })
+
+      it('should render the template with sla description markdown hyperlink', async function () {
+        const values = {
+          frontendConfig: {
+            sla: {
+              title: 'SLA title',
+              description: '[foo](https://bar.baz)'
+            }
+          }
+        }
+        const documents = await renderTemplates(templates, values)
+        expect(documents).toHaveLength(1)
+        const [configMap] = documents
+        const config = yaml.safeLoad(configMap.data['config.yaml'])
+        expect(pick(config, ['frontend.sla'])).toMatchSnapshot()
+      })
     })
   })
 })

--- a/charts/gardener-dashboard/templates/configmap.yaml
+++ b/charts/gardener-dashboard/templates/configmap.yaml
@@ -244,7 +244,7 @@ data:
       {{- if .Values.frontendConfig.sla }}
       sla:
         title: {{ .Values.frontendConfig.sla.title }}
-        description: {{ .Values.frontendConfig.sla.description }}
+        description: {{ toJson .Values.frontendConfig.sla.description }}
       {{- end }}
       {{- if .Values.frontendConfig.accessRestriction }}
       accessRestriction:

--- a/charts/gardener-dashboard/templates/configmap.yaml
+++ b/charts/gardener-dashboard/templates/configmap.yaml
@@ -32,7 +32,7 @@ data:
     gitHub:
       apiUrl: {{ .Values.gitHub.apiUrl }}
       {{- if .Values.gitHub.ca }}
-      ca: {{ toJson .Values.gitHub.ca }}
+      ca: {{ quote .Values.gitHub.ca }}
       {{- end }}
       org: {{ .Values.gitHub.org }}
       repository: {{ .Values.gitHub.repository }}
@@ -66,7 +66,7 @@ data:
       rejectUnauthorized: true
       {{- end }}
       {{- if .Values.oidc.ca }}
-      ca: {{ toJson .Values.oidc.ca }}
+      ca: {{ quote .Values.oidc.ca }}
       {{- end }}
       {{- if .Values.oidc.clockTolerance }}
       clockTolerance: {{ .Values.oidc.clockTolerance }}
@@ -182,7 +182,7 @@ data:
         {{- end }}
         gitHubRepoUrl: {{ .Values.frontendConfig.ticket.gitHubRepoUrl }}
         avatarSource: {{ .Values.frontendConfig.ticket.avatarSource | default "github" }}
-        issueDescriptionTemplate: {{ toJson .Values.frontendConfig.ticket.issueDescriptionTemplate }}
+        issueDescriptionTemplate: {{ quote .Values.frontendConfig.ticket.issueDescriptionTemplate }}
       {{- end }}
       features:
         terminalEnabled: {{ .Values.frontendConfig.features.terminalEnabled | default false }}
@@ -244,12 +244,12 @@ data:
       {{- if .Values.frontendConfig.sla }}
       sla:
         title: {{ .Values.frontendConfig.sla.title }}
-        description: {{ toJson .Values.frontendConfig.sla.description }}
+        description: {{ quote .Values.frontendConfig.sla.description }}
       {{- end }}
       {{- if .Values.frontendConfig.accessRestriction }}
       accessRestriction:
         {{- if  .Values.frontendConfig.accessRestriction.noItemsText }}
-        noItemsText: {{ toJson .Values.frontendConfig.accessRestriction.noItemsText }}
+        noItemsText: {{ quote .Values.frontendConfig.accessRestriction.noItemsText }}
         {{- end }}
         items:
         {{- range .Values.frontendConfig.accessRestriction.items }}
@@ -259,9 +259,9 @@ data:
             title: {{ .display.title }}{{- end }}{{- if .display.description }}
             description: {{ .display.description }}{{- end }}
           input:
-            title: {{ toJson .input.title }}
+            title: {{ quote .input.title }}
             {{- if .input.description }}
-            description: {{ toJson .input.description }}
+            description: {{ quote .input.description }}
             {{- end }}
             {{- if .input.inverted }}
             inverted: {{ .input.inverted }}
@@ -275,9 +275,9 @@ data:
               title: {{ .display.title }}{{- end }}{{- if .display.description }}
               description: {{ .display.description }}{{- end }}
             input:
-              title: {{ toJson .input.title }}
+              title: {{ quote .input.title }}
               {{- if .input.description }}
-              description: {{ toJson .input.description }}
+              description: {{ quote .input.description }}
               {{- end }}
               {{- if .input.inverted }}
               inverted: {{ .input.inverted }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently it is not possible have a markdown link within the description of the `sla` config.

Example:
```yaml
frontendConfig:
  sla:
    title: foo
    description: "[foo](https://bar.baz)"
```

This produced the following ConfigMap (snipped):
```yaml
apiVersion: v1
kind: ConfigMap
data:
  config.yaml: |
    ---
    frontend:
      sla:
        title: SLAs
        description: [foo](https://bar.baz)
```

instead of (note the quoted description string):
```yaml
apiVersion: v1
kind: ConfigMap
data:
  config.yaml: |
    ---
    frontend:
      sla:
        title: SLAs
        description: "[foo](https://bar.baz)"
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
