### PR TITLE
Link to ticket (github issue) instead of shoot details

### DIFF
--- a/frontend/src/components/ShootListRow.vue
+++ b/frontend/src/components/ShootListRow.vue
@@ -81,9 +81,9 @@ SPDX-License-Identifier: Apache-2.0
         <access-restriction-chips :selected-access-restrictions="shootSelectedAccessRestrictions"></access-restriction-chips>
       </template>
       <template v-if="cell.header.value === 'ticket'">
-        <router-link :to="{ name: 'ShootItem', params: { name: shootName, namespace: shootNamespace } }">
+        <external-link v-if="shootLastUpdatedTicketUrl" :url="shootLastUpdatedTicketUrl">
           <time-string :date-time="shootLastUpdatedTicketTimestamp" mode="past"></time-string>
-        </router-link>
+        </external-link>
       </template>
       <template v-if="cell.header.value === 'ticketLabels'">
         <template v-if="shootLastUpdatedTicketTimestamp && !shootTicketsLabels.length">
@@ -147,6 +147,7 @@ import ShootSeedName from '@/components/ShootSeedName'
 import ShootMessages from '@/components/ShootMessages/ShootMessages'
 import ShootListRowActions from '@/components/ShootListRowActions'
 import AutoHide from '@/components/AutoHide'
+import ExternalLink from '@/components/ExternalLink'
 
 import {
   isTypeDelete
@@ -169,7 +170,8 @@ export default {
     Vendor,
     ShootMessages,
     ShootListRowActions,
-    AutoHide
+    AutoHide,
+    ExternalLink
   },
   props: {
     visibleHeaders: {
@@ -218,8 +220,14 @@ export default {
         ? 'Cluster Access'
         : 'Show Cluster Access'
     },
-    shootLastUpdatedTicketTimestamp () {
+    shootLastUpdatedTicket () {
       return this.latestUpdatedTicketByNameAndNamespace(this.shootMetadata)
+    },
+    shootLastUpdatedTicketUrl () {
+      return get(this.shootLastUpdatedTicket, 'data.html_url')
+    },
+    shootLastUpdatedTicketTimestamp () {
+      return get(this.shootLastUpdatedTicket, 'metadata.updated_at')
     },
     shootTicketsLabels () {
       return this.ticketsLabels(this.shootMetadata)

--- a/frontend/src/store/modules/tickets.js
+++ b/frontend/src/store/modules/tickets.js
@@ -52,7 +52,7 @@ const getters = {
   },
   latestUpdated: (state) => ({ name, projectName }) => {
     const latestUpdatedIssue = head(getOpenIssues({ state, name, projectName }))
-    return get(latestUpdatedIssue, 'metadata.updated_at')
+    return latestUpdatedIssue
   },
   labels: (state) => ({ name, projectName }) => {
     const issues = getOpenIssues({ state, name, projectName })


### PR DESCRIPTION
**What this PR does / why we need it**:
![tickets](https://user-images.githubusercontent.com/5526658/108341850-68cce600-71da-11eb-8d9e-4abd1c64dda8.jpg)
When clicking on the ticket link it will now open the issue on github instead of just navigating to the shoot details page

**Which issue(s) this PR fixes**:
Fixes #949

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user

```
