### PR TITLE
OIDC token refresh and PKCE flow

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -2696,6 +2696,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@gardener-dashboard/kube-config", "workspace:packages/kube-config"],\
             ["@gardener-dashboard/logger", "workspace:packages/logger"],\
             ["@gardener-dashboard/request", "workspace:packages/request"],\
+            ["@gardener-dashboard/test-utils", "workspace:packages/test-utils"],\
             ["@godaddy/terminus", "npm:4.10.2"],\
             ["@octokit/rest", "npm:18.12.0"],\
             ["abort-controller", "npm:3.0.0"],\

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -2803,6 +2803,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["eventemitter3", "npm:4.0.7"],\
             ["get-contrast", "npm:3.0.0"],\
             ["highlight.js", "npm:11.5.1"],\
+            ["http-errors", "npm:2.0.0"],\
             ["jest", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:27.5.1"],\
             ["jest-fetch-mock", "npm:3.0.3"],\
             ["jest-serializer-vue", "npm:2.0.2"],\

--- a/backend/__fixtures__/auth.js
+++ b/backend/__fixtures__/auth.js
@@ -145,7 +145,8 @@ const mocks = {
         return Promise.reject(createError(503))
       }
       const { spec: { token } } = json
-      const { id: username, groups } = decode(token)
+      const { id, sub, email, groups } = decode(token)
+      const username = id || sub || email
       const authenticated = username.endsWith(domain)
       const user = authenticated ? { username, groups } : {}
       return Promise.resolve({

--- a/backend/__fixtures__/index.js
+++ b/backend/__fixtures__/index.js
@@ -6,6 +6,7 @@
 
 'use strict'
 
+const { matchers } = require('@gardener-dashboard/test-utils')
 const config = require('./config')
 const auth = require('./auth')
 const kube = require('./kube')
@@ -33,6 +34,7 @@ function resetAll () {
 }
 
 const fixtures = {
+  matchers,
   config,
   auth,
   user,

--- a/backend/__fixtures__/projects.js
+++ b/backend/__fixtures__/projects.js
@@ -160,6 +160,15 @@ const projectList = [
     uid: 6,
     name: 'secret',
     createdBy: 'admin@example.org',
+    members: [
+      {
+        apiGroup: 'rbac.authorization.k8s.io',
+        kind: 'ServiceAccount',
+        namespace: 'garden-bar',
+        name: 'robot',
+        roles: ['viewer']
+      }
+    ],
     description: 'secret-description',
     purpose: 'secret-purpose'
   }),

--- a/backend/jest.setup.js
+++ b/backend/jest.setup.js
@@ -12,7 +12,9 @@ const { Test } = require('supertest')
 const pEvent = require('p-event')
 const ioClient = require('socket.io-client')
 const { createTerminus } = require('@godaddy/terminus')
-const fixtures = require('./__fixtures__')
+const { matchers, ...fixtures } = require('./__fixtures__')
+
+expect.extend(matchers)
 
 function createHttpAgent () {
   const app = require('./lib/app')

--- a/backend/lib/auth.js
+++ b/backend/lib/auth.js
@@ -12,6 +12,7 @@ const cookieParser = require('cookie-parser')
 const {
   authorizationUrl,
   authorizationCallback,
+  refreshToken,
   authorizeToken,
   clearCookies
 } = require('./security')
@@ -56,5 +57,15 @@ router.route('/callback')
       res.redirect(redirectPath)
     } catch (err) {
       res.redirect(`/login#error=${encodeURIComponent(err.message)}`)
+    }
+  })
+
+router.route('/token')
+  .get(async (req, res, next) => {
+    try {
+      await refreshToken(req, res)
+      res.status(200).end()
+    } catch (err) {
+      next(err)
     }
   })

--- a/backend/lib/auth.js
+++ b/backend/lib/auth.js
@@ -63,8 +63,7 @@ router.route('/callback')
 router.route('/token')
   .get(async (req, res, next) => {
     try {
-      await refreshToken(req, res)
-      res.status(200).end()
+      res.status(200).send(await refreshToken(req, res))
     } catch (err) {
       next(err)
     }

--- a/backend/lib/cache/index.js
+++ b/backend/lib/cache/index.js
@@ -36,6 +36,10 @@ class Cache extends Map {
     return this.get('projects').list()
   }
 
+  getShoots () {
+    return this.get('shoots').list()
+  }
+
   getControllerRegistrations () {
     return this.get('controllerregistrations').list()
   }
@@ -81,6 +85,12 @@ module.exports = {
   },
   getProjects () {
     return cache.getProjects()
+  },
+  getShoots () {
+    return cache.getShoots()
+  },
+  getShoot (namespace, name) {
+    return cache.get('shoots').find({ metadata: { namespace, name } })
   },
   getControllerRegistrations () {
     return cache.getControllerRegistrations()

--- a/backend/lib/config/gardener.js
+++ b/backend/lib/config/gardener.js
@@ -101,7 +101,6 @@ module.exports = {
       requiredConfigurationProperties.push(
         'oidc.issuer',
         'oidc.client_id',
-        'oidc.client_secret',
         'oidc.redirect_uris'
       )
     }

--- a/backend/lib/config/gardener.js
+++ b/backend/lib/config/gardener.js
@@ -101,6 +101,7 @@ module.exports = {
       requiredConfigurationProperties.push(
         'oidc.issuer',
         'oidc.client_id',
+        'oidc.client_secret',
         'oidc.redirect_uris'
       )
     }

--- a/backend/lib/io.js
+++ b/backend/lib/io.js
@@ -11,7 +11,8 @@ const _ = require('lodash')
 const createServer = require('socket.io')
 const logger = require('./logger')
 const security = require('./security')
-const { isHttpError, Unauthorized } = require('http-errors')
+const createError = require('http-errors')
+const { isHttpError } = createError
 const { STATUS_CODES } = require('http')
 
 const { EventsEmitter, NamespacedBatchEmitter } = require('./utils/batchEmitter')
@@ -231,7 +232,7 @@ function registerShootHandlers (socket, cache) {
       const user = getUserFromSocket(socket)
       const namespaces = await listNamespaces(user)
       if (!_.includes(namespaces, namespace)) {
-        throw new Unauthorized(`Not authorized to subscribe for shoots in namepsace ${namespace}`)
+        throw createError(403, `Not authorized to subscribe for shoots in namespace ${namespace}`)
       }
 
       subscribeShoots(socket, { namespace, filter, user })

--- a/backend/lib/io.js
+++ b/backend/lib/io.js
@@ -6,7 +6,6 @@
 
 'use strict'
 
-const assert = require('assert').strict
 const _ = require('lodash')
 const createServer = require('socket.io')
 const logger = require('./logger')

--- a/backend/lib/io.js
+++ b/backend/lib/io.js
@@ -199,11 +199,11 @@ function registerShootHandlers (socket) {
         if (!_.includes(namespaces, namespace)) {
           throw createError(403, `Not authorized to subscribe for shoots in namespace ${namespace}`)
         }
-        subscribeShoots(socket, { namespaces: [namespace], filter, user })
+        await subscribeShoots(socket, { namespaces: [namespace], filter, user })
       } else if (await authorization.isAdmin(user)) {
-        subscribeShootsAdmin(socket, { namespaces, filter, user })
+        await subscribeShootsAdmin(socket, { namespaces, filter, user })
       } else {
-        subscribeShoots(socket, { namespaces, filter, user })
+        await subscribeShoots(socket, { namespaces, filter, user })
       }
     } catch (err) {
       logger.error('Socket %s: failed to subscribe to shoots: %s', socket.id, err)

--- a/backend/lib/middleware.js
+++ b/backend/lib/middleware.js
@@ -63,6 +63,9 @@ function errorToLocals (err, req) {
   if (code >= 500) {
     logger.error(err.message, err.stack)
   }
+  if (code === 401) {
+    logger.info('Authentication Failed: %s', err.message)
+  }
   return { code, reason, message, status, details }
 }
 

--- a/backend/lib/routes/user.js
+++ b/backend/lib/routes/user.js
@@ -62,7 +62,11 @@ router.route('/kubeconfig')
     } = config
     const {
       issuer: issuerUrl,
-      public: { clientId, clientSecret } = {}
+      public: {
+        clientId = oidc.client_id,
+        clientSecret,
+        usePKCE
+      } = {}
     } = oidc
     const body = {
       server,
@@ -70,9 +74,14 @@ router.route('/kubeconfig')
       insecureSkipTlsVerify,
       oidc: {
         issuerUrl,
-        clientId,
-        clientSecret
+        clientId
       }
+    }
+    if (clientSecret) {
+      body.oidc.clientSecret = clientSecret
+    }
+    if (usePKCE || !clientSecret) {
+      body.oidc.usePKCE = true
     }
     if (oidc.scope) {
       const extraScopes = []

--- a/backend/lib/security/constants.js
+++ b/backend/lib/security/constants.js
@@ -10,5 +10,6 @@ module.exports = {
   COOKIE_HEADER_PAYLOAD: 'gHdrPyl',
   COOKIE_SIGNATURE: 'gSgn',
   COOKIE_TOKEN: 'gTkn',
+  COOKIE_CODE_VERIFIER: 'gCdVrfr',
   GARDENER_AUDIENCE: 'gardener'
 }

--- a/backend/lib/security/index.js
+++ b/backend/lib/security/index.js
@@ -367,7 +367,8 @@ function authenticate (options = {}) {
   }
 }
 
-function authenticateSocket (options) {
+function authenticateSocket () {
+  const options = { createClient: () => false }
   const authenticateAsync = promisify(authenticate(options))
   const cookieParserAsync = promisify(cookieParser())
   return async (socket) => {

--- a/backend/lib/security/index.js
+++ b/backend/lib/security/index.js
@@ -42,7 +42,7 @@ const {
   scope,
   client_id: clientId,
   client_secret: clientSecret,
-  usePKCI = !clientSecret,
+  usePKCE = !clientSecret,
   refreshTokenLifetime = 86400,
   rejectUnauthorized = true,
   ca,
@@ -160,7 +160,7 @@ async function authorizationUrl (req, res) {
     state,
     scope
   }
-  if (usePKCI) {
+  if (usePKCE) {
     const codeChallengeMethod = getCodeChallengeMethod(client)
     const codeVerifier = generators.codeVerifier()
     res.cookie(COOKIE_CODE_VERIFIER, codeVerifier, {

--- a/backend/lib/security/jose.js
+++ b/backend/lib/security/jose.js
@@ -53,7 +53,7 @@ module.exports = sessionSecret => {
   return {
     encodeState,
     decodeState,
-    sign (payload, secretOrPrivateKey, options) {
+    sign (payload, secretOrPrivateKey, { expiresIn = '1d', jwtid = uuid.v1(), ...options } = {}) {
       if (isPlainObject(secretOrPrivateKey)) {
         options = secretOrPrivateKey
         secretOrPrivateKey = undefined
@@ -61,8 +61,13 @@ module.exports = sessionSecret => {
       if (!secretOrPrivateKey) {
         secretOrPrivateKey = sessionSecret
       }
-      const { expiresIn = '1d', jwtid = uuid.v1(), ...rest } = options || {}
-      return jwtSign(payload, secretOrPrivateKey, { expiresIn, jwtid, ...rest })
+      if (!payload.exp) {
+        options.expiresIn = expiresIn
+      }
+      if (!payload.jti) {
+        options.jwtid = jwtid
+      }
+      return jwtSign(payload, secretOrPrivateKey, options)
     },
     verify (token, options) {
       return jwtVerify(token, sessionSecret, options)

--- a/backend/lib/security/jose.js
+++ b/backend/lib/security/jose.js
@@ -53,7 +53,7 @@ module.exports = sessionSecret => {
   return {
     encodeState,
     decodeState,
-    sign (payload, secretOrPrivateKey, { expiresIn = '1d', jwtid = uuid.v1(), ...options } = {}) {
+    sign (payload, secretOrPrivateKey, { ...options } = {}) {
       if (isPlainObject(secretOrPrivateKey)) {
         options = secretOrPrivateKey
         secretOrPrivateKey = undefined
@@ -61,11 +61,11 @@ module.exports = sessionSecret => {
       if (!secretOrPrivateKey) {
         secretOrPrivateKey = sessionSecret
       }
-      if (!payload.exp) {
-        options.expiresIn = expiresIn
+      if (!payload.exp && !options.expiresIn) {
+        options.expiresIn = '1d'
       }
-      if (!payload.jti) {
-        options.jwtid = jwtid
+      if (!payload.jti && !options.jwtid) {
+        options.jwtid = uuid.v1()
       }
       return jwtSign(payload, secretOrPrivateKey, options)
     },

--- a/backend/lib/services/io.js
+++ b/backend/lib/services/io.js
@@ -1,0 +1,151 @@
+//
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+'use strict'
+
+const _ = require('lodash')
+const cache = require('../cache')
+const createError = require('http-errors')
+const { dashboardClient, Resources } = require('@gardener-dashboard/kube-client')
+
+async function hasAuthorization ({ id: user, groups }, { resourceAttributes }) {
+  const { apiVersion, kind } = Resources.SubjectAccessReview
+  const body = {
+    kind,
+    apiVersion,
+    spec: {
+      user,
+      groups,
+      resourceAttributes
+    }
+  }
+  const { status = {} } = await dashboardClient['authorization.k8s.io'].subjectaccessreviews.create(body)
+  return status.allowed
+}
+
+function canListShoots (user, namespace) {
+  const resourceAttributes = {
+    verb: 'list',
+    group: 'core.gardener.cloud',
+    resource: 'shoots',
+    namespace
+  }
+  return hasAuthorization(user, { resourceAttributes })
+}
+
+function canGetShoot (user, namespace, name) {
+  const resourceAttributes = {
+    verb: 'get',
+    group: 'core.gardener.cloud',
+    resource: 'shoots',
+    namespace,
+    name
+  }
+  return hasAuthorization(user, { resourceAttributes })
+}
+
+function isAdmin (user) {
+  const resourceAttributes = {
+    verb: 'get',
+    group: '',
+    resource: 'secrets'
+  }
+  return hasAuthorization(user, { resourceAttributes })
+}
+
+async function listShoots (user, { namespace, shootsWithIssuesOnly } = {}) {
+  const allowed = await canListShoots(user, namespace)
+  if (!allowed) {
+    const message = namespace
+      ? `Not authorized to list shoots in namepsace ${namespace}`
+      : 'Not authorized to list shoots of all namespaces'
+    throw createError(403, message)
+  }
+  const items = cache.getShoots().filter(({ metadata }) => {
+    if (metadata.namespace !== namespace) {
+      return false
+    }
+    if (shootsWithIssuesOnly === true) {
+      const { labels = {} } = metadata
+      if (!labels['shoot.gardener.cloud/status'] || labels['shoot.gardener.cloud/status'] === 'healthy') {
+        return false
+      }
+    }
+    return true
+  })
+  return {
+    apiVersion: 'v1',
+    kind: 'List',
+    metadata: {},
+    items
+  }
+}
+
+async function readShoot (user, namepsace, name) {
+  const allowed = await canGetShoot(user, namepsace, name)
+  if (!allowed) {
+    throw createError(403, `Not authorized to get shoot ${name} in namepsace ${namepsace}`)
+  }
+  const shoot = cache.getShoot(namepsace, name)
+  if (!shoot) {
+    throw createError(404, `Shoot "${name}" not found in namespace "${namepsace}"`)
+  }
+  return shoot
+}
+
+async function listNamespaces (user) {
+  const admin = await isAdmin(user)
+  const isMemberOf = project => {
+    return _
+      .chain(project)
+      .get('spec.members')
+      .find(({ kind, namespace, name }) => {
+        switch (kind) {
+          case 'Group':
+            if (_.includes(user.groups, name)) {
+              return true
+            }
+            break
+          case 'User':
+            if (user.id === name) {
+              return true
+            }
+            break
+          case 'ServiceAccount':
+            if (user.id === `system:serviceaccount:${namespace}:${name}`) {
+              return true
+            }
+            break
+        }
+        return false
+      })
+      .value()
+  }
+  const isReady = project => {
+    return _.get(project, 'status.phase') === 'Ready'
+  }
+  return _
+    .chain(cache.getProjects())
+    .filter(project => {
+      if (!admin && !isMemberOf(project)) {
+        return false
+      }
+      if (!isReady(project)) {
+        return false
+      }
+      return true
+    })
+    .map('spec.namespace')
+    .value()
+}
+
+module.exports = {
+  isAdmin,
+  canGetShoot,
+  listNamespaces,
+  listShoots,
+  readShoot
+}

--- a/backend/lib/services/projects.js
+++ b/backend/lib/services/projects.js
@@ -15,8 +15,8 @@ const {
 const { PreconditionFailed, InternalServerError } = require('http-errors')
 const shoots = require('./shoots')
 const authorization = require('./authorization')
+const { projectFilter } = require('../utils')
 const cache = require('../cache')
-const Member = require('./members/Member')
 const PROJECT_INITIALIZATION_TIMEOUT = 30 * 1000
 
 function fromResource ({ metadata, spec = {}, status = {} }) {
@@ -117,47 +117,10 @@ function getProjectName (namespace) {
 }
 
 exports.list = async function ({ user }) {
-  const projects = cache.getProjects()
   const isAdmin = await authorization.isAdmin(user)
-  const isMemberOf = project => {
-    const hasGroupMembership = _
-      .chain(project)
-      .get('spec.members')
-      .filter(['kind', 'Group'])
-      .map('name')
-      .intersection(user.groups)
-      .size()
-      .gt(0)
-      .value()
-
-    const hasUserMembership = _
-      .chain(project)
-      .get('spec.members')
-      .filter(['kind', 'User'])
-      .map('name')
-      .includes(user.id)
-      .value()
-
-    const member = Member.parseUsername(user.id)
-    const hasServiceAccountMembership = _
-      .chain(project)
-      .get('spec.members')
-      .filter(['kind', 'ServiceAccount'])
-      .find(member)
-      .value()
-
-    return hasGroupMembership || hasUserMembership || hasServiceAccountMembership
-  }
-
   return _
-    .chain(projects)
-    .filter(project => {
-      if (!isAdmin && !isMemberOf(project)) {
-        return false
-      }
-      const phase = _.get(project, 'status.phase', 'Pending')
-      return phase !== 'Pending'
-    })
+    .chain(cache.getProjects())
+    .filter(projectFilter(user, isAdmin))
     .map(fromResource)
     .value()
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -67,6 +67,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
+    "@gardener-dashboard/test-utils": "workspace:*",
     "abort-controller": "^3.0.0",
     "dockerfile-ast": "^0.4.2",
     "eslint": "^8.16.0",

--- a/backend/test/__snapshots__/services.io.spec.js.snap
+++ b/backend/test/__snapshots__/services.io.spec.js.snap
@@ -1,0 +1,389 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`services io projects should return the two projects for user foo@example.org 1`] = `
+Array [
+  Object {
+    "apiVersion": "authorization.k8s.io/v1",
+    "kind": "SubjectAccessReview",
+    "spec": Object {
+      "groups": Array [],
+      "resourceAttributes": Object {
+        "group": "",
+        "resource": "secrets",
+        "verb": "get",
+      },
+      "user": "foo@example.org",
+    },
+  },
+]
+`;
+
+exports[`services io shoots listing shoots in all namespaces should succeed 1`] = `
+Array [
+  Object {
+    "apiVersion": "authorization.k8s.io/v1",
+    "kind": "SubjectAccessReview",
+    "spec": Object {
+      "groups": Array [
+        "viewer",
+      ],
+      "resourceAttributes": Object {
+        "group": "core.gardener.cloud",
+        "namespace": undefined,
+        "resource": "shoots",
+        "verb": "list",
+      },
+      "user": "foo@example.org",
+    },
+  },
+]
+`;
+
+exports[`services io shoots listing shoots in all namespaces should succeed 2`] = `
+Array [
+  Object {
+    "metadata": Object {
+      "annotations": Object {
+        "gardener.cloud/created-by": "foo@example.org",
+      },
+      "labels": Object {
+        "shoot.gardener.cloud/status": "healthy",
+      },
+      "name": "fooShoot",
+      "namespace": "garden-foo",
+      "uid": 1,
+    },
+    "spec": Object {
+      "cloudProfileName": "infra1-profileName",
+      "hibernation": Object {
+        "enabled": false,
+      },
+      "kubernetes": Object {
+        "version": "1.16.0",
+      },
+      "provider": Object {
+        "type": "fooInfra",
+      },
+      "purpose": "fooPurpose",
+      "region": "foo-west",
+      "secretBindingName": "foo-infra1",
+      "seedName": "infra1-seed",
+    },
+    "status": Object {
+      "technicalID": "shoot--foo--fooShoot",
+    },
+  },
+  Object {
+    "metadata": Object {
+      "annotations": Object {
+        "gardener.cloud/created-by": "bar@example.org",
+      },
+      "labels": Object {
+        "shoot.gardener.cloud/status": "healthy",
+      },
+      "name": "barShoot",
+      "namespace": "garden-foo",
+      "uid": 2,
+    },
+    "spec": Object {
+      "cloudProfileName": "infra1-profileName",
+      "hibernation": Object {
+        "enabled": false,
+      },
+      "kubernetes": Object {
+        "version": "1.16.0",
+      },
+      "provider": Object {
+        "type": "fooInfra",
+      },
+      "purpose": "barPurpose",
+      "region": "foo-west",
+      "secretBindingName": "foo-infra1",
+      "seedName": "infra1-seed",
+    },
+    "status": Object {
+      "technicalID": "shoot--foo--barShoot",
+    },
+  },
+  Object {
+    "metadata": Object {
+      "annotations": Object {
+        "gardener.cloud/created-by": "foo@example.org",
+      },
+      "labels": Object {
+        "shoot.gardener.cloud/status": "unhealthy",
+      },
+      "name": "dummyShoot",
+      "namespace": "garden-foo",
+      "uid": 3,
+    },
+    "spec": Object {
+      "cloudProfileName": "infra1-profileName",
+      "hibernation": Object {
+        "enabled": false,
+      },
+      "kubernetes": Object {
+        "version": "1.16.0",
+      },
+      "provider": Object {
+        "type": "fooInfra",
+      },
+      "purpose": "fooPurpose",
+      "region": "foo-west",
+      "secretBindingName": "barSecretName",
+      "seedName": "infra4-seed-without-secretRef",
+    },
+    "status": Object {
+      "technicalID": "shoot--foo--dummyShoot",
+    },
+  },
+  Object {
+    "metadata": Object {
+      "annotations": Object {
+        "gardener.cloud/created-by": "admin@example.org",
+      },
+      "labels": Object {
+        "shoot.gardener.cloud/status": "healthy",
+      },
+      "name": "infra1-seed",
+      "namespace": "garden",
+      "uid": 4,
+    },
+    "spec": Object {
+      "cloudProfileName": "infra1-profileName",
+      "hibernation": Object {
+        "enabled": false,
+      },
+      "kubernetes": Object {
+        "version": "1.16.0",
+      },
+      "provider": Object {
+        "type": "fooInfra",
+      },
+      "purpose": "foo-purpose",
+      "region": "foo-west",
+      "secretBindingName": "soil-infra1",
+      "seedName": "soil-infra1",
+    },
+    "status": Object {
+      "technicalID": "shoot--garden--infra1-seed",
+    },
+  },
+]
+`;
+
+exports[`services io shoots listing shoots in namespace "garden-foo" should succeed 1`] = `
+Array [
+  Object {
+    "apiVersion": "authorization.k8s.io/v1",
+    "kind": "SubjectAccessReview",
+    "spec": Object {
+      "groups": Array [
+        "viewer",
+      ],
+      "resourceAttributes": Object {
+        "group": "core.gardener.cloud",
+        "namespace": "garden-foo",
+        "resource": "shoots",
+        "verb": "list",
+      },
+      "user": "foo@example.org",
+    },
+  },
+]
+`;
+
+exports[`services io shoots listing shoots in namespace "garden-foo" should succeed 2`] = `
+Array [
+  Object {
+    "metadata": Object {
+      "annotations": Object {
+        "gardener.cloud/created-by": "foo@example.org",
+      },
+      "labels": Object {
+        "shoot.gardener.cloud/status": "healthy",
+      },
+      "name": "fooShoot",
+      "namespace": "garden-foo",
+      "uid": 1,
+    },
+    "spec": Object {
+      "cloudProfileName": "infra1-profileName",
+      "hibernation": Object {
+        "enabled": false,
+      },
+      "kubernetes": Object {
+        "version": "1.16.0",
+      },
+      "provider": Object {
+        "type": "fooInfra",
+      },
+      "purpose": "fooPurpose",
+      "region": "foo-west",
+      "secretBindingName": "foo-infra1",
+      "seedName": "infra1-seed",
+    },
+    "status": Object {
+      "technicalID": "shoot--foo--fooShoot",
+    },
+  },
+  Object {
+    "metadata": Object {
+      "annotations": Object {
+        "gardener.cloud/created-by": "bar@example.org",
+      },
+      "labels": Object {
+        "shoot.gardener.cloud/status": "healthy",
+      },
+      "name": "barShoot",
+      "namespace": "garden-foo",
+      "uid": 2,
+    },
+    "spec": Object {
+      "cloudProfileName": "infra1-profileName",
+      "hibernation": Object {
+        "enabled": false,
+      },
+      "kubernetes": Object {
+        "version": "1.16.0",
+      },
+      "provider": Object {
+        "type": "fooInfra",
+      },
+      "purpose": "barPurpose",
+      "region": "foo-west",
+      "secretBindingName": "foo-infra1",
+      "seedName": "infra1-seed",
+    },
+    "status": Object {
+      "technicalID": "shoot--foo--barShoot",
+    },
+  },
+  Object {
+    "metadata": Object {
+      "annotations": Object {
+        "gardener.cloud/created-by": "foo@example.org",
+      },
+      "labels": Object {
+        "shoot.gardener.cloud/status": "unhealthy",
+      },
+      "name": "dummyShoot",
+      "namespace": "garden-foo",
+      "uid": 3,
+    },
+    "spec": Object {
+      "cloudProfileName": "infra1-profileName",
+      "hibernation": Object {
+        "enabled": false,
+      },
+      "kubernetes": Object {
+        "version": "1.16.0",
+      },
+      "provider": Object {
+        "type": "fooInfra",
+      },
+      "purpose": "fooPurpose",
+      "region": "foo-west",
+      "secretBindingName": "barSecretName",
+      "seedName": "infra4-seed-without-secretRef",
+    },
+    "status": Object {
+      "technicalID": "shoot--foo--dummyShoot",
+    },
+  },
+]
+`;
+
+exports[`services io shoots listing unhealthy shoots in all namespaces should succeed 1`] = `
+Array [
+  Object {
+    "metadata": Object {
+      "annotations": Object {
+        "gardener.cloud/created-by": "foo@example.org",
+      },
+      "labels": Object {
+        "shoot.gardener.cloud/status": "unhealthy",
+      },
+      "name": "dummyShoot",
+      "namespace": "garden-foo",
+      "uid": 3,
+    },
+    "spec": Object {
+      "cloudProfileName": "infra1-profileName",
+      "hibernation": Object {
+        "enabled": false,
+      },
+      "kubernetes": Object {
+        "version": "1.16.0",
+      },
+      "provider": Object {
+        "type": "fooInfra",
+      },
+      "purpose": "fooPurpose",
+      "region": "foo-west",
+      "secretBindingName": "barSecretName",
+      "seedName": "infra4-seed-without-secretRef",
+    },
+    "status": Object {
+      "technicalID": "shoot--foo--dummyShoot",
+    },
+  },
+]
+`;
+
+exports[`services io shoots reading a shoot in namespace "garden-foo" should succeed 1`] = `
+Array [
+  Object {
+    "apiVersion": "authorization.k8s.io/v1",
+    "kind": "SubjectAccessReview",
+    "spec": Object {
+      "groups": Array [
+        "viewer",
+      ],
+      "resourceAttributes": Object {
+        "group": "core.gardener.cloud",
+        "name": "fooShoot",
+        "namespace": "garden-foo",
+        "resource": "shoots",
+        "verb": "get",
+      },
+      "user": "foo@example.org",
+    },
+  },
+]
+`;
+
+exports[`services io shoots reading a shoot in namespace "garden-foo" should succeed 2`] = `
+Object {
+  "metadata": Object {
+    "annotations": Object {
+      "gardener.cloud/created-by": "foo@example.org",
+    },
+    "labels": Object {
+      "shoot.gardener.cloud/status": "healthy",
+    },
+    "name": "fooShoot",
+    "namespace": "garden-foo",
+    "uid": 1,
+  },
+  "spec": Object {
+    "cloudProfileName": "infra1-profileName",
+    "hibernation": Object {
+      "enabled": false,
+    },
+    "kubernetes": Object {
+      "version": "1.16.0",
+    },
+    "provider": Object {
+      "type": "fooInfra",
+    },
+    "purpose": "fooPurpose",
+    "region": "foo-west",
+    "secretBindingName": "foo-infra1",
+    "seedName": "infra1-seed",
+  },
+  "status": Object {
+    "technicalID": "shoot--foo--fooShoot",
+  },
+}
+`;

--- a/backend/test/acceptance/auth.spec.js
+++ b/backend/test/acceptance/auth.spec.js
@@ -8,6 +8,7 @@
 
 const { pick, head } = require('lodash')
 const assert = require('assert').strict
+const { TokenSet } = require('openid-client')
 const setCookieParser = require('set-cookie-parser')
 const { mockRequest } = require('@gardener-dashboard/request')
 
@@ -58,12 +59,10 @@ class Client {
   async callback (redirectUri, { code }, { response_type: responseType }) {
     assert.strictEqual(code, OTAC)
     assert.strictEqual(responseType, 'code')
-    const bearer = await this.user.bearer
-    const expiresIn = Math.floor(Date.now() / 1000) + 86400
-    return {
-      id_token: bearer,
-      expires_in: expiresIn
-    }
+    const idToken = await this.user.bearer
+    const tokenSet = new TokenSet({ id_token: idToken })
+    tokenSet.expires_at = tokenSet.claims().exp
+    return tokenSet
   }
 }
 
@@ -201,6 +200,8 @@ describe('auth', function () {
 
   it('should successfully login with a given token', async function () {
     const bearer = await user.bearer
+    const { exp: expiresAt } = security.decode(bearer)
+    const now = Math.floor(Date.now() / 1000)
 
     mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewToken())
 
@@ -239,18 +240,24 @@ describe('auth', function () {
     })
     const [header, payload] = cookieHeaderPayload.value.split('.')
     const signature = cookieSignature.value
-    const encryptedBearer = cookieToken.value
     const token = [header, payload, signature].join('.')
-    const tokenPayload = security.decode(token)
-    expect(tokenPayload.jti).toMatch(/[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}/i)
     expect(cookieHeaderPayload.sameSite).toBe('Lax')
     expect(cookieHeaderPayload.httpOnly).toBeUndefined()
     expect(cookieSignature.sameSite).toBe('Lax')
     expect(cookieSignature.httpOnly).toBe(true)
     expect(cookieToken.sameSite).toBe('Lax')
     expect(cookieToken.httpOnly).toBe(true)
-    expect(await security.verify(token)).toEqual(tokenPayload)
-    expect(await security.decrypt(encryptedBearer)).toBe(bearer)
+    expect(await security.verify(token)).toEqual(expect.objectContaining({
+      id,
+      iat: expect.toBeWithinRange(now, now + 3),
+      aud: ['gardener'],
+      exp: expiresAt,
+      jti: expect.stringMatching(/[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}/i)
+    }))
+    expect((await security.decrypt(cookieToken.value)).split(',')).toEqual([
+      bearer,
+      expiresAt.toString()
+    ])
     expect(res.body.id).toBe(id)
   })
 

--- a/backend/test/acceptance/auth.spec.js
+++ b/backend/test/acceptance/auth.spec.js
@@ -17,8 +17,43 @@ const {
   COOKIE_HEADER_PAYLOAD,
   COOKIE_SIGNATURE,
   COOKIE_TOKEN,
-  decodeState
+  decodeState,
+  setCookies,
+  sign,
+  decrypt,
+  decode
 } = security
+
+async function getCookieValue (tokenSet) {
+  const values = []
+  const res = {
+    cookie (key, value) {
+      values.push(`${key}=${value}`)
+    }
+  }
+  await setCookies(res, tokenSet)
+  return values.join(';')
+}
+
+async function parseCookies (res) {
+  const {
+    [COOKIE_HEADER_PAYLOAD]: cookieHeaderPayload,
+    [COOKIE_SIGNATURE]: cookieSignature,
+    [COOKIE_TOKEN]: cookieToken
+  } = setCookieParser.parse(res, {
+    decodeValues: true,
+    map: true
+  })
+  assert.strictEqual(cookieHeaderPayload.sameSite, 'Lax')
+  assert.strictEqual(cookieHeaderPayload.httpOnly, undefined)
+  assert.strictEqual(cookieSignature.sameSite, 'Lax')
+  assert.strictEqual(cookieSignature.httpOnly, true)
+  assert.strictEqual(cookieToken.sameSite, 'Lax')
+  assert.strictEqual(cookieToken.httpOnly, true)
+  const accessToken = [...cookieHeaderPayload.value.split('.'), cookieSignature.value].join('.')
+  const [idToken, refreshToken] = (await decrypt(cookieToken.value)).split(',')
+  return [accessToken, idToken, refreshToken]
+}
 
 const ZERO_DATE = new Date(0)
 const OTAC = 'jd93ke'
@@ -64,6 +99,15 @@ class Client {
     tokenSet.expires_at = tokenSet.claims().exp
     return tokenSet
   }
+
+  refresh (token) {
+    const tokenSet = new TokenSet({
+      id_token: token,
+      refresh_token: 'refresh-token'
+    })
+    tokenSet.expires_at = tokenSet.claims().exp
+    return tokenSet
+  }
 }
 
 describe('auth', function () {
@@ -73,6 +117,7 @@ describe('auth', function () {
 
   let agent
   let getIssuerClientStub
+  let mockRefresh
 
   beforeAll(() => {
     agent = createAgent()
@@ -88,6 +133,7 @@ describe('auth', function () {
       CLOCK_TOLERANCE: oidc.clockTolerance || 30
     })
     getIssuerClientStub = jest.spyOn(security, 'getIssuerClient').mockResolvedValue(client)
+    mockRefresh = jest.spyOn(client, 'refresh')
   })
 
   it('should redirect to authorization url without frontend redirectUrl', async function () {
@@ -230,34 +276,17 @@ describe('auth', function () {
       }
     ])
 
-    const {
-      [COOKIE_HEADER_PAYLOAD]: cookieHeaderPayload,
-      [COOKIE_SIGNATURE]: cookieSignature,
-      [COOKIE_TOKEN]: cookieToken
-    } = setCookieParser.parse(res, {
-      decodeValues: true,
-      map: true
-    })
-    const [header, payload] = cookieHeaderPayload.value.split('.')
-    const signature = cookieSignature.value
-    const token = [header, payload, signature].join('.')
-    expect(cookieHeaderPayload.sameSite).toBe('Lax')
-    expect(cookieHeaderPayload.httpOnly).toBeUndefined()
-    expect(cookieSignature.sameSite).toBe('Lax')
-    expect(cookieSignature.httpOnly).toBe(true)
-    expect(cookieToken.sameSite).toBe('Lax')
-    expect(cookieToken.httpOnly).toBe(true)
-    expect(await security.verify(token)).toEqual(expect.objectContaining({
+    const [accessToken, idToken, refreshToken] = await parseCookies(res)
+    const payload = await security.verify(accessToken)
+    expect(payload).toEqual(expect.objectContaining({
       id,
       iat: expect.toBeWithinRange(now, now + 3),
       aud: ['gardener'],
       exp: expiresAt,
       jti: expect.stringMatching(/[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}/i)
     }))
-    expect((await security.decrypt(cookieToken.value)).split(',')).toEqual([
-      bearer,
-      expiresAt.toString()
-    ])
+    expect(idToken).toEqual(bearer)
+    expect(refreshToken).toBeUndefined()
     expect(res.body.id).toBe(id)
   })
 
@@ -284,5 +313,76 @@ describe('auth', function () {
     expect(cookieSignature.expires).toEqual(ZERO_DATE)
     expect(cookieToken.value).toHaveLength(0)
     expect(cookieToken.expires).toEqual(ZERO_DATE)
+  })
+
+  it('should successfully refresh a token', async function () {
+    const iat = Math.floor(Date.now() / 1000)
+
+    const idTokenPayload = {
+      iat,
+      sub: id,
+      exp: iat - 60
+    }
+    const accessTokenPayload = {
+      iat,
+      id,
+      exp: iat + 24 * 60 * 60,
+      refresh_at: idTokenPayload.exp,
+      aud: ['gardener']
+    }
+    // in this test the refreshToken is return as new idToken in the `client.refresh` mock implementation
+    const refreshTokenPayload = {
+      iat: iat + 60,
+      sub: id,
+      exp: iat + 61 * 60
+    }
+    const tokenSet = new TokenSet({
+      id_token: await sign(idTokenPayload),
+      access_token: await sign(accessTokenPayload),
+      refresh_token: await sign(refreshTokenPayload)
+    })
+
+    mockRequest.mockImplementation(fixtures.auth.mocks.reviewToken())
+
+    const res = await agent
+      .get('/auth/token')
+      .set('cookie', await getCookieValue(tokenSet))
+      .expect('content-type', /json/)
+      .expect(200)
+
+    expect(mockRequest).toBeCalledTimes(1)
+    expect(mockRequest.mock.calls[0]).toEqual([
+      {
+        ...pick(fixtures.kube, [':scheme', ':authority', 'authorization']),
+        ':method': 'post',
+        ':path': '/apis/authentication.k8s.io/v1/tokenreviews'
+      },
+      {
+        apiVersion: 'authentication.k8s.io/v1',
+        kind: 'TokenReview',
+        metadata: {
+          name: expect.stringMatching(/^token-\d+/)
+        },
+        spec: {
+          token: tokenSet.refresh_token
+        }
+      }
+    ])
+    expect(mockRefresh).toBeCalledTimes(1)
+    expect(mockRefresh.mock.calls[0]).toEqual([tokenSet.refresh_token])
+
+    const [accessToken, idToken, refreshToken] = await parseCookies(res)
+    expect(idToken).toEqual(tokenSet.refresh_token)
+    expect(refreshToken).toBe('refresh-token')
+    const payload = decode(accessToken)
+    expect(payload).toEqual(res.body)
+    expect(payload).toEqual({
+      jti: expect.stringMatching(/^[a-z0-9-]+$/),
+      id,
+      iat: accessTokenPayload.iat,
+      exp: accessTokenPayload.exp,
+      aud: accessTokenPayload.aud,
+      refresh_at: refreshTokenPayload.exp
+    })
   })
 })

--- a/backend/test/acceptance/io.spec.js
+++ b/backend/test/acceptance/io.spec.js
@@ -41,9 +41,6 @@ describe('socket.io', function () {
     assert.ok(socket.client.user)
     assert.strictEqual(socket.client.user.id, id)
     assert.deepStrictEqual(socket.client.user.groups, groups)
-    assert.deepStrictEqual(socket.client.user.auth, {
-      bearer: await user.bearer
-    })
   }
 
   let agent

--- a/backend/test/acceptance/io.spec.js
+++ b/backend/test/acceptance/io.spec.js
@@ -106,16 +106,13 @@ describe('socket.io', function () {
       return new Promise(resolve => socket.emit('subscribeShoot', metadata, resolve))
     }
 
-    async function subscribeShoots (options = {}) {
+    async function subscribeShoots ({ namespace = '_all', ...options } = {}) {
       const asyncIterator = pEvent.iterator(socket, 'shoots', {
         timeout: 1000,
         resolutionEvents: ['subscription_done'],
         rejectionEvents: ['error', 'subscription_error']
       })
-      const event = !options.namespace
-        ? 'subscribeAllShoots'
-        : 'subscribeShoots'
-      socket.emit(event, options)
+      socket.emit('subscribeShoots', { namespace, ...options })
       const shootsByNamespace = {}
       for await (const namespacedEvent of asyncIterator) {
         for (const [key, items] of Object.entries(namespacedEvent.namespaces)) {

--- a/backend/test/security.spec.js
+++ b/backend/test/security.spec.js
@@ -6,24 +6,204 @@
 
 'use strict'
 
-const jose = require('../lib/security/jose')
+const _ = require('lodash')
 
 describe('security', function () {
   describe('jose', function () {
-    const secret = 'this-is-a-secret-only-used-for-tests'
+    const secret = Buffer.from('this-is-a-secret-only-used-for-tests').toString('base64')
+    const jose = require('../lib/security/jose')(secret)
+
     const value = 'hello world'
-    const { encrypt, decrypt } = jose(Buffer.from(secret).toString('base64'))
 
     it('should encrypt a value', async function () {
-      const encryptedValue = await encrypt(value)
-      const decryptedValue = await decrypt(encryptedValue)
+      const encryptedValue = await jose.encrypt(value)
+      const decryptedValue = await jose.decrypt(encryptedValue)
       expect(decryptedValue).toBe(value)
     })
 
     it('should decrypt a value', async function () {
       const encryptedValue = 'eyJlbmMiOiJBMTI4Q0JDLUhTMjU2IiwiYWxnIjoiUEJFUzItSFMyNTYrQTEyOEtXIiwicDJjIjozMTQ5LCJwMnMiOiIwenZfczdqbl9kcVBJOER2czQ3WWNRIn0.7Uh_sBteoCt2jlVBR87w00tuFuUqQfEhsXJ7jigqKZoEc5n2tw_h5A.adbP15XHdzAWCpzGCGYnXA.zVhhD1iRqJ-JnoIbyj-HeA.neL8L8Vtcgue-a8PYS4zCQ'
-      const decryptedValue = await decrypt(encryptedValue)
+      const decryptedValue = await jose.decrypt(encryptedValue)
       expect(decryptedValue).toBe(value)
+    })
+  })
+
+  describe('openid-client', () => {
+    const redirectUrl = new URL('/account', 'http://localhost:8080')
+    const sub = 'john.doe@example.org'
+    const expiresIn = 3600
+
+    let config
+    let authentication
+    let security
+    let jose
+    let issuer
+    let client
+
+    let mockGetIssuerClient
+    let mockCodeVerifier
+    let mockCodeChallenge
+    let mockRefresh
+    let mockIsAuthenticated
+
+    const now = () => Math.floor(Date.now() / 1000)
+
+    const mockSecurity = options => {
+      config = _
+        .chain(fixtures.config.default)
+        .cloneDeep()
+        .merge(options)
+        .value()
+      let openidClient
+      jest.isolateModules(() => {
+        require('../lib/config/gardener').readConfig.mockReturnValue(config)
+        openidClient = require('openid-client')
+        authentication = require('../lib/services/authentication')
+        jose = require('../lib/security/jose')(config.sessionSecret)
+        security = require('../lib/security')
+      })
+      const issuerUrl = config.oidc.issuer
+      issuer = new openidClient.Issuer({
+        issuer: issuerUrl,
+        authorization_endpoint: issuerUrl + '/oauth2/authorize',
+        token_endpoint: issuerUrl + '/oauth2/token',
+        jwks_uri: issuerUrl + '/oauth2/jwks',
+        code_challenge_methods_supported: ['S256', 'plain']
+      })
+      client = new issuer.Client({
+        client_id: config.oidc.client_id,
+        client_secret: config.oidc.client_secret
+      })
+      mockGetIssuerClient = jest.spyOn(security, 'getIssuerClient').mockResolvedValue(client)
+      mockRefresh = jest.spyOn(client, 'refresh').mockImplementation(async () => {
+        const idToken = await jose.sign({ sub }, { expiresIn })
+        return {
+          id_token: idToken,
+          expires_at: now() + expiresIn,
+          refresh_token: 'refresh-token'
+        }
+      })
+      mockCodeVerifier = jest.spyOn(openidClient.generators, 'codeVerifier').mockReturnValue('code-verifier')
+      mockCodeChallenge = jest.spyOn(openidClient.generators, 'codeChallenge').mockReturnValue('code-challenge')
+      mockIsAuthenticated = jest.spyOn(authentication, 'isAuthenticated').mockResolvedValue({ username: sub, groups: [] })
+    }
+
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    it('should return an authorization url with PKCE flow', async () => {
+      const scope = 'oidc email groups profile offline_access'
+      mockSecurity({ oidc: { scope, usePKCE: true } })
+      const query = {
+        redirectUrl: redirectUrl.toString()
+      }
+      const req = { query }
+      const res = {
+        cookie: jest.fn()
+      }
+      const authorizationUrl = await security.authorizationUrl(req, res)
+      const url = new URL(authorizationUrl)
+      expect(mockGetIssuerClient).toBeCalledTimes(1)
+      expect(mockCodeVerifier).toBeCalledTimes(1)
+      expect(mockCodeChallenge).toBeCalledTimes(1)
+      expect(mockCodeChallenge.mock.calls[0]).toEqual(['code-verifier'])
+      expect(res.cookie).toBeCalledTimes(1)
+      expect(res.cookie.mock.calls[0]).toEqual([
+        'gCdVrfr',
+        'code-verifier',
+        {
+          httpOnly: true,
+          maxAge: 300000,
+          path: '/auth/callback',
+          sameSite: 'Lax',
+          secure: false
+        }
+      ])
+      expect(url.origin).toBe(config.oidc.issuer)
+      const params = Object.fromEntries(url.searchParams)
+      expect(security.decodeState(params.state)).toEqual({
+        redirectOrigin: redirectUrl.origin,
+        redirectPath: redirectUrl.pathname
+      })
+      expect(params).toEqual(expect.objectContaining({
+        client_id: config.oidc.client_id,
+        scope,
+        response_type: 'code',
+        redirect_uri: redirectUrl.origin + '/auth/callback',
+        state: expect.any(String),
+        code_challenge: 'code-challenge',
+        code_challenge_method: 'S256'
+      }))
+    })
+
+    it('should refesh an expired token', async () => {
+      mockSecurity({ oidc: { scope: 'openid email' } })
+      const {
+        COOKIE_HEADER_PAYLOAD,
+        COOKIE_SIGNATURE,
+        COOKIE_TOKEN
+      } = security
+      const createClient = jest.fn()
+      const authenticate = security.authenticate({ createClient })
+      const exp = now() - 3600
+      const idToken = await jose.sign({ sub: 'john.doe@example.org', exp })
+      const encryptedValues = await jose.encrypt([idToken, exp, 'refresh-token'].join(','))
+      const req = {
+        headers: {
+          'x-requested-with': 'XMLHttpRequest'
+        },
+        cookies: {
+          [COOKIE_HEADER_PAYLOAD]: 'a.b',
+          [COOKIE_SIGNATURE]: 'c',
+          [COOKIE_TOKEN]: encryptedValues
+        }
+      }
+      const res = {
+        cookie: jest.fn(),
+        clearCookie: jest.fn()
+      }
+      const next = jest.fn()
+      await authenticate(req, res, next)
+      expect(mockGetIssuerClient).toBeCalledTimes(1)
+      expect(mockRefresh).toBeCalledTimes(1)
+      expect(mockRefresh.mock.calls[0]).toEqual(['refresh-token'])
+      const tokenSet = await mockRefresh.mock.results[0].value
+      expect(mockIsAuthenticated).toBeCalledTimes(1)
+      expect(mockIsAuthenticated.mock.calls[0]).toEqual([{
+        token: tokenSet.id_token
+      }])
+      expect(req.user).toEqual({
+        jti: expect.stringMatching(/^[a-z0-9-]{36}$/),
+        id: sub,
+        groups: [],
+        iat: expect.any(Number),
+        exp: expect.any(Number),
+        aud: ['gardener'],
+        auth: {
+          bearer: expect.stringMatching(/^[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]{43}$/)
+        }
+      })
+      expect(res.cookie).toBeCalledTimes(3)
+      expect(res.cookie.mock.calls).toEqual([
+        [
+          COOKIE_HEADER_PAYLOAD,
+          expect.stringMatching(/^[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+$/),
+          { secure: false, expires: undefined, sameSite: 'Lax' }
+        ],
+        [
+          COOKIE_SIGNATURE,
+          expect.stringMatching(/^[a-zA-Z0-9_-]{43}$/),
+          { secure: false, httpOnly: true, expires: undefined, sameSite: 'Lax' }
+        ],
+        [
+          COOKIE_TOKEN,
+          expect.stringMatching(/^[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+$/),
+          { secure: false, httpOnly: true, expires: undefined, sameSite: 'Lax' }
+        ]
+      ])
+      expect(next).toBeCalledTimes(1)
+      expect(next.mock.calls[0]).toEqual([])
     })
   })
 })

--- a/backend/test/services.io.spec.js
+++ b/backend/test/services.io.spec.js
@@ -1,0 +1,188 @@
+//
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+'use strict'
+
+const _ = require('lodash')
+const cache = require('../lib/cache')
+const { dashboardClient, Store } = require('@gardener-dashboard/kube-client')
+const { authorization, shoots, projects } = require('../lib/services/io')
+
+const setStatusLabel = obj => _.set(obj, 'metadata.labels["shoot.gardener.cloud/status"]', obj.metadata.uid === 3 ? 'unhealthy' : 'healthy')
+
+describe('services', () => {
+  describe('io', () => {
+    const user = {
+      groups: []
+    }
+    const informers = {
+      shoots: {
+        store: new Store()
+      },
+      projects: {
+        store: new Store()
+      }
+    }
+    cache.initialize(informers)
+
+    let mockCreateSubjectAccessReview
+
+    beforeAll(() => {
+      informers.projects.store.replace(fixtures.projects.list())
+      informers.shoots.store.replace(fixtures.shoots.list().map(setStatusLabel))
+    })
+
+    afterAll(() => {
+      cache.cache.clear()
+      mockCreateSubjectAccessReview.mockRestore()
+    })
+
+    beforeEach(() => {
+      user.id = 'foo@example.org'
+      user.groups = []
+      mockCreateSubjectAccessReview = jest.spyOn(dashboardClient['authorization.k8s.io'].subjectaccessreviews, 'create')
+        .mockImplementation(body => {
+          const {
+            spec: {
+              groups = [],
+              resourceAttributes
+            }
+          } = body
+          const allowed = groups.includes('admin') || (groups.includes('viewer') && ['shoots'].includes(resourceAttributes.resource))
+          return Promise.resolve({
+            status: {
+              allowed
+            }
+          })
+        })
+    })
+
+    afterEach(() => {
+      mockCreateSubjectAccessReview.mockClear()
+    })
+
+    describe('shoots', () => {
+      describe('listing shoots in all namespaces', () => {
+        it('should succeed', async () => {
+          user.groups.push('viewer')
+          const { items } = await shoots.list({ user })
+          expect(mockCreateSubjectAccessReview).toBeCalledTimes(1)
+          expect(mockCreateSubjectAccessReview.mock.calls[0]).toMatchSnapshot()
+          expect(items).toMatchSnapshot()
+        })
+
+        it('should throw  a not authorized error', async () => {
+          await expect(shoots.list({ user })).rejects.toThrowError('Not authorized to list shoots of all namespaces')
+          expect(mockCreateSubjectAccessReview).toBeCalledTimes(1)
+        })
+      })
+
+      describe('listing unhealthy shoots in all namespaces', () => {
+        it('should succeed', async () => {
+          user.groups.push('viewer')
+          const { items } = await shoots.list({ user, shootsWithIssuesOnly: true })
+          expect(mockCreateSubjectAccessReview).toBeCalledTimes(1)
+          expect(items).toMatchSnapshot()
+        })
+      })
+
+      describe('listing shoots in namespace "garden-foo"', () => {
+        const namespace = 'garden-foo'
+
+        it('should succeed', async () => {
+          user.groups.push('viewer')
+          const { items } = await shoots.list({ user, namespace })
+          expect(mockCreateSubjectAccessReview).toBeCalledTimes(1)
+          expect(mockCreateSubjectAccessReview.mock.calls[0]).toMatchSnapshot()
+          expect(items).toMatchSnapshot()
+        })
+
+        it('should throw a not authorized error', async () => {
+          await expect(shoots.list({ user, namespace })).rejects.toThrowError(`Not authorized to list shoots in namespace ${namespace}`)
+          expect(mockCreateSubjectAccessReview).toBeCalledTimes(1)
+        })
+      })
+
+      describe('reading a shoot in namespace "garden-foo"', () => {
+        const namespace = 'garden-foo'
+
+        it('should succeed', async () => {
+          user.groups.push('viewer')
+          const item = await shoots.read({ user, namespace, name: 'fooShoot' })
+          expect(mockCreateSubjectAccessReview).toBeCalledTimes(1)
+          expect(mockCreateSubjectAccessReview.mock.calls[0]).toMatchSnapshot()
+          expect(item).toMatchSnapshot()
+        })
+
+        it('should throw a not authorized error', async () => {
+          await expect(shoots.read({ user, namespace, name: 'fooShoot' })).rejects.toThrowError(`Not authorized to get shoot fooShoot in namespace ${namespace}`)
+          expect(mockCreateSubjectAccessReview).toBeCalledTimes(1)
+        })
+
+        it('should throw a not found error', async () => {
+          user.groups.push('viewer')
+          await expect(shoots.read({ user, namespace, name: 'bazShoot' })).rejects.toThrowError(`Shoot bazShoot not found in namespace ${namespace}`)
+          expect(mockCreateSubjectAccessReview).toBeCalledTimes(1)
+        })
+      })
+    })
+
+    describe('projects', () => {
+      const uids = items => _.map(items, 'metadata.uid')
+
+      it('should return the two projects for user foo@example.org', async () => {
+        const items = await projects.list({ user })
+        expect(mockCreateSubjectAccessReview).toBeCalledTimes(1)
+        expect(mockCreateSubjectAccessReview.mock.calls[0]).toMatchSnapshot()
+        expect(uids(items)).toEqual([1, 2])
+      })
+
+      describe('when the user is an administrator', () => {
+        beforeEach(() => {
+          user.groups.push('admin')
+        })
+
+        it('should return all projects', async () => {
+          const items = await projects.list({ user })
+          expect(mockCreateSubjectAccessReview).toBeCalledTimes(1)
+          expect(uids(items)).toEqual([1, 2, 3, 4, 6, 7])
+        })
+      })
+
+      describe('when the user is in group "group2"', () => {
+        beforeEach(() => {
+          user.groups.push('group2')
+        })
+
+        it('should return another project', async () => {
+          const items = await projects.list({ user })
+          expect(mockCreateSubjectAccessReview).toBeCalledTimes(1)
+          expect(uids(items)).toEqual([1, 2, 4])
+        })
+      })
+
+      describe('when the user is system:serviceaccount:garden-bar:robot', () => {
+        beforeEach(() => {
+          user.id = 'system:serviceaccount:garden-bar:robot'
+        })
+
+        it('should return only one project', async () => {
+          const items = await projects.list({ user })
+          expect(mockCreateSubjectAccessReview).toBeCalledTimes(1)
+          expect(uids(items)).toEqual([6])
+        })
+      })
+    })
+
+    describe('authorization', () => {
+      it('should deny access for incomplete responses bodies', async () => {
+        mockCreateSubjectAccessReview.mockResolvedValueOnce({})
+        await expect(authorization.isAdmin(user)).resolves.toBe(false)
+        expect(mockCreateSubjectAccessReview).toBeCalledTimes(1)
+      })
+    })
+  })
+})

--- a/charts/__tests__/gardener-dashboard/__snapshots__/configmap.spec.js.snap
+++ b/charts/__tests__/gardener-dashboard/__snapshots__/configmap.spec.js.snap
@@ -93,12 +93,9 @@ Object {
 }
 `;
 
-exports[`gardener-dashboard configmap kubeconfig download should render the template w/ \`oidc.public\` 1`] = `
+exports[`gardener-dashboard configmap kubeconfig download should render the template w/ \`public.client_secret\` 1`] = `
 Object {
   "apiServerCaData": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCllYQnBVMlZ5ZG1WeVEyRT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ==",
-  "apiServerUrl": "https://api.garden.example.org",
-  "logFormat": "text",
-  "logLevel": "debug",
   "oidc": Object {
     "ca": "-----BEGIN CERTIFICATE-----
 Li4u
@@ -115,9 +112,103 @@ Li4u
     "rejectUnauthorized": true,
     "scope": "openid email profile groups audience:server:client_id:dashboard audience:server:client_id:kube-kubectl",
   },
-  "port": 8080,
-  "readinessProbe": Object {
-    "periodSeconds": 10,
+}
+`;
+
+exports[`gardener-dashboard configmap kubeconfig download should render the template w/o \`public.client_secret\` 1`] = `
+Object {
+  "apiServerCaData": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCllYQnBVMlZ5ZG1WeVEyRT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ==",
+  "oidc": Object {
+    "ca": "-----BEGIN CERTIFICATE-----
+Li4u
+-----END CERTIFICATE-----",
+    "issuer": "https://identity.garden.example.org",
+    "public": Object {
+      "clientId": "kube-kubectl",
+      "usePKCE": true,
+    },
+    "redirect_uris": Array [
+      "https://dashboard.garden.example.org/auth/callback",
+      "https://dashboard.ingress.garden.example.org/auth/callback",
+    ],
+    "rejectUnauthorized": true,
+    "scope": "openid email profile groups audience:server:client_id:dashboard audience:server:client_id:kube-kubectl",
+  },
+}
+`;
+
+exports[`gardener-dashboard configmap kubeconfig download should render the template with PKCE flow for the public client 1`] = `
+Object {
+  "apiServerCaData": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCllYQnBVMlZ5ZG1WeVEyRT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ==",
+  "oidc": Object {
+    "ca": "-----BEGIN CERTIFICATE-----
+Li4u
+-----END CERTIFICATE-----",
+    "issuer": "https://identity.garden.example.org",
+    "public": Object {
+      "clientId": "kube-kubectl",
+      "clientSecret": "kube-kubectl-secret",
+      "usePKCE": true,
+    },
+    "redirect_uris": Array [
+      "https://dashboard.garden.example.org/auth/callback",
+      "https://dashboard.ingress.garden.example.org/auth/callback",
+    ],
+    "rejectUnauthorized": true,
+    "scope": "openid email profile groups audience:server:client_id:dashboard audience:server:client_id:kube-kubectl",
+  },
+}
+`;
+
+exports[`gardener-dashboard configmap oidc should render the template with PKCE flow for the internal client 1`] = `
+Object {
+  "oidc": Object {
+    "ca": "-----BEGIN CERTIFICATE-----
+Li4u
+-----END CERTIFICATE-----",
+    "issuer": "https://identity.garden.example.org",
+    "redirect_uris": Array [
+      "https://dashboard.garden.example.org/auth/callback",
+      "https://dashboard.ingress.garden.example.org/auth/callback",
+    ],
+    "rejectUnauthorized": true,
+    "scope": "openid email profile groups audience:server:client_id:dashboard audience:server:client_id:kube-kubectl",
+    "usePKCE": true,
+  },
+}
+`;
+
+exports[`gardener-dashboard configmap oidc should render the template with default scope 1`] = `
+Object {
+  "oidc": Object {
+    "ca": "-----BEGIN CERTIFICATE-----
+Li4u
+-----END CERTIFICATE-----",
+    "issuer": "https://identity.garden.example.org",
+    "redirect_uris": Array [
+      "https://dashboard.garden.example.org/auth/callback",
+      "https://dashboard.ingress.garden.example.org/auth/callback",
+    ],
+    "rejectUnauthorized": true,
+    "scope": "openid email profile groups audience:server:client_id:dashboard audience:server:client_id:kube-kubectl",
+  },
+}
+`;
+
+exports[`gardener-dashboard configmap oidc should render the template with scope containing offline_access 1`] = `
+Object {
+  "oidc": Object {
+    "ca": "-----BEGIN CERTIFICATE-----
+Li4u
+-----END CERTIFICATE-----",
+    "issuer": "https://identity.garden.example.org",
+    "redirect_uris": Array [
+      "https://dashboard.garden.example.org/auth/callback",
+      "https://dashboard.ingress.garden.example.org/auth/callback",
+    ],
+    "refreshTokenLifetime": 2592000,
+    "rejectUnauthorized": true,
+    "scope": "openid email groups offline_access",
   },
 }
 `;

--- a/charts/__tests__/gardener-dashboard/__snapshots__/configmap.spec.js.snap
+++ b/charts/__tests__/gardener-dashboard/__snapshots__/configmap.spec.js.snap
@@ -206,9 +206,9 @@ Li4u
       "https://dashboard.garden.example.org/auth/callback",
       "https://dashboard.ingress.garden.example.org/auth/callback",
     ],
-    "refreshTokenLifetime": 2592000,
     "rejectUnauthorized": true,
     "scope": "openid email groups offline_access",
+    "sessionLifetime": 2592000,
   },
 }
 `;

--- a/charts/__tests__/gardener-dashboard/configmap.spec.js
+++ b/charts/__tests__/gardener-dashboard/configmap.spec.js
@@ -108,7 +108,7 @@ describe('gardener-dashboard', function () {
       it('should render the template with scope containing offline_access', async function () {
         Object.assign(values.oidc, {
           scope: 'openid email groups offline_access',
-          refreshTokenLifetime: 30 * 24 * 60 * 60
+          sessionLifetime: 30 * 24 * 60 * 60
         })
         expect.assertions(2)
         await assertTemplate()

--- a/charts/__tests__/gardener-dashboard/configmap.spec.js
+++ b/charts/__tests__/gardener-dashboard/configmap.spec.js
@@ -39,21 +39,90 @@ describe('gardener-dashboard', function () {
     })
 
     describe('kubeconfig download', function () {
-      it('should render the template w/ `oidc.public`', async function () {
-        const values = {
-          apiServerCa: getCertificate('apiServerCa'),
-          oidc: {
-            public: {
-              clientId: 'kube-kubectl',
-              clientSecret: 'kube-kubectl-secret'
-            }
-          }
-        }
+      let values
+
+      const assertTemplate = async () => {
         const documents = await renderTemplates(templates, values)
         expect(documents).toHaveLength(1)
         const [configMap] = documents
         const config = yaml.load(configMap.data['config.yaml'])
-        expect(omit(config, ['frontend', 'terminal'])).toMatchSnapshot()
+        expect(pick(config, ['apiServerCaData', 'oidc'])).toMatchSnapshot()
+      }
+
+      beforeEach(() => {
+        values = {
+          apiServerCa: getCertificate('apiServerCa'),
+          oidc: {
+            public: {
+              clientId: 'kube-kubectl'
+            }
+          }
+        }
+      })
+
+      it('should render the template w/ `public.client_secret`', async function () {
+        Object.assign(values.oidc.public, {
+          clientSecret: 'kube-kubectl-secret'
+        })
+        expect.assertions(2)
+        await assertTemplate()
+      })
+
+      it('should render the template w/o `public.client_secret`', async function () {
+        expect.assertions(2)
+        await assertTemplate()
+      })
+
+      it('should render the template with PKCE flow for the public client', async function () {
+        Object.assign(values.oidc.public, {
+          clientSecret: 'kube-kubectl-secret',
+          usePKCE: true
+        })
+        expect.assertions(2)
+        await assertTemplate()
+      })
+    })
+
+    describe('oidc', () => {
+      let values
+
+      const assertTemplate = async () => {
+        const documents = await renderTemplates(templates, values)
+        expect(documents).toHaveLength(1)
+        const [configMap] = documents
+        const config = yaml.load(configMap.data['config.yaml'])
+        expect(pick(config, ['oidc'])).toMatchSnapshot()
+      }
+
+      beforeEach(() => {
+        values = {
+          oidc: {}
+        }
+      })
+
+      it('should render the template with default scope', async function () {
+        expect.assertions(2)
+        await assertTemplate()
+      })
+
+      it('should render the template with scope containing offline_access', async function () {
+        Object.assign(values.oidc, {
+          scope: 'openid email groups offline_access',
+          refreshTokenLifetime: 30 * 24 * 60 * 60
+        })
+        expect.assertions(2)
+        await assertTemplate()
+      })
+
+      it('should render the template with PKCE flow for the internal client', async function () {
+        Object.assign(values.oidc, {
+          usePKCE: true
+        })
+        const documents = await renderTemplates(templates, values)
+        expect(documents).toHaveLength(1)
+        const [configMap] = documents
+        const config = yaml.load(configMap.data['config.yaml'])
+        expect(pick(config, ['oidc'])).toMatchSnapshot()
       })
     })
 

--- a/charts/gardener-dashboard/templates/configmap.yaml
+++ b/charts/gardener-dashboard/templates/configmap.yaml
@@ -68,6 +68,12 @@ data:
     {{- if .Values.oidc }}
     oidc:
       issuer: {{ required ".Values.oidc.issuerUrl is required" .Values.oidc.issuerUrl }}
+      {{- if .Values.oidc.usePKCE }}
+      usePKCE: true
+      {{- end }}
+      {{- if .Values.oidc.refreshTokenLifetime }}
+      refreshTokenLifetime:  {{ .Values.oidc.refreshTokenLifetime }}
+      {{- end }}
       redirect_uris:
       {{- $protocol := ternary "http" "https" ( empty .Values.ingress.tls ) }}
       {{- range .Values.ingress.hosts }}
@@ -92,7 +98,12 @@ data:
       {{- if .Values.oidc.public }}
       public:
         clientId: {{ .Values.oidc.public.clientId | default "kube-kubectl" }}
-        clientSecret: {{ required ".Values.oidc.public.clientSecret" .Values.oidc.public.clientSecret }}
+        {{- if .Values.oidc.public.clientSecret }}
+        clientSecret: {{ .Values.oidc.public.clientSecret }}
+        {{- end }}
+        {{- if or .Values.oidc.public.usePKCE  (not .Values.oidc.public.clientSecret) }}
+        usePKCE: true
+        {{- end }}
       {{- end }}
     {{- end }}
     {{- if .Values.terminal }}

--- a/charts/gardener-dashboard/templates/configmap.yaml
+++ b/charts/gardener-dashboard/templates/configmap.yaml
@@ -71,8 +71,8 @@ data:
       {{- if .Values.oidc.usePKCE }}
       usePKCE: true
       {{- end }}
-      {{- if .Values.oidc.refreshTokenLifetime }}
-      refreshTokenLifetime:  {{ .Values.oidc.refreshTokenLifetime }}
+      {{- if .Values.oidc.sessionLifetime }}
+      sessionLifetime:  {{ .Values.oidc.sessionLifetime }}
       {{- end }}
       redirect_uris:
       {{- $protocol := ternary "http" "https" ( empty .Values.ingress.tls ) }}

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -85,6 +85,10 @@ oidc:
   clientId: dashboard
   # clientSecret is the private secret of the gardener-dashboard aplication
   clientSecret: ~
+  # # force PKCE usage
+  # usePKCE: true
+  # # refreshTokenLifetime is the refresh token expiration period in seconds (defaults to 86400)
+  # refreshTokenLifetime: 2592000 # 30 days
   # # certificate authority of the OpenID provider
   # ca: |
   #   -----BEGIN CERTIFICATE-----
@@ -100,6 +104,8 @@ oidc:
   #  clientId: kube-kubectl
   #  # clientSecret is the public client secret use by kubelogin and all users
   #  clientSecret: ~
+  #  # force PKCE usage (automatically enabled if no clientSecret is given)
+  #  usePKCE: true
 
 frontendConfig:
   landingPageUrl: https://github.com/gardener

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -87,8 +87,8 @@ oidc:
   clientSecret: ~
   # # force PKCE usage
   # usePKCE: true
-  # # refreshTokenLifetime is the refresh token expiration period in seconds (defaults to 86400)
-  # refreshTokenLifetime: 2592000 # 30 days
+  # # sessionLifetime is the maximum lifetime of a login session without reauthentication in seconds (defaults to 86400)
+  # sessionLifetime: 86400
   # # certificate authority of the OpenID provider
   # ca: |
   #   -----BEGIN CERTIFICATE-----

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -9,10 +9,10 @@ module.exports = {
   snapshotSerializers: [require.resolve('jest-serializer-vue')],
   coverageThreshold: {
     global: {
-      branches: 41.5,
-      functions: 26.5,
-      lines: 38.5,
-      statements: 38.5
+      branches: 42,
+      functions: 27,
+      lines: 39,
+      statements: 39
     }
   },
   setupFilesAfterEnv: [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,6 +42,7 @@
     "eventemitter3": "^4.0.7",
     "get-contrast": "^3.0.0",
     "highlight.js": "^11.5.1",
+    "http-errors": "^2.0.0",
     "js-yaml": "^4.1.0",
     "jwt-decode": "^3.1.2",
     "lodash": "4.17.21",

--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -5,6 +5,7 @@
 //
 
 import Vue from 'vue'
+import get from 'lodash/get'
 import store from '@/store'
 import createRouter from '@/router'
 import { registry, isHttpError } from '@/utils/fetch'
@@ -19,12 +20,12 @@ const App = Vue.extend({
     }
   },
   created () {
-    const signout = () => this.$auth.signout()
+    const signout = err => this.$auth.signout(err)
     this.unregister = registry.register({
       error (err) {
-        console.error('Interceptor', err)
         if (isHttpError(err) && err.statusCode === 401) {
-          setImmediate(signout)
+          const message = get(err, 'response.data.message', err.message)
+          setImmediate(() => signout(new Error(message)))
         }
         return Promise.reject(err)
       }

--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -29,7 +29,9 @@ const App = Vue.extend({
         }
         if (!refreshTokenPromise) {
           refreshTokenPromise = vm.$auth.refreshToken()
-          refreshTokenPromise.finally(() => (refreshTokenPromise = undefined))
+          refreshTokenPromise.finally(() => {
+            refreshTokenPromise = undefined
+          })
         }
         return refreshTokenPromise.then(() => args)
       },

--- a/frontend/src/plugins/auth.js
+++ b/frontend/src/plugins/auth.js
@@ -5,9 +5,10 @@
 //
 
 import Vue from 'vue'
+
 import { UserManager } from '@/utils/auth'
 
-const VueBus = {
+const VueAuth = {
   install (Vue) {
     const auth = new UserManager()
     Object.defineProperty(Vue, 'auth', { value: auth })
@@ -15,4 +16,4 @@ const VueBus = {
   }
 }
 
-Vue.use(VueBus)
+Vue.use(VueAuth)

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -1090,7 +1090,8 @@ const getters = {
     }
   },
   isKubeconfigEnabled (state) {
-    return !!(get(state, 'kubeconfigData.oidc.clientId') && get(state, 'kubeconfigData.oidc.clientSecret'))
+    const { clientId, clientSecret, usePKCE = false } = get(state, 'kubeconfigData.oidc', {})
+    return !!(clientId && (clientSecret || usePKCE))
   },
   onlyShootsWithIssues (state, getters) {
     return getters['shoots/onlyShootsWithIssues']

--- a/frontend/src/utils/Emitter.js
+++ b/frontend/src/utils/Emitter.js
@@ -175,9 +175,7 @@ class ShootsSubscription extends AbstractSubscription {
     const { namespace, filter } = this.subscribeTo
 
     this.store.commit('SET_SHOOTS_LOADING', true)
-    if (namespace === '_all') {
-      this.socket.emit('subscribeAllShoots', { filter })
-    } else if (namespace) {
+    if (namespace) {
       this.socket.emit('subscribeShoots', { namespace, filter })
     } else {
       console.error(new Error('no namespace specified'))

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -4,58 +4,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import get from 'lodash/get'
+import fetch from './fetch'
 
-/* General Purpose */
-async function toPlainResponseObject (response) {
-  const { status, statusText } = response
-  const contentType = response.headers.get('Content-Type')
-  const headers = {}
-  for (const [key, value] of response.headers.entries()) {
-    headers[key] = value
-  }
-  let data
-  if (contentType && typeof contentType === 'string') {
-    const [mediaType] = contentType.split(';')
-    switch (mediaType.trim()) {
-      case 'application/json':
-        data = await response.json()
-        break
-      default:
-        data = await response.text()
-        break
-    }
-  }
-  return {
-    status,
-    statusText,
-    headers,
-    data
-  }
-}
-
-async function request (method, url, data) {
-  const options = {
-    method,
-    cache: 'no-cache',
-    headers: {
-      Accept: 'application/json',
-      'X-Requested-With': 'XMLHttpRequest'
-    }
-  }
-  if (data) {
-    options.headers['Content-Type'] = 'application/json'
-    options.body = JSON.stringify(data)
-  }
-  let response = await fetch(url, options)
-  response = await toPlainResponseObject(response)
-  const { status } = response
-  if (status >= 200 && status < 300) {
-    return response
-  }
-  const error = new Error(`Request failed with status code ${status}`)
-  error.response = response
-  throw error
+function request (method, url, data) {
+  return fetch(url, { method, body: data })
 }
 
 function getResource (url) {
@@ -196,8 +148,8 @@ export function updateShootDns ({ namespace, name, data }) {
 }
 
 export async function getShootSchemaDefinition () {
-  const definitions = await getResource('/api/openapi')
-  return get(definitions, ['data', 'com.github.gardener.gardener.pkg.apis.core.v1beta1.Shoot'])
+  const { data = {} } = await getResource('/api/openapi')
+  return data['com.github.gardener.gardener.pkg.apis.core.v1beta1.Shoot']
 }
 
 export function updateShootPurpose ({ namespace, name, data }) {

--- a/frontend/src/utils/auth.js
+++ b/frontend/src/utils/auth.js
@@ -75,7 +75,7 @@ export class UserManager {
   }
 
   isRefreshRequired (tolerance = 30) {
-    const t = this.timeUntil('rat')
+    const t = this.timeUntil('refresh_at')
     return typeof t === 'number' && t > tolerance
   }
 

--- a/frontend/src/utils/auth.js
+++ b/frontend/src/utils/auth.js
@@ -6,7 +6,6 @@
 
 import Vue from 'vue'
 import decode from 'jwt-decode'
-import { createTokenReview } from './api'
 
 const COOKIE_HEADER_PAYLOAD = 'gHdrPyl'
 
@@ -47,10 +46,6 @@ export class UserManager {
 
   redirect (url) {
     window.location = url
-  }
-
-  signinWithToken (token) {
-    return createTokenReview({ token })
   }
 
   isUserLoggedIn () {

--- a/frontend/src/utils/auth.js
+++ b/frontend/src/utils/auth.js
@@ -76,7 +76,7 @@ export class UserManager {
 
   isRefreshRequired (tolerance = 30) {
     const t = this.timeUntil('refresh_at')
-    return typeof t === 'number' && t > tolerance
+    return typeof t === 'number' && t < tolerance
   }
 
   timeUntil (key) {

--- a/frontend/src/utils/fetch.js
+++ b/frontend/src/utils/fetch.js
@@ -1,0 +1,111 @@
+//
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import createError, { isHttpError } from 'http-errors'
+
+const interceptors = []
+
+const registry = {
+  register (interceptor) {
+    interceptors.unshift(interceptor)
+    return () => {
+      const index = interceptors.indexOf(interceptor)
+      if (index !== -1) {
+        interceptors.splice(index, 1)
+      }
+    }
+  },
+  clear () {
+    interceptors.splice(0, interceptors.length)
+  }
+}
+
+function fetchInterceptor (url, { method = 'GET', cache = 'no-cache', headers, body, ...options } = {}) {
+  headers = {
+    accept: 'application/json, text/*;q=0.9, */*;q=0.8',
+    'x-requested-with': 'XMLHttpRequest',
+    ...headers
+  }
+  if (body) {
+    if (typeof body === 'object') {
+      headers['content-type'] = 'application/json'
+      body = JSON.stringify(body)
+    }
+    options.body = body
+  }
+  const request = new Request(url, { method, cache, headers, ...options })
+  let promise = fetch(request).then(fulfilledFn(request), rejectedFn(request))
+  for (const { response, error } of interceptors) {
+    if (response || error) {
+      promise = promise.then(response, error)
+    }
+  }
+  return promise
+}
+
+function rejectedFn (request) {
+  return error => {
+    Object.defineProperty(error, 'request', {
+      value: request
+    })
+    return Promise.reject(error)
+  }
+}
+
+function fulfilledFn (request) {
+  return response => {
+    Object.defineProperties(response, {
+      request: {
+        value: request
+      },
+      headerMap: {
+        value: response.headers
+      },
+      headers: {
+        get () {
+          return Object.fromEntries(this.headerMap)
+        }
+      }
+    })
+
+    let promise = Promise.resolve(response)
+
+    const contentType = response.headers['content-type']
+    if (contentType) {
+      const method = contentType.startsWith('application/json')
+        ? 'json'
+        : 'text'
+      promise = response[method]().then(data => {
+        Object.defineProperty(response, 'data', {
+          value: data
+        })
+        return response
+      })
+    }
+
+    const status = response.status
+    if (status >= 200 && status < 300) {
+      return promise
+    }
+
+    let error
+    if (status < 400) {
+      const responseType = status < 300
+        ? 'informational'
+        : 'redirection'
+      error = new TypeError(`Unexpected ${responseType} response with status code ${status}`)
+    } else {
+      const message = status === 401
+        ? 'Authentication failed'
+        : `Request failed with status code ${status}`
+      error = createError(status, message, { response })
+    }
+
+    return Promise.reject(error)
+  }
+}
+
+export { fetchInterceptor as default, registry, isHttpError }

--- a/frontend/src/utils/fetch.js
+++ b/frontend/src/utils/fetch.js
@@ -19,11 +19,14 @@ const registry = {
     }
   },
   clear () {
-    interceptors.splice(0, interceptors.length)
+    interceptors.splice(0, this.size)
+  },
+  get size () {
+    return interceptors.length
   }
 }
 
-function fetchInterceptor (url, { method = 'GET', cache = 'no-cache', headers, body, ...options } = {}) {
+function fetchWrapper (url, { method = 'GET', cache = 'no-cache', headers, body, ...options } = {}) {
   headers = {
     accept: 'application/json, text/*;q=0.9, */*;q=0.8',
     'x-requested-with': 'XMLHttpRequest',
@@ -31,7 +34,7 @@ function fetchInterceptor (url, { method = 'GET', cache = 'no-cache', headers, b
   }
   if (body) {
     if (typeof body === 'object') {
-      headers['content-type'] = 'application/json'
+      headers['content-type'] = 'application/json; charset=UTF-8'
       body = JSON.stringify(body)
     }
     options.body = body
@@ -108,4 +111,4 @@ function fulfilledFn (request) {
   }
 }
 
-export { fetchInterceptor as default, registry, isHttpError }
+export { fetchWrapper as default, registry, isHttpError }

--- a/frontend/src/views/Account.vue
+++ b/frontend/src/views/Account.vue
@@ -335,13 +335,18 @@ export default {
         'oidc-login',
         'get-token',
         '--oidc-issuer-url=' + oidc.issuerUrl,
-        '--oidc-client-id=' + oidc.clientId,
-        '--oidc-client-secret=' + oidc.clientSecret
+        '--oidc-client-id=' + oidc.clientId
       ]
+      if (oidc.clientSecret) {
+        args.push('--oidc-client-secret=' + oidc.clientSecret)
+      }
       if (Array.isArray(oidc.extraScopes)) {
         for (const scope of oidc.extraScopes) {
           args.push('--oidc-extra-scope=' + scope)
         }
+      }
+      if (oidc.usePKCE || !oidc.clientSecret) {
+        args.push('--oidc-use-pkce')
       }
       if (oidc.certificateAuthorityData) {
         args.push('--certificate-authority-data=' + oidc.certificateAuthorityData)

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -80,6 +80,7 @@ import { SnotifyPosition } from 'vue-snotify'
 import get from 'lodash/get'
 import head from 'lodash/head'
 import { setDelayedInputFocus } from '@/utils'
+import { createTokenReview } from '@/utils/api'
 import GSnotify from '@/components/GSnotify.vue'
 import {
   getLoginConfiguration
@@ -157,7 +158,7 @@ export default {
       try {
         const token = this.token
         this.token = undefined
-        await this.$auth.signinWithToken(token)
+        await createTokenReview({ token })
         this.dialog = false
         try {
           await this.$router.push(this.redirectPath)

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -80,11 +80,8 @@ import { SnotifyPosition } from 'vue-snotify'
 import get from 'lodash/get'
 import head from 'lodash/head'
 import { setDelayedInputFocus } from '@/utils'
-import { createTokenReview } from '@/utils/api'
+import { createTokenReview, getLoginConfiguration } from '@/utils/api'
 import GSnotify from '@/components/GSnotify.vue'
-import {
-  getLoginConfiguration
-} from '@/utils/api'
 
 export default {
   components: {

--- a/frontend/tests/unit/utils.fetch.spec.js
+++ b/frontend/tests/unit/utils.fetch.spec.js
@@ -123,11 +123,11 @@ describe('utils', () => {
 
       beforeEach(() => {
         unregister = registry.register({
-          response (res) {
+          responseFulfilled (res) {
             res.headerMap.set('foo', 'bar')
             return Promise.resolve(res)
           },
-          error (err) {
+          responseRejected (err) {
             return Promise.reject(err)
           }
         })
@@ -147,7 +147,7 @@ describe('utils', () => {
         unregister()
         expect(registry.size).toBe(0)
         registry.register({
-          error (err) {
+          responseRejected (err) {
             return isHttpError(err) && err.status === 401
               ? Promise.resolve(err.response.data)
               : Promise.reject(err)

--- a/frontend/tests/unit/utils.fetch.spec.js
+++ b/frontend/tests/unit/utils.fetch.spec.js
@@ -1,0 +1,185 @@
+//
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import fetchWrapper, { registry, isHttpError } from '@/utils/fetch'
+
+describe('utils', () => {
+  describe('fetch', () => {
+    const url = 'http://example.org/test'
+
+    afterEach(() => {
+      fetch.resetMocks()
+    })
+
+    it('should respond with status 200 and json content', async () => {
+      const status = 200
+      const data = { foo: 'bar' }
+      fetch.mockResponseOnce(JSON.stringify(data), {
+        status,
+        headers: {
+          'content-type': 'application/json; charset=UTF-8'
+        }
+      })
+      const res = await fetchWrapper(url)
+      expect(res.status).toBe(status)
+      expect(res.data).toEqual(data)
+    })
+
+    it('should respond with status 200 and text content', async () => {
+      const status = 200
+      const text = 'foobar'
+      fetch.mockResponseOnce(text, {
+        status,
+        headers: {
+          'content-type': 'text/plain; charset=UTF-8'
+        }
+      })
+      const res = await fetchWrapper(url)
+      expect(res.status).toBe(status)
+      expect(res.data).toEqual(text)
+    })
+
+    it('should respond with status 100', async () => {
+      const status = 100
+      fetch.mockResponseOnce(null, {
+        status
+      })
+      await expect(fetchWrapper(url)).rejects.toThrowError(`Unexpected informational response with status code ${status}`)
+    })
+
+    it('should respond with status 300', async () => {
+      const status = 300
+      fetch.mockResponseOnce(null, {
+        status
+      })
+      await expect(fetchWrapper(url)).rejects.toThrowError(`Unexpected redirection response with status code ${status}`)
+    })
+
+    it('should respond with status 401', async () => {
+      const status = 401
+      fetch.mockResponseOnce(null, {
+        status
+      })
+      await expect(fetchWrapper(url)).rejects.toThrowError('Authentication failed')
+    })
+
+    it('should respond with status 500', async () => {
+      const status = 500
+      fetch.mockResponseOnce(null, {
+        status
+      })
+      await expect(fetchWrapper(url)).rejects.toThrowError(`Request failed with status code ${status}`)
+    })
+
+    it('should reject with an error', async () => {
+      const error = new Error('error message')
+      fetch.mockRejectOnce(error)
+      await expect(fetchWrapper(url)).rejects.toThrowError(error)
+    })
+
+    it('should send a request with json content', async () => {
+      const data = { foo: 'bar' }
+      fetch.mockResponseOnce('ok')
+      const res = await fetchWrapper(url, { method: 'POST', body: data })
+      expect(res.data).toEqual('ok')
+      expect(fetch).toBeCalledTimes(1)
+      const [req] = fetch.mock.calls[0]
+      expect(res.request).toBe(req)
+      expect(Object.fromEntries(req.headers)).toEqual({
+        accept: 'application/json, text/*;q=0.9, */*;q=0.8',
+        'x-requested-with': 'XMLHttpRequest',
+        'content-type': 'application/json; charset=UTF-8'
+      })
+      expect(JSON.parse(req.body)).toEqual(data)
+    })
+
+    it('should send a request with text content', async () => {
+      const text = 'foobar'
+      fetch.mockResponseOnce('ok')
+      const res = await fetchWrapper(url, {
+        method: 'POST',
+        headers: {
+          'content-type': 'text/plain; charset=UTF-8'
+        },
+        body: text
+      })
+      expect(res.data).toEqual('ok')
+      expect(fetch).toBeCalledTimes(1)
+      const [req] = fetch.mock.calls[0]
+      expect(res.request).toBe(req)
+      expect(Object.fromEntries(req.headers)).toEqual({
+        accept: 'application/json, text/*;q=0.9, */*;q=0.8',
+        'x-requested-with': 'XMLHttpRequest',
+        'content-type': 'text/plain; charset=UTF-8'
+      })
+      expect(req.body.toString('utf8')).toEqual(text)
+    })
+
+    describe('intercepting the fetch response', () => {
+      let unregister
+
+      beforeEach(() => {
+        unregister = registry.register({
+          response (res) {
+            res.headerMap.set('foo', 'bar')
+            return Promise.resolve(res)
+          },
+          error (err) {
+            return Promise.reject(err)
+          }
+        })
+      })
+
+      afterEach(() => {
+        registry.clear()
+      })
+
+      it('should intercepted a response and set a header field', async () => {
+        fetch.mockResponseOnce('ok')
+        const res = await fetchWrapper(url)
+        expect(res.headers.foo).toBe('bar')
+      })
+
+      it('should intercepted an http error', async () => {
+        unregister()
+        expect(registry.size).toBe(0)
+        registry.register({
+          error (err) {
+            return isHttpError(err) && err.status === 401
+              ? Promise.resolve(err.response.data)
+              : Promise.reject(err)
+          }
+        })
+        const status = 401
+        const data = { status, reason: 'Authentication failed' }
+        fetch.mockResponseOnce(JSON.stringify(data), {
+          status,
+          headers: {
+            'content-type': 'application/json; charset=UTF-8'
+          }
+        })
+        await expect(fetchWrapper(url)).resolves.toEqual(data)
+      })
+
+      it('should unregister the default interceptor twice', async () => {
+        expect(registry.size).toBe(1)
+        unregister()
+        expect(registry.size).toBe(0)
+        unregister()
+        expect(registry.size).toBe(0)
+      })
+
+      it('should register an empty interceptor', async () => {
+        unregister()
+        registry.register({})
+        expect(registry.size).toBe(1)
+        fetch.mockResponseOnce('ok')
+        const res = await fetchWrapper(url)
+        expect(res.headers.foo).toBeUndefined()
+      })
+    })
+  })
+})

--- a/packages/kube-client/__tests__/client.test.js
+++ b/packages/kube-client/__tests__/client.test.js
@@ -113,7 +113,8 @@ describe('kube-client', () => {
     it('should create a dashboard client', () => {
       expect(testClient.constructor.name).toBe('Client')
       expect(testClient.cluster.server).toEqual(server)
-      expect(extend).toHaveBeenCalledTimes(24)
+      const expectedNumberOfCalls = 25
+      expect(extend).toHaveBeenCalledTimes(expectedNumberOfCalls)
       for (let i = 0; i < extend.mock.calls.length; i++) {
         const call = extend.mock.calls[i]
         expect(call).toHaveLength(1)
@@ -122,7 +123,7 @@ describe('kube-client', () => {
         expect(clientConfig.url).toBe(url)
         expect(clientConfig.auth).toBe(auth)
         // all endpoints except healthz have json responseType
-        const responseType = i !== 22 ? 'json' : undefined
+        const responseType = i !== (expectedNumberOfCalls - 2) ? 'json' : undefined
         expect(clientConfig.responseType).toBe(responseType)
       }
     })

--- a/packages/kube-client/lib/resources/Authorization.js
+++ b/packages/kube-client/lib/resources/Authorization.js
@@ -31,7 +31,18 @@ class SelfSubjectRulesReview extends mix(Authorization).with(ClusterScoped, Crea
   }
 }
 
+class SubjectAccessReview extends mix(Authorization).with(ClusterScoped, Creatable) {
+  static get names () {
+    return {
+      plural: 'subjectaccessreviews',
+      singular: 'subjectaccessreview',
+      kind: 'SubjectAccessReview'
+    }
+  }
+}
+
 module.exports = {
   SelfSubjectAccessReview,
-  SelfSubjectRulesReview
+  SelfSubjectRulesReview,
+  SubjectAccessReview
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1451,6 +1451,7 @@ __metadata:
     "@gardener-dashboard/kube-config": "workspace:*"
     "@gardener-dashboard/logger": "workspace:*"
     "@gardener-dashboard/request": "workspace:*"
+    "@gardener-dashboard/test-utils": "workspace:*"
     "@godaddy/terminus": ^4.10.2
     "@octokit/rest": ^18.12.0
     abort-controller: ^3.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -1553,6 +1553,7 @@ __metadata:
     eventemitter3: ^4.0.7
     get-contrast: ^3.0.0
     highlight.js: ^11.5.1
+    http-errors: ^2.0.0
     jest: ^27.5.1
     jest-fetch-mock: ^3.0.3
     jest-serializer-vue: ^2.0.2


### PR DESCRIPTION
### !!!This PR is included in #1277 and should not be merged!!!

**What this PR does / why we need it**:

##### Refresh Token
[OpenID Connect](https://datatracker.ietf.org/doc/html/rfc7636) defines the `offline_access` scope value to request a `refresh_token` in addition to the `id_token` which allows to use OIDC provider with short `id_token` lifetimes. With this PR we support the usage of scope `offline_access`. Typically the `refresh_token` is an opaque token and not a JWT with `exp` claim. But the `refresh_token` has a limited lifetime. If the `refresh_token` is used to refresh an `id_token` a new `refresh_token` is returned and the old `refresh_token` can not be used once again. Therefore the client must check if an `id_token` will expire soon and refresh the `id_token` if necessary. Since the process can be repeated again and again we recommend to configure and absolute `sessionLifetime` that stops the automatic refresh process and forces a logout if the the lifetime of a session exceeds this limit. 
 
To enable this feature the operator has to configure the scope in the chart values:
```yaml
oidc:
  scope: "openid email groups profile offline_access"
  sessionLifetime: 86400 # 1 day
```
 
##### Authorization Code Flow + PKCE
Currently all downloaded user kubeconfigs contain a `client_secret`. With this PR we support the [PKCE flow](https://datatracker.ietf.org/doc/html/rfc7636) for the OIDC client used by the dashboard itself as well for the public client used for the downloaded kubeconfig. In order to remove the `client_secret` from the downloaded kubeconfig the operator needs to force the usage the PKCE flow for the public client. The PKCE flow will be enabled by default if no `clientSecret` is given in the values.
```yaml
oidc:
  ...
  public:
    clientId: 'my-public-client-id'
    # clientSecret: 'my-public-client-secret'
``` 

It is also possible to force PKCE flow for the client used by the dashboard but the client_secret is still required.
```yaml
oidc:
  clientId: 'my-internal-client-id'
  clientSecret: 'my-internal-client-secret'
  usePKCE: true
``` 

**Which issue(s) this PR fixes**:
Fixes #976

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Added support for OIDC refresh tokens. This allows an operator to configure short `id_token` lifetimes. 
```

```feature operator
Added support for PKCE flow to the internal and the public OIDC client. This allows an operator to configure the the public client without a `client_secret`. 
```

