### PR TITLE
Do not rely on secretRef for ManagedSeed

### DIFF
--- a/backend/__fixtures__/index.js
+++ b/backend/__fixtures__/index.js
@@ -12,6 +12,7 @@ const auth = require('./auth')
 const kube = require('./kube')
 const shoots = require('./shoots')
 const seeds = require('./seeds')
+const managedseeds = require('./managedseeds')
 const secrets = require('./secrets')
 const secretbindings = require('./secretbindings')
 const quotas = require('./quotas')
@@ -41,6 +42,7 @@ const fixtures = {
   kube,
   shoots,
   seeds,
+  managedseeds,
   secrets,
   secretbindings,
   projects,

--- a/backend/__fixtures__/managedseeds.js
+++ b/backend/__fixtures__/managedseeds.js
@@ -1,0 +1,88 @@
+//
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+'use strict'
+
+const { filter, find, cloneDeep } = require('lodash')
+const createError = require('http-errors')
+const pathToRegexp = require('path-to-regexp')
+
+const managedSeedList = [
+  getManagedSeed({
+    uid: 4,
+    name: 'infra1-seed',
+    namespace: 'garden',
+    project: 'garden',
+    createdBy: 'admin@example.org',
+    secretBindingName: 'soil-infra1',
+    seed: 'soil-infra1'
+  })
+]
+
+function getManagedSeed ({
+  name,
+  uid,
+  shootName
+}) {
+  const namespace = 'garden'
+  uid = uid || `${namespace}--${name}`
+  shootName ??= name
+
+  return {
+    metadata: {
+      uid,
+      name,
+      namespace
+    },
+    spec: {
+      shoot: {
+        name: shootName
+      }
+    },
+    status: {}
+  }
+}
+
+const managedSeeds = {
+  create (options) {
+    return getManagedSeed(options)
+  },
+  get (namespace, name) {
+    const items = managedSeeds.list(namespace)
+    return find(items, ['metadata.name', name])
+  },
+  list (namespace) {
+    const items = cloneDeep(managedSeedList)
+    return namespace
+      ? filter(items, ['metadata.namespace', namespace])
+      : items
+  }
+}
+
+const matchOptions = { decode: decodeURIComponent }
+const matchItem = pathToRegexp.match('/apis/seedmanagement.gardener.cloud/v1alpha1/namespaces/:namespace/managedseeds/:name', matchOptions)
+
+const mocks = {
+  get () {
+    return headers => {
+      const matchResult = matchItem(headers[':path'])
+      if (matchResult === false) {
+        return Promise.reject(createError(503))
+      }
+      const { params: { namespace, name } = {} } = matchResult
+      const item = managedSeeds.get(namespace, name)
+      if (!item) {
+        return Promise.reject(createError(404, `ManagedSeed ${namespace}/${name} not found`))
+      }
+      return Promise.resolve(item)
+    }
+  }
+}
+
+module.exports = {
+  ...managedSeeds,
+  mocks
+}

--- a/backend/__fixtures__/secrets.js
+++ b/backend/__fixtures__/secrets.js
@@ -14,7 +14,6 @@ const { toBase64, createUrl, parseLabelSelector } = require('./helper')
 const seeds = require('./seeds')
 
 const certificateAuthorityData = toBase64('certificate-authority-data')
-const caCrt = toBase64('ca.crt')
 const clientCertificateData = toBase64('client-certificate-data')
 const clientKeyData = toBase64('client-key-data')
 
@@ -176,7 +175,7 @@ const secrets = {
         'gardener.cloud/role': 'ca-cluster'
       },
       data: {
-        'ca.crt': caCrt
+        'ca.crt': 'ca.crt'
       }
     })
   },

--- a/backend/lib/services/terminals/index.js
+++ b/backend/lib/services/terminals/index.js
@@ -292,11 +292,11 @@ async function getTargetCluster ({ user, namespace, name, target, preferredHost,
         const shootRef = getShootRef(managedSeed)
         credentials = { shootRef }
 
-        const caCluster = await client.core.secrets.get(managedSeed.metadata.namespace, `${managedSeed.spec.shoot.name}.ca-cluster`)
+        const caCluster = await client.core.secrets.get(shootRef.namespace, `${shootRef.name}.ca-cluster`)
         caData = caCluster.data['ca.crt']
       } else {
         const seed = getSeed(seedName)
-        const secretRef = _.get(seed, 'spec.secretRef')
+        const secretRef = seed.spec?.secretRef
         credentials = { secretRef }
 
         const {
@@ -375,9 +375,8 @@ async function getSeedHostCluster (client, { namespace, name, target, body, shoo
     const shootRef = getShootRef(managedSeed)
     credentials = { shootRef }
   } else {
-    credentials = {
-      secretRef: _.get(seed, 'spec.secretRef')
-    }
+    const secretRef = seed.spec?.secretRef
+    credentials = { secretRef }
   }
 
   hostCluster.namespace = seedShootNamespace

--- a/backend/test/acceptance/__snapshots__/api.terminals.spec.js.snap
+++ b/backend/test/acceptance/__snapshots__/api.terminals.spec.js.snap
@@ -106,6 +106,24 @@ Array [
     Object {
       ":authority": "kubernetes:6443",
       ":method": "get",
+      ":path": "/apis/seedmanagement.gardener.cloud/v1alpha1/namespaces/garden/managedseeds/infra1-seed",
+      ":scheme": "https",
+      "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFkbWluQGV4YW1wbGUub3JnIiwiaWF0IjoxNTc3ODM2ODAwLCJhdWQiOlsiZ2FyZGVuZXIiXSwiZXhwIjozMTU1NzE2ODAwLCJqdGkiOiJqdGkifQ.PwFHRt9M8dJf8YcCVlbyH4xu2QpL3jBI1oEC_Zdmtzk",
+    },
+  ],
+  Array [
+    Object {
+      ":authority": "kubernetes:6443",
+      ":method": "get",
+      ":path": "/apis/seedmanagement.gardener.cloud/v1alpha1/namespaces/garden/managedseeds/infra1-seed",
+      ":scheme": "https",
+      "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFkbWluQGV4YW1wbGUub3JnIiwiaWF0IjoxNTc3ODM2ODAwLCJhdWQiOlsiZ2FyZGVuZXIiXSwiZXhwIjozMTU1NzE2ODAwLCJqdGkiOiJqdGkifQ.PwFHRt9M8dJf8YcCVlbyH4xu2QpL3jBI1oEC_Zdmtzk",
+    },
+  ],
+  Array [
+    Object {
+      ":authority": "kubernetes:6443",
+      ":method": "get",
       ":path": "/apis/core.gardener.cloud/v1beta1/namespaces/garden/shoots/infra1-seed",
       ":scheme": "https",
       "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFkbWluQGV4YW1wbGUub3JnIiwiaWF0IjoxNTc3ODM2ODAwLCJhdWQiOlsiZ2FyZGVuZXIiXSwiZXhwIjozMTU1NzE2ODAwLCJqdGkiOiJqdGkifQ.PwFHRt9M8dJf8YcCVlbyH4xu2QpL3jBI1oEC_Zdmtzk",
@@ -115,16 +133,7 @@ Array [
     Object {
       ":authority": "kubernetes:6443",
       ":method": "get",
-      ":path": "/api/v1/namespaces/garden/secrets/seedsecret-infra1-seed",
-      ":scheme": "https",
-      "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFkbWluQGV4YW1wbGUub3JnIiwiaWF0IjoxNTc3ODM2ODAwLCJhdWQiOlsiZ2FyZGVuZXIiXSwiZXhwIjozMTU1NzE2ODAwLCJqdGkiOiJqdGkifQ.PwFHRt9M8dJf8YcCVlbyH4xu2QpL3jBI1oEC_Zdmtzk",
-    },
-  ],
-  Array [
-    Object {
-      ":authority": "kubernetes:6443",
-      ":method": "get",
-      ":path": "/api/v1/namespaces/garden/secrets/seedsecret-infra1-seed",
+      ":path": "/api/v1/namespaces/garden/secrets/infra1-seed.ca-cluster",
       ":scheme": "https",
       "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFkbWluQGV4YW1wbGUub3JnIiwiaWF0IjoxNTc3ODM2ODAwLCJhdWQiOlsiZ2FyZGVuZXIiXSwiZXhwIjozMTU1NzE2ODAwLCJqdGkiOiJqdGkifQ.PwFHRt9M8dJf8YcCVlbyH4xu2QpL3jBI1oEC_Zdmtzk",
     },
@@ -157,8 +166,8 @@ Array [
       "spec": Object {
         "host": Object {
           "credentials": Object {
-            "secretRef": Object {
-              "name": "seedsecret-infra1-seed",
+            "shootRef": Object {
+              "name": "infra1-seed",
               "namespace": "garden",
             },
           },
@@ -183,7 +192,7 @@ Array [
         },
         "target": Object {
           "apiServer": Object {
-            "caData": "Y2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE=",
+            "caData": "Y2EuY3J0",
           },
           "authorization": Object {
             "projectMemberships": undefined,
@@ -199,8 +208,8 @@ Array [
             ],
           },
           "credentials": Object {
-            "secretRef": Object {
-              "name": "seedsecret-infra1-seed",
+            "shootRef": Object {
+              "name": "infra1-seed",
               "namespace": "garden",
             },
           },
@@ -357,7 +366,7 @@ Array [
     Object {
       ":authority": "kubernetes:6443",
       ":method": "get",
-      ":path": "/apis/core.gardener.cloud/v1beta1/namespaces/garden/shoots/infra1-seed2",
+      ":path": "/apis/seedmanagement.gardener.cloud/v1alpha1/namespaces/garden/managedseeds/infra1-seed2",
       ":scheme": "https",
       "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFkbWluQGV4YW1wbGUub3JnIiwiaWF0IjoxNTc3ODM2ODAwLCJhdWQiOlsiZ2FyZGVuZXIiXSwiZXhwIjozMTU1NzE2ODAwLCJqdGkiOiJqdGkifQ.PwFHRt9M8dJf8YcCVlbyH4xu2QpL3jBI1oEC_Zdmtzk",
     },
@@ -722,7 +731,7 @@ Array [
     Object {
       ":authority": "kubernetes:6443",
       ":method": "get",
-      ":path": "/apis/core.gardener.cloud/v1beta1/namespaces/garden/shoots/infra1-seed2",
+      ":path": "/apis/seedmanagement.gardener.cloud/v1alpha1/namespaces/garden/managedseeds/infra1-seed2",
       ":scheme": "https",
       "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFkbWluQGV4YW1wbGUub3JnIiwiaWF0IjoxNTc3ODM2ODAwLCJhdWQiOlsiZ2FyZGVuZXIiXSwiZXhwIjozMTU1NzE2ODAwLCJqdGkiOiJqdGkifQ.PwFHRt9M8dJf8YcCVlbyH4xu2QpL3jBI1oEC_Zdmtzk",
     },
@@ -876,7 +885,7 @@ Array [
         },
         "target": Object {
           "apiServer": Object {
-            "caData": "WTJFdVkzSjA=",
+            "caData": "Y2EuY3J0",
             "serviceRef": Object {
               "name": "kubernetes",
               "namespace": "default",

--- a/backend/test/acceptance/api.terminals.spec.js
+++ b/backend/test/acceptance/api.terminals.spec.js
@@ -137,7 +137,7 @@ describe('api', function () {
 
         mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
         mockRequest.mockImplementationOnce(fixtures.terminals.mocks.list())
-        mockRequest.mockImplementationOnce(fixtures.shoots.mocks.get())
+        mockRequest.mockImplementationOnce(fixtures.managedseeds.mocks.get())
         mockRequest.mockImplementationOnce(fixtures.secrets.mocks.get())
         mockRequest.mockImplementationOnce(fixtures.terminals.mocks.create())
 
@@ -169,7 +169,7 @@ describe('api', function () {
       it('should reuse a terminal session', async function () {
         mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
         mockRequest.mockImplementationOnce(fixtures.terminals.mocks.list())
-        mockRequest.mockImplementationOnce(fixtures.shoots.mocks.get())
+        mockRequest.mockImplementationOnce(fixtures.managedseeds.mocks.get())
         mockRequest.mockImplementationOnce(fixtures.secrets.mocks.get())
         mockRequest.mockImplementationOnce(fixtures.terminals.mocks.patch())
 
@@ -307,8 +307,9 @@ describe('api', function () {
         mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
         mockRequest.mockImplementationOnce(fixtures.terminals.mocks.list())
         mockRequest.mockImplementationOnce(fixtures.shoots.mocks.get())
+        mockRequest.mockImplementationOnce(fixtures.managedseeds.mocks.get())
+        mockRequest.mockImplementationOnce(fixtures.managedseeds.mocks.get())
         mockRequest.mockImplementationOnce(fixtures.shoots.mocks.get())
-        mockRequest.mockImplementationOnce(fixtures.secrets.mocks.get())
         mockRequest.mockImplementationOnce(fixtures.secrets.mocks.get())
         mockRequest.mockImplementationOnce(fixtures.terminals.mocks.create())
 
@@ -332,7 +333,7 @@ describe('api', function () {
         expect(makeSanitizedHtmlStub).toBeCalledTimes(1)
         expect(makeSanitizedHtmlStub.mock.calls).toEqual([['Dummy Image Description']])
 
-        expect(mockRequest).toBeCalledTimes(7)
+        expect(mockRequest).toBeCalledTimes(8)
         expect(mockRequest.mock.calls).toMatchSnapshot()
 
         expect(res.body).toMatchSnapshot()

--- a/backend/test/services.terminals.spec.js
+++ b/backend/test/services.terminals.spec.js
@@ -77,18 +77,14 @@ describe('services', function () {
           }
         }
       },
-      'seedmanagement.gardener.cloud': {
-        managedseeds: {
-          async get (namespace, name) {
-            await nextTick()
-            if (namespace === 'garden' && name === soilName) {
-              return
-            }
-            return {
-              metadata: { namespace, name },
-              spec: { shoot: { name } }
-            }
-          }
+      async getManagedSeed ({ namespace, name }) {
+        await nextTick()
+        if (namespace === 'garden' && name === soilName) {
+          return
+        }
+        return {
+          metadata: { namespace, name },
+          spec: { shoot: { name } }
         }
       },
       async getShoot ({ namespace, name }) {

--- a/charts/__tests__/gardener-dashboard/application/__snapshots__/clusterrole.spec.js.snap
+++ b/charts/__tests__/gardener-dashboard/application/__snapshots__/clusterrole.spec.js.snap
@@ -120,6 +120,28 @@ Object {
         "get",
       ],
     },
+    Object {
+      "apiGroups": Array [
+        "core.gardener.cloud",
+      ],
+      "resources": Array [
+        "shoots/adminkubeconfig",
+      ],
+      "verbs": Array [
+        "create",
+      ],
+    },
+    Object {
+      "apiGroups": Array [
+        "seedmanagement.gardener.cloud",
+      ],
+      "resources": Array [
+        "managedseeds",
+      ],
+      "verbs": Array [
+        "get",
+      ],
+    },
   ],
 }
 `;

--- a/charts/gardener-dashboard/charts/application/templates/clusterrole.yaml
+++ b/charts/gardener-dashboard/charts/application/templates/clusterrole.yaml
@@ -74,3 +74,15 @@ rules:
   - shoots
   verbs:
   - get
+- apiGroups:
+  - core.gardener.cloud
+  resources:
+  - shoots/adminkubeconfig
+  verbs:
+  - create
+- apiGroups:
+  - seedmanagement.gardener.cloud
+  resources:
+  - managedseeds
+  verbs:
+  - get

--- a/packages/kube-client/lib/Client.js
+++ b/packages/kube-client/lib/Client.js
@@ -96,6 +96,10 @@ class Client {
   getSecret (...args) {
     return getResource(this.core.secrets, ...args)
   }
+
+  getManagedSeed (...args) {
+    return getResource(this['seedmanagement.gardener.cloud'].managedseeds, ...args)
+  }
 }
 
 async function getResource (resource, { namespace, name, throwNotFound = true }) {


### PR DESCRIPTION
**What this PR does / why we need it**:
`spec.secretRef` is not required anymore if `Seed` is a `ManagedSeed`

**Which issue(s) this PR fixes**:
Fixes #1308

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Terminal: `spec.secretRef` is not required anymore if `Seed` is a `ManagedSeed`
```
