### PR TITLE
gardenctl-v2 commands

### DIFF
--- a/backend/lib/routes/info.js
+++ b/backend/lib/routes/info.js
@@ -51,3 +51,23 @@ async function fetchGardenerVersion () {
     logger.warn(`Could not fetch gardener version. Error: ${err.message}`)
   }
 }
+
+router.route('/identity')
+  .get(async (req, res, next) => {
+    try {
+      const clusterIdentity = await fetchIdentity()
+      res.send({ clusterIdentity })
+    } catch (err) {
+      next(err)
+    }
+  })
+
+async function fetchIdentity () {
+  const {
+    data: {
+      'cluster-identity': clusterIdentity
+    }
+  } = await dashboardClient.core.configmaps.get('kube-system', 'cluster-identity')
+
+  return clusterIdentity
+}

--- a/backend/test/acceptance/__snapshots__/api.info.spec.js.snap
+++ b/backend/test/acceptance/__snapshots__/api.info.spec.js.snap
@@ -1,6 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`api info should reject requests csrf protection error 1`] = `
+exports[`api info identity should return identity 1`] = `
+Array [
+  Array [
+    Object {
+      ":authority": "kubernetes:6443",
+      ":method": "get",
+      ":path": "/api/v1/namespaces/kube-system/configmaps/cluster-identity",
+      ":scheme": "https",
+      "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwic3ViIjoic3lzdGVtOnNlcnZpY2VhY2NvdW50OmdhcmRlbjpkZWZhdWx0In0.-4rSuvvj5BStN6DwnmLAaRVbgpl5iCn2hG0pcqx0NPw",
+    },
+  ],
+]
+`;
+
+exports[`api info identity should return identity 2`] = `
+Object {
+  "clusterIdentity": "test-id",
+}
+`;
+
+exports[`api info version should reject requests csrf protection error 1`] = `
 Object {
   "code": 403,
   "details": Any<Object>,
@@ -10,7 +30,7 @@ Object {
 }
 `;
 
-exports[`api info should reject requests with invalid audience 1`] = `
+exports[`api info version should reject requests with invalid audience 1`] = `
 Object {
   "code": 401,
   "details": Any<Object>,
@@ -20,7 +40,7 @@ Object {
 }
 `;
 
-exports[`api info should reject requests with invalid signature 1`] = `
+exports[`api info version should reject requests with invalid signature 1`] = `
 Object {
   "code": 401,
   "details": Any<Object>,
@@ -30,7 +50,7 @@ Object {
 }
 `;
 
-exports[`api info should reject requests without authorization header 1`] = `
+exports[`api info version should reject requests without authorization header 1`] = `
 Object {
   "code": 401,
   "details": Any<Object>,
@@ -40,7 +60,7 @@ Object {
 }
 `;
 
-exports[`api info should return information with version 1`] = `
+exports[`api info version should return information with version 1`] = `
 Array [
   Array [
     Object {
@@ -62,7 +82,7 @@ Array [
 ]
 `;
 
-exports[`api info should return information with version 2`] = `
+exports[`api info version should return information with version 2`] = `
 Object {
   "gardenerVersion": Object {
     "major": "1",
@@ -72,7 +92,7 @@ Object {
 }
 `;
 
-exports[`api info should return information without version 1`] = `
+exports[`api info version should return information without version 1`] = `
 Array [
   Array [
     Object {
@@ -94,7 +114,7 @@ Array [
 ]
 `;
 
-exports[`api info should return information without version 2`] = `
+exports[`api info version should return information without version 2`] = `
 Object {
   "version": Any<String>,
 }

--- a/charts/__tests__/gardener-dashboard/__snapshots__/configmap.spec.js.snap
+++ b/charts/__tests__/gardener-dashboard/__snapshots__/configmap.spec.js.snap
@@ -168,6 +168,10 @@ Object {
       "projectTerminalShortcutsEnabled": false,
       "terminalEnabled": false,
     },
+    "gardenctl": Object {
+      "legacyCommands": false,
+      "shell": "bash",
+    },
     "helpMenuItems": Array [
       Object {
         "icon": "description",

--- a/charts/gardener-dashboard/templates/configmap.yaml
+++ b/charts/gardener-dashboard/templates/configmap.yaml
@@ -311,3 +311,8 @@ data:
           {{- end }}
         {{- end }}
       {{- end }}
+      {{- if .Values.frontendConfig.gardenctl }}
+      gardenctl:
+        legacyCommands: {{ .Values.frontendConfig.gardenctl.legacyCommands | default false }}
+        shell: {{ .Values.frontendConfig.gardenctl.shell | default "bash" }}
+      {{- end }}

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -241,6 +241,11 @@ frontendConfig:
   #    error: 'red.darken4'
   #    warning: 'orange.darken4'
 
+  # gardenctl - configure the default settings for the gardenctl commands
+  gardenctl:
+    legacyCommands: false # false to show gardenctl-v2 commands by default, true to show the legacy gardenctl commands. Can be overwritten by the user.
+    shell: bash # default shell. Should be one of bash, fish, powershell, zsh. Can be overwritten by the user.
+
 # # github configuration of the ticket feature
 # gitHub:
 #   apiUrl: https://api.foo-github.com

--- a/frontend/src/components/GardenctlSettings.vue
+++ b/frontend/src/components/GardenctlSettings.vue
@@ -1,0 +1,78 @@
+<!--
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+ -->
+
+<template>
+  <v-card flat class="mx-2 mt-2">
+    <v-card-text class="pt-0">
+      <v-radio-group
+        v-model="legacyCommands"
+        label="Select Version"
+        hint="Choose for which gardenctl version the commands should be displayed"
+        persistent-hint
+        @change="onChangeLegacyCommands"
+        class="pb-4"
+      >
+        <v-radio
+          label="Legacy Gardenctl"
+          :value="true"
+          color="primary"
+        ></v-radio>
+        <v-radio
+          label="Gardenctl-v2"
+          :value="false"
+          color="primary"
+        ></v-radio>
+      </v-radio-group>
+      <v-select
+        v-show="!legacyCommands"
+        color="primary"
+        item-color="primary"
+        label="Shell"
+        :items="['bash', 'fish', 'powershell', 'zsh']"
+        hint="Choose for which shell the commands should be displayed"
+        persistent-hint
+        v-model="shell"
+        @input="onInputShell"
+      ></v-select>
+    </v-card-text>
+  </v-card>
+</template>
+
+<script>
+import { mapActions } from 'vuex'
+
+export default {
+  data () {
+    return {
+      legacyCommands: false,
+      shell: 'bash'
+    }
+  },
+  methods: {
+    ...mapActions([
+      'refreshGardenctlOptions'
+    ]),
+    onInputShell () {
+      this.store()
+    },
+    onChangeLegacyCommands () {
+      this.store()
+    },
+    store () {
+      const gardenctlOptions = {
+        legacyCommands: this.legacyCommands,
+        shell: this.shell
+      }
+      this.$store.commit('SET_GARDENCTL_OPTIONS', gardenctlOptions)
+    }
+  },
+  async mounted () {
+    const { legacyCommands, shell } = await this.refreshGardenctlOptions()
+    this.legacyCommands = legacyCommands
+    this.shell = shell
+  }
+}
+</script>

--- a/frontend/src/components/ShootDetails/GardenctlCommands.vue
+++ b/frontend/src/components/ShootDetails/GardenctlCommands.vue
@@ -28,13 +28,40 @@ SPDX-License-Identifier: Apache-2.0
             <span>{{visibilityTitle(index)}}</span>
           </v-tooltip>
         </v-list-item-action>
+        <v-list-item-action class="mx-0">
+          <g-popper
+            title="Customize Gardenctl Commands"
+            popper-key="gardenctl"
+          >
+            <template v-slot:popperRef>
+              <v-btn icon  color="action-button">
+                <v-tooltip top>
+                  <template v-slot:activator="{ on }">
+                    <v-icon v-on="on">mdi-cog-outline</v-icon>
+                  </template>
+                  <span>Instructions on how to customize the <span class="font-family-monospace">gardenctl</span> commands</span>
+                </v-tooltip>
+              </v-btn>
+            </template>
+            <v-list class="py-0">
+              <v-list-item class="px-0">
+                <v-list-item-icon>
+                  <v-icon>mdi-information-outline</v-icon>
+                </v-list-item-icon>
+                <v-list-item-content>
+                  <span>Go to <router-link :to="{ name: 'Account', query: { namespace: shootNamespace } }">My Account</router-link> to customize the <span class="font-family-monospace">gardenctl</span> command</span>
+                </v-list-item-content>
+              </v-list-item>
+            </v-list>
+          </g-popper>
+        </v-list-item-action>
       </v-list-item>
       <v-list-item v-if="expansionPanel[index]" :key="'expansion-' + title">
         <v-list-item-icon></v-list-item-icon>
         <v-list-item-content class="pt-0">
           <code-block
             lang="shell"
-            :content="'$ ' + value.replace(/ --/g, ' \\\n    --')"
+            :content="'$ ' + value.replace(/ --/g, ' \\\n    --').replace(/ &&/g, ' \\\n  &&')"
             :show-copy-button="false"
           ></code-block>
         </v-list-item-content>
@@ -44,17 +71,20 @@ SPDX-License-Identifier: Apache-2.0
 </template>
 
 <script>
+import GPopper from '@/components/GPopper'
 import CopyBtn from '@/components/CopyBtn'
 import CodeBlock from '@/components/CodeBlock'
 import { shootItem } from '@/mixins/shootItem'
-import { mapState, mapGetters } from 'vuex'
+import { mapState, mapGetters, mapActions } from 'vuex'
 import get from 'lodash/get'
+import includes from 'lodash/includes'
 import Vue from 'vue'
 
 export default {
   components: {
     CopyBtn,
-    CodeBlock
+    CodeBlock,
+    GPopper
   },
   mixins: [shootItem],
   data () {
@@ -67,27 +97,57 @@ export default {
       'cfg'
     ]),
     ...mapGetters([
-      'projectFromProjectList'
+      'projectFromProjectList',
+      'gardenctlOptions',
+      'clusterIdentity'
     ]),
     projectName () {
       const project = this.projectFromProjectList
       return get(project, 'metadata.name')
     },
     commands () {
+      const gardenctlVersion = this.legacyCommands ? 'Legacy gardenctl' : 'Gardenctl-v2'
+      const additionalInfo = this.legacyCommands ? '' : `(${this.shell})`
       return [
         {
           title: 'Target Control Plane',
-          subtitle: 'Gardenctl command to target the shoot namespace on the seed cluster',
-          value: this.targetSeedCommand
+          subtitle: `${gardenctlVersion} command to target the control plane of the shoot cluster ${additionalInfo}`,
+          value: this.targetControlPlaneCommand
         },
         {
           title: 'Target Cluster',
-          subtitle: 'Gardenctl command to target the shoot cluster',
+          subtitle: `${gardenctlVersion} command to target the shoot cluster ${additionalInfo}`,
           value: this.targetShootCommand
         }
       ]
     },
-    targetSeedCommand () {
+    legacyCommands () {
+      return get(this.gardenctlOptions, 'legacyCommands', false)
+    },
+    shell () {
+      const shell = get(this.gardenctlOptions, 'shell')
+
+      if (!includes(['bash', 'fish', 'powershell', 'zsh'], shell)) {
+        return 'bash'
+      }
+
+      return shell
+    },
+    targetControlPlaneCommand () {
+      if (this.legacyCommands) {
+        return this.targetControlPlaneCommandV1
+      }
+
+      return this.targetControlPlaneCommandV2
+    },
+    targetShootCommand () {
+      if (this.legacyCommands) {
+        return this.targetShootCommandV1
+      }
+
+      return this.targetShootCommandV2
+    },
+    targetControlPlaneCommandV1 () {
       const args = []
       if (this.cfg.apiServerUrl) {
         args.push(`--server ${this.cfg.apiServerUrl}`)
@@ -101,7 +161,23 @@ export default {
 
       return `gardenctl target ${args.join(' ')}`
     },
-    targetShootCommand () {
+    targetControlPlaneCommandV2 () {
+      const args = []
+      if (this.clusterIdentity) {
+        args.push(`--garden ${this.clusterIdentity}`)
+      }
+      if (this.projectName) {
+        args.push(`--project ${this.projectName}`)
+      }
+      if (this.shootName) {
+        args.push(`--shoot ${this.shootName}`)
+      }
+
+      args.push('--control-plane')
+
+      return `gardenctl target ${args.join(' ')} && ${this.kubectlEnvCommandV2}`
+    },
+    targetShootCommandV1 () {
       const args = []
       if (this.cfg.apiServerUrl) {
         args.push(`--server ${this.cfg.apiServerUrl}`)
@@ -114,9 +190,30 @@ export default {
       }
 
       return `gardenctl target ${args.join(' ')}`
+    },
+    targetShootCommandV2 () {
+      const args = []
+      if (this.clusterIdentity) {
+        args.push(`--garden ${this.clusterIdentity}`)
+      }
+      if (this.projectName) {
+        args.push(`--project ${this.projectName}`)
+      }
+      if (this.shootName) {
+        args.push(`--shoot ${this.shootName}`)
+      }
+
+      return `gardenctl target ${args.join(' ')} && ${this.kubectlEnvCommandV2}`
+    },
+    kubectlEnvCommandV2 () {
+      return this.invokeCommandString(`gardenctl kubectl-env ${this.shell}`)
     }
   },
   methods: {
+    ...mapActions([
+      'initializeClusterIdentity',
+      'refreshGardenctlOptions'
+    ]),
     visibilityIcon (index) {
       return this.expansionPanel[index] ? 'mdi-eye-off' : 'mdi-eye'
     },
@@ -125,7 +222,21 @@ export default {
     },
     toggle (index) {
       Vue.set(this.expansionPanel, index, !this.expansionPanel[index])
+    },
+    invokeCommandString (command) {
+      switch (this.shell) {
+        case 'powershell':
+          return `& ${command} | Invoke-Expression`
+        case 'fish':
+          return `eval (${command})`
+        default:
+          return `eval $(${command})`
+      }
     }
+  },
+  async mounted () {
+    await this.initializeClusterIdentity()
+    await this.refreshGardenctlOptions()
   }
 }
 </script>

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -305,6 +305,10 @@ export function getInfo () {
   return getResource('/api/info')
 }
 
+export function getClusterIdentity () {
+  return getResource('/api/info/identity')
+}
+
 /* Terminals */
 
 export function createTerminal ({ namespace, name, target, body = {} }) {

--- a/frontend/src/views/Account.vue
+++ b/frontend/src/views/Account.vue
@@ -64,6 +64,35 @@ SPDX-License-Identifier: Apache-2.0
             </v-list-item>
           </v-list>
         </v-card>
+        <v-card class="mt-4">
+          <v-toolbar flat dense class="toolbar-background toolbar-title--text">
+            <v-toolbar-title>Dashboard Customization</v-toolbar-title>
+          </v-toolbar>
+          <v-list>
+            <v-list-item>
+              <v-list-item-avatar>
+                <v-icon color="primary">mdi-console-line</v-icon>
+              </v-list-item-avatar>
+              <v-list-item-content>
+                <v-list-item-title>Gardenctl</v-list-item-title>
+                <v-list-item-subtitle class="line-clamp-2">Personalize the <span class="font-family-monospace">gardenctl</span> command that is shown on the cluster details page</v-list-item-subtitle>
+              </v-list-item-content>
+              <v-list-item-action class="mx-0">
+                <v-tooltip top>
+                  <template v-slot:activator="{ on }">
+                    <v-btn v-on="on" icon @click.native.stop="gardenctlExpansionPanel = !gardenctlExpansionPanel" color="action-button">
+                      <v-icon>{{gardenctlExpansionPanelIcon}}</v-icon>
+                    </v-btn>
+                  </template>
+                  <span>{{gardenctlExpansionPanelTooltip}}</span>
+                </v-tooltip>
+              </v-list-item-action>
+            </v-list-item>
+            <v-expand-transition>
+              <gardenctl-settings v-if="gardenctlExpansionPanel"></gardenctl-settings>
+            </v-expand-transition>
+          </v-list>
+        </v-card>
       </v-col>
       <v-col cols="12" md="6">
         <v-card>
@@ -109,16 +138,16 @@ SPDX-License-Identifier: Apache-2.0
                 <v-list-item-action class="mx-0">
                   <v-tooltip top>
                     <template v-slot:activator="{ on }">
-                      <v-btn v-on="on" icon @click.native.stop="expansionPanel = !expansionPanel" color="action-button">
-                        <v-icon>{{expansionPanelIcon}}</v-icon>
+                      <v-btn v-on="on" icon @click.native.stop="kubeconfigExpansionPanel = !kubeconfigExpansionPanel" color="action-button">
+                        <v-icon>{{kubeconfigExpansionPanelIcon}}</v-icon>
                       </v-btn>
                     </template>
-                    <span>{{expansionPanelTooltip}}</span>
+                    <span>{{kubeconfigExpansionPanelTooltip}}</span>
                   </v-tooltip>
                 </v-list-item-action>
               </v-list-item>
               <v-expand-transition>
-                <v-card v-if="expansionPanel" flat class="mx-2 mt-2">
+                <v-card v-if="kubeconfigExpansionPanel" flat class="mx-2 mt-2">
                   <v-card-text class="pt-0">
                     <div>
                       The downloaded <span class="font-family-monospace">kubeconfig</span> will initiate
@@ -199,6 +228,7 @@ import CopyBtn from '@/components/CopyBtn'
 import CodeBlock from '@/components/CodeBlock'
 import ExternalLink from '@/components/ExternalLink'
 import AccountAvatar from '@/components/AccountAvatar'
+import GardenctlSettings from '@/components/GardenctlSettings'
 import { getToken } from '@/utils/api'
 import moment from '@/utils/moment'
 
@@ -207,12 +237,14 @@ export default {
     CopyBtn,
     CodeBlock,
     ExternalLink,
-    AccountAvatar
+    AccountAvatar,
+    GardenctlSettings
   },
   name: 'profile',
   data () {
     return {
-      expansionPanel: false,
+      kubeconfigExpansionPanel: false,
+      gardenctlExpansionPanel: false,
       projectName: undefined,
       skipOpenBrowser: false,
       grantType: 'auto',
@@ -239,11 +271,17 @@ export default {
       'canCreateProject',
       'isKubeconfigEnabled'
     ]),
-    expansionPanelIcon () {
-      return this.expansionPanel ? 'mdi-chevron-up' : 'mdi-chevron-down'
+    kubeconfigExpansionPanelIcon () {
+      return this.expansionPanelIcon(this.kubeconfigExpansionPanel)
     },
-    expansionPanelTooltip () {
-      return this.expansionPanel ? 'Hide advanced options' : 'Show advanced options'
+    gardenctlExpansionPanelIcon () {
+      return this.expansionPanelIcon(this.gardenctlExpansionPanel)
+    },
+    kubeconfigExpansionPanelTooltip () {
+      return this.expansionPanelTooltip(this.kubeconfigExpansionPanel)
+    },
+    gardenctlExpansionPanelTooltip () {
+      return this.expansionPanelTooltip(this.gardenctlExpansionPanel)
     },
     icon () {
       return this.isAdmin ? 'mdi-account-supervisor' : 'mdi-account'
@@ -349,6 +387,12 @@ export default {
     },
     async updateKubeconfigYaml (value) {
       this.kubeconfigYaml = await this.$yaml.safeDump(value)
+    },
+    expansionPanelIcon (value) {
+      return value ? 'mdi-chevron-up' : 'mdi-chevron-down'
+    },
+    expansionPanelTooltip (value) {
+      return value ? 'Hide advanced options' : 'Show advanced options'
     }
   },
   async mounted () {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for `gardenctl-v2` commands. 

The user has the option to choose to see the legacy `gardenctl` commands or the `gardenctl-v2` commands. 
The user can also choose the preferred `shell`. The commands are then adapted to the selected shell.

<img width="1943" alt="Screenshot 2021-12-21 at 15 58 29" src="https://user-images.githubusercontent.com/5526658/146951226-a71350ce-732c-4669-8c2a-cbf27459772a.png">


<img width="831" alt="Screenshot 2021-12-21 at 16 00 07" src="https://user-images.githubusercontent.com/5526658/146951266-b2127c49-404b-4ed7-bbaa-56c4e648c4ff.png">
<img width="1942" alt="Screenshot 2021-12-21 at 15 58 38" src="https://user-images.githubusercontent.com/5526658/146951290-27173083-bdfb-487e-ad7f-9f9cb1595fa3.png">

<img width="831" alt="Screenshot 2021-12-21 at 15 58 47" src="https://user-images.githubusercontent.com/5526658/146951310-06d303d9-7e22-4a53-abd0-b7d705538b5a.png">

<img width="813" alt="Screenshot 2021-12-21 at 15 59 38" src="https://user-images.githubusercontent.com/5526658/146951355-2727a21f-7ee0-4f99-a280-0471c8a1dd6f.png">

The default selected `gardenctl` version (legacy vs. `gardenctl-v2`) and the default shell can be set using the chart's `values.yaml`.

Example `values.yaml`:
```yaml
frontendConfig:
  # gardenctl - configure the default settings for the gardenctl commands
  gardenctl:
    legacyCommands: false # false to show gardenctl-v2 commands by default, true to show the legacy gardenctl commands. Can be overwritten by the user.
    shell: bash # default shell. Should be one of bash, fish, powershell, zsh. Can be overwritten by the user.
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
You can now switch between legacy `gardenctl` and `gardenctl-v2` commands on the `My Account` page. You can also choose your preferred shell for which the commands will be adapted.
```
