### PR TITLE
Reset service account

### DIFF
--- a/backend/lib/routes/members.js
+++ b/backend/lib/routes/members.js
@@ -8,6 +8,7 @@
 
 const express = require('express')
 const { members } = require('../services')
+const { UnprocessableEntity } = require('http-errors')
 
 const router = module.exports = express.Router({
   mergeParams: true
@@ -52,6 +53,24 @@ router.route('/:name')
       const name = req.params.name
       const body = req.body
       res.send(await members.update({ user, namespace, name, body }))
+    } catch (err) {
+      next(err)
+    }
+  })
+  .post(async (req, res, next) => {
+    try {
+      const user = req.user
+      const { namespace, name } = req.params
+      const { method } = req.body
+
+      switch (method) {
+        case 'resetServiceAccount':
+          await members.resetServiceAccount({ user, namespace, name })
+          res.status(204).end()
+          break
+        default:
+          throw new UnprocessableEntity(`${method} not allowed for members`)
+      }
     } catch (err) {
       next(err)
     }

--- a/backend/lib/routes/members.js
+++ b/backend/lib/routes/members.js
@@ -65,8 +65,7 @@ router.route('/:name')
 
       switch (method) {
         case 'resetServiceAccount':
-          await members.resetServiceAccount({ user, namespace, name })
-          res.status(204).end()
+          res.send(await members.resetServiceAccount({ user, namespace, name }))
           break
         default:
           throw new UnprocessableEntity(`${method} not allowed for members`)

--- a/backend/lib/services/members/MemberManager.js
+++ b/backend/lib/services/members/MemberManager.js
@@ -107,6 +107,19 @@ class MemberManager {
     return this.subjectList.members
   }
 
+  async resetServiceAccount (id) {
+    const item = this.subjectList.get(id)
+    if (!item) {
+      return
+    }
+
+    if (item.kind !== 'ServiceAccount') {
+      throw new UnprocessableEntity('Member is not a ServiceAccount')
+    }
+
+    await this.recreateServiceAccount(item)
+  }
+
   setItemRoles (item, roles) {
     roles = _.compact(roles)
     if (!roles.length && item.kind !== 'ServiceAccount') {
@@ -182,6 +195,65 @@ class MemberManager {
       }
     }
     this.subjectList.delete(item.id)
+  }
+
+  async recreateServiceAccount (item) {
+    const { namespace, name } = Member.parseUsername(item.id)
+    if (namespace !== this.namespace) {
+      throw new UnprocessableEntity('It is not possible to reset a ServiceAccount from another namespace')
+    }
+
+    try {
+      await this.client.core.serviceaccounts.delete(namespace, name)
+    } catch (err) {
+      if (!isHttpError(err) || err.statusCode !== 404) {
+        throw err
+      }
+    }
+
+    const createdBy = item.extensions?.createdBy
+    const description = item.extensions?.description
+
+    const annotations = {
+      'dashboard.gardener.cloud/created-by': createdBy, // restore original creator
+      'dashboard.gardener.cloud/description': description
+    }
+
+    let serviceAccount
+    try {
+      serviceAccount = await this.client.core.serviceaccounts.create(namespace, {
+        metadata: {
+          name,
+          namespace,
+          annotations
+        }
+      })
+    } catch (err) {
+      if (!isHttpError(err) || err.statusCode !== 409) {
+        throw err
+      }
+
+      // the create usually will fail for the "default" service account as it will be automatically created after it was deleted
+      // in this case we just want to restore the annotations
+      serviceAccount = await this.client.core.serviceaccounts.mergePatch(namespace, name, {
+        metadata: {
+          annotations
+        }
+      })
+    }
+
+    const {
+      metadata: {
+        creationTimestamp
+      }
+    } = serviceAccount
+
+    item.extend({
+      createdBy,
+      creationTimestamp,
+      description
+    })
+    this.subjectList.set(item.id, item)
   }
 
   async getKubeconfig (item) {

--- a/backend/lib/services/members/MemberManager.js
+++ b/backend/lib/services/members/MemberManager.js
@@ -110,7 +110,7 @@ class MemberManager {
   async resetServiceAccount (id) {
     const item = this.subjectList.get(id)
     if (!item) {
-      return
+      return this.subjectList.members
     }
 
     if (item.kind !== 'ServiceAccount') {
@@ -130,11 +130,11 @@ class MemberManager {
       }
     }
 
-    const createdBy = item.extensions?.createdBy
+    const createdBy = item.extensions?.createdBy ?? this.userId // restore original creator, fallback to current user
     const description = item.extensions?.description
 
     const annotations = {
-      'dashboard.gardener.cloud/created-by': createdBy, // restore original creator
+      'dashboard.gardener.cloud/created-by': createdBy,
       'dashboard.gardener.cloud/description': description
     }
 
@@ -170,9 +170,12 @@ class MemberManager {
     item.extend({
       createdBy,
       creationTimestamp,
-      description
+      description,
+      orphaned: false
     })
     this.subjectList.set(item.id, item)
+
+    return this.subjectList.members
   }
 
   setItemRoles (item, roles) {

--- a/backend/lib/services/members/MemberManager.js
+++ b/backend/lib/services/members/MemberManager.js
@@ -117,7 +117,62 @@ class MemberManager {
       throw new UnprocessableEntity('Member is not a ServiceAccount')
     }
 
-    await this.recreateServiceAccount(item)
+    const { namespace, name } = Member.parseUsername(item.id)
+    if (namespace !== this.namespace) {
+      throw new UnprocessableEntity('It is not possible to reset a ServiceAccount from another namespace')
+    }
+
+    try {
+      await this.client.core.serviceaccounts.delete(namespace, name)
+    } catch (err) {
+      if (!isHttpError(err) || err.statusCode !== 404) {
+        throw err
+      }
+    }
+
+    const createdBy = item.extensions?.createdBy
+    const description = item.extensions?.description
+
+    const annotations = {
+      'dashboard.gardener.cloud/created-by': createdBy, // restore original creator
+      'dashboard.gardener.cloud/description': description
+    }
+
+    let serviceAccount
+    try {
+      serviceAccount = await this.client.core.serviceaccounts.create(namespace, {
+        metadata: {
+          name,
+          namespace,
+          annotations
+        }
+      })
+    } catch (err) {
+      if (!isHttpError(err) || err.statusCode !== 409) {
+        throw err
+      }
+
+      // the create usually will fail for the "default" service account as it will be automatically created after it was deleted
+      // in this case we just want to restore the annotations
+      serviceAccount = await this.client.core.serviceaccounts.mergePatch(namespace, name, {
+        metadata: {
+          annotations
+        }
+      })
+    }
+
+    const {
+      metadata: {
+        creationTimestamp
+      }
+    } = serviceAccount
+
+    item.extend({
+      createdBy,
+      creationTimestamp,
+      description
+    })
+    this.subjectList.set(item.id, item)
   }
 
   setItemRoles (item, roles) {
@@ -195,65 +250,6 @@ class MemberManager {
       }
     }
     this.subjectList.delete(item.id)
-  }
-
-  async recreateServiceAccount (item) {
-    const { namespace, name } = Member.parseUsername(item.id)
-    if (namespace !== this.namespace) {
-      throw new UnprocessableEntity('It is not possible to reset a ServiceAccount from another namespace')
-    }
-
-    try {
-      await this.client.core.serviceaccounts.delete(namespace, name)
-    } catch (err) {
-      if (!isHttpError(err) || err.statusCode !== 404) {
-        throw err
-      }
-    }
-
-    const createdBy = item.extensions?.createdBy
-    const description = item.extensions?.description
-
-    const annotations = {
-      'dashboard.gardener.cloud/created-by': createdBy, // restore original creator
-      'dashboard.gardener.cloud/description': description
-    }
-
-    let serviceAccount
-    try {
-      serviceAccount = await this.client.core.serviceaccounts.create(namespace, {
-        metadata: {
-          name,
-          namespace,
-          annotations
-        }
-      })
-    } catch (err) {
-      if (!isHttpError(err) || err.statusCode !== 409) {
-        throw err
-      }
-
-      // the create usually will fail for the "default" service account as it will be automatically created after it was deleted
-      // in this case we just want to restore the annotations
-      serviceAccount = await this.client.core.serviceaccounts.mergePatch(namespace, name, {
-        metadata: {
-          annotations
-        }
-      })
-    }
-
-    const {
-      metadata: {
-        creationTimestamp
-      }
-    } = serviceAccount
-
-    item.extend({
-      createdBy,
-      creationTimestamp,
-      description
-    })
-    this.subjectList.set(item.id, item)
   }
 
   async getKubeconfig (item) {

--- a/backend/lib/services/members/index.js
+++ b/backend/lib/services/members/index.js
@@ -32,3 +32,8 @@ exports.remove = async function ({ user, namespace, name }) {
   const memberManager = await MemberManager.create(user, namespace)
   return memberManager.delete(name)
 }
+
+exports.resetServiceAccount = async function ({ user, namespace, name }) {
+  const memberManager = await MemberManager.create(user, namespace)
+  await memberManager.resetServiceAccount(name)
+}

--- a/backend/lib/services/members/index.js
+++ b/backend/lib/services/members/index.js
@@ -35,5 +35,5 @@ exports.remove = async function ({ user, namespace, name }) {
 
 exports.resetServiceAccount = async function ({ user, namespace, name }) {
   const memberManager = await MemberManager.create(user, namespace)
-  await memberManager.resetServiceAccount(name)
+  return memberManager.resetServiceAccount(name)
 }

--- a/backend/test/acceptance/__snapshots__/api.members.spec.js.snap
+++ b/backend/test/acceptance/__snapshots__/api.members.spec.js.snap
@@ -1224,6 +1224,57 @@ Array [
 ]
 `;
 
+exports[`api members should reset a service account 1`] = `
+Array [
+  Array [
+    Object {
+      ":authority": "kubernetes:6443",
+      ":method": "get",
+      ":path": "/apis/core.gardener.cloud/v1beta1/projects/foo",
+      ":scheme": "https",
+      "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImJhckBleGFtcGxlLm9yZyIsImlhdCI6MTU3NzgzNjgwMCwiYXVkIjpbImdhcmRlbmVyIl0sImV4cCI6MzE1NTcxNjgwMCwianRpIjoianRpIn0.7WKy0sNVkJzIqh3QJIF1zk3QjzwFe_zMTv8PmnOCsxg",
+    },
+  ],
+  Array [
+    Object {
+      ":authority": "kubernetes:6443",
+      ":method": "get",
+      ":path": "/api/v1/namespaces/garden-foo/serviceaccounts",
+      ":scheme": "https",
+      "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImJhckBleGFtcGxlLm9yZyIsImlhdCI6MTU3NzgzNjgwMCwiYXVkIjpbImdhcmRlbmVyIl0sImV4cCI6MzE1NTcxNjgwMCwianRpIjoianRpIn0.7WKy0sNVkJzIqh3QJIF1zk3QjzwFe_zMTv8PmnOCsxg",
+    },
+  ],
+  Array [
+    Object {
+      ":authority": "kubernetes:6443",
+      ":method": "delete",
+      ":path": "/api/v1/namespaces/garden-foo/serviceaccounts/robot",
+      ":scheme": "https",
+      "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImJhckBleGFtcGxlLm9yZyIsImlhdCI6MTU3NzgzNjgwMCwiYXVkIjpbImdhcmRlbmVyIl0sImV4cCI6MzE1NTcxNjgwMCwianRpIjoianRpIn0.7WKy0sNVkJzIqh3QJIF1zk3QjzwFe_zMTv8PmnOCsxg",
+    },
+  ],
+  Array [
+    Object {
+      ":authority": "kubernetes:6443",
+      ":method": "post",
+      ":path": "/api/v1/namespaces/garden-foo/serviceaccounts",
+      ":scheme": "https",
+      "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImJhckBleGFtcGxlLm9yZyIsImlhdCI6MTU3NzgzNjgwMCwiYXVkIjpbImdhcmRlbmVyIl0sImV4cCI6MzE1NTcxNjgwMCwianRpIjoianRpIn0.7WKy0sNVkJzIqh3QJIF1zk3QjzwFe_zMTv8PmnOCsxg",
+    },
+    Object {
+      "metadata": Object {
+        "annotations": Object {
+          "dashboard.gardener.cloud/created-by": undefined,
+          "dashboard.gardener.cloud/description": undefined,
+        },
+        "name": "robot",
+        "namespace": "garden-foo",
+      },
+    },
+  ],
+]
+`;
+
 exports[`api members should return a service account 1`] = `
 Array [
   Array [

--- a/backend/test/acceptance/__snapshots__/api.members.spec.js.snap
+++ b/backend/test/acceptance/__snapshots__/api.members.spec.js.snap
@@ -1264,7 +1264,7 @@ Array [
     Object {
       "metadata": Object {
         "annotations": Object {
-          "dashboard.gardener.cloud/created-by": undefined,
+          "dashboard.gardener.cloud/created-by": "bar@example.org",
           "dashboard.gardener.cloud/description": undefined,
         },
         "name": "robot",
@@ -1272,6 +1272,50 @@ Array [
       },
     },
   ],
+]
+`;
+
+exports[`api members should reset a service account 2`] = `
+Array [
+  Object {
+    "roles": Array [
+      "admin",
+    ],
+    "username": "foo@example.org",
+  },
+  Object {
+    "roles": Array [
+      "admin",
+      "owner",
+    ],
+    "username": "bar@example.org",
+  },
+  Object {
+    "createdBy": "bar@example.org",
+    "creationTimestamp": "now",
+    "orphaned": false,
+    "roles": Array [
+      "viewer",
+    ],
+    "username": "system:serviceaccount:garden-foo:robot",
+  },
+  Object {
+    "roles": Array [
+      "viewer",
+      "admin",
+    ],
+    "username": "system:serviceaccount:garden-baz:robot",
+  },
+  Object {
+    "creationTimestamp": "2020-01-01T00:00:00Z",
+    "roles": Array [],
+    "username": "system:serviceaccount:garden-foo:robot-nomember",
+  },
+  Object {
+    "creationTimestamp": "2020-01-01T00:00:00Z",
+    "roles": Array [],
+    "username": "system:serviceaccount:garden-foo:dashboard-webterminal",
+  },
 ]
 `;
 

--- a/backend/test/acceptance/api.members.spec.js
+++ b/backend/test/acceptance/api.members.spec.js
@@ -92,12 +92,12 @@ describe('api', function () {
         .send({
           method: 'resetServiceAccount'
         })
-        .expect(204)
+        .expect(200)
 
       expect(mockRequest).toBeCalledTimes(4)
       expect(mockRequest.mock.calls).toMatchSnapshot()
 
-      expect(res.noContent).toBe(true)
+      expect(res.body).toMatchSnapshot()
     })
 
     it('should add a project member', async function () {

--- a/backend/test/acceptance/api.members.spec.js
+++ b/backend/test/acceptance/api.members.spec.js
@@ -78,6 +78,28 @@ describe('api', function () {
       expect(res.body).toMatchSnapshot()
     })
 
+    it('should reset a service account', async function () {
+      const name = 'system:serviceaccount:garden-foo:robot'
+
+      mockRequest.mockImplementationOnce(fixtures.projects.mocks.get())
+      mockRequest.mockImplementationOnce(fixtures.serviceaccounts.mocks.list())
+      mockRequest.mockImplementationOnce(fixtures.serviceaccounts.mocks.delete())
+      mockRequest.mockImplementationOnce(fixtures.serviceaccounts.mocks.create())
+
+      const res = await agent
+        .post(`/api/namespaces/${namespace}/members/${name}`)
+        .set('cookie', await user.cookie)
+        .send({
+          method: 'resetServiceAccount'
+        })
+        .expect(204)
+
+      expect(mockRequest).toBeCalledTimes(4)
+      expect(mockRequest.mock.calls).toMatchSnapshot()
+
+      expect(res.noContent).toBe(true)
+    })
+
     it('should add a project member', async function () {
       mockRequest.mockImplementationOnce(fixtures.projects.mocks.get())
       mockRequest.mockImplementationOnce(fixtures.serviceaccounts.mocks.list())

--- a/backend/test/services.members.spec.js
+++ b/backend/test/services.members.spec.js
@@ -452,6 +452,26 @@ describe('services', function () {
         })
       })
 
+      describe('#resetServiceAccount', function () {
+        it('should delete and create a serviceaccount', async function () {
+          const id = 'system:serviceaccount:garden-foo:robot-sa'
+          await memberManager.resetServiceAccount(id)
+          expect(client.core.serviceaccounts.delete).toBeCalledWith('garden-foo', 'robot-sa')
+          const body = {
+            metadata: {
+              annotations: {
+                'dashboard.gardener.cloud/created-by': 'foo',
+                'dashboard.gardener.cloud/description': 'description'
+              },
+              creationTimestamp: 'now',
+              name: 'robot-sa',
+              namespace: 'garden-foo'
+            }
+          }
+          expect(client.core.serviceaccounts.create).toBeCalledWith('garden-foo', body)
+        })
+      })
+
       describe('#getKubeconfig', function () {
         it('should return kubeconfig with token of newest secret', async function () {
           const id = 'system:serviceaccount:garden-foo:robot-user'

--- a/backend/test/services.members.spec.js
+++ b/backend/test/services.members.spec.js
@@ -438,7 +438,8 @@ describe('services', function () {
           const id = 'system:serviceaccount:garden-foo:robot-sa'
           const item = memberManager.subjectList.get(id)
           await memberManager.deleteServiceAccount(item)
-          expect(client.core.serviceaccounts.delete).toBeCalledWith('garden-foo', 'robot-sa')
+          expect(client.core.serviceaccounts.delete).toBeCalledTimes(1)
+          expect(client.core.serviceaccounts.delete.mock.calls[0]).toEqual(['garden-foo', 'robot-sa'])
           expect(memberManager.subjectList.has(id)).toBe(false)
         })
 
@@ -454,7 +455,8 @@ describe('services', function () {
           const id = 'system:serviceaccount:garden-foo:robot-orphaned'
           const item = memberManager.subjectList.get(id)
           await memberManager.deleteServiceAccount(item)
-          expect(client.core.serviceaccounts.delete).toBeCalledWith('garden-foo', 'robot-orphaned')
+          expect(client.core.serviceaccounts.delete).toBeCalledTimes(1)
+          expect(client.core.serviceaccounts.delete.mock.calls[0]).toEqual(['garden-foo', 'robot-orphaned'])
           expect(memberManager.subjectList.has(id)).toBe(false)
         })
       })
@@ -472,7 +474,8 @@ describe('services', function () {
         it('should delete and create a serviceaccount', async function () {
           const id = 'system:serviceaccount:garden-foo:robot-sa'
           await memberManager.resetServiceAccount(id)
-          expect(client.core.serviceaccounts.delete).toBeCalledWith('garden-foo', 'robot-sa')
+          expect(client.core.serviceaccounts.delete).toBeCalledTimes(1)
+          expect(client.core.serviceaccounts.delete.mock.calls[0]).toEqual(['garden-foo', 'robot-sa'])
           const body = {
             metadata: {
               annotations: {
@@ -484,7 +487,8 @@ describe('services', function () {
               namespace: 'garden-foo'
             }
           }
-          expect(client.core.serviceaccounts.create).toBeCalledWith('garden-foo', body)
+          expect(client.core.serviceaccounts.create).toBeCalledTimes(1)
+          expect(client.core.serviceaccounts.create.mock.calls[0]).toEqual(['garden-foo', body])
         })
 
         it('should throw an error for foreign service accounts', async function () {
@@ -507,7 +511,8 @@ describe('services', function () {
         it('should patch the default service account', async function () {
           const id = 'system:serviceaccount:garden-foo:default'
           await memberManager.resetServiceAccount(id)
-          expect(client.core.serviceaccounts.delete).toBeCalledWith('garden-foo', 'default')
+          expect(client.core.serviceaccounts.delete).toBeCalledTimes(1)
+          expect(client.core.serviceaccounts.delete.mock.calls[0]).toEqual(['garden-foo', 'default'])
           const body = {
             metadata: {
               annotations: {
@@ -518,16 +523,19 @@ describe('services', function () {
               namespace: 'garden-foo'
             }
           }
-          expect(client.core.serviceaccounts.create).toBeCalledWith('garden-foo', body)
+          expect(client.core.serviceaccounts.create).toBeCalledTimes(1)
+          expect(client.core.serviceaccounts.create.mock.calls[0]).toEqual(['garden-foo', body])
           const patch = {
             metadata: {
               annotations: {
                 'dashboard.gardener.cloud/created-by': 'k8s',
                 'dashboard.gardener.cloud/description': 'description'
-              }
+              },
+              creationTimestamp: 'bar-time'
             }
           }
-          expect(client.core.serviceaccounts.mergePatch).toBeCalledWith('garden-foo', 'default', patch)
+          expect(client.core.serviceaccounts.mergePatch).toBeCalledTimes(1)
+          expect(client.core.serviceaccounts.mergePatch.mock.calls[0]).toEqual(['garden-foo', 'default', patch])
         })
       })
 
@@ -536,8 +544,7 @@ describe('services', function () {
           const id = 'system:serviceaccount:garden-foo:robot-user'
           const item = memberManager.subjectList.get(id)
           const kubeConfig = parseKubeconfig(await memberManager.getKubeconfig(item))
-
-          expect(client.core.serviceaccounts.createTokenRequest).toHaveBeenNthCalledWith(1, 'garden-foo', 'robot-user', {
+          const body = {
             apiVersion: 'authentication.k8s.io/v1',
             kind: 'TokenRequest',
             spec: {
@@ -547,7 +554,9 @@ describe('services', function () {
             status: {
               token: 'secret'
             }
-          })
+          }
+          expect(client.core.serviceaccounts.createTokenRequest).toBeCalledTimes(1)
+          expect(client.core.serviceaccounts.createTokenRequest.mock.calls[0]).toEqual(['garden-foo', 'robot-user', body])
           expect(kubeConfig.users[0].user.token).toContain('secret')
         })
       })

--- a/frontend/src/components/ProjectServiceAccountRow.vue
+++ b/frontend/src/components/ProjectServiceAccountRow.vue
@@ -71,6 +71,16 @@ SPDX-License-Identifier: Apache-2.0
             <span>Show Kubeconfig</span>
           </v-tooltip>
         </div>
+        <div v-if="!foreign && canDeleteServiceAccounts && canCreateServiceAccounts" class="ml-1">
+          <v-tooltip top>
+            <template v-slot:activator="{ on }">
+              <v-btn v-on="on" color="action-button"  icon @click="onResetServiceAccount" :disabled="orphaned">
+                <v-icon>mdi-refresh</v-icon>
+              </v-btn>
+            </template>
+            <span>Reset Service Account</span>
+          </v-tooltip>
+        </div>
         <div v-if="canManageServiceAccountMembers" class="ml-1">
           <v-tooltip top>
             <template v-slot:activator="{ on }">
@@ -132,6 +142,7 @@ export default {
     ]),
     ...mapGetters([
       'canManageServiceAccountMembers',
+      'canCreateServiceAccounts',
       'canDeleteServiceAccounts',
       'canCreateTokenRequest'
     ]),
@@ -173,6 +184,9 @@ export default {
     },
     onKubeconfig () {
       this.$emit('kubeconfig', this.item)
+    },
+    onResetServiceAccount () {
+      this.$emit('reset-serviceaccount', this.item)
     },
     onEdit () {
       this.$emit('edit', this.item)

--- a/frontend/src/components/ProjectServiceAccountRow.vue
+++ b/frontend/src/components/ProjectServiceAccountRow.vue
@@ -74,7 +74,7 @@ SPDX-License-Identifier: Apache-2.0
         <div v-if="!foreign && canDeleteServiceAccounts && canCreateServiceAccounts" class="ml-1">
           <v-tooltip top>
             <template v-slot:activator="{ on }">
-              <v-btn v-on="on" color="action-button"  icon @click="onResetServiceAccount" :disabled="orphaned">
+              <v-btn v-on="on" color="action-button"  icon @click="onResetServiceAccount">
                 <v-icon>mdi-refresh</v-icon>
               </v-btn>
             </template>

--- a/frontend/src/components/messages/ResetServiceAccount.vue
+++ b/frontend/src/components/messages/ResetServiceAccount.vue
@@ -1,0 +1,21 @@
+<!--
+SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
+<template>
+  <div>
+    Do you want to reset the service account <em>{{name}}</em>?<br />This will delete and recreate the service account. The member roles will not change. Attention: The current kubeconfig credentials will be revoked
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    name: {
+      type: String,
+      required: true
+    }
+  }
+}
+</script>

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -1489,6 +1489,15 @@ const actions = {
       await dispatch('setError', { message: `Delete member failed. ${err.message}` })
     }
   },
+  async resetServiceAccount ({ dispatch, commit }, payload) {
+    try {
+      const result = await dispatch('members/resetServiceAccount', payload)
+      await dispatch('setAlert', { message: 'Service Account Reset', type: 'success' })
+      return result
+    } catch (err) {
+      await dispatch('setError', { message: `Failed to Reset Service Account ${err.message}` })
+    }
+  },
   setConfiguration ({ commit, getters }, value) {
     commit('SET_CONFIGURATION', value)
 

--- a/frontend/src/store/modules/members.js
+++ b/frontend/src/store/modules/members.js
@@ -44,7 +44,8 @@ const actions = {
   },
   async resetServiceAccount ({ commit, rootState }, name) {
     const namespace = rootState.namespace
-    await resetServiceAccount({ namespace, name })
+    const res = await resetServiceAccount({ namespace, name })
+    commit('RECEIVE', res.data)
   }
 }
 

--- a/frontend/src/store/modules/members.js
+++ b/frontend/src/store/modules/members.js
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { getMembers, addMember, updateMember, deleteMember } from '@/utils/api'
+import { getMembers, addMember, updateMember, deleteMember, resetServiceAccount } from '@/utils/api'
 
 // initial state
 const state = {
@@ -41,6 +41,10 @@ const actions = {
     const namespace = rootState.namespace
     const res = await deleteMember({ namespace, name })
     commit('RECEIVE', res.data)
+  },
+  async resetServiceAccount ({ commit, rootState }, name) {
+    const namespace = rootState.namespace
+    await resetServiceAccount({ namespace, name })
   }
 }
 

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -265,6 +265,14 @@ export function deleteMember ({ namespace, name }) {
   return deleteResource(`/api/namespaces/${namespace}/members/${name}`)
 }
 
+export function resetServiceAccount ({ namespace, name }) {
+  namespace = encodeURIComponent(namespace)
+  name = encodeURIComponent(name)
+  return callResourceMethod(`/api/namespaces/${namespace}/members/${name}`, {
+    method: 'resetServiceAccount'
+  })
+}
+
 /* User */
 export function createTokenReview (data) {
   return createResource('/auth', data)

--- a/frontend/src/views/Members.vue
+++ b/frontend/src/views/Members.vue
@@ -151,6 +151,7 @@ SPDX-License-Identifier: Apache-2.0
             :key="`${item.namespace}_${item.username}`"
             @download="onDownload"
             @kubeconfig="onKubeconfig"
+            @reset-serviceaccount="onResetServiceAccount"
             @delete="onDeleteServiceAccount"
             @edit="onEditServiceAccount"
           ></project-service-account-row>
@@ -203,6 +204,7 @@ import ProjectUserRow from '@/components/ProjectUserRow'
 import ProjectServiceAccountRow from '@/components/ProjectServiceAccountRow'
 import RemoveProjectMember from '@/components/messages/RemoveProjectMember'
 import DeleteServiceAccount from '@/components/messages/DeleteServiceAccount'
+import ResetServiceAccount from '@/components/messages/ResetServiceAccount.vue'
 import TableColumnSelection from '@/components/TableColumnSelection.vue'
 
 import {
@@ -422,6 +424,7 @@ export default {
     ...mapActions([
       'addMember',
       'deleteMember',
+      'resetServiceAccount',
       'setError'
     ]),
     openUserAddDialog () {
@@ -524,6 +527,12 @@ export default {
         return this.deleteMember(username)
       }
     },
+    async onResetServiceAccount ({ username }) {
+      const resetConfirmed = await this.confirmResetServiceAccount(username)
+      if (resetConfirmed) {
+        return this.resetServiceAccount(username)
+      }
+    },
     confirmRemoveForeignServiceAccount (serviceAccountName) {
       const { projectName } = this.projectDetails
       const { namespace, name } = parseServiceAccountUsername(serviceAccountName)
@@ -549,6 +558,18 @@ export default {
         messageHtml: message.innerHTML,
         confirmValue: name,
         width: '550'
+      })
+    },
+    confirmResetServiceAccount (name) {
+      name = displayName(name)
+      const message = this.$renderComponent(ResetServiceAccount, {
+        name
+      })
+      return this.$refs.confirmDialog.waitForConfirmation({
+        confirmButtonText: 'Reset',
+        captionText: 'Confirm Service Account Reset',
+        messageHtml: message.innerHTML,
+        confirmValue: name
       })
     },
     onEditUser ({ username, roles }) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a "Reset Service Account" Button. The service account will be deleted and recreated with the previous owner information and description.

![Screenshot 2022-11-25 at 14 41 50](https://user-images.githubusercontent.com/5526658/203997887-ef5da168-1bb4-42df-b710-663bd946a2ca.png)
![Screenshot 2022-11-25 at 14 42 02](https://user-images.githubusercontent.com/5526658/203997881-50b39f35-7785-4b8e-9196-d79a5aad308a.png)


**Which issue(s) this PR fixes**:
Fixes #1358 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
You can now "reset" a service account on the project `Member` page to invalidate all tokens related to this service account.
```
