### PR TITLE
Chart: Support for projected service account tokens

### DIFF
--- a/charts/__tests__/gardener-dashboard/__snapshots__/deployment.spec.js.snap
+++ b/charts/__tests__/gardener-dashboard/__snapshots__/deployment.spec.js.snap
@@ -121,6 +121,11 @@ Object {
                 "name": "gardener-dashboard-login-config",
                 "subPath": "login-config.json",
               },
+              Object {
+                "mountPath": "/var/run/secrets/projected/serviceaccount",
+                "name": "service-account-token",
+                "readOnly": true,
+              },
             ],
           },
         ],
@@ -152,6 +157,19 @@ Object {
               "name": "gardener-dashboard-configmap",
             },
             "name": "gardener-dashboard-login-config",
+          },
+          Object {
+            "name": "service-account-token",
+            "projected": Object {
+              "sources": Array [
+                Object {
+                  "serviceAccountToken": Object {
+                    "expirationSeconds": 43200,
+                    "path": "token",
+                  },
+                },
+              ],
+            },
           },
         ],
       },

--- a/charts/gardener-dashboard/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener-dashboard/charts/runtime/templates/deployment.yaml
@@ -60,6 +60,17 @@ spec:
           name: dashboard-assets
           defaultMode: 0444
       {{- end }}
+      {{- if .Values.global.serviceAccountTokenVolumeProjection.enabled }}
+      - name: service-account-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              path: token
+              expirationSeconds: {{ required ".Values.global.serviceAccountTokenVolumeProjection.expirationSeconds is required" .Values.global.serviceAccountTokenVolumeProjection.expirationSeconds }}
+              {{- if .Values.global.serviceAccountTokenVolumeProjection.audience }}
+              audience: {{ .Values.global.serviceAccountTokenVolumeProjection.audience }}
+              {{- end }}
+      {{- end }}
       {{- if .Values.global.kubeconfig }}
       - name: gardener-dashboard-secret-kubeconfig
         secret:
@@ -67,8 +78,11 @@ spec:
       {{- end }}
       {{- if .Values.global.kubeconfig }}
       automountServiceAccountToken: false
+      {{- end }}
+      {{- if .Values.global.serviceAccountTokenVolumeProjection.enabled }}
+      serviceAccountName: {{ required ".Values.global.serviceAccountName is required" .Values.global.serviceAccountName }}
       {{- else }}
-      serviceAccountName: gardener-dashboard
+      serviceAccountName: default
       {{- end }}
       containers:
         - name: gardener-dashboard
@@ -160,6 +174,11 @@ spec:
           {{- if .Values.global.frontendConfig.assets }}
           - name: assets
             mountPath: /app/public/static/assets
+          {{- end }}
+          {{- if .Values.global.serviceAccountTokenVolumeProjection.enabled }}
+          - name: service-account-token
+            mountPath: /var/run/secrets/projected/serviceaccount
+            readOnly: true
           {{- end }}
           {{- if .Values.global.kubeconfig }}
           - name: gardener-dashboard-secret-kubeconfig

--- a/charts/gardener-dashboard/charts/runtime/templates/serviceaccount.yaml
+++ b/charts/gardener-dashboard/charts/runtime/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if and .Values.global.virtualGarden.enabled .Values.global.virtualGarden.userName }}
+{{- if and .Values.global.virtualGarden.enabled .Values.global.serviceAccountTokenVolumeProjection.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -17,10 +17,15 @@ global:
   virtualGarden:
     # enabled should be set to true if the application and runtime charts should be deployed on two separate clusters, usually in a so-called "virtual garden" setup
     enabled: false
-    # userName is the fully qualified name of the dashboard user, as it would be returned by the tokenreview (.status.user.username) on the virtual garden
+    # # userName is the fully qualified name of the dashboard user, as it would be returned by the tokenreview (.status.user.username) on the virtual garden
     # userName: runtime-cluster:system:serviceaccount:garden:gardener-dashboard
 
   serviceAccountName: gardener-dashboard
+
+  serviceAccountTokenVolumeProjection:
+    enabled: true
+    expirationSeconds: 43200 # 12 hours
+    audience: ''
 
   # vertical Pod autoscaling disabled by default
   # vpa:


### PR DESCRIPTION
**What this PR does / why we need it**:
The chart was adapted to support projected service account tokens ([ref](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection)).

**Which issue(s) this PR fixes**:
Fixes #1282 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
