### PR TITLE
Disable delete button for deleted service account

### DIFF
--- a/backend/lib/services/members/Member.js
+++ b/backend/lib/services/members/Member.js
@@ -8,7 +8,7 @@
 
 const { pick } = require('lodash')
 
-const PROPERTY_NAMES = ['createdBy', 'creationTimestamp', 'description', 'kubeconfig', 'orphaned']
+const PROPERTY_NAMES = ['createdBy', 'creationTimestamp', 'deletionTimestamp', 'description', 'kubeconfig', 'orphaned']
 
 class Member {
   constructor (username, { roles, extensions } = {}) {

--- a/backend/lib/services/members/SubjectList.js
+++ b/backend/lib/services/members/SubjectList.js
@@ -19,7 +19,7 @@ class SubjectList {
       }
     } = project
     const createServiceAccountItem = ({ metadata, secrets }) => {
-      const { namespace, name, annotations = {}, creationTimestamp } = metadata
+      const { namespace, name, annotations = {}, creationTimestamp, deletionTimestamp } = metadata
       const createdByLegacy = annotations['garden.sapcloud.io/createdBy']
       const createdByTerminal = annotations['terminal.dashboard.gardener.cloud/created-by']
       const createdBy = annotations['dashboard.gardener.cloud/created-by'] || createdByLegacy || createdByTerminal
@@ -33,6 +33,7 @@ class SubjectList {
         createdBy,
         description,
         creationTimestamp,
+        deletionTimestamp,
         secrets
       })
       return item

--- a/backend/test/services.members.spec.js
+++ b/backend/test/services.members.spec.js
@@ -119,12 +119,7 @@ describe('services', function () {
             'dashboard.gardener.cloud/description': 'description'
           },
           creationTimestamp: 'bar-time'
-        },
-        secrets: [
-          {
-            name: 'secret-1'
-          }
-        ]
+        }
       },
       {
         metadata: {
@@ -144,18 +139,7 @@ describe('services', function () {
             'dashboard.gardener.cloud/created-by': 'foo'
           },
           creationTimestamp: 'bar-time'
-        },
-        secrets: [
-          {
-            name: 'secret-1'
-          },
-          {
-            name: 'secret-2'
-          },
-          {
-            name: 'missing-secret'
-          }
-        ]
+        }
       },
       {
         metadata: {
@@ -173,29 +157,6 @@ describe('services', function () {
           namespace: 'garden-foo',
           creationTimestamp: 'bar-time',
           deletionTimestamp: 'baz-time'
-        }
-      }
-    ]
-
-    const secrets = [
-      {
-        metadata: {
-          namespace: 'garden-foo',
-          name: 'secret-1',
-          creationTimestamp: '2019-03-13T13:11:36Z'
-        },
-        data: {
-          token: Buffer.from('secret-1').toString('base64')
-        }
-      },
-      {
-        metadata: {
-          namespace: 'garden-foo',
-          name: 'secret-2',
-          creationTimestamp: '2021-03-13T13:11:36Z'
-        },
-        data: {
-          token: Buffer.from('secret-2').toString('base64')
         }
       }
     ]
@@ -238,10 +199,6 @@ describe('services', function () {
         }),
         delete: jest.fn().mockImplementation(findObjectFn(serviceAccounts)),
         mergePatch: jest.fn().mockResolvedValue()
-      }
-      client.core.secrets = {
-        delete: jest.fn().mockImplementation(findObjectFn(secrets)),
-        get: jest.fn().mockImplementation(findObjectFn(secrets))
       }
     })
 

--- a/backend/test/services.members.spec.js
+++ b/backend/test/services.members.spec.js
@@ -166,6 +166,14 @@ describe('services', function () {
           },
           creationTimestamp: 'bar-time'
         }
+      },
+      {
+        metadata: {
+          name: 'robot-deleted',
+          namespace: 'garden-foo',
+          creationTimestamp: 'bar-time',
+          deletionTimestamp: 'baz-time'
+        }
       }
     ]
 
@@ -270,7 +278,7 @@ describe('services', function () {
         it('should merge multiple occurences of same user in members list', async function () {
           const frontendMemberList = memberManager.list()
 
-          expect(frontendMemberList).toHaveLength(9)
+          expect(frontendMemberList).toHaveLength(10)
           expect(frontendMemberList).toContainEqual({
             username: 'mutiple@bar.com',
             roles: ['admin', 'viewer']
@@ -297,6 +305,12 @@ describe('services', function () {
             username: 'system:serviceaccount:garden-foo:robot-orphaned',
             roles: ['myrole'],
             orphaned: true
+          })
+          expect(frontendMemberList).toContainEqual({
+            username: 'system:serviceaccount:garden-foo:robot-deleted',
+            roles: [],
+            creationTimestamp: 'bar-time',
+            deletionTimestamp: 'baz-time'
           })
         })
 

--- a/frontend/src/components/ProjectServiceAccountRow.vue
+++ b/frontend/src/components/ProjectServiceAccountRow.vue
@@ -84,11 +84,13 @@ SPDX-License-Identifier: Apache-2.0
         <div v-if="canManageServiceAccountMembers && canDeleteServiceAccounts" class="ml-1">
           <v-tooltip top>
             <template v-slot:activator="{ on }">
-              <v-btn v-on="on" icon color="action-button" @click.native.stop="onDelete">
-                <v-icon>{{ foreign ? 'mdi-close' : 'mdi-delete' }}</v-icon>
-              </v-btn>
+               <div v-on="on">
+                <v-btn icon color="action-button" @click.native.stop="onDelete" :disabled="!canDelete">
+                  <v-icon>{{ foreign || orphaned ? 'mdi-close' : 'mdi-delete' }}</v-icon>
+                </v-btn>
+               </div>
             </template>
-            <span>{{ foreign ? 'Remove Foreign Service Account from Project' : 'Delete Service Account' }}</span>
+            <span>{{deleteTooltip}}</span>
           </v-tooltip>
         </div>
       </div>
@@ -138,6 +140,21 @@ export default {
     },
     foreign () {
       return isForeignServiceAccount(this.namespace, this.item.username)
+    },
+    canDelete () {
+      return this.foreign || this.orphaned || !this.item.deletionTimestamp
+    },
+    deleteTooltip () {
+      if (!this.canDelete) {
+        return 'Service Account is already marked for deletion'
+      }
+      if (this.orphaned) {
+        return 'Remove Service Account from Project'
+      }
+      if (this.foreign) {
+        return 'Remove foreign Service Account from Project'
+      }
+      return 'Delete Service Account'
     },
     createdByClasses () {
       return this.item.createdBy ? ['font-weight-bold'] : ['grey--text']


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR the delete button is disabled for service accounts that were deleted (deletionTimestamp is set). There might be finalizers on the service account preventing the final deletion of the object. In this case we disable the delete button.

<img width="1334" alt="Screenshot 2022-10-05 at 10 54 16" src="https://user-images.githubusercontent.com/5526658/194021603-5ed870b9-3eda-4c0b-96c8-4a5bf339ae24.png">


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Members page: The delete button for service accounts is now disabled in case the service account was already marked for deletion (`deletionTimestamp` is set)
```
