### PR TITLE
Solve problem with issue polling

### DIFF
--- a/backend/lib/cache/tickets.js
+++ b/backend/lib/cache/tickets.js
@@ -50,7 +50,7 @@ function init () {
   }
 
   function getIssueNumbers () {
-    return _.map(getIssues(), 'metadata.number')
+    return _.map(getIssues(), 'metadata.number') // dummy
   }
 
   function getIssueNumbersForNameAndProjectName ({ name, projectName }) {

--- a/backend/lib/cache/tickets.js
+++ b/backend/lib/cache/tickets.js
@@ -50,7 +50,7 @@ function init () {
   }
 
   function getIssueNumbers () {
-    return _.map(getIssues(), 'metadata.number') // dummy
+    return _.map(getIssues(), 'metadata.number')
   }
 
   function getIssueNumbersForNameAndProjectName ({ name, projectName }) {

--- a/backend/lib/cache/tickets.js
+++ b/backend/lib/cache/tickets.js
@@ -49,6 +49,10 @@ function init () {
     return issues[number]
   }
 
+  function getIssueNumbers () {
+    return _.map(getIssues(), 'metadata.number')
+  }
+
   function getIssueNumbersForNameAndProjectName ({ name, projectName }) {
     return _
       .chain(getIssues())
@@ -129,6 +133,7 @@ function init () {
     getIssue,
     getIssues,
     getCommentsForIssue,
+    getIssueNumbers,
     getIssueNumbersForNameAndProjectName,
     addOrUpdateIssues,
     addOrUpdateIssue,


### PR DESCRIPTION
**What this PR does / why we need it**:
By accident the function `getIssueNumbers` has been removed from the ticketCache. I thought it was no longer used but it is of course used in landscape where  issue polling is enabled. This PR adds this function back to the ticketCache.
 
**Which issue(s) this PR fixes**:
Fixes #1347

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed a problem with issue polling for landscapes that cannot be accessed from github webhooks. This regression was introduced with release 1.62.0.
```
