### PR TITLE
[hotfix-1.55]Fix identity ingress backend name

### DIFF
--- a/charts/identity/templates/ingress.yaml
+++ b/charts/identity/templates/ingress.yaml
@@ -29,7 +29,7 @@ spec:
         paths:
           - backend:
               service:
-               name: gardener-dashboard-service
+               name: identity-service
                port:
                  number: {{ $.Values.servicePort }}
             path: "{{ $pathname }}"


### PR DESCRIPTION
(cherry picked from commit b35662377e1db60b457b5f19e7a8a3e301b2e016)

**What this PR does / why we need it**:
With https://github.com/gardener/dashboard/pull/1173 the identity ingress backend name was mistakenly renamed. This is reverted with this PR

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed the `identity-ingress` backend name
```
