### PR TITLE
Docforge version update in check-docforge.sh

### DIFF
--- a/.ci/check-docforge
+++ b/.ci/check-docforge
@@ -16,8 +16,8 @@
 
 set -e
 
-docforgeVersion="v0.28.0"
-docCommitHash="6a018dc6a0307e64192ab48dcb90034dd0c5102a"
+docforgeVersion="v0.32.0"
+docCommitHash="7709601d0ce25e21c8b68dd6a2de91a326b9d41d"
 
 echo "> Check Docforge Manifest"
 repoPath=${1-"$(readlink -f "$(dirname "${0}")/..")"}


### PR DESCRIPTION
**What this PR does / why we need it**:
check-docforge script uses newest docforge version 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc developer
NONE
```
