### PR TITLE
Improve container runtime handling when machine image changes

### DIFF
--- a/frontend/src/components/ShootWorkers/WorkerInputGeneric.vue
+++ b/frontend/src/components/ShootWorkers/WorkerInputGeneric.vue
@@ -41,7 +41,6 @@ SPDX-License-Identifier: Apache-2.0
           :machine-image-cri="machineImageCri"
           :worker="worker"
           :kubernetes-version="kubernetesVersion"
-          :cri-name-is-required="isNew"
           @valid="onContainerRuntimeValid">
         </container-runtime>
       </div>


### PR DESCRIPTION
**What this PR does / why we need it**:
- When selecting a machine image that does not support the currently selected container runtime, the Dashboard does no longer implicitly set the container runtime to something else
- If the user switches back to another image that supports the previously selected runtime it is restored
- This also applies for new clusters, I think it makes sense as the user may not notice it otherwise
- Container Runtime is now a required field also for not new clusters. There might still exist some very old worker groups without a container runtime set explicitly. However, modifying those would cause Gardener to add this now required field automatically anyway

**Which issue(s) this PR fixes**:
Fixes #1111

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
When selecting a machine image that does not support the currently selected container runtime, the Dashboard does no longer implicitly set the container runtime to something else
```
