### PR TITLE
[hotfix-1.52] Support search for gardener error codes

### DIFF
--- a/frontend/src/store/modules/shoots/getters.js
+++ b/frontend/src/store/modules/shoots/getters.js
@@ -47,6 +47,8 @@ export function getRawVal (rootGetters, item, column) {
       const labels = rootGetters.ticketsLabels(metadata)
       return join(map(labels, 'name'), ' ')
     }
+    case 'errorCodes':
+      return join(errorCodesFromArray(get(item, 'status.lastErrors', [])), ' ')
     default: {
       if (startsWith(column, 'Z_')) {
         const path = get(rootGetters.shootCustomFields, [column, 'path'])
@@ -160,6 +162,7 @@ export default {
         getRawVal(rootGetters, item, 'purpose'),
         getRawVal(rootGetters, item, 'k8sVersion'),
         getRawVal(rootGetters, item, 'ticketLabels'),
+        getRawVal(rootGetters, item, 'errorCodes'),
         ...map(searchableCustomFields, ({ key }) => getRawVal(rootGetters, item, key))
       ]
 


### PR DESCRIPTION
**What this PR does / why we need it**:
 Support gardener error codes in the cluster search field. Below some examples are listed:
 
- `ERR_INFRA_UNAUTHORIZED`
- `ERR_INFRA_INSUFFICIENT_PRIVILEGES`
- `ERR_INFRA_QUOTA_EXCEEDED`
- `ERR_INFRA_DEPENDENCIES`
- `ERR_CLEANUP_CLUSTER_RESOURCES`
- `ERR_INFRA_RESOURCES_DEPLETED`
- `ERR_CONFIGURATION_PROBLEM`
- `ERR_RETRYABLE_CONFIGURATION_PROBLEM`
- `ERR_INFRA_RATE_LIMITS_EXCEEDED`
- `ERR_RETRYABLE_INFRA_DEPENDENCIES`
- ...
 
<img width="640" src="https://user-images.githubusercontent.com/1574023/144095378-4715c231-1c0a-448a-bca3-931dbbbbeaf3.png"/>

 
**Which issue(s) this PR fixes**:
Fixes #1136 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
 Support gardener error codes in the cluster search field. 
```
