### PR TITLE
fix: theme (dark/light) not correctly applied on first visit

### DIFF
--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -8,6 +8,7 @@ import Vuetify from 'vuetify'
 import fetchMock from 'jest-fetch-mock'
 
 Vue.use(Vuetify)
+Object.defineProperty(Vue, 'vuetify', { value: new Vuetify() })
 
 fetchMock.enableMocks()
 

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -97,13 +97,13 @@ const debug = includes(split(process.env.VUE_APP_DEBUG, ','), 'vuex')
 
 // plugins
 const plugins = [
-  createSocketPlugin(userManager, logger),
-  createMediaPlugin(vuetify)
+  createSocketPlugin(userManager, logger)
 ]
 // localStorage can be undefined in some unit tests
 if (localStorage) {
   plugins.push(createStoragePlugin(localStorage))
 }
+plugins.push(createMediaPlugin(vuetify))
 if (debug) {
   plugins.push(createLogger())
 }
@@ -164,7 +164,7 @@ const state = {
       description: 'Indicates whether Gardener is able to hibernate this cluster. If you do not resolve this issue your hibernation schedule may not have any effect.'
     }
   },
-  prefersColorScheme: 'light'
+  prefersColorScheme: null
 }
 class Shortcut {
   constructor (shortcut, unverified = true) {

--- a/frontend/src/store/plugins/mediaPlugin.js
+++ b/frontend/src/store/plugins/mediaPlugin.js
@@ -10,13 +10,14 @@ export default function (vuetify) {
       store.commit('SET_PREFERS_COLOR_SCHEME', dark ? 'dark' : 'light')
     }
     const mq = window.matchMedia('(prefers-color-scheme: dark)')
-    mq.addEventListener('change', e => setPrefersColorScheme(e.matches))
     setPrefersColorScheme(mq.matches)
+    mq.addEventListener('change', e => setPrefersColorScheme(e.matches))
 
     const colorScheme = (state, getters) => getters.colorScheme
     const setDarkTheme = value => {
       vuetify.framework.theme.dark = value === 'dark'
     }
+    setDarkTheme(store.getters.colorScheme)
     store.watch(colorScheme, setDarkTheme)
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Upon first visit of the page the users system/OS wide preferred color theme was not correctly applied. Additionally dark mode users that first to explicitly select "light" mode and only then could switch to dark mode or auto.

**Which issue(s) this PR fixes**:
Fixes #1324

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed initial "auto choose theme based on system settings" not working
```
