### PR TITLE
[hotfix-1.51] Fix typo in TicketComment component

### DIFF
--- a/frontend/src/components/ShootTickets/TicketComment.vue
+++ b/frontend/src/components/ShootTickets/TicketComment.vue
@@ -16,7 +16,7 @@ SPDX-License-Identifier: Apache-2.0
     </v-list-item-icon>
     <v-list-item-content class="comment">
       <v-list-item-title class="comment-header toolbar-background toolbar-title--text">
-        <span class="font-weight-bold">{{login}}</span> commented <a :href="sanitizeUr(htmlUrl)" target="_blank" rel="noopener"><time-string :date-time="createdAt" mode="past" class="toolbar-title--text"></time-string></a>
+        <span class="font-weight-bold">{{login}}</span> commented <a :href="sanitizeUrl(htmlUrl)" target="_blank" rel="noopener"><time-string :date-time="createdAt" mode="past" class="toolbar-title--text"></time-string></a>
       </v-list-item-title>
       <v-list-item-subtitle class="wrap-text comment-body" v-html="commentHtml"></v-list-item-subtitle>
     </v-list-item-content>


### PR DESCRIPTION
**What this PR does / why we need it**:
A typo in the TicketComment component causes it not to be rendered anymore.

**Which issue(s) this PR fixes**:
Fixes #1078

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed an issue in the TicketComment component causes it not to be rendered anymore.
```
