### PR TITLE
add support for image references with digests in the helm charts

### DIFF
--- a/charts/gardener-dashboard/templates/_helper.tpl
+++ b/charts/gardener-dashboard/templates/_helper.tpl
@@ -1,0 +1,7 @@
+{{- define "image" -}}
+{{- if hasPrefix "sha256:" (required "$.tag is required" $.tag) -}}
+{{ required "$.repository is required" $.repository }}@{{ required "$.tag is required" $.tag }}
+{{- else -}}
+{{ required "$.repository is required" $.repository }}:{{ required "$.tag is required" $.tag }}
+{{- end -}}
+{{- end -}}

--- a/charts/gardener-dashboard/templates/deployment.yaml
+++ b/charts/gardener-dashboard/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
         - name: gardener-dashboard
           args:
             - /etc/gardener-dashboard/config.yaml
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ include "image" .Values.image }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/identity/templates/_helper.tpl
+++ b/charts/identity/templates/_helper.tpl
@@ -1,0 +1,7 @@
+{{- define "image" -}}
+{{- if hasPrefix "sha256:" (required "$.tag is required" $.tag) -}}
+{{ required "$.repository is required" $.repository }}@{{ required "$.tag is required" $.tag }}
+{{- else -}}
+{{ required "$.repository is required" $.repository }}:{{ required "$.tag is required" $.tag }}
+{{- end -}}
+{{- end -}}

--- a/charts/identity/templates/deployment.yaml
+++ b/charts/identity/templates/deployment.yaml
@@ -58,7 +58,7 @@ spec:
             - /usr/local/bin/dex
             - serve
             - /etc/dex/config.yaml
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ include "image" .Values.image }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           livenessProbe:
             failureThreshold: 3


### PR DESCRIPTION
**What this PR does / why we need it**:

add support in the helm charts for image references with digests

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
NONE
```
