### PR TITLE
[hotfix-1.52] Add missing "zone" to "ControlPlaneConfig" for "hcloud" 

### DIFF
--- a/frontend/src/utils/createShoot.js
+++ b/frontend/src/utils/createShoot.js
@@ -314,6 +314,7 @@ export function getControlPlaneZone (workers, infrastructureKind, oldControlPlan
   const workerZones = flatMap(workers, 'zones')
   switch (infrastructureKind) {
     case 'gcp':
+    case 'hcloud':
     case 'openstack':
       if (includes(workerZones, oldControlPlaneZone)) {
         return oldControlPlaneZone


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed missing `ControlPlaneConfig` `zone` value for hcloud
```
