### PR TITLE
[master] Fixed memory leak in cluster list

### DIFF
--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -15,9 +15,9 @@ const App = Vue.extend({
   created () {
     // provide the keyboard events for dialogs. Dialogs can't catch keyboard events
     // if any input element of the dialog didn't have the focus.
-    window.addEventListener('keyup', ({ keyCode }) => {
-      if (keyCode === 27) {
-        this.$bus.$emit('esc-pressed')
+    window.addEventListener('keyup', ({ key }) => {
+      if (key === 'Escape' || key === 'Esc') {
+        this.$bus.emit('esc-pressed')
       }
     })
 

--- a/frontend/src/components/GPopper.vue
+++ b/frontend/src/components/GPopper.vue
@@ -38,7 +38,6 @@ SPDX-License-Identifier: Apache-2.0
 
 <script>
 import Popper from 'vue-popperjs'
-import { closePopover } from '@/utils'
 import 'vue-popperjs/dist/vue-popper.css'
 
 export default {
@@ -86,8 +85,10 @@ export default {
     }
   },
   methods: {
-    closePopover () {
-      closePopover(this.$refs.popper)
+    closePopper () {
+      if (this.$refs.popper) {
+        this.$refs.popper.doClose()
+      }
     },
     customArrowStyles (data) {
       if (data.placement === 'bottom') {
@@ -113,12 +114,13 @@ export default {
   },
   created () {
     /*
-       * listen on the global "esc-key" event to close all tooltips.
-       * shorthand instead of click outside of the tooltip.
-       */
-    this.$bus.$on('esc-pressed', () => {
-      this.closePopover()
-    })
+     * listen on the global "esc-key" event to close all tooltips.
+     * shorthand instead of click outside of the tooltip.
+     */
+    this.$bus.on('esc-pressed', this.closePopper)
+  },
+  beforeDestroy () {
+    this.$bus.off('esc-pressed', this.closePopper)
   }
 }
 </script>

--- a/frontend/src/plugins/bus.js
+++ b/frontend/src/plugins/bus.js
@@ -5,11 +5,15 @@
 //
 
 import Vue from 'vue'
+import EventEmitter from 'events'
 
 const VueBus = {
   install (Vue) {
-    const bus = new Vue({})
-    Object.defineProperty(Vue.prototype, '$bus', { value: bus })
+    const bus = new EventEmitter()
+    bus.setMaxListeners(200)
+    Object.defineProperty(Vue.prototype, '$bus', {
+      value: bus
+    })
   }
 }
 

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -72,15 +72,6 @@ export function handleTextFieldDrop (textField, fileTypePattern, onDrop = (value
   textarea.addEventListener('drop', drop, false)
 }
 
-/*
- * popperRefs can be an array or a vue popper object
- */
-export function closePopover (refs) {
-  if (refs) {
-    [].concat(refs).forEach(ref => ref.doClose())
-  }
-}
-
 export function getValidationErrors (vm, field) {
   const errors = []
   const validationForField = get(vm.$v, field)

--- a/frontend/src/views/Members.vue
+++ b/frontend/src/views/Members.vue
@@ -247,7 +247,6 @@ export default {
       serviceAccountDescription: undefined,
       userFilter: '',
       serviceAccountFilter: '',
-      fab: false,
       currentServiceAccountName: undefined,
       currentServiceAccountKubeconfig: undefined,
       userAccountTableOptions: undefined,
@@ -654,6 +653,15 @@ export default {
         ...this.defaultServiceAccountTableOptions,
         ...serviceAccountTableOptions
       }
+    },
+    closeDialogs () {
+      this.userAddDialog = false
+      this.userHelpDialog = false
+      this.userUpdateDialog = false
+      this.serviceAccountAddDialog = false
+      this.serviceAccountHelpDialog = false
+      this.serviceAccountUpdateDialog = false
+      this.kubeconfigDialog = false
     }
   },
   watch: {
@@ -679,16 +687,10 @@ export default {
     }
   },
   created () {
-    this.$bus.$on('esc-pressed', () => {
-      this.userAddDialog = false
-      this.userHelpDialog = false
-      this.userUpdateDialog = false
-      this.serviceAccountAddDialog = false
-      this.serviceAccountHelpDialog = false
-      this.serviceAccountUpdateDialog = false
-      this.kubeconfigDialog = false
-      this.fab = false
-    })
+    this.$bus.on('esc-pressed', this.closeDialogs)
+  },
+  beforeDestroy () {
+    this.$bus.off('esc-pressed', this.closeDialogs)
   },
   beforeRouteEnter (to, from, next) {
     next(vm => {

--- a/frontend/tests/unit/StatusTag.spec.js
+++ b/frontend/tests/unit/StatusTag.spec.js
@@ -5,9 +5,9 @@
 //
 
 // Libraries
-import Vue from 'vue'
 import Vuetify from 'vuetify'
 import Vuex from 'vuex'
+import EventEmitter from 'events'
 
 // Components
 import StatusTag from '@/components/StatusTag'
@@ -18,7 +18,7 @@ import { state, actions, getters, mutations } from '@/store'
 
 describe('StatusTag.vue', () => {
   const localVue = createLocalVue()
-  const bus = new Vue({})
+  const bus = new EventEmitter()
 
   localVue.use(Vuetify)
   localVue.use(Vuex)


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixed a memory leak problem caused by registering popovers to the global esc key event. The popover components were registered to the global esc key event on creation but not deregistered on beforeDestroy. Therefore, the popover components could no longer be cleared by the garbage collector.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed a memory leak in the cluster list. The memory consumption of the browser increased over time until finally the corresponding process crashed.
```
