### PR TITLE
Add serviceaccountmanager role

### DIFF
--- a/docs/usage/working-with-service-accounts.md
+++ b/docs/usage/working-with-service-accounts.md
@@ -25,9 +25,10 @@ The cluster operations that are performed manually in the dashboard or via `kube
 
    | Role | Granted Permissions |
    |:---|:---|
-   | *Admin* | Fully manage resources inside the project. |
+   | *Admin* | Fully manage resources inside the project, except for member management. Also the delete/modify permissions for `ServiceAccount`s are now deprecated for this role and will be removed in a future version of Gardener, use the <code>Service Account Manager</code> role instead. |
    | *Viewer* | Read all resources inside the project except secrets. |
    | *UAM* | Manage human users or groups in the project member list. Service accounts can only be managed admins. |
+   | *Service Account Manager* | This allows to fully manage service accounts inside the project namespace and request tokens for them. Please refer to [this document](https://github.com/gardener/gardener/blob/master/docs/usage/project_namespace_access.md). For security reasons this role should not be assigned to service accounts, especially it should be prevented that a service account can refresh tokens for itself. |
 
 4. Choose *CREATE*.
 

--- a/frontend/src/components/dialogs/MemberDialog.vue
+++ b/frontend/src/components/dialogs/MemberDialog.vue
@@ -13,8 +13,8 @@ SPDX-License-Identifier: Apache-2.0
       </v-card-title>
       <v-card-text>
         <v-container  class="pa-0 ma-0">
-          <v-row >
-            <v-col cols="8">
+          <v-row>
+            <v-col cols="7">
               <v-text-field
                 :disabled="isUpdateDialog"
                 color="primary"
@@ -29,7 +29,7 @@ SPDX-License-Identifier: Apache-2.0
                 tabindex="1"
               ></v-text-field>
             </v-col>
-            <v-col cols="4">
+            <v-col cols="5">
               <v-select
                 color="primary"
                 item-color="primary"

--- a/frontend/src/components/dialogs/MemberHelpDialog.vue
+++ b/frontend/src/components/dialogs/MemberHelpDialog.vue
@@ -28,19 +28,22 @@ SPDX-License-Identifier: Apache-2.0
         </template>
          <div class="text-h6 grey--text text--darken-1 my-4">Assign roles to your members.</div>
           <p class="text-body-1">
-            Add roles to your members to restrict access to resources of this project. Currently supported built-in roles are:
+            Add roles to your members to gain access to resources of this project. Currently supported built-in roles are:
             <ul>
               <li>
-                <code>owner</code> - Access to all resources and ability to manage members. Currently there can only be one owner per project. You can change the owner on the project administration page.
+                <code>Owner</code> - Access to all resources and ability to manage members. Currently there can only be one owner per project. You can change the owner on the project administration page.
               </li>
               <li>
-                <code>admin</code> - Access to all resources of this project, except for member management.
+                <code>Admin</code> - Access to all resources of this project, except for member management. Also the delete/modify permissions for `ServiceAccount`s are now deprecated for this role and will be removed in a future version of Gardener, use the <code>Service Account Manager</code> role instead.
               </li>
               <li>
-                <code>viewer</code> - Read access to project details and shoots. Has access to shoots but is not able to create new ones. Cannot read cloud provider secrets.
+                <code>Viewer</code> - Read access to project details and shoots. Has access to shoots but is not able to create new ones. Cannot read cloud provider secrets.
               </li>
               <li>
                 <code>UAM</code> - Give the member User Access Management rights. Members with this role can manage members, should be used in combination with admin role to extend rights. In case an external UAM system is connected via a service account, only this account should get the <code>UAM</code> role.
+              </li>
+              <li>
+                <code>Service Account Manager</code> - Manage service accounts inside the project namespace and request tokens for them. For security reasons this role should not be assigned to service accounts, especially it should be prevented that a service account can refresh tokens for itself.
               </li>
             </ul>
           </p>

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -532,6 +532,10 @@ export const MEMBER_ROLE_DESCRIPTORS = [
     displayName: 'UAM'
   },
   {
+    name: 'serviceaccountmanager',
+    displayName: 'Service Account Manager'
+  },
+  {
     name: 'owner',
     displayName: 'Owner',
     notEditable: true,

--- a/frontend/src/views/Members.vue
+++ b/frontend/src/views/Members.vue
@@ -601,10 +601,13 @@ export default {
           if (includes(roles, 'admin')) {
             return 3
           }
-          if (includes(roles, 'viewer')) {
+          if (includes(roles, 'serviceaccountmanager')) {
             return 4
           }
-          return 5
+          if (includes(roles, 'viewer')) {
+            return 5
+          }
+          return 6
         default:
           return get(item, sortBy)
       }


### PR DESCRIPTION
**What this PR does / why we need it**:
Add `serviceaccountmanager` role

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
ref https://github.com/gardener/gardener/pull/5971

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
This Dashboard version is not compatible with Gardener versions prior `v1.48.x`
```

/hold until g/g `v1.48.0` is released
