### PR TITLE
[hotfix 1.51] Unify width of dialogs

### DIFF
--- a/frontend/src/components/PurposeConfiguration.vue
+++ b/frontend/src/components/PurposeConfiguration.vue
@@ -10,7 +10,7 @@ SPDX-License-Identifier: Apache-2.0
     :valid="valid"
     @dialog-opened="onConfigurationDialogOpened"
     ref="actionDialog"
-    width="400"
+    width="450"
     caption="Configure Purpose">
     <template v-slot:actionComponent>
       <purpose

--- a/frontend/src/components/ShootAccessRestrictions/AccessRestrictionsConfiguration.vue
+++ b/frontend/src/components/ShootAccessRestrictions/AccessRestrictionsConfiguration.vue
@@ -11,7 +11,7 @@ SPDX-License-Identifier: Apache-2.0
     :tooltip="tooltip"
     @dialog-opened="onConfigurationDialogOpened"
     ref="actionDialog"
-    width="760"
+    width="900"
     caption="Configure Access Restrictions">
     <template v-slot:actionComponent>
       <access-restrictions

--- a/frontend/src/components/ShootDns/DnsConfiguration.vue
+++ b/frontend/src/components/ShootDns/DnsConfiguration.vue
@@ -10,7 +10,7 @@ SPDX-License-Identifier: Apache-2.0
     :valid="dnsConfigurationValid"
     ref="actionDialog"
     caption="Configure DNS"
-    width="1000"
+    width="900"
     confirm-required
     @dialog-opened="onConfigurationDialogOpened"
     >

--- a/frontend/src/components/ShootHibernation/HibernationConfiguration.vue
+++ b/frontend/src/components/ShootHibernation/HibernationConfiguration.vue
@@ -10,6 +10,7 @@ SPDX-License-Identifier: Apache-2.0
     :valid="hibernationScheduleValid"
     @dialog-opened="onConfigurationDialogOpened"
     ref="actionDialog"
+    width="900"
     caption="Configure Hibernation Schedule">
     <template v-slot:actionComponent>
       <manage-hibernation-schedule

--- a/frontend/src/components/ShootMaintenance/MaintenanceConfiguration.vue
+++ b/frontend/src/components/ShootMaintenance/MaintenanceConfiguration.vue
@@ -10,6 +10,7 @@ SPDX-License-Identifier: Apache-2.0
     :valid="maintenanceTimeValid"
     @dialog-opened="onConfigurationDialogOpened"
     ref="actionDialog"
+    width="900"
     caption="Configure Maintenance">
     <template v-slot:actionComponent>
       <maintenance-time

--- a/frontend/src/components/ShootMaintenance/MaintenanceStart.vue
+++ b/frontend/src/components/ShootMaintenance/MaintenanceStart.vue
@@ -10,10 +10,10 @@ SPDX-License-Identifier: Apache-2.0
     :loading="isMaintenanceToBeScheduled"
     @dialog-opened="startDialogVisible"
     ref="actionDialog"
+    width="900"
     :caption="caption"
     icon="mdi-refresh"
     :button-text="buttonText"
-    max-width="850"
     confirm-button-text="Trigger now">
     <template v-slot:actionComponent>
       <div class="text-subtitle-1 pt-4">Do you want to start the maintenance of your cluster outside of the configured maintenance time window?</div>

--- a/frontend/src/components/ShootVersion/ShootVersion.vue
+++ b/frontend/src/components/ShootVersion/ShootVersion.vue
@@ -45,6 +45,7 @@ SPDX-License-Identifier: Apache-2.0
       :error-message.sync="updateErrorMessage"
       :detailed-error-message.sync="updateDetailedErrorMessage"
       ref="gDialog"
+      width="450"
       >
       <template v-slot:caption>Update Cluster</template>
       <template v-slot:affectedObjectName>{{shootName}}</template>

--- a/frontend/src/components/ShootWorkers/WorkerConfiguration.vue
+++ b/frontend/src/components/ShootWorkers/WorkerConfiguration.vue
@@ -10,7 +10,7 @@ SPDX-License-Identifier: Apache-2.0
     :valid="workersValid"
     @dialog-opened="onConfigurationDialogOpened"
     ref="actionDialog"
-    width="1000"
+    width="900"
     confirm-required
     caption="Configure Workers"
     disable-confirm-input-focus>

--- a/frontend/src/components/dialogs/CreateTerminalSessionDialog.vue
+++ b/frontend/src/components/dialogs/CreateTerminalSessionDialog.vue
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Apache-2.0
   <g-dialog
     confirm-button-text="Create"
     :confirm-disabled="!valid"
-    width="750px"
+    width="750"
     max-height="100vh"
     ref="gDialog"
   >

--- a/frontend/src/components/dialogs/TerminalSettingsDialog.vue
+++ b/frontend/src/components/dialogs/TerminalSettingsDialog.vue
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Apache-2.0
   <g-dialog
     confirm-button-text="Change"
     :confirm-disabled="!validSettings"
-    width="750px"
+    width="750"
     max-height="100vh"
     ref="gDialog"
     >

--- a/frontend/src/components/dialogs/UnverifiedTerminalShortcutsDialog.vue
+++ b/frontend/src/components/dialogs/UnverifiedTerminalShortcutsDialog.vue
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 <template>
   <g-dialog
     confirm-button-text="Confirm"
-    width="750px"
+    width="750"
     max-height="100vh"
     ref="gDialog"
     >

--- a/frontend/src/components/dialogs/WebterminalServiceAccountDialog.vue
+++ b/frontend/src/components/dialogs/WebterminalServiceAccountDialog.vue
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 <template>
   <g-dialog
     :confirm-button-text="confirmButtonText"
-    width="750px"
+    width="750"
     max-height="100vh"
     ref="gDialog"
     >

--- a/frontend/src/views/Administration.vue
+++ b/frontend/src/views/Administration.vue
@@ -292,7 +292,8 @@ SPDX-License-Identifier: Apache-2.0
     <g-dialog
       :error-message.sync="errorMessage"
       :detailed-error-message.sync="detailedErrorMessage"
-      ref="gDialog">
+      ref="gDialog"
+      width="600">
       <template v-slot:caption>
         Confirm Delete
       </template>


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR unifies the default width of all dialogs to four sizes 450px, 600px, 750px and 900px.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixes a bug with the size of dialogs. In some cases the dialogs were too small to display the complete content clearly. The size of all dialogs has been adjusted and unified.
```
