### PR TITLE
Clarify behaviour after Secret change in dialogue

### DIFF
--- a/frontend/src/components/dialogs/SecretDialog.vue
+++ b/frontend/src/components/dialogs/SecretDialog.vue
@@ -62,7 +62,7 @@ SPDX-License-Identifier: Apache-2.0
         This secret is used by {{relatedShootCount}} clusters. The new secret should be part of the same account as the one that gets replaced.
       </v-alert>
        <v-alert :value="!isCreateMode && relatedShootCount > 0" type="warning" tile>
-        Shoots will only start using the new secret after they got reconciled. Therefore, wait until all {{relatedShootCount}} Shoots using the secret are reconciled before you disable the old secret in your infrastructure account. Otherwise the Shoots will no longer function.
+        Clusters will only start using the new secret after they got reconciled. Therefore, wait until all clusters using the secret are reconciled before you disable the old secret in your infrastructure account. Otherwise the clusters will no longer function.
       </v-alert>
       <v-divider></v-divider>
       <v-card-actions>

--- a/frontend/src/components/dialogs/SecretDialog.vue
+++ b/frontend/src/components/dialogs/SecretDialog.vue
@@ -61,6 +61,9 @@ SPDX-License-Identifier: Apache-2.0
       <v-alert :value="!isCreateMode && relatedShootCount > 0" type="warning" tile>
         This secret is used by {{relatedShootCount}} clusters. The new secret should be part of the same account as the one that gets replaced.
       </v-alert>
+       <v-alert :value="!isCreateMode && relatedShootCount > 0" type="warning" tile>
+        Shoots will only start using the new secret after they got reconciled. Therefore, wait until all {{relatedShootCount}} Shoots using the secret are reconciled before you disable the old secret in your infrastructure account. Otherwise the Shoots will no longer function.
+      </v-alert>
       <v-divider></v-divider>
       <v-card-actions>
         <v-spacer></v-spacer>


### PR DESCRIPTION
**What this PR does / why we need it**:

Repeatedly Shoot owners were surprised by the behaviour that after they rotate a
cloudprovider secret in the garden cluster it is not instantly synced to the Seed cluster.

This commit adds an additional alert dialogue to help the user understand when a Secret
change will become active for their Shoots.

**Which issue(s) this PR fixes**:
Fixes gardener/gardener#4630

**Special notes for your reviewer**:

cc @grolu 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc user
Added an additional warning message when changing cloud provider secrets to clarify when the change will become active for Shoot owners.
```
