### PR TITLE
gardener-dashboard chart: comment out oidc config

### DIFF
--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -93,34 +93,35 @@ global:
 
   # sessionSecret is used for signing and encrytion of session data
   sessionSecret: ~
-  oidc:
-    # well-known URL for OpenID Provider Issuer Discovery
-    issuerUrl: ~
-    # clientId is the public identifier of the gardener-dashboard aplication
-    clientId: dashboard
-    # clientSecret is the private secret of the gardener-dashboard aplication
-    clientSecret: ~
-    # # force PKCE usage
-    # usePKCE: true
-    # # sessionLifetime is the maximum lifetime of a login session without reauthentication in seconds (defaults to 86400)
-    # sessionLifetime: 86400
-    # # certificate authority of the OpenID provider
-    # ca: |
-    #   -----BEGIN CERTIFICATE-----
-    #   Li4u
-    #   -----END CERTIFICATE-----
-    # # secretKey reference to the certificate authority
-    # caSecretKeyRef:
-    #   name: oidc-ca-secret-name
-    #   key: ca.crt
-    # # configuration for kubeconfig download required by kubelogin
-    # public:
-    #   # clientId is the identifier of the public oidc client use by kubelogin
-    #   clientId: kube-kubectl
-    #   # clientSecret is the public client secret use by kubelogin and all users
-    #   clientSecret: ~
-    #   # force PKCE usage (automatically enabled if no clientSecret is given)
-    #   usePKCE: true
+
+  # oidc:
+  #   # well-known URL for OpenID Provider Issuer Discovery
+  #   issuerUrl: ~
+  #   # clientId is the public identifier of the gardener-dashboard aplication
+  #   clientId: dashboard
+  #   # clientSecret is the private secret of the gardener-dashboard aplication
+  #   clientSecret: ~
+  #   # force PKCE usage
+  #   usePKCE: true
+  #   # sessionLifetime is the maximum lifetime of a login session without reauthentication in seconds (defaults to 86400)
+  #   sessionLifetime: 86400
+  #   # certificate authority of the OpenID provider
+  #   ca: |
+  #     -----BEGIN CERTIFICATE-----
+  #     Li4u
+  #     -----END CERTIFICATE-----
+  #   # secretKey reference to the certificate authority
+  #   caSecretKeyRef:
+  #     name: oidc-ca-secret-name
+  #     key: ca.crt
+  #   # configuration for kubeconfig download required by kubelogin
+  #   public:
+  #     # clientId is the identifier of the public oidc client use by kubelogin
+  #     clientId: kube-kubectl
+  #     # clientSecret is the public client secret use by kubelogin and all users
+  #     clientSecret: ~
+  #     # force PKCE usage (automatically enabled if no clientSecret is given)
+  #     usePKCE: true
 
   frontendConfig:
     landingPageUrl: https://github.com/gardener


### PR DESCRIPTION
**What this PR does / why we need it**:
In the past the `oidc` configuration was required. This is not the case anymore. Meanwhile the dashboard can also be used with token login only.

**Which issue(s) this PR fixes**:
Fixes #1327

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
`.Values.global.oidc` is not defaulted anymore in the `values.yaml` file of the gardener-dashboard helm chart. Especially there is no default value for `.Values.global.oidc.clientId`, which was previously `dashboard`.
```
