### PR TITLE
Fixed KUBECONFIG file system watcher

### DIFF
--- a/packages/kube-config/lib/ClientConfig.js
+++ b/packages/kube-config/lib/ClientConfig.js
@@ -168,12 +168,10 @@ class ClientConfig {
       const watcher = new Watcher(Array.from(files.keys()), options)
       watcher.run((path, value) => {
         const key = files.get(path)
-        if (key) {
-          if (['certificateAuthority'].includes(key)) {
-            cluster[key] = value
-          } else if (['clientKey', 'clientCert', 'token'].includes(key)) {
-            user[key] = value
-          }
+        if (['certificateAuthority'].includes(key)) {
+          cluster[key] = value
+        } else if (['clientKey', 'clientCert', 'token'].includes(key)) {
+          user[key] = value
         }
         watcher.emit(`update:${key}`)
       })

--- a/packages/kube-config/lib/ClientConfig.js
+++ b/packages/kube-config/lib/ClientConfig.js
@@ -168,8 +168,13 @@ class ClientConfig {
       const watcher = new Watcher(Array.from(files.keys()), options)
       watcher.run((path, value) => {
         const key = files.get(path)
-        const obj = key === 'certificateAuthority' ? cluster : user
-        obj[key] = value
+        if (key) {
+          if (['certificateAuthority'].includes(key)) {
+            cluster[key] = value
+          } else if (['clientKey', 'clientCert', 'token'].includes(key)) {
+            user[key] = value
+          }
+        }
         watcher.emit(`update:${key}`)
       })
       properties.watcher = { value: watcher }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a bug in the file system watcher implementation when change events occur for files or directories that are not expected. With this fix these events are ignored and error during readFile are only logged as errors but do not destroy the watcher.

**Which issue(s) this PR fixes**:
Fixes #1331

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
NONE
```
