### PR TITLE
Use distroless base image

### DIFF
--- a/backend/test/docker.spec.js
+++ b/backend/test/docker.spec.js
@@ -6,16 +6,10 @@
 
 'use strict'
 
-const fs = require('fs')
+const { readFile } = require('fs/promises')
 const path = require('path')
 const _ = require('lodash')
-const { promisify } = require('util')
-const readFile = promisify(fs.readFile)
 const { DockerfileParser } = require('dockerfile-ast')
-const { extend, globalAgent } = jest.requireActual('@gardener-dashboard/request')
-const client = extend({
-  prefixUrl: 'https://raw.githubusercontent.com/nodejs/docker-node/main/'
-})
 
 /* Nodejs release schedule (see https://nodejs.org/en/about/releases/) */
 const activeNodeReleases = {
@@ -33,11 +27,6 @@ const activeNodeReleases = {
   }
 }
 
-async function getNodeDockerfile (nodeVersion, alpineVersion) {
-  const body = await client.request(`${nodeVersion}/alpine${alpineVersion}/Dockerfile`)
-  return DockerfileParser.parse(body)
-}
-
 async function getDashboardDockerfile () {
   const filename = path.join(__dirname, '..', '..', 'Dockerfile')
   const data = await readFile(filename, 'utf8')
@@ -45,12 +34,6 @@ async function getDashboardDockerfile () {
 }
 
 describe('dockerfile', function () {
-  const timeout = 15 * 1000
-
-  afterAll(() => {
-    globalAgent.destroy()
-  })
-
   it('should have the same alpine base image as the corresponding node image', async function () {
     const dashboardDockerfile = await getDashboardDockerfile()
 
@@ -60,18 +43,12 @@ describe('dockerfile', function () {
       .map(from => [from.getBuildStage(), from])
       .fromPairs()
       .value()
-    const imageTag = buildStages.builder.getImageTag()
-    const [, nodeRelease] = /^(\d+(?:\.\d+)?(?:\.\d+)?)-alpine/.exec(imageTag) || []
-    expect(_.keys(activeNodeReleases)).toContain(nodeRelease)
+    const nodeRelease = buildStages.builder.getImageTag()
+    expect(Object.keys(activeNodeReleases)).toContain(nodeRelease)
     const endOfLife = activeNodeReleases[nodeRelease].endOfLife
     // Node release ${nodeRelease} reached end of life. Update node base image in Dockerfile.
     expect(endOfLife.getTime()).toBeGreaterThan(Date.now())
     const dashboardReleaseBaseImage = buildStages.release.getImage()
-    const [, alpineVersion] = /alpine:(\d+\.\d+)/.exec(dashboardReleaseBaseImage)
-    const nodeDockerfile = await getNodeDockerfile(nodeRelease, alpineVersion)
-    expect(nodeDockerfile.getFROMs()).toHaveLength(1)
-    const nodeBaseImage = _.first(nodeDockerfile.getFROMs()).getImage()
-    // Alpine base images of "dashboard-release" image and "node" image do not match!
-    expect(dashboardReleaseBaseImage.endsWith(nodeBaseImage)).toBe(true)
-  }, timeout)
+    expect(dashboardReleaseBaseImage.endsWith(`nodejs:${nodeRelease}`)).toBe(true)
+  })
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
This uses a [distroless](https://github.com/GoogleContainerTools/distroless/blob/main/nodejs/README.md) nodejs base image for the dashboard release to get ride of many unused dependencies.  

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Use distroless base image
```
