### PR TITLE
 Use scratch as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,12 +67,10 @@ ENV PORT $PORT
 COPY --from=builder /tmp/passwd /tmp/group /etc/
 
 # copy binaries
-COPY --from=builder /usr/local/bin/node /usr/local/bin/
-COPY --from=builder /sbin/tini /sbin/ 
+COPY --from=builder /usr/local/bin/node  /sbin/tini /bin/
 
 # copy libraries
-COPY --from=builder /lib/ld-musl-x86_64.so* /lib/libcrypto.so* /lib/libssl.so* /lib/libz.so* /lib/
-COPY --from=builder /usr/lib/libstdc++.so* /usr/lib/libgcc_s.so* /usr/lib/engines-1.1 /usr/lib/
+COPY --from=builder /lib/ld-musl-x86_64.so* /usr/lib/libstdc++.so* /usr/lib/libgcc_s.so* /lib/
 
 # copy production directory
 COPY --chown=node:node --from=builder /usr/src/build .
@@ -83,5 +81,5 @@ EXPOSE $PORT
 
 VOLUME ["/home/node"]
 
-ENTRYPOINT [ "/sbin/tini", "--", "node", "--require=/usr/src/app/.pnp.cjs", "--experimental-loader=/usr/src/app/.pnp.loader.mjs"]
+ENTRYPOINT [ "tini", "--", "node", "--require=/usr/src/app/.pnp.cjs", "--experimental-loader=/usr/src/app/.pnp.loader.mjs"]
 CMD ["server.js"]

--- a/backend/test/docker.spec.js
+++ b/backend/test/docker.spec.js
@@ -12,10 +12,6 @@ const _ = require('lodash')
 const { promisify } = require('util')
 const readFile = promisify(fs.readFile)
 const { DockerfileParser } = require('dockerfile-ast')
-const { extend, globalAgent } = jest.requireActual('@gardener-dashboard/request')
-const client = extend({
-  prefixUrl: 'https://raw.githubusercontent.com/nodejs/docker-node/main/'
-})
 
 /* Nodejs release schedule (see https://nodejs.org/en/about/releases/) */
 const activeNodeReleases = {
@@ -40,12 +36,6 @@ async function getDashboardDockerfile () {
 }
 
 describe('dockerfile', function () {
-  const timeout = 15 * 1000
-
-  afterAll(() => {
-    globalAgent.destroy()
-  })
-
   it('should have the same alpine base image as the corresponding node image', async function () {
     const dashboardDockerfile = await getDashboardDockerfile()
 
@@ -62,5 +52,5 @@ describe('dockerfile', function () {
     // Node release ${nodeRelease} reached end of life. Update node base image in Dockerfile.
     expect(endOfLife.getTime()).toBeGreaterThan(Date.now())
     expect(buildStages.release.getImage()).toBe('scratch')
-  }, timeout)
+  })
 })

--- a/backend/test/docker.spec.js
+++ b/backend/test/docker.spec.js
@@ -33,11 +33,6 @@ const activeNodeReleases = {
   }
 }
 
-async function getNodeDockerfile (nodeVersion, alpineVersion) {
-  const body = await client.request(`${nodeVersion}/alpine${alpineVersion}/Dockerfile`)
-  return DockerfileParser.parse(body)
-}
-
 async function getDashboardDockerfile () {
   const filename = path.join(__dirname, '..', '..', 'Dockerfile')
   const data = await readFile(filename, 'utf8')
@@ -66,12 +61,6 @@ describe('dockerfile', function () {
     const endOfLife = activeNodeReleases[nodeRelease].endOfLife
     // Node release ${nodeRelease} reached end of life. Update node base image in Dockerfile.
     expect(endOfLife.getTime()).toBeGreaterThan(Date.now())
-    const dashboardReleaseBaseImage = buildStages.release.getImage()
-    const [, alpineVersion] = /alpine:(\d+\.\d+)/.exec(dashboardReleaseBaseImage)
-    const nodeDockerfile = await getNodeDockerfile(nodeRelease, alpineVersion)
-    expect(nodeDockerfile.getFROMs()).toHaveLength(1)
-    const nodeBaseImage = _.first(nodeDockerfile.getFROMs()).getImage()
-    // Alpine base images of "dashboard-release" image and "node" image do not match!
-    expect(dashboardReleaseBaseImage.endsWith(nodeBaseImage)).toBe(true)
+    expect(buildStages.release.getImage()).toBe('scratch')
   }, timeout)
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
The goal of this PR was to get rid of all unused dependencies in the dashboard docker image, so as not to get false positive security messages from the image scan. To achieve this goal there were two possible base images. In both cases a C standard library implementation needs to be added as well as the shared libraries `libstdc++.so.6` and `libgcc_s.so.1`. Below you can find the two different approaches. 

1. Image base on `scratch`
```dockerfile
FROM node:18-alpine3.16 as builder

WORKDIR /usr/src/app

RUN mkdir -p ./.yarn/cache && echo "console.log('Hello World')" > ./server.js

WORKDIR /volume

RUN apk add --no-cache tini \
    # tini and node binaries
    && mkdir -p ./sbin ./usr/local/bin \
    && cp /sbin/tini ./sbin/ \
    && cp /usr/local/bin/node ./usr/local/bin/ \
    # root ca certificates
    && mkdir -p ./etc/ssl \
    && cp -r /etc/ssl/certs ./etc/ssl \
    # node user
    && echo 'node:x:1000:1000:node,,,:/home/node:/sbin/nologin' > ./etc/passwd \
    && echo 'node:x:1000:node' > ./etc/group \
    && mkdir -p ./home/node \
    && chown 1000:1000 ./home/node \
    # libc, libgcc and libstdc++ libraries
    && mkdir -p ./lib ./usr/lib \
    && cp -d /lib/ld-musl-x86_64.so.* ./lib \
    && cp -d /lib/libc.musl-x86_64.so.* ./lib \
    && cp -d /usr/lib/libgcc_s.so.* ./usr/lib \
    && cp -d /usr/lib/libstdc++.so.* ./usr/lib \
    # application
    && mv /usr/src/app ./app \
    && find ./app/.yarn -mindepth 1 -name cache -prune -o -exec rm -rf {} + \
    && chown -R 1000:1000 ./app

FROM scratch

WORKDIR /app

COPY --from=builder /volume /

USER node

ENTRYPOINT [ "tini", "--", "node" ]
CMD [ "server.js" ]
```
In this case the `node` binary uses the [`musl`](https://musl.libc.org/) as C standard library implementation. A nonroot `node` use and the ssl ca certificates must be added to the image.

2. Image base on `gcr.io/distroless/static-debian11`
```dockerfile
FROM node:18-bullseye-slim as builder

WORKDIR /usr/src/app

RUN mkdir -p ./.yarn/cache && echo "console.log('Hello World')" > ./server.js

WORKDIR /volume

ARG GLIBC_VERSION=2.31
ARG GLIBC_DIR=x86_64-linux-gnu
ARG NONROOT=65532

RUN apt-get update \
    && apt-get -y install tini \
    # tini and node binaries
    && mkdir -p ./usr/bin ./usr/local/bin \
    && cp /usr/bin/tini ./usr/bin \
    && cp /usr/local/bin/node ./usr/local/bin \
    # libc, libgcc and libstdc++ libraries
    && mkdir -p ./lib/${GLIBC_DIR} ./usr/lib/${GLIBC_DIR} ./lib64 ./etc \
    && cp -d /lib/${GLIBC_DIR}/ld-${GLIBC_VERSION}.so ./lib/${GLIBC_DIR} \
    && cp -d /lib/${GLIBC_DIR}/ld-linux-x86-64.so.* ./lib/${GLIBC_DIR} \
    && cp -d /lib/${GLIBC_DIR}/libc-${GLIBC_VERSION}.so ./lib/${GLIBC_DIR} \
    && cp -d /lib/${GLIBC_DIR}/libc.so.* ./lib/${GLIBC_DIR} \
    && cp -d /lib/${GLIBC_DIR}/libdl-${GLIBC_VERSION}.so ./lib/${GLIBC_DIR} \
    && cp -d /lib/${GLIBC_DIR}/libdl.so.* ./lib/${GLIBC_DIR} \
    && cp -d /lib/${GLIBC_DIR}/libm-${GLIBC_VERSION}.so ./lib/${GLIBC_DIR} \
    && cp -d /lib/${GLIBC_DIR}/libm.so.* ./lib/${GLIBC_DIR} \
    && cp -d /lib/${GLIBC_DIR}/libpthread-${GLIBC_VERSION}.so ./lib/${GLIBC_DIR} \
    && cp -d /lib/${GLIBC_DIR}/libpthread.so.* ./lib/${GLIBC_DIR} \
    && cp -d /lib/${GLIBC_DIR}/libgcc_s.so.* ./lib/${GLIBC_DIR} \
    && cp -d /usr/lib/${GLIBC_DIR}/libstdc++.so.* ./usr/lib/${GLIBC_DIR} \
    && cp -r /lib64/ld-linux-x86-64.so.* ./lib64 \
    && cp -r /etc/ld.so.conf.d ./etc \
    # application
    && mv /usr/src/app ./app \
    && find ./app/.yarn -mindepth 1 -name cache -prune -o -exec rm -rf {} + \
    && chown -R ${NONROOT}:${NONROOT} ./app

FROM gcr.io/distroless/static-debian11

WORKDIR /app

COPY --from=builder /volume /

USER nonroot

ENTRYPOINT [ "tini", "--", "node" ]
CMD [ "server.js" ]
```
In this case the `node` binary uses the [`glibc`](https://www.gnu.org/software/libc/) as C standard library implementation. A `nonroot` user and the ssl ca certificates are already included in the base image.

We decided to with `scratch`and `musl` as `libc` impl.
```
Image name: eu.gcr.io/gardener-project/gardener/dashboard:latest
Total Image size: 116 MB
Potential wasted space: 0 B
Image efficiency score: 100 %
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Use `scratch` as base image 
```
