### PR TITLE
Fixed ingress deployed by helm for k8s versions >=1.22

### DIFF
--- a/charts/__tests__/gardener-dashboard/__snapshots__/configmap.spec.js.snap
+++ b/charts/__tests__/gardener-dashboard/__snapshots__/configmap.spec.js.snap
@@ -169,7 +169,7 @@ Object {
       "terminalEnabled": false,
     },
     "gardenctl": Object {
-      "legacyCommands": false,
+      "legacyCommands": true,
       "shell": "bash",
     },
     "helpMenuItems": Array [

--- a/charts/__tests__/gardener-dashboard/__snapshots__/ingress.spec.js.snap
+++ b/charts/__tests__/gardener-dashboard/__snapshots__/ingress.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`gardener-dashboard ingress should render the template with tls and a secret 1`] = `
 Object {
-  "apiVersion": "extensions/v1beta1",
+  "apiVersion": "networking.k8s.io/v1",
   "kind": "Ingress",
   "metadata": Object {
     "annotations": Object {
@@ -27,8 +27,12 @@ Object {
           "paths": Array [
             Object {
               "backend": Object {
-                "serviceName": "gardener-dashboard-service",
-                "servicePort": 8080,
+                "service": Object {
+                  "name": "gardener-dashboard-service",
+                  "port": Object {
+                    "number": 8080,
+                  },
+                },
               },
               "path": "/",
               "pathType": "Prefix",
@@ -42,8 +46,12 @@ Object {
           "paths": Array [
             Object {
               "backend": Object {
-                "serviceName": "gardener-dashboard-service",
-                "servicePort": 8080,
+                "service": Object {
+                  "name": "gardener-dashboard-service",
+                  "port": Object {
+                    "number": 8080,
+                  },
+                },
               },
               "path": "/",
               "pathType": "Prefix",

--- a/charts/_versions.tpl
+++ b/charts/_versions.tpl
@@ -12,5 +12,9 @@ apps/v1
 {{- end -}}
 
 {{- define "ingressversion" -}}
+networking.k8s.io/v1
+{{- end -}}
+
+{{- define "legacyingressversion" -}}
 extensions/v1beta1
 {{- end -}}

--- a/charts/_versions.tpl
+++ b/charts/_versions.tpl
@@ -14,7 +14,3 @@ apps/v1
 {{- define "ingressversion" -}}
 networking.k8s.io/v1
 {{- end -}}
-
-{{- define "legacyingressversion" -}}
-extensions/v1beta1
-{{- end -}}

--- a/charts/gardener-dashboard/templates/ingress.yaml
+++ b/charts/gardener-dashboard/templates/ingress.yaml
@@ -2,7 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: {{ include "ingressversion" . }}
+{{- else }}
+apiVersion: {{ include "legacyingressversion" . }}
+{{- end }}
 kind: Ingress
 metadata:
   name: gardener-dashboard-ingress
@@ -31,8 +35,15 @@ spec:
     http:
       paths:
       - backend:
+      {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+          service:
+              name: gardener-dashboard-service
+              port:
+                number: {{ $.Values.servicePort }}
+      {{- else }}
           serviceName: gardener-dashboard-service
           servicePort: {{ $.Values.servicePort }}
+      {{- end }}
         path: /
         pathType: Prefix
   {{- end }}

--- a/charts/gardener-dashboard/templates/ingress.yaml
+++ b/charts/gardener-dashboard/templates/ingress.yaml
@@ -2,11 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: {{ include "ingressversion" . }}
-{{- else }}
-apiVersion: {{ include "legacyingressversion" . }}
-{{- end }}
 kind: Ingress
 metadata:
   name: gardener-dashboard-ingress
@@ -35,15 +31,10 @@ spec:
     http:
       paths:
       - backend:
-      {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
           service:
               name: gardener-dashboard-service
               port:
                 number: {{ $.Values.servicePort }}
-      {{- else }}
-          serviceName: gardener-dashboard-service
-          servicePort: {{ $.Values.servicePort }}
-      {{- end }}
         path: /
         pathType: Prefix
   {{- end }}

--- a/charts/identity/templates/ingress.yaml
+++ b/charts/identity/templates/ingress.yaml
@@ -2,7 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: {{ include "ingressversion" . }}
+{{- else }}
+apiVersion: {{ include "legacyingressversion" . }}
+{{- end }}
 kind: Ingress
 metadata:
   name: identity-ingress
@@ -28,6 +32,14 @@ spec:
       http:
         paths:
           - backend:
+          {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+             service:
+              name: gardener-dashboard-service
+              port:
+                number: {{ $.Values.servicePort }}
+          {{- else }}
               serviceName: identity-service
               servicePort: {{ $.Values.servicePort }}
+          {{- end }}
             path: "{{ $pathname }}"
+            pathType: Prefix

--- a/charts/identity/templates/ingress.yaml
+++ b/charts/identity/templates/ingress.yaml
@@ -2,11 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: {{ include "ingressversion" . }}
-{{- else }}
-apiVersion: {{ include "legacyingressversion" . }}
-{{- end }}
 kind: Ingress
 metadata:
   name: identity-ingress
@@ -32,14 +28,9 @@ spec:
       http:
         paths:
           - backend:
-          {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-             service:
-              name: gardener-dashboard-service
-              port:
-                number: {{ $.Values.servicePort }}
-          {{- else }}
-              serviceName: identity-service
-              servicePort: {{ $.Values.servicePort }}
-          {{- end }}
+              service:
+               name: gardener-dashboard-service
+               port:
+                 number: {{ $.Values.servicePort }}
             path: "{{ $pathname }}"
             pathType: Prefix


### PR DESCRIPTION
Ingress for gardener-dashboard and identity service was broken, due to the removal of the Ingress resource from API extensions/v1beta1

According to the contribution guidelines, I should tag a maintainer for this simple fix:
@holgerkoser 

**What this PR does / why we need it**:
This PR fixes helm not being able to create the necessary ingress resources on K8s clusters running version >=1.22.0
It adds additional logic to the Helm templates so that the correct apiVersion is chosen for corresponding Kubernetes versions. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed an issue preventing HELM from creating the necessary ingress resources on K8s >=v1.22.0
```

```breaking operator
Make sure that the k8s cluster, on which the dashboard will be deployed, is on version v1.19.0 or higher. Older versions are not supported anymore.
```