### PR TITLE
Remove shell

### DIFF
--- a/charts/__tests__/gardener-dashboard/__snapshots__/configmap.spec.js.snap
+++ b/charts/__tests__/gardener-dashboard/__snapshots__/configmap.spec.js.snap
@@ -170,8 +170,7 @@ Object {
       "terminalEnabled": false,
     },
     "gardenctl": Object {
-      "legacyCommands": true,
-      "shell": "bash",
+      "legacyCommands": false
     },
     "helpMenuItems": Array [
       Object {

--- a/charts/gardener-dashboard/templates/configmap.yaml
+++ b/charts/gardener-dashboard/templates/configmap.yaml
@@ -317,7 +317,6 @@ data:
       {{- if .Values.frontendConfig.gardenctl }}
       gardenctl:
         legacyCommands: {{ .Values.frontendConfig.gardenctl.legacyCommands | default false }}
-        shell: {{ .Values.frontendConfig.gardenctl.shell | default "bash" }}
       {{- end }}
       {{- if .Values.frontendConfig.defaultNodesCIDR }}
       defaultNodesCIDR: {{ .Values.frontendConfig.defaultNodesCIDR }}

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -45,8 +45,8 @@ resources:
     cpu: 100m
     memory: 120Mi
 
-# If dashboard is running in an environment with less than 1.5GB of available memory 
-# you should cap the maximum available "old space". In a Docker-512MB-Container, 
+# If dashboard is running in an environment with less than 1.5GB of available memory
+# you should cap the maximum available "old space". In a Docker-512MB-Container,
 # the value should not be greater than 90% of the available memory.
 # nodeOptions: [--optimize-for-size, --max-old-space-size=460, --gc-interval=100]
 
@@ -251,8 +251,7 @@ frontendConfig:
   # gardenctl - configure the default settings for the gardenctl commands
   gardenctl:
     legacyCommands: true # false to show gardenctl-v2 commands by default, true to show the legacy gardenctl commands. Can be overwritten by the user.
-    shell: bash # default shell. Should be one of bash, fish, powershell, zsh. Can be overwritten by the user.
-  
+
   defaultNodesCIDR: 10.250.0.0/16 # default CIDR used for nodes network when creating new shoots
 
 # # github configuration of the ticket feature

--- a/frontend/src/components/GardenctlSettings.vue
+++ b/frontend/src/components/GardenctlSettings.vue
@@ -25,16 +25,6 @@ SPDX-License-Identifier: Apache-2.0
           color="primary"
         ></v-radio>
       </v-radio-group>
-      <v-select
-        v-show="!legacyCommands"
-        color="primary"
-        item-color="primary"
-        label="Shell"
-        :items="['bash', 'fish', 'powershell', 'zsh']"
-        hint="Choose for which shell the commands should be displayed"
-        persistent-hint
-        v-model="shell"
-      ></v-select>
     </v-card-text>
   </v-card>
 </template>
@@ -55,17 +45,6 @@ export default {
         this.setGardenctlOptions({
           ...this.$store.state.gardenctlOptions,
           legacyCommands: value
-        })
-      }
-    },
-    shell: {
-      get () {
-        return this.gardenctlOptions.shell
-      },
-      set (value) {
-        this.setGardenctlOptions({
-          ...this.$store.state.gardenctlOptions,
-          shell: value
         })
       }
     }

--- a/frontend/src/components/ShootDetails/GardenctlCommands.vue
+++ b/frontend/src/components/ShootDetails/GardenctlCommands.vue
@@ -77,7 +77,6 @@ import CodeBlock from '@/components/CodeBlock'
 import { shootItem } from '@/mixins/shootItem'
 import { mapState, mapGetters } from 'vuex'
 import get from 'lodash/get'
-import includes from 'lodash/includes'
 import Vue from 'vue'
 
 export default {
@@ -112,17 +111,16 @@ export default {
       }
 
       const gardenctlVersion = this.legacyCommands ? 'Legacy gardenctl' : 'Gardenctl-v2'
-      const additionalInfo = this.legacyCommands ? '' : `(${this.shell})`
       return [
         {
           title: 'Target Control Plane',
-          subtitle: `${gardenctlVersion} command to target the control plane of the shoot cluster ${additionalInfo}`,
+          subtitle: `${gardenctlVersion} command to target the control plane of the shoot cluster`,
           value: this.targetControlPlaneCommand,
           displayValue: displayValue(this.targetControlPlaneCommand)
         },
         {
           title: 'Target Cluster',
-          subtitle: `${gardenctlVersion} command to target the shoot cluster ${additionalInfo}`,
+          subtitle: `${gardenctlVersion} command to target the shoot cluster`,
           value: this.targetShootCommand,
           displayValue: displayValue(this.targetShootCommand)
         }
@@ -130,15 +128,6 @@ export default {
     },
     legacyCommands () {
       return get(this.gardenctlOptions, 'legacyCommands', false)
-    },
-    shell () {
-      const shell = get(this.gardenctlOptions, 'shell')
-
-      if (!includes(['bash', 'fish', 'powershell', 'zsh'], shell)) {
-        return 'bash'
-      }
-
-      return shell
     },
     targetControlPlaneCommand () {
       if (this.legacyCommands) {
@@ -182,7 +171,7 @@ export default {
 
       args.push('--control-plane')
 
-      return `gardenctl target ${args.join(' ')} && ${this.kubectlEnvCommandV2}`
+      return `gardenctl target ${args.join(' ')}`
     },
     targetShootCommandV1 () {
       const args = []
@@ -210,10 +199,7 @@ export default {
         args.push(`--shoot ${this.shootName}`)
       }
 
-      return `gardenctl target ${args.join(' ')} && ${this.kubectlEnvCommandV2}`
-    },
-    kubectlEnvCommandV2 () {
-      return this.invokeCommandString(`gardenctl kubectl-env ${this.shell}`)
+      return `gardenctl target ${args.join(' ')}`
     }
   },
   methods: {
@@ -225,16 +211,6 @@ export default {
     },
     toggle (index) {
       Vue.set(this.expansionPanel, index, !this.expansionPanel[index])
-    },
-    invokeCommandString (command) {
-      switch (this.shell) {
-        case 'powershell':
-          return `& ${command} | Invoke-Expression`
-        case 'fish':
-          return `eval (${command})`
-        default:
-          return `eval $(${command})`
-      }
     }
   }
 }

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -1269,7 +1269,6 @@ const getters = {
   defaultGardenctlOptions (state) {
     return {
       legacyCommands: false,
-      shell: 'bash',
       ...get(state, 'cfg.gardenctl')
     }
   },


### PR DESCRIPTION
**What this PR does / why we need it**:
With https://github.com/gardener/gardenctl-v2/pull/86 it is now easier to target a (shoot) cluster. Running `eval $(gardenctl provider-env bash)` after running the target command is not required any more to set the `KUBECONFIG` env variable. Instead, it only has to be run once (e.g. by including it into the shell profile). See more details here https://github.com/gardener/gardenctl-v2/blob/master/docs/concepts/cli_interaction.md#behavior-with-symlink

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
