### PR TITLE
[hotfix-1.51] DNS provider w/o secretBinding should be readonly

### DIFF
--- a/frontend/src/components/SelectSecret.vue
+++ b/frontend/src/components/SelectSecret.vue
@@ -11,6 +11,7 @@ SPDX-License-Identifier: Apache-2.0
       color="primary"
       item-color="primary"
       label="Secret"
+      :disabled="disabled"
       :items="secretList"
       item-value="metadata.name"
       return-object
@@ -70,6 +71,10 @@ export default {
     valid: {
       type: Boolean,
       default: true
+    },
+    disabled: {
+      type: Boolean,
+      default: false
     },
     cloudProfileName: {
       type: String

--- a/frontend/src/components/ShootDns/DnsProvider.vue
+++ b/frontend/src/components/ShootDns/DnsProvider.vue
@@ -16,7 +16,7 @@ SPDX-License-Identifier: Apache-2.0
         outlined
         class="cursor-pointer my-0 ml-0">
           <vendor-icon :value="type" :size="20"></vendor-icon>
-          {{secretName}}
+          <span class="px-1">{{secretName}}</span>
           <v-icon v-if="primary" small>mdi-star</v-icon>
       </v-chip>
     </template>

--- a/frontend/src/components/ShootDns/ManageDns.vue
+++ b/frontend/src/components/ShootDns/ManageDns.vue
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Apache-2.0
   <v-container class="pa-0 ma-0">
     <template v-if="dnsProviderIds.length">
       <v-row class="ma-0">
-        <v-col cols="6">
+        <v-col cols="7">
           <v-text-field
             color="primary"
             label="Cluster Domain"
@@ -19,7 +19,7 @@ SPDX-License-Identifier: Apache-2.0
             :hint="domainHint"
           ></v-text-field>
         </v-col>
-        <v-col cols="3" v-show="primaryProviderVisible">
+        <v-col cols="4" v-show="primaryProviderVisible">
           <v-select
             color="primary"
             item-color="primary"


### PR DESCRIPTION
**What this PR does / why we need it**:
If no secret binding was found for a given secretName and the cluster is not new,
then we assume that the secret exists and was manually created.
The DNS provider row should not be changed in this case.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed a problem in the DNS provider configuration that caused a newly added DNS provider to always be disabled on an existing cluster.
```
