### PR TITLE
Create orphaned service account on member update

### DIFF
--- a/backend/lib/services/members/MemberManager.js
+++ b/backend/lib/services/members/MemberManager.js
@@ -77,7 +77,17 @@ class MemberManager {
     this.setItemRoles(item, roles)
 
     if (item.kind === 'ServiceAccount') {
-      await this.updateServiceAccount(item, { description })
+      if (item.extensions?.orphaned) {
+        await this.createServiceAccount(item, {
+          createdBy: this.userId,
+          description
+        })
+        item.extend({
+          orphaned: false
+        })
+      } else {
+        await this.updateServiceAccount(item, { description })
+      }
     }
     await this.save()
     return this.subjectList.members

--- a/backend/test/services.members.spec.js
+++ b/backend/test/services.members.spec.js
@@ -427,6 +427,23 @@ describe('services', function () {
           expect(newMemberListItem.subject.roles).toEqual(expect.arrayContaining(['viewer']))
           expect(newMemberListItem.roles).toEqual(roles)
         })
+
+        it('should create orphaned service account', async function () {
+          const name = 'system:serviceaccount:garden-foo:robot-orphaned'
+          const roles = ['role1', 'role2']
+
+          await memberManager.update(name, { roles }) // assign user to project
+          const memberSubjects = memberManager.subjectList
+          const newMemberListItem = memberSubjects.subjectListItems[name]
+
+          expect(newMemberListItem.subject.name).toEqual('robot-orphaned')
+          expect(newMemberListItem.subject.namespace).toEqual('garden-foo')
+          expect(newMemberListItem.subject.kind).toBe('ServiceAccount')
+          expect(newMemberListItem.subject.role).toBe('role1')
+          expect(newMemberListItem.subject.roles).toEqual(expect.arrayContaining(['role2']))
+          expect(newMemberListItem.roles).toEqual(roles)
+          expect(newMemberListItem.extensions.orphaned).toBe(false)
+        })
       })
 
       describe('#deleteServiceAccount', function () {

--- a/frontend/src/components/dialogs/MemberDialog.vue
+++ b/frontend/src/components/dialogs/MemberDialog.vue
@@ -65,6 +65,15 @@ SPDX-License-Identifier: Apache-2.0
               ></v-text-field>
             </v-col>
           </v-row>
+          <v-alert
+            v-if="isUpdateDialog && orphaned"
+            :value="true"
+            type="info"
+            color="primary"
+            outlined
+          >
+            The service account will be created in case it does not exist
+          </v-alert>
           <g-message color="error" :message.sync="errorMessage" :detailed-message.sync="detailedErrorMessage"></g-message>
         </v-container>
       </v-card-text>
@@ -122,6 +131,9 @@ export default {
       type: Array
     },
     isCurrentUser: {
+      type: Boolean
+    },
+    orphaned: {
       type: Boolean
     }
   },

--- a/frontend/src/components/dialogs/MemberDialog.vue
+++ b/frontend/src/components/dialogs/MemberDialog.vue
@@ -72,7 +72,7 @@ SPDX-License-Identifier: Apache-2.0
             color="primary"
             outlined
           >
-            The service account will be created in case it does not exist
+            The service account does not exist anymore and will be re-created if you update the roles.
           </v-alert>
           <g-message color="error" :message.sync="errorMessage" :detailed-message.sync="detailedErrorMessage"></g-message>
         </v-container>

--- a/frontend/src/views/Members.vue
+++ b/frontend/src/views/Members.vue
@@ -161,7 +161,7 @@ SPDX-License-Identifier: Apache-2.0
     <member-dialog type="adduser" v-model="userAddDialog"></member-dialog>
     <member-dialog type="addservice" v-model="serviceAccountAddDialog"></member-dialog>
     <member-dialog type="updateuser" :name="memberName" :is-current-user="isCurrentUser(memberName)" :roles="memberRoles" v-model="userUpdateDialog"></member-dialog>
-    <member-dialog type="updateservice" :name="memberName" :description="serviceAccountDescription" :is-current-user="isCurrentUser(memberName)" :roles="memberRoles" v-model="serviceAccountUpdateDialog"></member-dialog>
+    <member-dialog type="updateservice" :name="memberName" :description="serviceAccountDescription" :is-current-user="isCurrentUser(memberName)" :roles="memberRoles" :orphaned="orphaned" v-model="serviceAccountUpdateDialog"></member-dialog>
     <member-help-dialog type="user" v-model="userHelpDialog"></member-help-dialog>
     <member-help-dialog type="service" v-model="serviceAccountHelpDialog"></member-help-dialog>
     <v-dialog v-model="kubeconfigDialog" persistent max-width="67%">
@@ -242,6 +242,7 @@ export default {
       memberName: undefined,
       memberRoles: undefined,
       serviceAccountDescription: undefined,
+      orphaned: false,
       userFilter: '',
       serviceAccountFilter: '',
       currentServiceAccountName: undefined,
@@ -555,10 +556,11 @@ export default {
       this.memberRoles = roles
       this.openUserUpdateDialog()
     },
-    onEditServiceAccount ({ username, roles, description }) {
+    onEditServiceAccount ({ username, roles, description, orphaned }) {
       this.memberName = username
       this.memberRoles = roles
       this.serviceAccountDescription = description
+      this.orphaned = orphaned
       this.openServiceAccountUpdateDialog()
     },
     sortedRoleDisplayNames (roleNames) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Create orphaned service account on member update

<img width="464" alt="Screenshot 2022-09-30 at 15 54 42" src="https://user-images.githubusercontent.com/5526658/193285427-d17fe774-8234-49f9-936c-99d0fd9ba1f7.png">

<img width="1564" alt="Screenshot 2022-10-03 at 11 45 13" src="https://user-images.githubusercontent.com/5526658/193548329-a34250ab-ab67-4fbd-a584-9ce07415101d.png">


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
When updating a service account project member the service account will be created in case the service account is listed as project member but does not actually exist
```
