### PR TITLE
terminal: use TokenRequest to get service account token

### DIFF
--- a/backend/test/acceptance/__snapshots__/api.terminals.spec.js.snap
+++ b/backend/test/acceptance/__snapshots__/api.terminals.spec.js.snap
@@ -562,17 +562,16 @@ Array [
   Array [
     Object {
       ":authority": "api.host.garden.shoot.cluster",
-      ":method": "get",
-      ":path": "/api/v1/namespaces/term-host-1/serviceaccounts?watch=true&fieldSelector=metadata.name%3Dterm-attach-1",
+      ":method": "post",
+      ":path": "/api/v1/namespaces/term-host-1/serviceaccounts/term-attach-1/token",
       ":scheme": "https",
     },
-  ],
-  Array [
     Object {
-      ":authority": "api.host.garden.shoot.cluster",
-      ":method": "get",
-      ":path": "/api/v1/namespaces/term-host-1/secrets/term-attach-1-token-74657",
-      ":scheme": "https",
+      "apiVersion": "authentication.k8s.io/v1",
+      "kind": "TokenRequest",
+      "spec": Object {
+        "expirationSeconds": 86400,
+      },
     },
   ],
 ]
@@ -585,7 +584,7 @@ Object {
       "container": "terminal",
       "name": "term-1",
     },
-    "token": "term-attach-1-token-74657",
+    "token": "secret",
   },
   "metadata": Object {
     "identifier": "1",

--- a/backend/test/acceptance/__snapshots__/api.terminals.spec.js.snap
+++ b/backend/test/acceptance/__snapshots__/api.terminals.spec.js.snap
@@ -570,7 +570,7 @@ Array [
       "apiVersion": "authentication.k8s.io/v1",
       "kind": "TokenRequest",
       "spec": Object {
-        "expirationSeconds": 86400,
+        "expirationSeconds": 43200,
       },
     },
   ],

--- a/backend/test/acceptance/api.terminals.spec.js
+++ b/backend/test/acceptance/api.terminals.spec.js
@@ -202,8 +202,7 @@ describe('api', function () {
         mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
         mockRequest.mockImplementationOnce(fixtures.terminals.mocks.watch())
         mockRequest.mockImplementationOnce(fixtures.secrets.mocks.get())
-        mockRequest.mockImplementationOnce(fixtures.serviceaccounts.mocks.watch())
-        mockRequest.mockImplementationOnce(fixtures.secrets.mocks.get())
+        mockRequest.mockImplementationOnce(fixtures.serviceaccounts.mocks.createTokenRequest())
 
         const res = await agent
           .post('/api/terminals')
@@ -218,7 +217,7 @@ describe('api', function () {
           .expect('content-type', /json/)
           .expect(200)
 
-        expect(mockRequest).toBeCalledTimes(5)
+        expect(mockRequest).toBeCalledTimes(4)
         expect(mockRequest.mock.calls).toMatchSnapshot()
 
         expect(res.body).toMatchSnapshot()

--- a/charts/__tests__/gardener-dashboard/__snapshots__/configmap.spec.js.snap
+++ b/charts/__tests__/gardener-dashboard/__snapshots__/configmap.spec.js.snap
@@ -191,6 +191,7 @@ Object {
     ],
     "landingPageUrl": "https://gardener.cloud/",
     "seedCandidateDeterminationStrategy": "SameRegion",
+    "serviceAccountDefaultTokenExpiration": 7776000,
   },
   "logFormat": "text",
   "logLevel": "debug",

--- a/charts/__tests__/gardener-dashboard/__snapshots__/configmap.spec.js.snap
+++ b/charts/__tests__/gardener-dashboard/__snapshots__/configmap.spec.js.snap
@@ -232,6 +232,34 @@ Li4u
 }
 `;
 
+exports[`gardener-dashboard configmap terminal config should render the template 1`] = `
+Object {
+  "terminal": Object {
+    "bootstrap": Object {
+      "disabled": false,
+      "gardenTerminalHostDisabled": true,
+      "seedDisabled": true,
+      "shootDisabled": true,
+    },
+    "container": Object {
+      "image": "chart-test:0.1.0",
+    },
+    "garden": Object {
+      "operatorCredentials": Object {
+        "serviceAccountRef": Object {
+          "name": "robot",
+          "namespace": "garden",
+        },
+      },
+    },
+    "gardenTerminalHost": Object {
+      "seedRef": "my-seed",
+    },
+    "serviceAccountTokenExpiration": 42,
+  },
+}
+`;
+
 exports[`gardener-dashboard configmap terminal shortcuts should render the template 1`] = `
 Object {
   "frontend": Object {

--- a/charts/__tests__/gardener-dashboard/configmap.spec.js
+++ b/charts/__tests__/gardener-dashboard/configmap.spec.js
@@ -279,6 +279,38 @@ describe('gardener-dashboard', function () {
       })
     })
 
+    describe('terminal config', function () {
+      it('should render the template', async function () {
+        const values = {
+          terminal: {
+            bootstrap: {
+              disabled: false
+            },
+            container: {
+              image: 'chart-test:0.1.0'
+            },
+            garden: {
+              operatorCredentials: {
+                serviceAccountRef: {
+                  name: 'robot',
+                  namespace: 'garden'
+                }
+              }
+            },
+            gardenTerminalHost: {
+              seedRef: 'my-seed'
+            },
+            serviceAccountTokenExpiration: 42
+          }
+        }
+        const documents = await renderTemplates(templates, values)
+        expect(documents).toHaveLength(1)
+        const [configMap] = documents
+        const config = yaml.load(configMap.data['config.yaml'])
+        expect(pick(config, ['terminal'])).toMatchSnapshot()
+      })
+    })
+
     describe('themes', function () {
       it('should render the template', async function () {
         const values = {

--- a/charts/gardener-dashboard/templates/configmap.yaml
+++ b/charts/gardener-dashboard/templates/configmap.yaml
@@ -103,6 +103,9 @@ data:
         description: {{ .description }}
       {{- end }}
       {{- end }}
+      {{- if .Values.terminal.serviceAccountTokenExpiration }}
+      serviceAccountTokenExpiration: {{ .Values.terminal.serviceAccountTokenExpiration }}
+      {{- end }}
       gardenTerminalHost:
         {{- if .Values.terminal.gardenTerminalHost.secretRef }}
         apiServerIngressHost: {{ .Values.terminal.gardenTerminalHost.apiServerIngressHost }}

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -297,6 +297,10 @@ readinessProbe:
 #   containerImageDescriptions:
 #   - image: /eu.gcr.io/gardener-project/gardener/ops-toolbelt:.*/ # regexp must start and end with '/', otherwise it's an exact match
 #     description: Run `ghelp` to get information about installed tools and packages
+#   # serviceAccountTokenExpiration - is the default requested duration of validity of the token request for the "attach" service account (residing in the terminal host cluster)
+#   # If no value is provided, the default value corresponds to 12 hours
+#   # The token issuer may return a token with a different validity duration
+#   serviceAccountTokenExpiration: 43200 # seconds
 #   gardenTerminalHost: # cluster that hosts the terminal pods for the (virtual) garden cluster
 #     apiServerIngressHost: api.example.org # is host in browser-trusted certificate. Optional, but required if using secretRef
 #     secretRef:


### PR DESCRIPTION
**What this PR does / why we need it**:
use TokenRequest to get service account token for the attach service account that is required to attach to the terminal pod.

**Which issue(s) this PR fixes**:
Fixes #1219

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
