### PR TITLE
Robust token refresh test

### DIFF
--- a/backend/test/security.spec.js
+++ b/backend/test/security.spec.js
@@ -203,7 +203,7 @@ describe('security', function () {
         auth: { bearer: tokenSet.id_token }
       }])
       expect(user).toEqual({
-        iat: accessTokenPayload.iat,
+        iat: expect.toBeWithinRange(iat, iat + 5),
         jti: expect.stringMatching(/^[a-z0-9-]+$/),
         id: sub,
         groups: [],


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes the token refresh test more robust. From time to time the `iat` value differed from the expected value. Now the value is expected to be in a range of 5 seconds.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
NONE
```
