### PR TITLE
[hotfix-1.52] Upgrade node image version in check step of pipeline definition

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -30,7 +30,7 @@ dashboard:
         pull-request: ~
       steps:
         check:
-          image: 'eu.gcr.io/gardener-project/3rd/node:14-alpine3.12'
+          image: 'eu.gcr.io/gardener-project/3rd/node:16-alpine3.13'
     release:
       traits:
         version:


### PR DESCRIPTION
**What this PR does / why we need it**:
In the [image](https://github.com/gardener/dashboard/blob/master/Dockerfile#L6) use in the container build and the [image](https://github.com/gardener/dashboard/blob/master/.ci/pipeline_definitions#L33) used in the check step of the pipeline definition should be in sync.
Use the newer image `eu.gcr.io/gardener-project/3rd/node:16-alpine3.13` also in the check step.

**Which issue(s) this PR fixes**:
Fixes #1140 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
