### PR TITLE
doc: Clean up old API version

### DIFF
--- a/docs/usage/project-operations.md
+++ b/docs/usage/project-operations.md
@@ -80,12 +80,6 @@ You can now execute `kubectl` commands on the garden cluster using the technical
     shoots                                            core.gardener.cloud            true         Shoot
     shootstates                                       core.gardener.cloud            true         ShootState
     terminals                                         dashboard.gardener.cloud       true         Terminal
-    cloudprofiles                     cprofile,cpfl   garden.sapcloud.io             false        CloudProfile
-    projects                                          garden.sapcloud.io             false        Project
-    quotas                            squota          garden.sapcloud.io             true         Quota
-    secretbindings                    sb              garden.sapcloud.io             true         SecretBinding
-    seeds                                             garden.sapcloud.io             false        Seed
-    shoots                                            garden.sapcloud.io             true         Shoot
     clusteropenidconnectpresets       coidcps         settings.gardener.cloud        false        ClusterOpenIDConnectPreset
     openidconnectpresets              oidcps          settings.gardener.cloud        true         OpenIDConnectPreset
     ```
@@ -102,7 +96,6 @@ You can now execute `kubectl` commands on the garden cluster using the technical
     core.gardener.cloud/v1alpha1
     core.gardener.cloud/v1beta1
     dashboard.gardener.cloud/v1alpha1
-    garden.sapcloud.io/v1beta1
     settings.gardener.cloud/v1alpha1
     ```
 


### PR DESCRIPTION
/area documentation
/kind cleanup

The `garden.sapcloud.io` API version is removed since a longtime (with the extensibility story) and replaced by `core.gardener.cloud`. This PR removes the `garden.sapcloud.io` API version to prevent any confusion for the reader.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
NONE
```
