### PR TITLE
Proposal for changes to PR gardenctl-v2 commands

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -50,5 +50,5 @@
   "jestrunner.enableYarnPnpSupport": true,
   "jestrunner.jestCommand": "scripts/jest",
   "vetur.useWorkspaceDependencies": true,
-  "vetur.experimental.templateInterpolationService": true
+  "vetur.experimental.templateInterpolationService": false
 }

--- a/backend/lib/api.js
+++ b/backend/lib/api.js
@@ -13,10 +13,10 @@ const cookieParser = require('cookie-parser')
 const logger = require('./logger')
 const routes = require('./routes')
 const hooks = require('./hooks')()
+const frontendConfigHandler = require('./frontendConfigHandler')
 const { authenticate } = require('./security')
-const { createClient } = require('@gardener-dashboard/kube-client')
-const { frontendConfig, notFound, sendError } = require('./middleware')
-
+const { dashboardClient, createClient } = require('@gardener-dashboard/kube-client')
+const { notFound, sendError } = require('./middleware')
 // configure router
 const router = express.Router()
 
@@ -34,5 +34,7 @@ router.use(sendError)
 module.exports = {
   router,
   hooks,
-  frontendConfig
+  frontendConfig (config) {
+    return frontendConfigHandler(config, dashboardClient)
+  }
 }

--- a/backend/lib/config/gardener.js
+++ b/backend/lib/config/gardener.js
@@ -112,6 +112,7 @@ module.exports = {
 
     _.set(config, 'frontend.primaryLoginType', config.oidc ? 'oidc' : 'token')
     _.set(config, 'frontend.apiServerUrl', config.apiServerUrl)
+    _.set(config, 'frontend.clusterIdentity', config.clusterIdentity)
     if (!config.gitHub && _.has(config, 'frontend.ticket')) {
       _.unset(config, 'frontend.ticket')
     }

--- a/backend/lib/frontendConfigHandler.js
+++ b/backend/lib/frontendConfigHandler.js
@@ -1,0 +1,77 @@
+//
+// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+'use strict'
+
+const _ = require('lodash')
+const logger = require('./logger')
+const markdown = require('./markdown')
+
+module.exports = function handler (config, dashboardClient) {
+  const frontendConfig = sanitizeFrontendConfig(config.frontend)
+
+  return async (req, res) => {
+    if (!frontendConfig.clusterIdentity) {
+      try {
+        const { data } = await dashboardClient.core.configmaps.get('kube-system', 'cluster-identity')
+        frontendConfig.clusterIdentity = data['cluster-identity']
+      } catch (err) {
+        logger.error('Failed to get configmap kube-system/cluster-identity: %s', err.message)
+      }
+    }
+    res.json(frontendConfig)
+  }
+}
+
+function sanitizeFrontendConfig (frontendConfig) {
+  const converter = markdown.createConverter()
+  const convertAndSanitize = (obj, key) => {
+    if (obj[key]) {
+      obj[key] = converter.makeSanitizedHtml(obj[key])
+    }
+  }
+
+  const sanitizedFrontendConfig = _.cloneDeep(frontendConfig)
+  const {
+    alert = {},
+    costObject = {},
+    sla = {},
+    addonDefinition = {},
+    accessRestriction: {
+      items = []
+    } = {},
+    vendorHints = []
+  } = sanitizedFrontendConfig
+
+  convertAndSanitize(alert, 'message')
+  convertAndSanitize(costObject, 'description')
+  convertAndSanitize(sla, 'description')
+  convertAndSanitize(addonDefinition, 'description')
+
+  for (const item of items) {
+    const {
+      display = {},
+      input = {},
+      options = []
+    } = item
+    convertAndSanitize(display, 'description')
+    convertAndSanitize(input, 'description')
+    for (const option of options) {
+      const {
+        display = {},
+        input = {}
+      } = option
+      convertAndSanitize(display, 'description')
+      convertAndSanitize(input, 'description')
+    }
+  }
+
+  for (const vendorHint of vendorHints) {
+    convertAndSanitize(vendorHint, 'message')
+  }
+
+  return sanitizedFrontendConfig
+}

--- a/backend/lib/middleware.js
+++ b/backend/lib/middleware.js
@@ -8,61 +8,8 @@
 
 const _ = require('lodash')
 const logger = require('./logger')
-const markdown = require('./markdown')
 const { NotFound, InternalServerError, isHttpError } = require('http-errors')
 const { STATUS_CODES } = require('http')
-
-function frontendConfig (config) {
-  const converter = markdown.createConverter()
-  const convertAndSanitize = (obj, key) => {
-    if (obj[key]) {
-      obj[key] = converter.makeSanitizedHtml(obj[key])
-    }
-  }
-
-  const frontendConfig = _.cloneDeep(config.frontend)
-  const {
-    alert = {},
-    costObject = {},
-    sla = {},
-    addonDefinition = {},
-    accessRestriction: {
-      items = []
-    } = {},
-    vendorHints = []
-  } = frontendConfig
-
-  convertAndSanitize(alert, 'message')
-  convertAndSanitize(costObject, 'description')
-  convertAndSanitize(sla, 'description')
-  convertAndSanitize(addonDefinition, 'description')
-
-  for (const item of items) {
-    const {
-      display = {},
-      input = {},
-      options = []
-    } = item
-    convertAndSanitize(display, 'description')
-    convertAndSanitize(input, 'description')
-    for (const option of options) {
-      const {
-        display = {},
-        input = {}
-      } = option
-      convertAndSanitize(display, 'description')
-      convertAndSanitize(input, 'description')
-    }
-  }
-
-  for (const vendorHint of vendorHints) {
-    convertAndSanitize(vendorHint, 'message')
-  }
-
-  return (req, res, next) => {
-    res.json(frontendConfig)
-  }
-}
 
 function noCache () {
   return (req, res, next) => {
@@ -150,7 +97,6 @@ const ErrorTemplate = _.template(`<!doctype html>
 </html>`)
 
 module.exports = {
-  frontendConfig,
   noCache,
   historyFallback,
   notFound,

--- a/backend/lib/routes/info.js
+++ b/backend/lib/routes/info.js
@@ -51,23 +51,3 @@ async function fetchGardenerVersion () {
     logger.warn(`Could not fetch gardener version. Error: ${err.message}`)
   }
 }
-
-router.route('/identity')
-  .get(async (req, res, next) => {
-    try {
-      const clusterIdentity = await fetchIdentity()
-      res.send({ clusterIdentity })
-    } catch (err) {
-      next(err)
-    }
-  })
-
-async function fetchIdentity () {
-  const {
-    data: {
-      'cluster-identity': clusterIdentity
-    }
-  } = await dashboardClient.core.configmaps.get('kube-system', 'cluster-identity')
-
-  return clusterIdentity
-}

--- a/backend/test/acceptance/__snapshots__/api.info.spec.js.snap
+++ b/backend/test/acceptance/__snapshots__/api.info.spec.js.snap
@@ -1,26 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`api info identity should return identity 1`] = `
-Array [
-  Array [
-    Object {
-      ":authority": "kubernetes:6443",
-      ":method": "get",
-      ":path": "/api/v1/namespaces/kube-system/configmaps/cluster-identity",
-      ":scheme": "https",
-      "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwic3ViIjoic3lzdGVtOnNlcnZpY2VhY2NvdW50OmdhcmRlbjpkZWZhdWx0In0.-4rSuvvj5BStN6DwnmLAaRVbgpl5iCn2hG0pcqx0NPw",
-    },
-  ],
-]
-`;
-
-exports[`api info identity should return identity 2`] = `
-Object {
-  "clusterIdentity": "test-id",
-}
-`;
-
-exports[`api info version should reject requests csrf protection error 1`] = `
+exports[`api info should reject requests csrf protection error 1`] = `
 Object {
   "code": 403,
   "details": Any<Object>,
@@ -30,7 +10,7 @@ Object {
 }
 `;
 
-exports[`api info version should reject requests with invalid audience 1`] = `
+exports[`api info should reject requests with invalid audience 1`] = `
 Object {
   "code": 401,
   "details": Any<Object>,
@@ -40,7 +20,7 @@ Object {
 }
 `;
 
-exports[`api info version should reject requests with invalid signature 1`] = `
+exports[`api info should reject requests with invalid signature 1`] = `
 Object {
   "code": 401,
   "details": Any<Object>,
@@ -50,7 +30,7 @@ Object {
 }
 `;
 
-exports[`api info version should reject requests without authorization header 1`] = `
+exports[`api info should reject requests without authorization header 1`] = `
 Object {
   "code": 401,
   "details": Any<Object>,
@@ -60,7 +40,7 @@ Object {
 }
 `;
 
-exports[`api info version should return information with version 1`] = `
+exports[`api info should return information with version 1`] = `
 Array [
   Array [
     Object {
@@ -82,7 +62,7 @@ Array [
 ]
 `;
 
-exports[`api info version should return information with version 2`] = `
+exports[`api info should return information with version 2`] = `
 Object {
   "gardenerVersion": Object {
     "major": "1",
@@ -92,7 +72,7 @@ Object {
 }
 `;
 
-exports[`api info version should return information without version 1`] = `
+exports[`api info should return information without version 1`] = `
 Array [
   Array [
     Object {
@@ -114,7 +94,7 @@ Array [
 ]
 `;
 
-exports[`api info version should return information without version 2`] = `
+exports[`api info should return information without version 2`] = `
 Object {
   "version": Any<String>,
 }

--- a/backend/test/acceptance/__snapshots__/config.spec.js.snap
+++ b/backend/test/acceptance/__snapshots__/config.spec.js.snap
@@ -1,0 +1,44 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`config should return the frontend configuration 1`] = `
+Array [
+  Array [
+    Object {
+      ":authority": "kubernetes:6443",
+      ":method": "get",
+      ":path": "/api/v1/namespaces/kube-system/configmaps/cluster-identity",
+      ":scheme": "https",
+      "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwic3ViIjoic3lzdGVtOnNlcnZpY2VhY2NvdW50OmdhcmRlbjpkZWZhdWx0In0.-4rSuvvj5BStN6DwnmLAaRVbgpl5iCn2hG0pcqx0NPw",
+    },
+  ],
+]
+`;
+
+exports[`config should return the frontend configuration 2`] = `
+Object {
+  "apiServerUrl": "https://kubernetes.external.foo.bar",
+  "clusterIdentity": "test-id",
+  "features": Object {
+    "terminalEnabled": true,
+  },
+  "helpMenuItems": Array [
+    Object {
+      "icon": "description",
+      "title": "Getting Started",
+      "url": "https://gardener.cloud/about/",
+    },
+    Object {
+      "icon": "mdi-slack",
+      "title": "Feedback",
+      "url": "https://kubernetes.slack.com/messages/gardener/",
+    },
+    Object {
+      "icon": "mdi-bug",
+      "title": "Issues",
+      "url": "https://github.com/gardener/dashboard/issues/",
+    },
+  ],
+  "landingPageUrl": "https://gardener.cloud/",
+  "primaryLoginType": "oidc",
+}
+`;

--- a/backend/test/acceptance/api.info.spec.js
+++ b/backend/test/acceptance/api.info.spec.js
@@ -27,133 +27,109 @@ describe('api', function () {
   describe('info', function () {
     const id = 'john.doe@example.org'
     const aud = ['gardener']
+    const service = {
+      name: 'gardener-apiserver',
+      namespace: 'gardener'
+    }
+    const caBundle = fixtures.helper.toBase64('ca')
 
-    describe('version', function () {
-      const service = {
-        name: 'gardener-apiserver',
-        namespace: 'gardener'
-      }
-      const caBundle = fixtures.helper.toBase64('ca')
+    it('should reject requests csrf protection error', async function () {
+      const res = await agent
+        .post('/api/info')
+        .unset('x-requested-with')
+        .expect('content-type', /json/)
+        .expect(403)
 
-      it('should reject requests csrf protection error', async function () {
-        const res = await agent
-          .post('/api/info')
-          .unset('x-requested-with')
-          .expect('content-type', /json/)
-          .expect(403)
+      expect(mockRequest).not.toBeCalled()
 
-        expect(mockRequest).not.toBeCalled()
-
-        expect(res.body).toMatchSnapshot({
-          details: expect.any(Object)
-        })
-      })
-
-      it('should reject requests without authorization header', async function () {
-        const res = await agent
-          .get('/api/info')
-          .expect('content-type', /json/)
-          .expect(401)
-
-        expect(mockRequest).not.toBeCalled()
-
-        expect(res.body).toMatchSnapshot({
-          details: expect.any(Object)
-        })
-      })
-
-      it('should reject requests with invalid signature', async function () {
-        const user = fixtures.user.create({ id, aud }, true)
-
-        const res = await agent
-          .get('/api/info')
-          .set('cookie', await user.cookie)
-          .expect('content-type', /json/)
-          .expect(401)
-
-        expect(mockRequest).not.toBeCalled()
-
-        expect(res.body).toMatchSnapshot({
-          details: expect.any(Object)
-        })
-      })
-
-      it('should reject requests with invalid audience', async function () {
-        const user = fixtures.user.create({ id, aud: ['invalid-audience'] })
-
-        const res = await agent
-          .get('/api/info')
-          .set('cookie', await user.cookie)
-          .expect('content-type', /json/)
-          .expect(401)
-
-        expect(mockRequest).not.toBeCalled()
-
-        expect(res.body).toMatchSnapshot({
-          details: expect.any(Object)
-        })
-      })
-
-      it('should return information with version', async function () {
-        const user = fixtures.user.create({ id, aud })
-        const gardenerVersion = { major: '1', minor: '0' }
-
-        mockRequest.mockResolvedValueOnce({ spec: { service, caBundle } })
-        mockRequest.mockResolvedValueOnce(gardenerVersion)
-
-        const res = await agent
-          .get('/api/info')
-          .set('cookie', await user.cookie)
-          .expect('content-type', /json/)
-          .expect(200)
-
-        expect(mockRequest).toBeCalledTimes(2)
-        expect(mockRequest.mock.calls).toMatchSnapshot()
-
-        expect(res.body).toMatchSnapshot({
-          version: expect.any(String)
-        })
-      })
-
-      it('should return information without version', async function () {
-        const user = fixtures.user.create({ id, aud })
-
-        mockRequest.mockResolvedValueOnce({ spec: { service, caBundle } })
-        mockRequest.mockRejectedValueOnce(createError(404, 'Not found'))
-
-        const res = await agent
-          .get('/api/info')
-          .set('cookie', await user.cookie)
-          .expect('content-type', /json/)
-          .expect(200)
-
-        expect(mockRequest).toBeCalledTimes(2)
-        expect(mockRequest.mock.calls).toMatchSnapshot()
-
-        expect(res.body).toMatchSnapshot({
-          version: expect.any(String)
-        })
+      expect(res.body).toMatchSnapshot({
+        details: expect.any(Object)
       })
     })
 
-    describe('identity', function () {
-      it('should return identity', async function () {
-        const user = fixtures.user.create({ id, aud })
+    it('should reject requests without authorization header', async function () {
+      const res = await agent
+        .get('/api/info')
+        .expect('content-type', /json/)
+        .expect(401)
 
-        mockRequest.mockResolvedValueOnce({ data: { 'cluster-identity': 'test-id' } })
+      expect(mockRequest).not.toBeCalled()
 
-        const res = await agent
-          .get('/api/info/identity')
-          .set('cookie', await user.cookie)
-          .expect('content-type', /json/)
-          .expect(200)
+      expect(res.body).toMatchSnapshot({
+        details: expect.any(Object)
+      })
+    })
 
-        expect(mockRequest).toBeCalledTimes(1)
-        expect(mockRequest.mock.calls).toMatchSnapshot()
+    it('should reject requests with invalid signature', async function () {
+      const user = fixtures.user.create({ id, aud }, true)
 
-        expect(res.body).toMatchSnapshot({
-          clusterIdentity: 'test-id'
-        })
+      const res = await agent
+        .get('/api/info')
+        .set('cookie', await user.cookie)
+        .expect('content-type', /json/)
+        .expect(401)
+
+      expect(mockRequest).not.toBeCalled()
+
+      expect(res.body).toMatchSnapshot({
+        details: expect.any(Object)
+      })
+    })
+
+    it('should reject requests with invalid audience', async function () {
+      const user = fixtures.user.create({ id, aud: ['invalid-audience'] })
+
+      const res = await agent
+        .get('/api/info')
+        .set('cookie', await user.cookie)
+        .expect('content-type', /json/)
+        .expect(401)
+
+      expect(mockRequest).not.toBeCalled()
+
+      expect(res.body).toMatchSnapshot({
+        details: expect.any(Object)
+      })
+    })
+
+    it('should return information with version', async function () {
+      const user = fixtures.user.create({ id, aud })
+      const gardenerVersion = { major: '1', minor: '0' }
+
+      mockRequest.mockResolvedValueOnce({ spec: { service, caBundle } })
+      mockRequest.mockResolvedValueOnce(gardenerVersion)
+
+      const res = await agent
+        .get('/api/info')
+        .set('cookie', await user.cookie)
+        .expect('content-type', /json/)
+        .expect(200)
+
+      expect(mockRequest).toBeCalledTimes(2)
+      expect(mockRequest.mock.calls).toMatchSnapshot()
+
+      expect(res.body).toMatchSnapshot({
+        version: expect.any(String)
+      })
+    })
+
+    it('should return information without version', async function () {
+      const user = fixtures.user.create({ id, aud })
+
+      mockRequest.mockResolvedValueOnce({ spec: { service, caBundle } })
+      mockRequest.mockRejectedValueOnce(createError(404, 'Not found'))
+
+      const res = await agent
+        .get('/api/info')
+        .set('cookie', await user.cookie)
+        .expect('content-type', /json/)
+        .expect(200)
+
+      expect(mockRequest).toBeCalledTimes(2)
+      expect(mockRequest.mock.calls).toMatchSnapshot()
+
+      expect(res.body).toMatchSnapshot({
+        version: expect.any(String)
       })
     })
   })

--- a/backend/test/acceptance/config.spec.js
+++ b/backend/test/acceptance/config.spec.js
@@ -24,14 +24,16 @@ describe('config', function () {
   })
 
   it('should return the frontend configuration', async function () {
+    mockRequest.mockResolvedValueOnce({ data: { 'cluster-identity': 'test-id' } })
+
     const res = await agent
       .get('/config.json')
       .expect('content-type', /json/)
       .expect(200)
 
-    expect(mockRequest).not.toBeCalled()
-    expect(Array.isArray(res.body.helpMenuItems)).toBe(true)
-    expect(res.body.helpMenuItems).toHaveLength(3)
-    expect(res.body.landingPageUrl).toBe('https://gardener.cloud/')
+    expect(mockRequest).toBeCalledTimes(1)
+    expect(mockRequest.mock.calls).toMatchSnapshot()
+
+    expect(res.body).toMatchSnapshot()
   })
 })

--- a/charts/__tests__/gardener-dashboard/configmap.spec.js
+++ b/charts/__tests__/gardener-dashboard/configmap.spec.js
@@ -351,5 +351,17 @@ describe('gardener-dashboard', function () {
         expect(pick(config, ['frontend.vendorHints'])).toMatchSnapshot()
       })
     })
+
+    describe('clusterIdentity', function () {
+      it('should render the template', async function () {
+        const clusterIdentity = 'my-lanscape-dev'
+
+        const documents = await renderTemplates(templates, { clusterIdentity })
+        expect(documents).toHaveLength(1)
+        const [configMap] = documents
+        const config = yaml.safeLoad(configMap.data['config.yaml'])
+        expect(config.clusterIdentity).toBe(clusterIdentity)
+      })
+    })
   })
 })

--- a/charts/gardener-dashboard/templates/configmap.yaml
+++ b/charts/gardener-dashboard/templates/configmap.yaml
@@ -26,6 +26,9 @@ data:
     {{- else if eq (default false .Values.apiServerSkipTlsVerify) true }}
     apiServerSkipTlsVerify: true
     {{- end }}
+    {{- if .Values.clusterIdentity }}
+    clusterIdentity: {{ .Values.clusterIdentity }}
+    {{- end }}
     readinessProbe:
       periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
     {{- if .Values.gitHub }}

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -33,7 +33,7 @@ logLevel: debug
 #   -----END CERTIFICATE-----
 # # or skip tls verify (insecure)
 # apiServerSkipTlsVerify: true
-# # the identifier of the gardener landscape (defaults to the name store in kube-system/cluster-identity configmap)
+# # the identifier of the gardener landscape (defaults to the name stored in kube-system/cluster-identity configmap)
 # clusterIdentity: my-landscape-dev
 containerPort: 8080
 servicePort: 8080

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -33,6 +33,8 @@ logLevel: debug
 #   -----END CERTIFICATE-----
 # # or skip tls verify (insecure)
 # apiServerSkipTlsVerify: true
+# # the identifier of the gardener landscape (defaults to the name store in kube-system/cluster-identity configmap)
+# clusterIdentity: my-landscape-dev
 containerPort: 8080
 servicePort: 8080
 resources:

--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -21,8 +21,13 @@ const App = Vue.extend({
       }
     })
 
-    const colorScheme = window.localStorage.getItem('global/color-scheme')
+    const colorScheme = this.$localStorage.getItem('global/color-scheme')
     this.$store.commit('SET_COLOR_SCHEME', colorScheme)
+    const options = {
+      ...this.$store.getters.defaultGardenctlOptions,
+      ...this.$localStorage.getObject('global/gardenctl')
+    }
+    this.$store.commit('SET_GARDENCTL_OPTIONS', options)
   },
   render (createElement) {
     return createElement('router-view')

--- a/frontend/src/components/GardenctlSettings.vue
+++ b/frontend/src/components/GardenctlSettings.vue
@@ -12,7 +12,6 @@ SPDX-License-Identifier: Apache-2.0
         label="Select Version"
         hint="Choose for which gardenctl version the commands should be displayed"
         persistent-hint
-        @change="onChangeLegacyCommands"
         class="pb-4"
       >
         <v-radio
@@ -35,44 +34,46 @@ SPDX-License-Identifier: Apache-2.0
         hint="Choose for which shell the commands should be displayed"
         persistent-hint
         v-model="shell"
-        @input="onInputShell"
       ></v-select>
     </v-card-text>
   </v-card>
 </template>
 
 <script>
-import { mapActions } from 'vuex'
+import { mapState, mapMutations } from 'vuex'
 
 export default {
-  data () {
-    return {
-      legacyCommands: false,
-      shell: 'bash'
+  computed: {
+    ...mapState([
+      'gardenctlOptions'
+    ]),
+    legacyCommands: {
+      get () {
+        return this.gardenctlOptions.legacyCommands
+      },
+      set (value) {
+        this.setGardenctlOptions({
+          ...this.gardenctlOptions,
+          legacyCommands: value
+        })
+      }
+    },
+    shell: {
+      get () {
+        return this.gardenctlOptions.shell
+      },
+      set (value) {
+        this.setGardenctlOptions({
+          ...this.gardenctlOptions,
+          shell: value
+        })
+      }
     }
   },
   methods: {
-    ...mapActions([
-      'refreshGardenctlOptions'
-    ]),
-    onInputShell () {
-      this.store()
-    },
-    onChangeLegacyCommands () {
-      this.store()
-    },
-    store () {
-      const gardenctlOptions = {
-        legacyCommands: this.legacyCommands,
-        shell: this.shell
-      }
-      this.$store.commit('SET_GARDENCTL_OPTIONS', gardenctlOptions)
-    }
-  },
-  async mounted () {
-    const { legacyCommands, shell } = await this.refreshGardenctlOptions()
-    this.legacyCommands = legacyCommands
-    this.shell = shell
+    ...mapMutations({
+      setGardenctlOptions: 'SET_GARDENCTL_OPTIONS'
+    })
   }
 }
 </script>

--- a/frontend/src/components/ShootDetails/GardenctlCommands.vue
+++ b/frontend/src/components/ShootDetails/GardenctlCommands.vue
@@ -75,7 +75,7 @@ import GPopper from '@/components/GPopper'
 import CopyBtn from '@/components/CopyBtn'
 import CodeBlock from '@/components/CodeBlock'
 import { shootItem } from '@/mixins/shootItem'
-import { mapState, mapGetters, mapActions } from 'vuex'
+import { mapState, mapGetters } from 'vuex'
 import get from 'lodash/get'
 import includes from 'lodash/includes'
 import Vue from 'vue'
@@ -94,12 +94,11 @@ export default {
   },
   computed: {
     ...mapState([
-      'cfg'
+      'cfg',
+      'gardenctlOptions'
     ]),
     ...mapGetters([
-      'projectFromProjectList',
-      'gardenctlOptions',
-      'clusterIdentity'
+      'projectFromProjectList'
     ]),
     projectName () {
       const project = this.projectFromProjectList
@@ -163,8 +162,8 @@ export default {
     },
     targetControlPlaneCommandV2 () {
       const args = []
-      if (this.clusterIdentity) {
-        args.push(`--garden ${this.clusterIdentity}`)
+      if (this.cfg.clusterIdentity) {
+        args.push(`--garden ${this.cfg.clusterIdentity}`)
       }
       if (this.projectName) {
         args.push(`--project ${this.projectName}`)
@@ -193,8 +192,8 @@ export default {
     },
     targetShootCommandV2 () {
       const args = []
-      if (this.clusterIdentity) {
-        args.push(`--garden ${this.clusterIdentity}`)
+      if (this.cfg.clusterIdentity) {
+        args.push(`--garden ${this.cfg.clusterIdentity}`)
       }
       if (this.projectName) {
         args.push(`--project ${this.projectName}`)
@@ -210,10 +209,6 @@ export default {
     }
   },
   methods: {
-    ...mapActions([
-      'initializeClusterIdentity',
-      'refreshGardenctlOptions'
-    ]),
     visibilityIcon (index) {
       return this.expansionPanel[index] ? 'mdi-eye-off' : 'mdi-eye'
     },
@@ -233,10 +228,6 @@ export default {
           return `eval $(${command})`
       }
     }
-  },
-  async mounted () {
-    await this.initializeClusterIdentity()
-    await this.refreshGardenctlOptions()
   }
 }
 </script>

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -305,12 +305,7 @@ export function getInfo () {
   return getResource('/api/info')
 }
 
-export function getClusterIdentity () {
-  return getResource('/api/info/identity')
-}
-
 /* Terminals */
-
 export function createTerminal ({ namespace, name, target, body = {} }) {
   body.coordinate = {
     name,


### PR DESCRIPTION
**What this PR does / why we need it**:
Proposal for changes to PR #1148.
* treat `clusterIdentity` like `apiServerUrl` and allow configuration. Fallback to configmap `kube-system/cluster-identity` if the value is not configured.
* tread `gardenctlOptions` like all other properties in localStorage and do not keep copies in component data in order to avoid refreshing/sync in lifecycle hooks.
* move `frontendConfig[Handler]` from middleware into an own file and pass dashboardClient for the fallback code.
* fix vetur config

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
