### PR TITLE
dexidp: use latest distroless image

### DIFF
--- a/charts/identity/values.yaml
+++ b/charts/identity/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/dexidp/dex
-  tag: v2.31.1
+  tag: v2.32.0-distroless
   pullPolicy: IfNotPresent
 
 containerPort: 5556


### PR DESCRIPTION
**What this PR does / why we need it**:
To reduce the attack surface, use latest distroless image for dexidp, which was introduced with https://github.com/dexidp/dex/releases/tag/v2.32.0

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Identity chart: bumped version of dex to `v2.32.0-distroless` 
```
