### PR TITLE
Use pull policy "IfNotPresent" for dashboard image by default

### DIFF
--- a/charts/__tests__/gardener-dashboard/__snapshots__/deployment.spec.js.snap
+++ b/charts/__tests__/gardener-dashboard/__snapshots__/deployment.spec.js.snap
@@ -70,7 +70,7 @@ Object {
               },
             ],
             "image": "eu.gcr.io/gardener-project/gardener/dashboard:1.26.0-dev-4d529c1",
-            "imagePullPolicy": "Always",
+            "imagePullPolicy": "IfNotPresent",
             "livenessProbe": Object {
               "failureThreshold": 6,
               "initialDelaySeconds": 15,

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 1
 image:
   repository: eu.gcr.io/gardener-project/gardener/dashboard
   tag: latest
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
 
 # vertical Pod autoscaling disabled by default
 # vpa:


### PR DESCRIPTION
**What this PR does / why we need it**:
Use pull policy "IfNotPresent" for dashboard image by default. 
This way the start-up time for new replicas are much faster when the image is always available on the node. It also saves some network costs by avoiding to pull the image when not needed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
