### PR TITLE
[master] Do not show scrollbars when there is enough space.

### DIFF
--- a/frontend/src/components/GPopper.vue
+++ b/frontend/src/components/GPopper.vue
@@ -138,7 +138,7 @@ export default {
   .inner-card {
     max-width: 1000px;
     max-height: 85vh;
-    overflow-y: scroll;
+    overflow-y: auto;
   }
 
   ::v-deep .v-toolbar__content {

--- a/frontend/src/components/ProjectServiceAccountRow.vue
+++ b/frontend/src/components/ProjectServiceAccountRow.vue
@@ -191,6 +191,6 @@ export default {
   .description-column {
     max-width: 20vw;
     max-height: 60px;
-    overflow: scroll;
+    overflow: auto;
   }
 </style>

--- a/frontend/src/components/ShootDetails/ShootAccessCard.vue
+++ b/frontend/src/components/ShootDetails/ShootAccessCard.vue
@@ -300,7 +300,7 @@ export default {
 <style lang="scss" scoped>
 
   .scroll {
-    overflow-x: scroll;
+    overflow-x: auto;
   }
 
   .wrap-text {

--- a/frontend/src/components/ShootHibernation/HibernationScheduleEvent.vue
+++ b/frontend/src/components/ShootHibernation/HibernationScheduleEvent.vue
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 -->
 
 <template>
-  <v-row align="center">
+  <v-row align="center" class="ma-0">
     <v-col cols="11">
       <v-row class="ma-0">
         <v-col cols="5">

--- a/frontend/src/components/ShootMessageDetails.vue
+++ b/frontend/src/components/ShootMessageDetails.vue
@@ -144,7 +144,7 @@ export default {
 
   .message-block {
     max-height: 230px;
-    overflow-y: scroll;
+    overflow-y: auto;
   }
 
   .wrap {

--- a/frontend/src/components/dialogs/SecretDialog.vue
+++ b/frontend/src/components/dialogs/SecretDialog.vue
@@ -341,7 +341,7 @@ export default {
 
   .help {
     max-width: 80%;
-    overflow-y: scroll;
+    overflow-y: auto;
   }
 
 </style>

--- a/frontend/src/views/NewShoot.vue
+++ b/frontend/src/views/NewShoot.vue
@@ -523,7 +523,7 @@ export default {
 
   .newshoot-cards {
     max-height: calc(100% - 48px);
-    overflow: scroll;
+    overflow: auto;
   }
 
 </style>


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the problem that scroll bars are displayed in the UI even if there is enough space available

**Which issue(s) this PR fixes**:
Fixes #1085 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixes the problem that scroll bars are displayed in the UI even if there is enough space available.
```
