### PR TITLE
Fix HCloud Secret dialog

### DIFF
--- a/frontend/src/components/dialogs/SecretDialogHCloud.vue
+++ b/frontend/src/components/dialogs/SecretDialogHCloud.vue
@@ -10,7 +10,7 @@ SPDX-License-Identifier: Apache-2.0
     :data="secretData"
     :data-valid="valid"
     :secret="secret"
-    cloud-provider-kind="hcloud"
+    vendor="hcloud"
     create-title="Add new Hetzner Cloud Secret"
     replace-title="Replace Hetzner Cloud Secret"
     @input="onInput">


### PR DESCRIPTION
**What this PR does / why we need it**:
A recent refactoring/change renamed cloud-provider-kind to vendor. This was missed for HCloud.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fix HCloud Secret Dialog
```
