### PR TITLE
Handle non JSON responses when json is expected

### DIFF
--- a/packages/request/__tests__/client.test.js
+++ b/packages/request/__tests__/client.test.js
@@ -10,7 +10,7 @@ const http2 = require('http2')
 const zlib = require('zlib')
 const { globalLogger: logger } = require('@gardener-dashboard/logger')
 const { Client, extend } = require('../lib')
-const exp = require('constants')
+
 const {
   HTTP2_HEADER_METHOD,
   HTTP2_HEADER_AUTHORITY,

--- a/packages/request/__tests__/errors.test.js
+++ b/packages/request/__tests__/errors.test.js
@@ -7,7 +7,14 @@
 'use strict'
 
 const createError = require('http-errors')
-const { TimeoutError, StreamError, isAbortError, createHttpError, isHttpError } = require('../lib/errors')
+const {
+  TimeoutError,
+  StreamError,
+  ParseError,
+  isAbortError,
+  createHttpError,
+  isHttpError
+} = require('../lib/errors')
 
 describe('errors', () => {
   it('#isAbortError', () => {
@@ -24,6 +31,18 @@ describe('errors', () => {
       expect(error.name).toBe('TimeoutError')
       expect(error.message).toBe(message)
       expect(error.code).toBe('ETIMEDOUT')
+    })
+  })
+
+  describe('ParseError', () => {
+    it('#constructor', () => {
+      const message = 'parsing failed'
+      const foo = 'bar'
+      const error = new ParseError(message, { foo })
+      expect(error.name).toBe('ParseError')
+      expect(error.message).toBe(message)
+      expect(error.code).toBe('ERR_BODY_PARSE_FAILURE')
+      expect(error.foo).toBe(foo)
     })
   })
 

--- a/packages/request/lib/Client.js
+++ b/packages/request/lib/Client.js
@@ -213,13 +213,18 @@ class Client {
         const streams = [
           stream,
           async source => {
+            const text = await concat(source)
             switch (this.type) {
               case 'text':
-                return concat(source)
+                return text
               case 'json':
-                return JSON.parse(await concat(source))
+                try {
+                  return JSON.parse(text)
+                } catch (err) {
+                  return text
+                }
               default:
-                return Buffer.from(concat(source), 'utf8')
+                return Buffer.from(text, 'utf8')
             }
           }
         ]

--- a/packages/request/lib/Client.js
+++ b/packages/request/lib/Client.js
@@ -228,6 +228,7 @@ class Client {
                       rawBody: text
                     })
                   }
+                  // return the raw body text if the response status is not ok (keep the original http error in this case)
                   return text
                 }
               default:

--- a/packages/request/lib/Client.js
+++ b/packages/request/lib/Client.js
@@ -14,7 +14,7 @@ const zlib = require('zlib')
 const typeis = require('type-is')
 const { pick, omit } = require('lodash')
 const { globalLogger: logger } = require('@gardener-dashboard/logger')
-const { createHttpError } = require('./errors')
+const { createHttpError, ParseError } = require('./errors')
 const { globalAgent } = require('./Agent')
 const { pipeline } = require('stream')
 
@@ -221,6 +221,13 @@ class Client {
                 try {
                   return JSON.parse(text)
                 } catch (err) {
+                  logger.error('Failed to parse response body: %s', text)
+                  if (this.ok) {
+                    throw new ParseError(err.message, {
+                      headers,
+                      rawBody: text
+                    })
+                  }
                   return text
                 }
               default:

--- a/packages/request/lib/errors.js
+++ b/packages/request/lib/errors.js
@@ -27,6 +27,18 @@ class StreamError extends Error {
   }
 }
 
+class ParseError extends Error {
+  constructor (message, properties) {
+    super(message)
+    Object.assign(this, {
+      name: this.constructor.name,
+      code: 'ERR_BODY_PARSE_FAILURE',
+      ...properties
+    })
+    Error.captureStackTrace(this, this.constructor)
+  }
+}
+
 function isAbortError (err = {}) {
   return err.code === 'ABORT_ERR'
 }
@@ -64,6 +76,7 @@ function isHttpError (err, expectedStatusCode) {
 module.exports = {
   TimeoutError,
   StreamError,
+  ParseError,
   createHttpError,
   isHttpError,
   isAbortError


### PR DESCRIPTION
**What this PR does / why we need it**:
If we send a request to a server with the following header
```
Accept: application/json
```
sometimes a server responds with content-type `text/plain`. In this case the client should not fail but return the text as body.

**Which issue(s) this PR fixes**:
Fixes #1329 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
When the upstream server responds with content-type `text/plain` where `application/json` is expected an error message like `Unexpected token x in JSON at position y` could be seen in the logs. You are now able to see what the actual server response was
```
