### PR TITLE
Gardenctl commands: Update store only on settings change

### DIFF
--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -28,6 +28,11 @@ const App = Vue.extend({
     if (options) {
       this.$store.commit('SET_GARDENCTL_OPTIONS', options)
     }
+    window.addEventListener('storage', ({ key, newValue } = {}) => {
+      if (key === 'global/gardenctl') {
+        this.$store.commit('SET_GARDENCTL_OPTIONS', JSON.parse(newValue))
+      }
+    }, false)
   },
   render (createElement) {
     return createElement('router-view')

--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -23,11 +23,11 @@ const App = Vue.extend({
 
     const colorScheme = this.$localStorage.getItem('global/color-scheme')
     this.$store.commit('SET_COLOR_SCHEME', colorScheme)
-    const options = {
-      ...this.$store.getters.defaultGardenctlOptions,
-      ...this.$localStorage.getObject('global/gardenctl')
+
+    const options = this.$localStorage.getObject('global/gardenctl')
+    if (options) {
+      this.$store.commit('SET_GARDENCTL_OPTIONS', options)
     }
-    this.$store.commit('SET_GARDENCTL_OPTIONS', options)
   },
   render (createElement) {
     return createElement('router-view')

--- a/frontend/src/components/GardenctlSettings.vue
+++ b/frontend/src/components/GardenctlSettings.vue
@@ -40,11 +40,11 @@ SPDX-License-Identifier: Apache-2.0
 </template>
 
 <script>
-import { mapState, mapMutations } from 'vuex'
+import { mapGetters, mapMutations } from 'vuex'
 
 export default {
   computed: {
-    ...mapState([
+    ...mapGetters([
       'gardenctlOptions'
     ]),
     legacyCommands: {
@@ -53,7 +53,7 @@ export default {
       },
       set (value) {
         this.setGardenctlOptions({
-          ...this.gardenctlOptions,
+          ...this.$store.state.gardenctlOptions,
           legacyCommands: value
         })
       }
@@ -64,7 +64,7 @@ export default {
       },
       set (value) {
         this.setGardenctlOptions({
-          ...this.gardenctlOptions,
+          ...this.$store.state.gardenctlOptions,
           shell: value
         })
       }

--- a/frontend/src/components/ShootDetails/GardenctlCommands.vue
+++ b/frontend/src/components/ShootDetails/GardenctlCommands.vue
@@ -94,11 +94,11 @@ export default {
   },
   computed: {
     ...mapState([
-      'cfg',
-      'gardenctlOptions'
+      'cfg'
     ]),
     ...mapGetters([
-      'projectFromProjectList'
+      'projectFromProjectList',
+      'gardenctlOptions'
     ]),
     projectName () {
       const project = this.projectFromProjectList

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -150,10 +150,7 @@ const state = {
   darkTheme: false,
   colorScheme: 'auto',
   subscriptions: {},
-  gardenctlOptions: {
-    legacyCommands: false,
-    shell: null
-  }
+  gardenctlOptions: {}
 }
 class Shortcut {
   constructor (shortcut, unverified = true) {
@@ -1272,6 +1269,12 @@ const getters = {
       legacyCommands: false,
       shell: 'bash',
       ...get(state, 'cfg.gardenctl')
+    }
+  },
+  gardenctlOptions (state, getters) {
+    return {
+      ...getters.defaultGardenctlOptions,
+      ...state.gardenctlOptions
     }
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The store should only be updated when the user changes the `gardenctl` settings on the `My Account` page. 
This way, when the defaults change, it will be applied for all users that haven't actively changed the settings.

**Which issue(s) this PR fixes**:
Precondition:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
