### PR TITLE
Update mount path hint

### DIFF
--- a/frontend/src/components/TerminalSettings.vue
+++ b/frontend/src/components/TerminalSettings.vue
@@ -42,7 +42,7 @@ SPDX-License-Identifier: Apache-2.0
         color="primary"
         v-model="selectedPrivilegedMode"
         label="Privileged"
-        hint="Enable to schedule a privileged Container, with hostPID and hostNetwork enabled. The host root filesystem will be mounted under the path /hostroot."
+        hint="Enable to schedule a privileged Container, with hostPID and hostNetwork enabled. The host root filesystem will be mounted under the path /host."
         persistent-hint
         :class="{ 'ml-4': isAdmin }"
         class="ml-2"


### PR DESCRIPTION
**What this PR does / why we need it**:
As agreed in https://github.com/gardener/ops-toolbelt/pull/82#discussion_r925724996 we are aligning the mountPath of the hosts root fs to /host (https://github.com/gardener/ops-toolbelt/blob/master/hacks/ops-pod#L177)

Related change in the `terminal-controller-manager`: https://github.com/gardener/terminal-controller-manager/pull/78

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
