### PR TITLE
Read SubjectRules also if no project / namespace is selected

### DIFF
--- a/frontend/src/router/guards.js
+++ b/frontend/src/router/guards.js
@@ -79,7 +79,10 @@ function ensureDataLoaded (store, localStorage, logger) {
       ]
 
       const namespace = to.params.namespace || to.query.namespace
-      if (namespace && namespace !== store.state.namespace) {
+      if (!namespace) {
+        // fetch cluster scoped roles only (e.g can create projects)
+        promises.push(store.dispatch('refreshSubjectRules', undefined))
+      } else if (namespace !== store.state.namespace) {
         store.commit('SET_NAMESPACE', namespace)
         promises.push(store.dispatch('refreshSubjectRules', namespace))
       }


### PR DESCRIPTION
**What this PR does / why we need it**:
With release `1.62.0` we introduced a regression whereby it was no longer possible to create new projects. The button was always disabled even for users who have the appropriate permission. This PR 

**Which issue(s) this PR fixes**:
Fixes #1342

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixes a problem when creating new projects that was introduced with release 1.62.0. Now the button is enabled again if the user has the appropriate permission.
```
