### PR TITLE
Adapted DNS Provider List getters to work with latest Gardener Releases

### DIFF
--- a/backend/__fixtures__/controllerregistrations.js
+++ b/backend/__fixtures__/controllerregistrations.js
@@ -55,10 +55,11 @@ const controllerRegistrationList = [
   }),
   getControllerRegistration({
     uid: 2,
-    name: 'DNS Registration',
+    name: 'Provider-Foo',
     resources: [{
-      kind: 'DNSProvider',
-      type: 'gardenland'
+      kind: 'DNSRecord',
+      type: 'gardenland',
+      primary: true
     }]
   })
 ]

--- a/backend/test/acceptance/__snapshots__/api.controllerregistrations.spec.js.snap
+++ b/backend/test/acceptance/__snapshots__/api.controllerregistrations.spec.js.snap
@@ -61,10 +61,11 @@ Array [
     ],
   },
   Object {
-    "name": "DNS Registration",
+    "name": "Provider-Foo",
     "resources": Array [
       Object {
-        "kind": "DNSProvider",
+        "kind": "DNSRecord",
+        "primary": true,
         "type": "gardenland",
       },
     ],
@@ -115,15 +116,6 @@ Array [
       Object {
         "kind": "Network",
         "type": "foobium",
-      },
-    ],
-  },
-  Object {
-    "name": "DNS Registration",
-    "resources": Array [
-      Object {
-        "kind": "DNSProvider",
-        "type": "gardenland",
       },
     ],
   },

--- a/frontend/src/components/dialogs/SecretDialog.vue
+++ b/frontend/src/components/dialogs/SecretDialog.vue
@@ -156,7 +156,9 @@ export default {
       'infrastructureSecretList',
       'cloudProfilesByCloudProviderKind',
       'shootList',
-      'sortedCloudProviderKindList',
+      'sortedCloudProviderKindList'
+    ]),
+    ...mapGetters('gardenerExtensions', [
       'sortedDnsProviderList'
     ]),
     dnsProviderTypes () {

--- a/frontend/src/mixins/shootItem.js
+++ b/frontend/src/mixins/shootItem.js
@@ -144,7 +144,7 @@ export const shootItem = {
       return get(this.shootSpec, 'dns.domain')
     },
     isCustomShootDomain () {
-      return some(this.shootDnsProviders, ['primary', true])
+      return some(this.shootDnsProviders, 'primary')
     },
     shootDnsProviders () {
       return get(this.shootSpec, 'dns.providers')

--- a/frontend/src/store/modules/gardenerExtensions.js
+++ b/frontend/src/store/modules/gardenerExtensions.js
@@ -10,7 +10,6 @@ import map from 'lodash/map'
 import flatMap from 'lodash/flatMap'
 import filter from 'lodash/filter'
 import some from 'lodash/some'
-import compact from 'lodash/compact'
 import get from 'lodash/get'
 import find from 'lodash/find'
 
@@ -44,12 +43,9 @@ const getters = {
     const dnsServiceExtensionDeployed = some(state.all, ['name', 'extension-shoot-dns-service'])
     if (dnsServiceExtensionDeployed) {
       return dnsProviderList
-    } else {
-      // return only DNS Providers backed by DNSRecord resource in sorted order
-      return compact(map(dnsProvidersFromDnsRecords, poviderType => {
-        return filter(dnsProviderList, ['primary', true])
-      }))
     }
+    // return only primary DNS Providers backed by DNSRecord
+    return filter(dnsProviderList, 'primary')
   }
 }
 

--- a/frontend/src/store/modules/gardenerExtensions.js
+++ b/frontend/src/store/modules/gardenerExtensions.js
@@ -9,6 +9,10 @@ import { getGardenerExtensions } from '@/utils/api'
 import map from 'lodash/map'
 import flatMap from 'lodash/flatMap'
 import filter from 'lodash/filter'
+import some from 'lodash/some'
+import compact from 'lodash/compact'
+import get from 'lodash/get'
+import find from 'lodash/find'
 
 // initial state
 const state = {
@@ -25,9 +29,27 @@ const getters = {
     const networkingResources = filter(resources, ['kind', 'Network'])
     return map(networkingResources, 'type')
   },
-  dnsProviderList (state) {
+  sortedDnsProviderList (state) {
+    const supportedProviderTypes = ['aws-route53', 'azure-dns', 'azure-private-dns', 'google-clouddns', 'openstack-designate', 'alicloud-dns', 'infoblox-dns', 'netlify-dns']
     const resources = flatMap(state.all, 'resources')
-    return filter(resources, ['kind', 'DNSProvider'])
+    const dnsProvidersFromDnsRecords = filter(resources, ['kind', 'DNSRecord'])
+
+    const dnsProviderList = map(supportedProviderTypes, type => {
+      return {
+        type,
+        primary: get(find(dnsProvidersFromDnsRecords, { type }), 'primary', false)
+      }
+    })
+
+    const dnsServiceExtensionDeployed = some(state.all, ['name', 'extension-shoot-dns-service'])
+    if (dnsServiceExtensionDeployed) {
+      return dnsProviderList
+    } else {
+      // return only DNS Providers backed by DNSRecord resource in sorted order
+      return compact(map(dnsProvidersFromDnsRecords, poviderType => {
+        return filter(dnsProviderList, ['primary', true])
+      }))
+    }
   }
 }
 

--- a/frontend/src/store/modules/shootStaging.js
+++ b/frontend/src/store/modules/shootStaging.js
@@ -53,7 +53,7 @@ const getters = {
     return map(rootGetters['gardenerExtensions/sortedDnsProviderList'], 'type')
   },
   dnsProviderTypesWithPrimarySupport (state, getters, rootState, rootGetters) {
-    return map(filter(rootGetters['gardenerExtensions/sortedDnsProviderList'], ['primary', true]), 'type')
+    return map(filter(rootGetters['gardenerExtensions/sortedDnsProviderList'], 'primary'), 'type')
   },
   getDnsProviderSecrets (state, getters, rootState, rootGetters) {
     return type => rootGetters.dnsSecretsByProviderKind(type)

--- a/frontend/src/store/modules/shootStaging.js
+++ b/frontend/src/store/modules/shootStaging.js
@@ -50,10 +50,10 @@ const getters = {
     return notYetCreated(state)
   },
   dnsProviderTypes (state, getters, rootState, rootGetters) {
-    return map(rootGetters.sortedDnsProviderList, 'type')
+    return map(rootGetters['gardenerExtensions/sortedDnsProviderList'], 'type')
   },
   dnsProviderTypesWithPrimarySupport (state, getters, rootState, rootGetters) {
-    return map(filter(rootGetters.sortedDnsProviderList, 'primary'), 'type')
+    return map(filter(rootGetters['gardenerExtensions/sortedDnsProviderList'], ['primary', true]), 'type')
   },
   getDnsProviderSecrets (state, getters, rootState, rootGetters) {
     return type => rootGetters.dnsSecretsByProviderKind(type)

--- a/frontend/src/views/Secrets.vue
+++ b/frontend/src/views/Secrets.vue
@@ -220,7 +220,9 @@ export default {
       'dnsSecretList',
       'shootList',
       'canCreateSecrets',
-      'sortedCloudProviderKindList',
+      'sortedCloudProviderKindList'
+    ]),
+    ...mapGetters('gardenerExtensions', [
       'sortedDnsProviderList'
     ]),
     hasCloudProfileForCloudProviderKind () {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds compatibility with the latest gardener release.
As https://github.com/gardener/gardener/issues/5270 moved the DNSProvider capabilities out of g/g, we need a different approach to fetch the DNS Provider List

**Which issue(s) this PR fixes**:
Fixes #1305

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
NONE
```
