### PR TITLE
Update the Azure secret dialog

### DIFF
--- a/frontend/src/components/dialogs/SecretDialogAzure.vue
+++ b/frontend/src/components/dialogs/SecretDialogAzure.vue
@@ -64,11 +64,15 @@ SPDX-License-Identifier: Apache-2.0
     <template v-slot:help-slot>
       <div v-if="vendor==='azure'">
         <p>
-          Before you can provision and access a Kubernetes cluster on Azure, you need to add account credentials.
-          The Gardener needs the credentials to provision and operate the Azure infrastructure for your Kubernetes cluster.
+          Before you can provision and access a Kubernetes cluster on Azure, you need to add account/subscription credentials.
+          The Gardener needs the credentials of a service principal assigned to an account/subscription to provision
+          and operate the Azure infrastructure for your Kubernetes cluster.
         </p>
         <p>
-          Ensure that the account has the <strong>contributor</strong> role.
+          Ensure that the service principal has the permissions defined
+          <external-link url="https://github.com/gardener/gardener-extension-provider-azure/blob/master/docs/azure-permissions.md">
+          here</external-link> within your subscription assigned.
+          If no fine-grained permissions are required then assign the <strong>Contributor</strong> role.
         </p>
         <p>
           Read the


### PR DESCRIPTION
**What this PR does / why we need it**:
Update the Azure secret dialog with a hint to use fine-grained permissions instead of simply the Contributor role.

**Special notes for your reviewer**:
Depend on https://github.com/gardener/gardener-extension-provider-azure/pull/536 (until this merged → draft)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The Azure secret dialog hints now to use more fine-grained Azure permissions for Shoots on Azure.
```
