### PR TITLE
Show user error as dedicated icon

### DIFF
--- a/frontend/src/components/ShootListRow.vue
+++ b/frontend/src/components/ShootListRow.vue
@@ -62,12 +62,12 @@ SPDX-License-Identifier: Apache-2.0
         </v-tooltip>
       </template>
       <template v-if="cell.header.value === 'purpose'">
-        <div class="d-flex justify-center pr-4">
+        <div class="d-flex justify-center">
           <purpose-tag :purpose="shootPurpose"></purpose-tag>
         </div>
       </template>
       <template v-if="cell.header.value === 'lastOperation'">
-        <div class="d-flex align-center justify-center pr-4">
+        <div class="d-flex align-center justify-center">
           <shoot-status
           :popper-key="`${shootNamespace}/${shootName}`"
           :shoot-item="shootItem">
@@ -75,12 +75,12 @@ SPDX-License-Identifier: Apache-2.0
         </div>
       </template>
       <template v-if="cell.header.value === 'k8sVersion'">
-        <div class="d-flex justify-center pr-4">
+        <div class="d-flex justify-center">
           <shoot-version :shoot-item="shootItem" chip></shoot-version>
         </div>
       </template>
       <template v-if="cell.header.value === 'readiness'">
-        <div class="d-flex pr-4">
+        <div class="d-flex">
           <status-tags :shoot-item="shootItem"></status-tags>
         </div>
       </template>

--- a/frontend/src/components/ShootStatus.vue
+++ b/frontend/src/components/ShootStatus.vue
@@ -12,45 +12,29 @@ SPDX-License-Identifier: Apache-2.0
           <div>
             <v-tooltip top>
               <template v-slot:activator="{ on }">
-                <div v-on="on">
-                  <v-progress-circular v-if="showProgress" class="vertical-align-middle cursor-pointer" :size="27" :width="3" :value="shootLastOperation.progress" :color="color" :rotate="-90">
-                    <v-badge
-                      left
-                      overlap
-                      bordered
-                      offset-x="1"
-                      color="error"
-                      icon="mdi-account-alert"
-                      :value="isUserError"
-                    >
+                <div v-on="on" class="d-flex align-center">
+                  <div class="icon-slot cursor-pointer">
+                    <v-icon v-if="isUserError" class="vertical-align-middle status-icon" color="error">mdi-account-alert</v-icon>
+                  </div>
+                  <div class="icon-slot cursor-pointer">
+                    <v-progress-circular v-if="showProgress" class="vertical-align-middle" :size="27" :width="3" :value="shootLastOperation.progress" :color="color" :rotate="-90">
                       <v-icon v-if="isShootStatusHibernated" class="vertical-align-middle progress-icon" :color="color">mdi-sleep</v-icon>
-                      <v-icon v-else-if="isUserError" class="vertical-align-middle progress-icon-user-error" :color="color">mdi-account-alert</v-icon>
                       <v-icon v-else-if="isShootLastOperationTypeDelete" class="vertical-align-middle progress-icon" :color="color">mdi-delete</v-icon>
                       <v-icon v-else-if="isShootMarkedForDeletion" class="vertical-align-middle progress-icon" :color="color">mdi-delete-clock</v-icon>
                       <v-icon v-else-if="isTypeCreate" class="vertical-align-middle progress-icon" :color="color">mdi-plus</v-icon>
                       <v-icon v-else-if="isTypeReconcile && !isError" class="vertical-align-middle progress-icon-check" :color="color">mdi-check</v-icon>
                       <span v-else-if="isError" class="vertical-align-middle error-exclamation-mark">!</span>
                       <template v-else>{{shootLastOperation.progress}}</template>
-                    </v-badge>
-                  </v-progress-circular>
-                  <v-badge
-                    v-else
-                    left
-                    overlap
-                    bordered
-                    color="error"
-                    icon="mdi-account-alert"
-                    :value="isUserError"
-                  >
-                    <v-icon v-if="isShootStatusHibernated" class="vertical-align-middle cursor-pointer status-icon" :color="color">mdi-sleep</v-icon>
-                    <v-icon v-else-if="isShootReconciliationDeactivated" class="vertical-align-middle cursor-pointer status-icon" :color="color">mdi-block-helper</v-icon>
-                    <v-icon v-else-if="isAborted && isShootLastOperationTypeDelete" class="vertical-align-middle cursor-pointer status-icon" :color="color">mdi-delete</v-icon>
+                    </v-progress-circular>
+                    <v-icon v-else-if="isShootStatusHibernated" class="vertical-align-middle status-icon" :color="color">mdi-sleep</v-icon>
+                    <v-icon v-else-if="isShootReconciliationDeactivated" class="vertical-align-middle status-icon" :color="color">mdi-block-helper</v-icon>
+                    <v-icon v-else-if="isAborted && isShootLastOperationTypeDelete" class="vertical-align-middle status-icon" :color="color">mdi-delete</v-icon>
                     <v-icon v-else-if="isAborted && isShootMarkedForDeletion" class="vertical-align-middle progress-icon" :color="color">mdi-delete-clock</v-icon>
-                    <v-icon v-else-if="isAborted && isTypeCreate" class="vertical-align-middle cursor-pointer status-icon" :color="color">mdi-plus</v-icon>
-                    <v-icon v-else-if="isError" class="vertical-align-middle cursor-pointer status-icon" :color="color">mdi-alert-outline</v-icon>
-                    <v-progress-circular v-else-if="isPending" class="vertical-align-middle cursor-pointer" :size="27" :width="3" indeterminate :color="color"></v-progress-circular>
-                    <v-icon v-else class="vertical-align-middle cursor-pointer status-icon-check" color="success">mdi-check-circle-outline</v-icon>
-                  </v-badge>
+                    <v-icon v-else-if="isAborted && isTypeCreate" class="vertical-align-middle status-icon" :color="color">mdi-plus</v-icon>
+                    <v-icon v-else-if="isError" class="vertical-align-middle status-icon" :color="color">mdi-alert-outline</v-icon>
+                    <v-progress-circular v-else-if="isPending" class="vertical-align-middle" :size="27" :width="3" indeterminate :color="color"></v-progress-circular>
+                    <v-icon v-else class="vertical-align-middle status-icon-check" color="success">mdi-check-circle-outline</v-icon>
+                  </div>
                 </div>
               </template>
               <div>
@@ -73,7 +57,9 @@ SPDX-License-Identifier: Apache-2.0
           :namespace="shootNamespace"
         />
       </g-popper>
-      <retry-operation :shoot-item="shootItem"></retry-operation>
+      <div class="icon-slot">
+        <retry-operation :shoot-item="shootItem"></retry-operation>
+      </div>
       <span v-if="showStatusText" class="ml-2">{{statusTitle}}</span>
     </div>
     <template v-if="showStatusText">
@@ -254,6 +240,12 @@ export default {
 
   .status-icon-check {
     font-size: 30px;
+  }
+
+  .icon-slot {
+    width: 30px;
+    height: auto;
+    text-align: center;
   }
 
   ::v-deep .v-card  {

--- a/frontend/src/components/ShootStatus.vue
+++ b/frontend/src/components/ShootStatus.vue
@@ -16,7 +16,7 @@ SPDX-License-Identifier: Apache-2.0
                   <div class="icon-slot cursor-pointer">
                     <v-icon v-if="isUserError" class="vertical-align-middle status-icon" color="error">mdi-account-alert</v-icon>
                   </div>
-                  <div class="icon-slot cursor-pointer">
+                  <div class="icon-slot cursor-pointer mx-1">
                     <v-progress-circular v-if="showProgress" class="vertical-align-middle" :size="27" :width="3" :value="shootLastOperation.progress" :color="color" :rotate="-90">
                       <v-icon v-if="isShootStatusHibernated" class="vertical-align-middle progress-icon" :color="color">mdi-sleep</v-icon>
                       <v-icon v-else-if="isShootLastOperationTypeDelete" class="vertical-align-middle progress-icon" :color="color">mdi-delete</v-icon>

--- a/frontend/src/components/ShootStatus.vue
+++ b/frontend/src/components/ShootStatus.vue
@@ -14,24 +14,43 @@ SPDX-License-Identifier: Apache-2.0
               <template v-slot:activator="{ on }">
                 <div v-on="on">
                   <v-progress-circular v-if="showProgress" class="vertical-align-middle cursor-pointer" :size="27" :width="3" :value="shootLastOperation.progress" :color="color" :rotate="-90">
-                    <v-icon v-if="isShootStatusHibernated" class="vertical-align-middle progress-icon" :color="color">mdi-sleep</v-icon>
-                    <v-icon v-else-if="isUserError" class="vertical-align-middle progress-icon-user-error" :color="color">mdi-account-alert</v-icon>
-                    <v-icon v-else-if="isShootLastOperationTypeDelete" class="vertical-align-middle progress-icon" :color="color">mdi-delete</v-icon>
-                    <v-icon v-else-if="isShootMarkedForDeletion" class="vertical-align-middle progress-icon" :color="color">mdi-delete-clock</v-icon>
-                    <v-icon v-else-if="isTypeCreate" class="vertical-align-middle progress-icon" :color="color">mdi-plus</v-icon>
-                    <v-icon v-else-if="isTypeReconcile && !isError" class="vertical-align-middle progress-icon-check" :color="color">mdi-check</v-icon>
-                    <span v-else-if="isError" class="vertical-align-middle error-exclamation-mark">!</span>
-                    <template v-else>{{shootLastOperation.progress}}</template>
+                    <v-badge
+                      left
+                      overlap
+                      bordered
+                      offset-x="1"
+                      color="error"
+                      icon="mdi-account-alert"
+                      :value="isUserError"
+                    >
+                      <v-icon v-if="isShootStatusHibernated" class="vertical-align-middle progress-icon" :color="color">mdi-sleep</v-icon>
+                      <v-icon v-else-if="isUserError" class="vertical-align-middle progress-icon-user-error" :color="color">mdi-account-alert</v-icon>
+                      <v-icon v-else-if="isShootLastOperationTypeDelete" class="vertical-align-middle progress-icon" :color="color">mdi-delete</v-icon>
+                      <v-icon v-else-if="isShootMarkedForDeletion" class="vertical-align-middle progress-icon" :color="color">mdi-delete-clock</v-icon>
+                      <v-icon v-else-if="isTypeCreate" class="vertical-align-middle progress-icon" :color="color">mdi-plus</v-icon>
+                      <v-icon v-else-if="isTypeReconcile && !isError" class="vertical-align-middle progress-icon-check" :color="color">mdi-check</v-icon>
+                      <span v-else-if="isError" class="vertical-align-middle error-exclamation-mark">!</span>
+                      <template v-else>{{shootLastOperation.progress}}</template>
+                    </v-badge>
                   </v-progress-circular>
-                  <v-icon v-else-if="isShootStatusHibernated" class="vertical-align-middle cursor-pointer status-icon" :color="color">mdi-sleep</v-icon>
-                  <v-icon v-else-if="isShootReconciliationDeactivated" class="vertical-align-middle cursor-pointer status-icon" :color="color">mdi-block-helper</v-icon>
-                  <v-icon v-else-if="isAborted && isShootLastOperationTypeDelete" class="vertical-align-middle cursor-pointer status-icon" :color="color">mdi-delete</v-icon>
-                  <v-icon v-else-if="isAborted && isShootMarkedForDeletion" class="vertical-align-middle progress-icon" :color="color">mdi-delete-clock</v-icon>
-                  <v-icon v-else-if="isAborted && isTypeCreate" class="vertical-align-middle cursor-pointer status-icon" :color="color">mdi-plus</v-icon>
-                  <v-icon v-else-if="isUserError" class="vertical-align-middle cursor-pointer status-icon" :color="color">mdi-account-alert</v-icon>
-                  <v-icon v-else-if="isError" class="vertical-align-middle cursor-pointer status-icon" :color="color">mdi-alert-outline</v-icon>
-                  <v-progress-circular v-else-if="isPending" class="vertical-align-middle cursor-pointer" :size="27" :width="3" indeterminate :color="color"></v-progress-circular>
-                  <v-icon v-else class="vertical-align-middle cursor-pointer status-icon-check" color="success">mdi-check-circle-outline</v-icon>
+                  <v-badge
+                    v-else
+                    left
+                    overlap
+                    bordered
+                    color="error"
+                    icon="mdi-account-alert"
+                    :value="isUserError"
+                  >
+                    <v-icon v-if="isShootStatusHibernated" class="vertical-align-middle cursor-pointer status-icon" :color="color">mdi-sleep</v-icon>
+                    <v-icon v-else-if="isShootReconciliationDeactivated" class="vertical-align-middle cursor-pointer status-icon" :color="color">mdi-block-helper</v-icon>
+                    <v-icon v-else-if="isAborted && isShootLastOperationTypeDelete" class="vertical-align-middle cursor-pointer status-icon" :color="color">mdi-delete</v-icon>
+                    <v-icon v-else-if="isAborted && isShootMarkedForDeletion" class="vertical-align-middle progress-icon" :color="color">mdi-delete-clock</v-icon>
+                    <v-icon v-else-if="isAborted && isTypeCreate" class="vertical-align-middle cursor-pointer status-icon" :color="color">mdi-plus</v-icon>
+                    <v-icon v-else-if="isError" class="vertical-align-middle cursor-pointer status-icon" :color="color">mdi-alert-outline</v-icon>
+                    <v-progress-circular v-else-if="isPending" class="vertical-align-middle cursor-pointer" :size="27" :width="3" indeterminate :color="color"></v-progress-circular>
+                    <v-icon v-else class="vertical-align-middle cursor-pointer status-icon-check" color="success">mdi-check-circle-outline</v-icon>
+                  </v-badge>
                 </div>
               </template>
               <div>


### PR DESCRIPTION
**What this PR does / why we need it**:
Show user error as badge so that the underlying error is still visible, see also linked issue.

<img width="170" alt="Screen Shot 2022-07-04 at 12 49 32" src="https://user-images.githubusercontent.com/35373687/177140005-858cb4f3-d579-4e5e-a203-20591968933e.png">

I'm not sure about the layout though. It looks kind of unsteady. We should discuss this.

**Which issue(s) this PR fixes**:
Fixes #1032

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Added dedicated icon for user errors in shoot status so that the underlying shoot status is still visible
```
