### PR TITLE
[master] Set apiServer of the target cluster in case of garden terminals

### DIFF
--- a/backend/lib/services/terminals/index.js
+++ b/backend/lib/services/terminals/index.js
@@ -209,6 +209,10 @@ async function getTargetCluster ({ user, namespace, name, target, preferredHost,
   switch (target) {
     case TargetEnum.GARDEN: {
       targetCluster.kubeconfigContextNamespace = namespace
+      targetCluster.apiServer = {
+        server: config.apiServerUrl
+      }
+
       if (isAdmin) {
         targetCluster.namespace = 'garden'
         targetCluster.credentials = getConfigValue('terminal.garden.operatorCredentials')
@@ -244,9 +248,6 @@ async function getTargetCluster ({ user, namespace, name, target, preferredHost,
             ]
           }
         ]
-        targetCluster.apiServer = {
-          server: config.apiServerUrl
-        }
       }
 
       break

--- a/backend/test/acceptance/__snapshots__/api.terminals.spec.js.snap
+++ b/backend/test/acceptance/__snapshots__/api.terminals.spec.js.snap
@@ -408,7 +408,9 @@ Array [
           "temporaryNamespace": true,
         },
         "target": Object {
-          "apiServer": undefined,
+          "apiServer": Object {
+            "server": "https://kubernetes.external.foo.bar",
+          },
           "authorization": Object {
             "projectMemberships": undefined,
             "roleBindings": Array [


### PR DESCRIPTION
**What this PR does / why we need it**:
The apiServer for the garden target cluster must always be set.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
