### PR TITLE
Read controllerregistration version from annotation

### DIFF
--- a/backend/__fixtures__/controllerregistrations.js
+++ b/backend/__fixtures__/controllerregistrations.js
@@ -6,7 +6,7 @@
 
 'use strict'
 
-const { cloneDeep, find } = require('lodash')
+const { cloneDeep, find, set } = require('lodash')
 
 function getControllerRegistration ({ uid, name, version, resources }) {
   const metadata = {
@@ -18,15 +18,7 @@ function getControllerRegistration ({ uid, name, version, resources }) {
     spec.resources = resources
   }
   if (version) {
-    spec.deployment = {
-      providerConfig: {
-        values: {
-          image: {
-            tag: version
-          }
-        }
-      }
-    }
+    set(metadata, ['annotations', 'dashboard.gardener.cloud/version'], version)
   }
   return { metadata, spec }
 }

--- a/backend/lib/services/controllerregistrations.js
+++ b/backend/lib/services/controllerregistrations.js
@@ -18,7 +18,8 @@ exports.listExtensions = async function ({ user }) {
   for (const { metadata, spec = {} } of controllerregistrations) {
     const name = metadata.name
     if (allowed) {
-      const version = _.get(spec, 'deployment.providerConfig.values.image.tag')
+      const annotations = _.get(metadata, 'annotations', {})
+      const version = _.get(annotations, 'dashboard.gardener.cloud/version')
       const resources = spec.resources
       extensions.push({ name, version, resources })
     } else {


### PR DESCRIPTION
**What this PR does / why we need it**:
The Dashboard currently does not show the version of deployed extensions.
With this PR we adapted the dashboard to look for an annotation `dashboard.gardener.cloud/version` in the `controllerregistration` resource. This annotation has to be set in the landscape deployment process.

Background: We used to read the version from the `controllerregistration` spec using the image tag. However since the extension deployment process changed this is no longer possible. We discussed with @rfranzke that there is currently no feasible way to automatically determine the version with the information accessible by the dashboard. So the only solution is to explicitly set the version in the `controllerregistration` resource itself.

**Which issue(s) this PR fixes**:
Fixes #1033

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Extension version can be specified for each `controllerregistration` resource using the `dashboard.gardener.cloud/version` annotation. The dashboard will show the defined version in the about dialog
```
