### PR TITLE
Hide oidc login if not configured

### DIFF
--- a/backend/lib/config/gardener.js
+++ b/backend/lib/config/gardener.js
@@ -110,7 +110,7 @@ module.exports = {
       assert.ok(_.get(config, path), `Configuration value '${path}' is required`)
     })
 
-    _.set(config, 'frontend.primaryLoginType', config.oidc ? 'oidc' : 'token')
+    _.set(config, 'frontend.loginTypes', config.oidc ? ['oidc', 'token'] : ['token'])
     _.set(config, 'frontend.apiServerUrl', config.apiServerUrl)
     _.set(config, 'frontend.clusterIdentity', config.clusterIdentity)
     if (!config.gitHub && _.has(config, 'frontend.ticket')) {

--- a/backend/test/acceptance/__snapshots__/config.spec.js.snap
+++ b/backend/test/acceptance/__snapshots__/config.spec.js.snap
@@ -39,7 +39,10 @@ Object {
     },
   ],
   "landingPageUrl": "https://gardener.cloud/",
-  "primaryLoginType": "oidc",
+  "loginTypes": Array [
+    "oidc",
+    "token",
+  ],
   "serviceAccountDefaultTokenExpiration": 42,
 }
 `;

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -23,7 +23,7 @@ SPDX-License-Identifier: Apache-2.0
                   v-model="loginType"
                 >
                 <v-tab
-                  v-for="item in loginTypes"
+                  v-for="item in cfg.loginTypes"
                   :key="item"
                   :href="`#${item}`"
                 >
@@ -73,6 +73,7 @@ SPDX-License-Identifier: Apache-2.0
 import { mapState } from 'vuex'
 import { SnotifyPosition } from 'vue-snotify'
 import get from 'lodash/get'
+import head from 'lodash/head'
 import { setDelayedInputFocus } from '@/utils'
 import GSnotify from '@/components/GSnotify.vue'
 
@@ -85,11 +86,7 @@ export default {
       dialog: false,
       showToken: false,
       token: '',
-
-      loginType: undefined,
-      loginTypes: [
-        'oidc', 'token'
-      ]
+      loginType: undefined
     }
   },
   computed: {
@@ -100,7 +97,7 @@ export default {
       return get(this.$route.query, 'redirectPath', '/')
     },
     primaryLoginType () {
-      return this.cfg.primaryLoginType || 'oidc'
+      return head(this.cfg.loginTypes) || 'oidc'
     },
     showTokenLoginLink () {
       return this.primaryLoginType === 'oidc'


### PR DESCRIPTION
**What this PR does / why we need it**:
If oidc is not configured only token login should be available

**Which issue(s) this PR fixes**:
Fixes #1233 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed an issue where the OIDC login was not hidden on the login screen if it was not configured by the gardener dashboard administrator
```
