### PR TITLE
Remove redundant loadBalancerProvider in hcloud ControlPlaneConfig

### DIFF
--- a/frontend/src/utils/createShoot.js
+++ b/frontend/src/utils/createShoot.js
@@ -177,8 +177,7 @@ function getProviderTemplate (infrastructureKind, defaultWorkerCIDR) {
         },
         controlPlaneConfig: {
           apiVersion: 'hcloud.provider.extensions.gardener.cloud/v1alpha1',
-          kind: 'ControlPlaneConfig',
-          loadBalancerProvider: 'provider'
+          kind: 'ControlPlaneConfig'
         }
       }
   }


### PR DESCRIPTION
Signed-off-by: Jens Schneider <schneider@23technologies.cloud>

-------

**What this PR does / why we need it**:
There is no loadBalancerProvider for hcloud shoots. Therefore, this is a bugfix.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Would be nice, if you could trigger a patch release, so that we can use the dashboard including this change soon.


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
NONE
```