### PR TITLE
Add "deletion scheduled" to shoot status

### DIFF
--- a/frontend/src/components/ShootStatus.vue
+++ b/frontend/src/components/ShootStatus.vue
@@ -15,6 +15,7 @@ SPDX-License-Identifier: Apache-2.0
                 <v-icon v-if="isShootStatusHibernated" class="vertical-align-middle progress-icon" :color="color">mdi-sleep</v-icon>
                 <v-icon v-else-if="isUserError" class="vertical-align-middle progress-icon-user-error" :color="color">mdi-account-alert</v-icon>
                 <v-icon v-else-if="isShootLastOperationTypeDelete" class="vertical-align-middle progress-icon" :color="color">mdi-delete</v-icon>
+                <v-icon v-else-if="isShootMarkedForDeletion" class="vertical-align-middle progress-icon" :color="color">mdi-delete-clock</v-icon>
                 <v-icon v-else-if="isTypeCreate" class="vertical-align-middle progress-icon" :color="color">mdi-plus</v-icon>
                 <v-icon v-else-if="isTypeReconcile && !isError" class="vertical-align-middle progress-icon-check" :color="color">mdi-check</v-icon>
                 <span v-else-if="isError" class="vertical-align-middle error-exclamation-mark">!</span>
@@ -23,6 +24,7 @@ SPDX-License-Identifier: Apache-2.0
               <v-icon v-else-if="isShootStatusHibernated" class="vertical-align-middle cursor-pointer status-icon" :color="color">mdi-sleep</v-icon>
               <v-icon v-else-if="isShootReconciliationDeactivated" class="vertical-align-middle cursor-pointer status-icon" :color="color">mdi-block-helper</v-icon>
               <v-icon v-else-if="isAborted && isShootLastOperationTypeDelete" class="vertical-align-middle cursor-pointer status-icon" :color="color">mdi-delete</v-icon>
+              <v-icon v-else-if="isAborted && isShootMarkedForDeletion" class="vertical-align-middle progress-icon" :color="color">mdi-delete-clock</v-icon>
               <v-icon v-else-if="isAborted && isTypeCreate" class="vertical-align-middle cursor-pointer status-icon" :color="color">mdi-plus</v-icon>
               <v-icon v-else-if="isUserError" class="vertical-align-middle cursor-pointer status-icon" :color="color">mdi-account-alert</v-icon>
               <v-icon v-else-if="isError" class="vertical-align-middle cursor-pointer status-icon" :color="color">mdi-alert-outline</v-icon>
@@ -141,6 +143,10 @@ export default {
         statusTitle.push('Reconciliation Deactivated')
       } else {
         statusTitle.push(`${this.operationType} ${this.operationState}`)
+      }
+
+      if (this.isShootMarkedForDeletion) {
+        statusTitle.push('Cluster marked for deletion')
       }
 
       return join(statusTitle, ', ')


### PR DESCRIPTION
**What this PR does / why we need it**:
<img width="466" alt="Screen Shot 2022-05-12 at 18 02 58" src="https://user-images.githubusercontent.com/35373687/168124555-4490bc8e-9370-49ce-b214-8e034f7aa1be.png">

**Which issue(s) this PR fixes**:
Fixes #849

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The cluster status now shows if a cluster has been marked for deletion
```
