### PR TITLE
Modify docs manifest

### DIFF
--- a/.docforge/manifest.yaml
+++ b/.docforge/manifest.yaml
@@ -1,8 +1,49 @@
-# The documentation matches the file/folder structure at /docs
-nodesSelector:
-  path: https://github.com/gardener/dashboard/tree/master/docs    
+{{- $vers := Split .versions "," -}}
+{{ $defaultBranch := (index $vers 0) }}
+structure:
+- name: _index.md
+  source: https://github.com/gardener/dashboard/blob/{{$defaultBranch}}/README.md
+- name: architecture
+  properties:
+    frontmatter:
+      title: Architecture
+      weight: 1
+  nodes:
+  - nodesSelector:
+      path: https://github.com/gardener/dashboard/tree/{{$defaultBranch}}/docs/architecture
+- name: concepts
+  properties:
+    frontmatter:
+      title: Concepts
+      weight: 2
+  nodes:
+  - nodesSelector:
+      path: https://github.com/gardener/dashboard/tree/{{$defaultBranch}}/docs/concepts
+- name: deployment
+  properties:
+    frontmatter:
+      title: Deployment
+      weight: 3
+  nodes:
+  - nodesSelector:
+      path: https://github.com/gardener/dashboard/tree/{{$defaultBranch}}/docs/deployment
+- name: development
+  properties:
+    frontmatter:
+      title: Development
+      weight: 4
+  nodes:
+  - nodesSelector:
+      path: https://github.com/gardener/dashboard/tree/{{$defaultBranch}}/docs/development
+- name: usage
+  properties:
+    frontmatter:
+      title: Usage
+      weight: 5
+  nodes:
+  - nodesSelector:
+      path: https://github.com/gardener/dashboard/tree/{{$defaultBranch}}/docs/usage
 links:
   downloads:
     scope:
-      # all referenced files that reside in dashboard's docs dir are forged into the documentation
-      gardener/dashboard/(blob|raw)/(.*)/docs: ~
+      "gardener/dashboard/(blob|raw)/(.*)/docs": ~


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR modifies the docs manifest. Now can be listed particular directories, which will be attached to the website.
Also it uses the new docforge feature, where the default branch will be dynamically taken. This means that if in the future the default branch is changed from master to main for example, the documentation together with all relative links will continue to work.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
None
```
