### PR TITLE
[hotfix-1.61] Remove redundant loadBalancerProvider in hcloud ControlPlaneConfig

### DIFF
--- a/frontend/src/utils/createShoot.js
+++ b/frontend/src/utils/createShoot.js
@@ -177,8 +177,7 @@ function getProviderTemplate (infrastructureKind, defaultWorkerCIDR) {
         },
         controlPlaneConfig: {
           apiVersion: 'hcloud.provider.extensions.gardener.cloud/v1alpha1',
-          kind: 'ControlPlaneConfig',
-          loadBalancerProvider: 'provider'
+          kind: 'ControlPlaneConfig'
         }
       }
   }


### PR DESCRIPTION
(cherry picked from commit 7f95af05fd29606e434561d545460a4e22fa6778)

**What this PR does / why we need it**:
There is no loadBalancerProvider for hcloud shoots. Therefore, this is a bugfix.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user  github.com/gardener/dashboard #1310 @JensAc
Removed `loadBalancerProvider` property from `hcloud` `controlPlaneConfig`
```
