### PR TITLE
[hotfix-1.52] Fixed: Invalid (outdated) image breaks configure worker dialog

### DIFF
--- a/frontend/src/components/ShootWorkers/WorkerGroup.vue
+++ b/frontend/src/components/ShootWorkers/WorkerGroup.vue
@@ -15,7 +15,7 @@ SPDX-License-Identifier: Apache-2.0
         class="cursor-pointer my-0 ml-0"
         outlined
         color="primary">
-          <vendor-icon :value="machineImage.icon" :size="20"></vendor-icon>
+          <vendor-icon :value="machineImageIcon" :size="20"></vendor-icon>
           {{workerGroup.name}}
       </v-chip>
     </template>
@@ -188,6 +188,9 @@ export default {
       }
 
       return item
+    },
+    machineImageIcon () {
+      return get(this.machineImage, 'icon')
     }
   }
 }

--- a/frontend/src/components/ShootWorkers/WorkerInputGeneric.vue
+++ b/frontend/src/components/ShootWorkers/WorkerInputGeneric.vue
@@ -397,7 +397,7 @@ export default {
       return find(this.machineImages, this.worker.machine.image)
     },
     machineImageCri () {
-      return this.selectedMachineImage.cri
+      return get(this.selectedMachineImage, 'cri')
     }
   },
   methods: {


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed an issue that caused `Configure Workers` dialog to break if a cluster has an outdated worker image configured that is no longer in the list of supported images (removed from cloud profile)
```
