### PR TITLE
[hotfix] Fixed DNS Provider List not visible for non-admin users

### DIFF
--- a/backend/__fixtures__/controllerregistrations.js
+++ b/backend/__fixtures__/controllerregistrations.js
@@ -50,7 +50,7 @@ const controllerRegistrationList = [
     }]
   }),
   getControllerRegistration({
-    uid: 2,
+    uid: 3,
     name: 'Network Registration 2',
     resources: [{
       kind: 'Network',
@@ -62,12 +62,20 @@ const controllerRegistrationList = [
     }]
   }),
   getControllerRegistration({
-    uid: 2,
+    uid: 4,
     name: 'Provider-Foo',
     resources: [{
       kind: 'DNSRecord',
       type: 'gardenland',
       primary: true
+    }]
+  }),
+  getControllerRegistration({
+    uid: 5,
+    name: 'extension-shoot-dns-service',
+    resources: [{
+      kind: 'Foo',
+      type: 'bar'
     }]
   })
 ]

--- a/backend/lib/services/controllerregistrations.js
+++ b/backend/lib/services/controllerregistrations.js
@@ -10,7 +10,8 @@ const { getControllerRegistrations } = require('../cache')
 const authorization = require('./authorization')
 const _ = require('lodash')
 
-const REQUIRED_RESOURCE_KINDS = ['Network', 'DNSProvider']
+const REQUIRED_RESOURCE_KINDS = ['Network', 'DNSRecord']
+const REQUIRED_RESOURCE_NAMES = ['extension-shoot-dns-service']
 exports.listExtensions = async function ({ user }) {
   const controllerregistrations = getControllerRegistrations()
   const allowed = await authorization.canListControllerRegistrations(user)
@@ -25,7 +26,7 @@ exports.listExtensions = async function ({ user }) {
       // required resoure kinds are essential for the frontend and need to be returned even if the user has not the permission to read controllerregistrations
       const resources = _.filter(spec.resources, ({ kind }) => REQUIRED_RESOURCE_KINDS.includes(kind))
       // only expose the extension if it contains one of the required resources
-      if (!_.isEmpty(resources)) {
+      if (!_.isEmpty(resources) || REQUIRED_RESOURCE_NAMES.includes(name)) {
         extensions.push({ name, resources })
       }
     }

--- a/backend/test/acceptance/__snapshots__/api.controllerregistrations.spec.js.snap
+++ b/backend/test/acceptance/__snapshots__/api.controllerregistrations.spec.js.snap
@@ -70,6 +70,15 @@ Array [
       },
     ],
   },
+  Object {
+    "name": "extension-shoot-dns-service",
+    "resources": Array [
+      Object {
+        "kind": "Foo",
+        "type": "bar",
+      },
+    ],
+  },
 ]
 `;
 
@@ -118,6 +127,20 @@ Array [
         "type": "foobium",
       },
     ],
+  },
+  Object {
+    "name": "Provider-Foo",
+    "resources": Array [
+      Object {
+        "kind": "DNSRecord",
+        "primary": true,
+        "type": "gardenland",
+      },
+    ],
+  },
+  Object {
+    "name": "extension-shoot-dns-service",
+    "resources": Array [],
   },
 ]
 `;


### PR DESCRIPTION
**What this PR does / why we need it**:
Regular users cannot access `controllerregistration` resources. Need to add changed `controllerregistration` resources for DNS Providers to list of allowed resources.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed DNS Provider List not visible for regular users (non-operators)
```