### PR TITLE
Show gardenctl target cluster for non-admins

### DIFF
--- a/frontend/src/components/ShootDetails/GardenctlCommands.vue
+++ b/frontend/src/components/ShootDetails/GardenctlCommands.vue
@@ -96,6 +96,7 @@ export default {
       'cfg'
     ]),
     ...mapGetters([
+      'isAdmin',
       'projectFromProjectList',
       'gardenctlOptions'
     ]),
@@ -111,13 +112,7 @@ export default {
       }
 
       const gardenctlVersion = this.legacyCommands ? 'Legacy gardenctl' : 'Gardenctl-v2'
-      return [
-        {
-          title: 'Target Control Plane',
-          subtitle: `${gardenctlVersion} command to target the control plane of the shoot cluster`,
-          value: this.targetControlPlaneCommand,
-          displayValue: displayValue(this.targetControlPlaneCommand)
-        },
+      const cmds = [
         {
           title: 'Target Cluster',
           subtitle: `${gardenctlVersion} command to target the shoot cluster`,
@@ -125,6 +120,16 @@ export default {
           displayValue: displayValue(this.targetShootCommand)
         }
       ]
+
+      if (this.isAdmin) {
+        cmds.unshift({
+          title: 'Target Control Plane',
+          subtitle: `${gardenctlVersion} command to target the control plane of the shoot cluster`,
+          value: this.targetControlPlaneCommand,
+          displayValue: displayValue(this.targetControlPlaneCommand)
+        })
+      }
+      return cmds
     },
     legacyCommands () {
       return get(this.gardenctlOptions, 'legacyCommands', false)

--- a/frontend/src/components/ShootDetails/ShootAccessCard.vue
+++ b/frontend/src/components/ShootDetails/ShootAccessCard.vue
@@ -185,6 +185,7 @@ export default {
     ...mapGetters([
       'hasShootTerminalAccess',
       'isAdmin',
+      'canCreateShootsAdminkubeconfig',
       'hasControlPlaneTerminalAccess',
       'isTerminalShortcutsFeatureEnabled',
       'canPatchShoots'
@@ -265,7 +266,7 @@ export default {
       return this.isKubeconfigAvailable || this.canPatchShoots
     },
     isGardenctlTileVisible () {
-      return this.isAdmin
+      return this.canCreateShootsAdminkubeconfig
     },
     isTerminalTileVisible () {
       return !isEmpty(this.shootItem) && this.hasShootTerminalAccess && !this.isSeedUnreachable

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -1054,6 +1054,9 @@ const getters = {
   canCreateSecrets (state) {
     return canI(state.subjectRules, 'create', '', 'secrets')
   },
+  canCreateShootsAdminkubeconfig (state) {
+    return canI(state.subjectRules, 'create', 'core.gardener.cloud', 'shoots/adminkubeconfig')
+  },
   canPatchSecrets (state) {
     return canI(state.subjectRules, 'patch', '', 'secrets')
   },


### PR DESCRIPTION
**What this PR does / why we need it**:
The gardenctl `Target Cluster` command is shown for users with `create` `shoots/adminkubeconfig` permission (e.g. for users having the `admin` project role). Previously this was only shown for gardener admins.

**Which issue(s) this PR fixes**:
Fixes #1298

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The gardenctl `Target Cluster` command is now shown for users with `create` `shoots/adminkubeconfig` permission (e.g. for users having the `admin` project role). Previously this was only shown for gardener admins.
```
