### PR TITLE
Cleanup dashboard-webterminal service account if not used

### DIFF
--- a/backend/__fixtures__/serviceaccounts.js
+++ b/backend/__fixtures__/serviceaccounts.js
@@ -15,6 +15,7 @@ const { getTokenPayload } = require('./auth')
 const serviceAccountList = [
   getServiceAccount({ namespace: 'garden-foo', name: 'robot', createdBy: 'foo@example.org' }),
   getServiceAccount({ namespace: 'garden-foo', name: 'robot-nomember' }),
+  getServiceAccount({ namespace: 'garden-foo', name: 'dashboard-webterminal' }),
   getServiceAccount({ namespace: 'garden-bar', name: 'robot', createdBy: 'bar@example.org' }),
   getServiceAccount({ namespace: 'term-host-1', name: 'term-attach-1' }),
   getServiceAccount({ namespace: 'term-host-2', name: 'term-attach-2' }),

--- a/backend/__fixtures__/serviceaccounts.js
+++ b/backend/__fixtures__/serviceaccounts.js
@@ -9,7 +9,7 @@ const { cloneDeep, merge, get, set, filter, find, split } = require('lodash')
 const createError = require('http-errors')
 const pathToRegexp = require('path-to-regexp')
 
-const { toHex, parseFieldSelector } = require('./helper')
+const { parseFieldSelector } = require('./helper')
 const { getTokenPayload } = require('./auth')
 
 const serviceAccountList = [
@@ -36,10 +36,7 @@ function getServiceAccount ({
       annotations: {
         'gardener.cloud/created-by': createdBy
       }
-    },
-    secrets: [{
-      name: [name, 'token', toHex(name).substring(0, 5)].join('-')
-    }]
+    }
   }
 }
 

--- a/backend/lib/services/terminals/index.js
+++ b/backend/lib/services/terminals/index.js
@@ -230,7 +230,7 @@ async function getTargetCluster ({ user, namespace, name, target, preferredHost,
 
         // test if service account exists and is not in deletion
         const serviceAccount = await client.core.serviceaccounts.get(namespace, serviceAccountName)
-        if (serviceAccount.metadata?.deletionTimestamp) {
+        if (serviceAccount.metadata.deletionTimestamp) {
           throw new Error('Can\'t create terminal for ServiceAccount that is marked for deletion')
         }
 
@@ -611,7 +611,7 @@ async function getOrCreateTerminalSession ({ user, namespace, name, target, body
   }
 
   if (target === TargetEnum.GARDEN && !isAdmin) {
-    ensureServiceAccountCleanup(client, { terminal, namespace, name: DASHBOARD_WEBTERMINAL_NAME })
+    await ensureServiceAccountCleanup(client, { terminal, namespace, name: DASHBOARD_WEBTERMINAL_NAME })
   }
 
   return {
@@ -643,12 +643,12 @@ async function ensureServiceAccountCleanup (client, { terminal, namespace, name 
 
   let dirty = false
 
-  if (!_.some(finalizers, 'gardener.cloud/terminal')) {
+  if (!finalizers.includes('gardener.cloud/terminal')) {
     finalizers.push('gardener.cloud/terminal')
     dirty = true
   }
 
-  if (!_.some(ownerReferences, { uid: ownerRef.uid })) {
+  if (!_.some(ownerReferences, ['uid', ownerRef.uid])) {
     ownerReferences.push(ownerRef)
     dirty = true
   }

--- a/backend/lib/services/terminals/index.js
+++ b/backend/lib/services/terminals/index.js
@@ -393,7 +393,7 @@ async function getSeedHostCluster (client, { namespace, name, target, body, shoo
   return hostCluster
 }
 
-async function getShootHostCluster (client, { namespace, name, target, body, shootResource }) {
+async function getShootHostCluster (client, { namespace, name, body, shootResource }) {
   const hostCluster = {}
   hostCluster.config = getConfigFromBody(body)
 
@@ -442,7 +442,7 @@ function getHostCluster ({ user, namespace, name, target, preferredHost, body, s
   }
 
   // host cluster is the shoot
-  return getShootHostCluster(client, { namespace, name, target, body, shootResource })
+  return getShootHostCluster(client, { namespace, name, body, shootResource })
 }
 
 async function createTerminal ({ user, namespace, target, hostCluster, targetCluster, identifier, preferredHost }) {

--- a/backend/lib/services/terminals/index.js
+++ b/backend/lib/services/terminals/index.js
@@ -633,7 +633,13 @@ async function ensureServiceAccountCleanup (client, { terminal, namespace, name 
     uid: terminal.metadata.uid
   }
 
-  const { metadata: { ownerReferences = [], labels = {}, finalizers = [] } } = await client.core.serviceaccounts.get(namespace, name)
+  const {
+    metadata: {
+      ownerReferences = [],
+      labels = {},
+      finalizers = []
+    }
+  } = await client.core.serviceaccounts.get(namespace, name)
 
   let dirty = false
 

--- a/backend/lib/services/terminals/index.js
+++ b/backend/lib/services/terminals/index.js
@@ -45,6 +45,9 @@ const markdown = require('../../markdown')
 
 const TERMINAL_CONTAINER_NAME = 'terminal'
 
+// name of the dashboard webterminal serviceaccount used by non-admins
+const DASHBOARD_WEBTERMINAL_NAME = 'dashboard-webterminal'
+
 const TargetEnum = {
   GARDEN: 'garden',
   CONTROL_PLANE: 'cp',
@@ -191,6 +194,7 @@ async function getTargetCluster ({ user, namespace, name, target, preferredHost,
     kubeconfigContextNamespace: undefined,
     namespace: undefined, // this is the namespace where the "access" service account will be created
     credentials: undefined,
+    cleanupProjectMembership: false,
     authorization: {
       roleBindings: undefined,
       projectMemberships: undefined
@@ -222,10 +226,13 @@ async function getTargetCluster ({ user, namespace, name, target, preferredHost,
       } else {
         const projectName = findProjectByNamespace(namespace).metadata.name
         targetCluster.namespace = namespace
-        const serviceAccountName = 'dashboard-webterminal'
+        const serviceAccountName = DASHBOARD_WEBTERMINAL_NAME
 
-        // test if service account exists
-        await client.core.serviceaccounts.get(namespace, serviceAccountName)
+        // test if service account exists and is not in deletion
+        const serviceAccount = await client.core.serviceaccounts.get(namespace, serviceAccountName)
+        if (serviceAccount.metadata?.deletionTimestamp) {
+          throw new Error('Can\'t create terminal for ServiceAccount that is marked for deletion')
+        }
 
         targetCluster.credentials = {
           serviceAccountRef: {
@@ -233,6 +240,7 @@ async function getTargetCluster ({ user, namespace, name, target, preferredHost,
             namespace
           }
         }
+        targetCluster.cleanupProjectMembership = true
         targetCluster.authorization.projectMemberships = [
           {
             projectName,
@@ -523,7 +531,7 @@ function createHost ({ credentials, namespace, container, podLabels, node, hostP
   return host
 }
 
-function createTarget ({ kubeconfigContextNamespace, apiServer, credentials, authorization, namespace }) {
+function createTarget ({ kubeconfigContextNamespace, apiServer, credentials, authorization, namespace, cleanupProjectMembership }) {
   const temporaryNamespace = _.isEmpty(namespace)
   return {
     credentials,
@@ -531,7 +539,8 @@ function createTarget ({ kubeconfigContextNamespace, apiServer, credentials, aut
     apiServer,
     authorization,
     namespace,
-    temporaryNamespace
+    temporaryNamespace,
+    cleanupProjectMembership
   }
 }
 
@@ -557,6 +566,7 @@ async function readTerminalUntilReady ({ user, namespace, name }) {
 async function getOrCreateTerminalSession ({ user, namespace, name, target, body = {} }) {
   const username = user.id
   const client = user.client
+  const isAdmin = user.isAdmin
 
   let [
     terminal,
@@ -600,6 +610,10 @@ async function getOrCreateTerminalSession ({ user, namespace, name, target, body
       .catch(_.noop) // ignore error
   }
 
+  if (target === TargetEnum.GARDEN && !isAdmin) {
+    ensureServiceAccountCleanup(client, { terminal, namespace, name: DASHBOARD_WEBTERMINAL_NAME })
+  }
+
   return {
     metadata: toTerminalMetadata(terminal),
     hostCluster: {
@@ -608,6 +622,49 @@ async function getOrCreateTerminalSession ({ user, namespace, name, target, body
     },
     imageHelpText: imageHelpText(terminal)
   }
+}
+
+async function ensureServiceAccountCleanup (client, { terminal, namespace, name }) {
+  const ownerRef = {
+    apiVersion: terminal.apiVersion,
+    kind: terminal.kind,
+    blockOwnerDeletion: false,
+    name: terminal.metadata.name,
+    uid: terminal.metadata.uid
+  }
+
+  const { metadata: { ownerReferences = [], labels = {}, finalizers = [] } } = await client.core.serviceaccounts.get(namespace, name)
+
+  let dirty = false
+
+  if (!_.some(finalizers, 'gardener.cloud/terminal')) {
+    finalizers.push('gardener.cloud/terminal')
+    dirty = true
+  }
+
+  if (!_.some(ownerReferences, { uid: ownerRef.uid })) {
+    ownerReferences.push(ownerRef)
+    dirty = true
+  }
+
+  if (labels['reference.dashboard.gardener.cloud/terminal'] !== 'true') {
+    labels['reference.dashboard.gardener.cloud/terminal'] = 'true'
+    dirty = true
+  }
+
+  if (!dirty) {
+    return
+  }
+
+  const payload = {
+    metadata: {
+      finalizers,
+      ownerReferences,
+      labels
+    }
+  }
+
+  await client.core.serviceaccounts.mergePatch(namespace, name, payload)
 }
 
 async function createHostClient (client, { shootRef, secretRef }) {

--- a/backend/test/acceptance/__snapshots__/api.members.spec.js.snap
+++ b/backend/test/acceptance/__snapshots__/api.members.spec.js.snap
@@ -112,6 +112,11 @@ Array [
     "username": "system:serviceaccount:garden-foo:robot-nomember",
   },
   Object {
+    "creationTimestamp": "2020-01-01T00:00:00Z",
+    "roles": Array [],
+    "username": "system:serviceaccount:garden-foo:dashboard-webterminal",
+  },
+  Object {
     "roles": Array [
       "myrole",
     ],
@@ -233,6 +238,11 @@ Array [
     "creationTimestamp": "2020-01-01T00:00:00Z",
     "roles": Array [],
     "username": "system:serviceaccount:garden-foo:robot-nomember",
+  },
+  Object {
+    "creationTimestamp": "2020-01-01T00:00:00Z",
+    "roles": Array [],
+    "username": "system:serviceaccount:garden-foo:dashboard-webterminal",
   },
   Object {
     "roles": Array [
@@ -375,6 +385,11 @@ Array [
     "username": "system:serviceaccount:garden-foo:robot-nomember",
   },
   Object {
+    "creationTimestamp": "2020-01-01T00:00:00Z",
+    "roles": Array [],
+    "username": "system:serviceaccount:garden-foo:dashboard-webterminal",
+  },
+  Object {
     "createdBy": "bar@example.org",
     "creationTimestamp": "now",
     "description": "description",
@@ -499,6 +514,11 @@ Array [
     ],
     "username": "system:serviceaccount:garden-foo:robot-nomember",
   },
+  Object {
+    "creationTimestamp": "2020-01-01T00:00:00Z",
+    "roles": Array [],
+    "username": "system:serviceaccount:garden-foo:dashboard-webterminal",
+  },
 ]
 `;
 
@@ -577,6 +597,11 @@ Array [
     "creationTimestamp": "2020-01-01T00:00:00Z",
     "roles": Array [],
     "username": "system:serviceaccount:garden-foo:robot-nomember",
+  },
+  Object {
+    "creationTimestamp": "2020-01-01T00:00:00Z",
+    "roles": Array [],
+    "username": "system:serviceaccount:garden-foo:dashboard-webterminal",
   },
   Object {
     "createdBy": "bar@example.org",
@@ -676,6 +701,11 @@ Array [
     "roles": Array [],
     "username": "system:serviceaccount:garden-foo:robot-nomember",
   },
+  Object {
+    "creationTimestamp": "2020-01-01T00:00:00Z",
+    "roles": Array [],
+    "username": "system:serviceaccount:garden-foo:dashboard-webterminal",
+  },
 ]
 `;
 
@@ -767,6 +797,11 @@ Array [
     "creationTimestamp": "2020-01-01T00:00:00Z",
     "roles": Array [],
     "username": "system:serviceaccount:garden-foo:robot-nomember",
+  },
+  Object {
+    "creationTimestamp": "2020-01-01T00:00:00Z",
+    "roles": Array [],
+    "username": "system:serviceaccount:garden-foo:dashboard-webterminal",
   },
 ]
 `;
@@ -871,6 +906,11 @@ Array [
     "roles": Array [],
     "username": "system:serviceaccount:garden-foo:robot-nomember",
   },
+  Object {
+    "creationTimestamp": "2020-01-01T00:00:00Z",
+    "roles": Array [],
+    "username": "system:serviceaccount:garden-foo:dashboard-webterminal",
+  },
 ]
 `;
 
@@ -930,6 +970,11 @@ Array [
     "creationTimestamp": "2020-01-01T00:00:00Z",
     "roles": Array [],
     "username": "system:serviceaccount:garden-foo:robot-nomember",
+  },
+  Object {
+    "creationTimestamp": "2020-01-01T00:00:00Z",
+    "roles": Array [],
+    "username": "system:serviceaccount:garden-foo:dashboard-webterminal",
   },
 ]
 `;
@@ -1057,6 +1102,11 @@ Array [
     "roles": Array [],
     "username": "system:serviceaccount:garden-foo:robot-nomember",
   },
+  Object {
+    "creationTimestamp": "2020-01-01T00:00:00Z",
+    "roles": Array [],
+    "username": "system:serviceaccount:garden-foo:dashboard-webterminal",
+  },
 ]
 `;
 
@@ -1165,6 +1215,11 @@ Array [
     "creationTimestamp": "2020-01-01T00:00:00Z",
     "roles": Array [],
     "username": "system:serviceaccount:garden-foo:robot-nomember",
+  },
+  Object {
+    "creationTimestamp": "2020-01-01T00:00:00Z",
+    "roles": Array [],
+    "username": "system:serviceaccount:garden-foo:dashboard-webterminal",
   },
 ]
 `;
@@ -1299,6 +1354,11 @@ Array [
     "roles": Array [],
     "username": "system:serviceaccount:garden-foo:robot-nomember",
   },
+  Object {
+    "creationTimestamp": "2020-01-01T00:00:00Z",
+    "roles": Array [],
+    "username": "system:serviceaccount:garden-foo:dashboard-webterminal",
+  },
 ]
 `;
 
@@ -1402,6 +1462,11 @@ Array [
     "creationTimestamp": "2020-01-01T00:00:00Z",
     "roles": Array [],
     "username": "system:serviceaccount:garden-foo:robot-nomember",
+  },
+  Object {
+    "creationTimestamp": "2020-01-01T00:00:00Z",
+    "roles": Array [],
+    "username": "system:serviceaccount:garden-foo:dashboard-webterminal",
   },
 ]
 `;
@@ -1527,6 +1592,11 @@ Array [
     "creationTimestamp": "2020-01-01T00:00:00Z",
     "roles": Array [],
     "username": "system:serviceaccount:garden-foo:robot-nomember",
+  },
+  Object {
+    "creationTimestamp": "2020-01-01T00:00:00Z",
+    "roles": Array [],
+    "username": "system:serviceaccount:garden-foo:dashboard-webterminal",
   },
 ]
 `;

--- a/backend/test/acceptance/__snapshots__/api.terminals.spec.js.snap
+++ b/backend/test/acceptance/__snapshots__/api.terminals.spec.js.snap
@@ -207,6 +207,7 @@ Array [
               },
             ],
           },
+          "cleanupProjectMembership": false,
           "credentials": Object {
             "shootRef": Object {
               "name": "infra1-seed",
@@ -445,6 +446,7 @@ Array [
               },
             ],
           },
+          "cleanupProjectMembership": false,
           "credentials": Object {
             "serviceAccountRef": Object {
               "name": "dashboard-terminal-admin",
@@ -904,6 +906,7 @@ Array [
               },
             ],
           },
+          "cleanupProjectMembership": false,
           "credentials": Object {
             "shootRef": Object {
               "name": "fooShoot",

--- a/backend/test/acceptance/__snapshots__/api.terminals.spec.js.snap
+++ b/backend/test/acceptance/__snapshots__/api.terminals.spec.js.snap
@@ -331,6 +331,189 @@ Object {
 }
 `;
 
+exports[`api terminals garden as enduser should create a terminal resource 1`] = `
+Array [
+  Array [
+    Object {
+      ":authority": "kubernetes:6443",
+      ":method": "post",
+      ":path": "/apis/authorization.k8s.io/v1/selfsubjectaccessreviews",
+      ":scheme": "https",
+      "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImZvb0BleGFtcGxlLm9yZyIsImlhdCI6MTU3NzgzNjgwMCwiYXVkIjpbImdhcmRlbmVyIl0sImV4cCI6MzE1NTcxNjgwMCwianRpIjoianRpIn0.k3kGjF6AgugJLdwERXEWZPaibFAPFPOnmpT3YM9H0xU",
+    },
+    Object {
+      "apiVersion": "authorization.k8s.io/v1",
+      "kind": "SelfSubjectAccessReview",
+      "spec": Object {
+        "nonResourceAttributes": undefined,
+        "resourceAttributes": Object {
+          "group": "",
+          "resource": "secrets",
+          "verb": "get",
+        },
+      },
+    },
+  ],
+  Array [
+    Object {
+      ":authority": "kubernetes:6443",
+      ":method": "get",
+      ":path": "/apis/dashboard.gardener.cloud/v1alpha1/namespaces/garden-foo/terminals?labelSelector=dashboard.gardener.cloud%2Fcreated-by-hash%3D7d13090703e44f7e8e6bd8b3c1a97863a0ac056b%2Cdashboard.gardener.cloud%2Fidentifier-hash%3D722a7be5c00be4e48b037831452206aa150b30a6",
+      ":scheme": "https",
+      "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImZvb0BleGFtcGxlLm9yZyIsImlhdCI6MTU3NzgzNjgwMCwiYXVkIjpbImdhcmRlbmVyIl0sImV4cCI6MzE1NTcxNjgwMCwianRpIjoianRpIn0.k3kGjF6AgugJLdwERXEWZPaibFAPFPOnmpT3YM9H0xU",
+    },
+  ],
+  Array [
+    Object {
+      ":authority": "kubernetes:6443",
+      ":method": "get",
+      ":path": "/apis/core.gardener.cloud/v1beta1/namespaces/garden-foo/shoots/fooShoot",
+      ":scheme": "https",
+      "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImZvb0BleGFtcGxlLm9yZyIsImlhdCI6MTU3NzgzNjgwMCwiYXVkIjpbImdhcmRlbmVyIl0sImV4cCI6MzE1NTcxNjgwMCwianRpIjoianRpIn0.k3kGjF6AgugJLdwERXEWZPaibFAPFPOnmpT3YM9H0xU",
+    },
+  ],
+  Array [
+    Object {
+      ":authority": "kubernetes:6443",
+      ":method": "get",
+      ":path": "/api/v1/namespaces/garden-foo/serviceaccounts/dashboard-webterminal",
+      ":scheme": "https",
+      "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImZvb0BleGFtcGxlLm9yZyIsImlhdCI6MTU3NzgzNjgwMCwiYXVkIjpbImdhcmRlbmVyIl0sImV4cCI6MzE1NTcxNjgwMCwianRpIjoianRpIn0.k3kGjF6AgugJLdwERXEWZPaibFAPFPOnmpT3YM9H0xU",
+    },
+  ],
+  Array [
+    Object {
+      ":authority": "kubernetes:6443",
+      ":method": "post",
+      ":path": "/apis/dashboard.gardener.cloud/v1alpha1/namespaces/garden-foo/terminals",
+      ":scheme": "https",
+      "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImZvb0BleGFtcGxlLm9yZyIsImlhdCI6MTU3NzgzNjgwMCwiYXVkIjpbImdhcmRlbmVyIl0sImV4cCI6MzE1NTcxNjgwMCwianRpIjoianRpIn0.k3kGjF6AgugJLdwERXEWZPaibFAPFPOnmpT3YM9H0xU",
+    },
+    Object {
+      "apiVersion": "dashboard.gardener.cloud/v1alpha1",
+      "kind": "Terminal",
+      "metadata": Object {
+        "annotations": Object {
+          "dashboard.gardener.cloud/identifier": "21",
+          "dashboard.gardener.cloud/preferredHost": "shoot",
+        },
+        "generateName": "term-garden-",
+        "labels": Object {
+          "component": "dashboard-terminal",
+          "dashboard.gardener.cloud/created-by-hash": "7d13090703e44f7e8e6bd8b3c1a97863a0ac056b",
+          "dashboard.gardener.cloud/identifier-hash": "722a7be5c00be4e48b037831452206aa150b30a6",
+        },
+        "namespace": "garden-foo",
+        "ownerReferences": undefined,
+      },
+      "spec": Object {
+        "host": Object {
+          "credentials": Object {
+            "shootRef": Object {
+              "name": "fooShoot",
+              "namespace": "garden-foo",
+            },
+          },
+          "namespace": undefined,
+          "pod": Object {
+            "container": Object {
+              "args": undefined,
+              "command": undefined,
+              "image": "dummyImage:1.0.0",
+              "privileged": false,
+            },
+            "hostNetwork": false,
+            "hostPID": false,
+            "labels": Object {},
+          },
+          "temporaryNamespace": true,
+        },
+        "target": Object {
+          "apiServer": Object {
+            "caData": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCkxpNHUKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ==",
+            "server": "https://kubernetes.external.foo.bar",
+          },
+          "authorization": Object {
+            "projectMemberships": Array [
+              Object {
+                "projectName": "foo",
+                "roles": Array [
+                  "admin",
+                ],
+              },
+            ],
+            "roleBindings": undefined,
+          },
+          "cleanupProjectMembership": true,
+          "credentials": Object {
+            "serviceAccountRef": Object {
+              "name": "dashboard-webterminal",
+              "namespace": "garden-foo",
+            },
+          },
+          "kubeconfigContextNamespace": "garden-foo",
+          "namespace": "garden-foo",
+          "temporaryNamespace": false,
+        },
+      },
+    },
+  ],
+  Array [
+    Object {
+      ":authority": "kubernetes:6443",
+      ":method": "get",
+      ":path": "/api/v1/namespaces/garden-foo/serviceaccounts/dashboard-webterminal",
+      ":scheme": "https",
+      "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImZvb0BleGFtcGxlLm9yZyIsImlhdCI6MTU3NzgzNjgwMCwiYXVkIjpbImdhcmRlbmVyIl0sImV4cCI6MzE1NTcxNjgwMCwianRpIjoianRpIn0.k3kGjF6AgugJLdwERXEWZPaibFAPFPOnmpT3YM9H0xU",
+    },
+  ],
+  Array [
+    Object {
+      ":authority": "kubernetes:6443",
+      ":method": "patch",
+      ":path": "/api/v1/namespaces/garden-foo/serviceaccounts/dashboard-webterminal",
+      ":scheme": "https",
+      "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImZvb0BleGFtcGxlLm9yZyIsImlhdCI6MTU3NzgzNjgwMCwiYXVkIjpbImdhcmRlbmVyIl0sImV4cCI6MzE1NTcxNjgwMCwianRpIjoianRpIn0.k3kGjF6AgugJLdwERXEWZPaibFAPFPOnmpT3YM9H0xU",
+      "content-type": "application/merge-patch+json",
+    },
+    Object {
+      "metadata": Object {
+        "finalizers": Array [
+          "gardener.cloud/terminal",
+        ],
+        "labels": Object {
+          "reference.dashboard.gardener.cloud/terminal": "true",
+        },
+        "ownerReferences": Array [
+          Object {
+            "apiVersion": "dashboard.gardener.cloud/v1alpha1",
+            "blockOwnerDeletion": false,
+            "kind": "Terminal",
+            "name": "term-garden-00021",
+            "uid": undefined,
+          },
+        ],
+      },
+    },
+  ],
+]
+`;
+
+exports[`api terminals garden as enduser should create a terminal resource 2`] = `
+Object {
+  "hostCluster": Object {
+    "kubeApiServer": "k-cq94yw.ingress.foo-east.infra1.example.org",
+    "namespace": "term-host-21",
+  },
+  "imageHelpText": "Dummy Image Description",
+  "metadata": Object {
+    "identifier": "21",
+    "name": "term-garden-00021",
+    "namespace": "garden-foo",
+  },
+}
+`;
+
 exports[`api terminals garden should create a terminal resource 1`] = `
 Array [
   Array [

--- a/frontend/src/components/dialogs/CreateTerminalSessionDialog.vue
+++ b/frontend/src/components/dialogs/CreateTerminalSessionDialog.vue
@@ -212,7 +212,7 @@ export default {
           const serviceAccountName = `system:serviceaccount:${this.namespace}:dashboard-webterminal`
           const member = find(projectMembers, ['username', serviceAccountName])
           const roles = get(member, 'roles')
-          if (includes(roles, 'admin')) {
+          if (includes(roles, 'admin') && includes(roles, 'serviceaccountmanager')) {
             return true
           }
 

--- a/frontend/src/components/dialogs/WebterminalServiceAccountDialog.vue
+++ b/frontend/src/components/dialogs/WebterminalServiceAccountDialog.vue
@@ -127,7 +127,7 @@ export default {
         return false
       }
 
-      const description = 'Service account required to manage temporary service accounts for the webterminal feature of the gardener dashboard'
+      const description = 'Service account required to manage temporary service accounts for the webterminal feature of the gardener dashboard. Will be cleaned up automatically if not referenced anymore by a webterminal'
       try {
         if (this.needsUpdate) {
           await this.updateMember({

--- a/frontend/src/components/dialogs/WebterminalServiceAccountDialog.vue
+++ b/frontend/src/components/dialogs/WebterminalServiceAccountDialog.vue
@@ -22,12 +22,12 @@ SPDX-License-Identifier: Apache-2.0
     <template v-slot:message>
       <div key="confirm-message" style="min-height:100px">
         <div>
-          <span v-if="needsUpdate">To access the garden cluster the <span class="font-family-monospace">{{serviceAccountName}}</span> service account requires the <span class="font-family-monospace">admin</span> role.</span>
+          <span v-if="needsUpdate">To access the garden cluster the <span class="font-family-monospace">{{serviceAccountName}}</span> service account requires the <span class="font-family-monospace">admin</span> and <span class="font-family-monospace">serviceaccountmanager</span> role.</span>
           <span v-else>To access the garden cluster a dedicated service account is required.</span>
         </div>
         <div>
-           <span v-if="needsUpdate">Do you want grant the <span class="font-family-monospace">admin</span> role to the service account?</span>
-           <span v-else>Do you want to create the <span class="font-family-monospace">{{serviceAccountName}}</span> service account and add it as member with <span class="font-family-monospace">admin</span> role to this project?</span>
+           <span v-if="needsUpdate">Do you want grant the <span class="font-family-monospace">admin</span> and <span class="font-family-monospace">serviceaccountmanager</span> role to the service account?</span>
+           <span v-else>Do you want to create the <span class="font-family-monospace">{{serviceAccountName}}</span> service account and add it as member with <span class="font-family-monospace">admin</span> and <span class="font-family-monospace">serviceaccountmanager</span> role to this project?</span>
           <v-list>
             <v-list-item>
               <v-list-item-content>
@@ -104,6 +104,7 @@ export default {
     desiredRoles () {
       const roles = [...get(this.member, 'roles', [])]
       roles.push('admin')
+      roles.push('serviceaccountmanager')
       return roles
     }
   },
@@ -126,18 +127,19 @@ export default {
         return false
       }
 
+      const description = 'Service account required to manage temporary service accounts for the webterminal feature of the gardener dashboard'
       try {
         if (this.needsUpdate) {
           await this.updateMember({
             name: this.serviceAccountUsername,
             roles: this.desiredRoles,
-            description: 'Service account required to manage temporary service accounts for the webterminal feature of the gardener dashboard'
+            description
           })
         } else {
           await this.addMember({
             name: this.serviceAccountUsername,
-            roles: ['admin'],
-            description: 'Service account required to manage temporary service accounts for the webterminal feature of the gardener dashboard'
+            roles: this.desiredRoles,
+            description
           })
         }
         return true

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -981,7 +981,7 @@ const getters = {
     return getters['shoots/initialNewShootResource']
   },
   hasGardenTerminalAccess (state, getters) {
-    return getters.isTerminalEnabled && getters.canCreateTerminals
+    return getters.isTerminalEnabled && getters.canCreateTerminals && getters.canPatchServiceAccounts && getters.canCreateServiceAccounts
   },
   hasControlPlaneTerminalAccess (state, getters) {
     return getters.isTerminalEnabled && getters.canCreateTerminals && getters.isAdmin
@@ -1033,6 +1033,9 @@ const getters = {
   },
   canCreateServiceAccounts (state) {
     return canI(state.subjectRules, 'create', '', 'serviceaccounts')
+  },
+  canPatchServiceAccounts (state) {
+    return canI(state.subjectRules, 'patch', '', 'serviceaccounts')
   },
   canDeleteServiceAccounts (state) {
     return canI(state.subjectRules, 'delete', '', 'serviceaccounts')

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -981,7 +981,10 @@ const getters = {
     return getters['shoots/initialNewShootResource']
   },
   hasGardenTerminalAccess (state, getters) {
-    return getters.isTerminalEnabled && getters.canCreateTerminals && getters.canPatchServiceAccounts && getters.canCreateServiceAccounts
+    return getters.isTerminalEnabled &&
+      getters.canCreateTerminals &&
+      getters.canPatchServiceAccounts &&
+      getters.canCreateServiceAccounts
   },
   hasControlPlaneTerminalAccess (state, getters) {
     return getters.isTerminalEnabled && getters.canCreateTerminals && getters.isAdmin


### PR DESCRIPTION
**What this PR does / why we need it**:
Cleanup `dashboard-webterminal` service account if not referenced by webterminals.

**Which issue(s) this PR fixes**:
Fixes #1268

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Terminal: The `dashboard-webterminal` service account is now cleaned up for new terminals if it is not referenced anymore by any webterminal session.
```

```bugfix user
Terminal: Fixed an issue where the `garden` cluster terminal could not be successfully started if the `dashboard-webterminal` does not have the required permissions (ref #1268)
```
