### PR TITLE
Specify SecretBinding `provider.type` field on SecretBinding creation

### DIFF
--- a/backend/lib/services/cloudProviderSecrets.js
+++ b/backend/lib/services/cloudProviderSecrets.js
@@ -90,13 +90,14 @@ function toSecretBindingResource ({ metadata }) {
   const resource = Resources.SecretBinding
   const apiVersion = resource.apiVersion
   const kind = resource.kind
-  const { name, secretRef } = metadata
+  const { name, secretRef, cloudProfileName, cloudProviderKind, dnsProviderName } = metadata
+  const providerType = cloudProviderKind || dnsProviderName
   const labels = {}
-  if (metadata.cloudProfileName) {
-    labels['cloudprofile.garden.sapcloud.io/name'] = metadata.cloudProfileName
+  if (cloudProfileName) {
+    labels['cloudprofile.garden.sapcloud.io/name'] = cloudProfileName
   }
-  if (metadata.dnsProviderName) {
-    labels['gardener.cloud/dnsProviderName'] = metadata.dnsProviderName
+  if (dnsProviderName) {
+    labels['gardener.cloud/dnsProviderName'] = dnsProviderName
   }
 
   metadata = _
@@ -104,7 +105,14 @@ function toSecretBindingResource ({ metadata }) {
     .pick(['namespace'])
     .assign({ name, labels })
     .value()
-  return { apiVersion, kind, metadata, secretRef }
+  const secretBinding = { apiVersion, kind, metadata, secretRef }
+  if (providerType) {
+    secretBinding.provider = {
+      type: providerType
+    }
+  }
+
+  return secretBinding
 }
 
 function resolveQuotas (secretBinding) {

--- a/backend/test/acceptance/__snapshots__/api.cloudProviderSecrets.spec.js.snap
+++ b/backend/test/acceptance/__snapshots__/api.cloudProviderSecrets.spec.js.snap
@@ -42,6 +42,9 @@ Array [
         "name": "new-dns1",
         "namespace": "garden-foo",
       },
+      "provider": Object {
+        "type": "foo-dns",
+      },
       "secretRef": Object {
         "name": "new-dns1",
         "namespace": "garden-foo",
@@ -114,6 +117,9 @@ Array [
         },
         "name": "new-infra1",
         "namespace": "garden-foo",
+      },
+      "provider": Object {
+        "type": "infra1",
       },
       "secretRef": Object {
         "name": "new-infra1",

--- a/backend/test/acceptance/api.cloudProviderSecrets.spec.js
+++ b/backend/test/acceptance/api.cloudProviderSecrets.spec.js
@@ -75,7 +75,8 @@ describe('api', function () {
     it('should create a cloudProvider infrastructure secret', async function () {
       const metadata = {
         name: 'new-infra1',
-        cloudProfileName
+        cloudProfileName,
+        cloudProviderKind: 'infra1'
       }
       const data = {
         key: 'myKey',


### PR DESCRIPTION
/kind enhancement

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/dashboard/issues/1147

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The creation of infrastructure secret functionality now requires gardener-apiserver version >= v1.38.0.
```

```other operator
The Gardener dashboard now specifies the SecretBinding `provider.type` field when creating SecretBindings.
```
