### PR TITLE
Fixed: Machine images with additional properties not matched

### DIFF
--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -1294,7 +1294,7 @@ const getters = {
     return (shootWorkerGroups, shootCloudProfileName, imageAutoPatch) => {
       const allMachineImages = getters.machineImagesByCloudProfileName(shootCloudProfileName)
       const workerGroups = map(shootWorkerGroups, worker => {
-        const workerImage = get(worker, 'machine.image')
+        const workerImage = get(worker, 'machine.image', {})
         const { name, version } = workerImage
         const workerImageDetails = find(allMachineImages, { name, version })
         if (!workerImageDetails) {

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -1295,7 +1295,8 @@ const getters = {
       const allMachineImages = getters.machineImagesByCloudProfileName(shootCloudProfileName)
       const workerGroups = map(shootWorkerGroups, worker => {
         const workerImage = get(worker, 'machine.image')
-        const workerImageDetails = find(allMachineImages, workerImage)
+        const { name, version } = workerImage
+        const workerImageDetails = find(allMachineImages, { name, version })
         if (!workerImageDetails) {
           return {
             ...workerImage,


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes false warnings about expired machine images in case additional properties have been configured for a machine image

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
NONE
```
