### PR TITLE
[master] Fixes regarding worker cri configuration

### DIFF
--- a/frontend/src/components/ShootWorkers/ContainerRuntime.vue
+++ b/frontend/src/components/ShootWorkers/ContainerRuntime.vue
@@ -34,7 +34,7 @@ SPDX-License-Identifier: Apache-2.0
 </template>
 
 <script>
-import { required } from 'vuelidate/lib/validators'
+import { requiredIf } from 'vuelidate/lib/validators'
 import { getValidationErrors, defaultCriNameByKubernetesVersion } from '@/utils'
 import find from 'lodash/find'
 import map from 'lodash/map'
@@ -52,7 +52,7 @@ const validationErrors = {
 
 const validations = {
   criName: {
-    required
+    required: requiredIf('criNameIsRequired')
   }
 }
 
@@ -69,6 +69,10 @@ export default {
     kubernetesVersion: {
       type: String,
       required: true
+    },
+    criNameIsRequired: {
+      type: Boolean,
+      default: false
     }
   },
   data () {
@@ -83,7 +87,7 @@ export default {
       return map(this.machineImageCri, 'name')
     },
     criContainerRuntimeTypes () {
-      const containerRuntime = find(this.machineImageCri, ['name', this.containerRuntime])
+      const containerRuntime = find(this.machineImageCri, ['name', this.criName])
       const ociRuntimes = get(containerRuntime, 'containerRuntimes', [])
       return map(ociRuntimes, 'type')
     },
@@ -92,7 +96,10 @@ export default {
         return get(this.worker, 'cri.name')
       },
       set (value) {
-        set(this.worker, 'cri.name', value)
+        this.$set(this.worker, 'cri', {
+          ...this.worker.cri,
+          name: value
+        })
       }
     },
     selectedCriContainerRuntimeTypes: {

--- a/frontend/src/components/ShootWorkers/WorkerInputGeneric.vue
+++ b/frontend/src/components/ShootWorkers/WorkerInputGeneric.vue
@@ -41,6 +41,7 @@ SPDX-License-Identifier: Apache-2.0
           :machine-image-cri="machineImageCri"
           :worker="worker"
           :kubernetes-version="kubernetesVersion"
+          :cri-name-is-required="isNew"
           @valid="onContainerRuntimeValid">
         </container-runtime>
       </div>

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -61,6 +61,7 @@ import forOwn from 'lodash/forOwn'
 import replace from 'lodash/replace'
 import sample from 'lodash/sample'
 import split from 'lodash/split'
+import pick from 'lodash/pick'
 
 import moment from '@/utils/moment'
 import { ioPlugin } from '@/utils/Emitter'
@@ -1114,7 +1115,7 @@ const getters = {
         maxSurge: 1,
         machine: {
           type: machineType.name,
-          image: machineImage
+          image: pick(machineImage, ['name', 'version'])
         },
         zones,
         cri: {


### PR DESCRIPTION
Existing workers may keep cri.name empty without failing validation
Selecting a container runtime validates correctly
Machine image included internal properties in create shoot editor
additional container runtimes selection did no longer show up

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
