### PR TITLE
Table menu should be scrollable

### DIFF
--- a/frontend/src/components/TableColumnSelection.vue
+++ b/frontend/src/components/TableColumnSelection.vue
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 -->
 
 <template>
-  <v-menu :nudge-bottom="20" :nudge-right="20" left v-model="columnSelectionMenu" absolute>
+  <v-menu :nudge-bottom="20" :nudge-right="20" max-height="80%" left v-model="columnSelectionMenu" absolute>
     <template v-slot:activator="{ on: menu }">
       <v-tooltip top>
         <template v-slot:activator="{ on: tooltip }">


### PR DESCRIPTION
**What this PR does / why we need it**:
On smaller window sizes the table menu (e.g. on the ALL PROJECT page) could get so large, that you can't get to the last items in the menu, as it is not scrollable.
With this PR I set a max-height of 80% for the menu which will make the menu scrollable in case it does not fit on the screen.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
The table menu is now scrollable in case the content does not fit on the window
```
