### PR TITLE
[hotfix-1.61] Fix: Machine images with additional properties not matched

### DIFF
--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -1291,8 +1291,9 @@ const getters = {
     return (shootWorkerGroups, shootCloudProfileName, imageAutoPatch) => {
       const allMachineImages = getters.machineImagesByCloudProfileName(shootCloudProfileName)
       const workerGroups = map(shootWorkerGroups, worker => {
-        const workerImage = get(worker, 'machine.image')
-        const workerImageDetails = find(allMachineImages, workerImage)
+        const workerImage = get(worker, 'machine.image', {})
+        const { name, version } = workerImage
+        const workerImageDetails = find(allMachineImages, { name, version })
         if (!workerImageDetails) {
           return {
             ...workerImage,


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed: The Dashboard displayed false expiration warnings for worker groups when additional machine image `providerConfig` values are configured
```
