### PR TITLE
Remove legacy gardenctl command

### DIFF
--- a/charts/__tests__/gardener-dashboard/runtime/__snapshots__/configmap.spec.js.snap
+++ b/charts/__tests__/gardener-dashboard/runtime/__snapshots__/configmap.spec.js.snap
@@ -278,9 +278,6 @@ Object {
       "projectTerminalShortcutsEnabled": false,
       "terminalEnabled": false,
     },
-    "gardenctl": Object {
-      "legacyCommands": true,
-    },
     "helpMenuItems": Array [
       Object {
         "icon": "description",

--- a/charts/gardener-dashboard/charts/runtime/templates/configmap.yaml
+++ b/charts/gardener-dashboard/charts/runtime/templates/configmap.yaml
@@ -344,10 +344,6 @@ data:
       resourceQuotaHelp:
         text: {{ required ".Values.global.frontendConfig.resourceQuotaHelp.text is required" .Values.global.frontendConfig.resourceQuotaHelp.text | quote }}
       {{- end }}
-      {{- if .Values.global.frontendConfig.gardenctl }}
-      gardenctl:
-        legacyCommands: {{ .Values.global.frontendConfig.gardenctl.legacyCommands | default false }}
-      {{- end }}
       {{- if .Values.global.frontendConfig.defaultNodesCIDR }}
       defaultNodesCIDR: {{ .Values.global.frontendConfig.defaultNodesCIDR }}
       {{- end }}

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -272,10 +272,6 @@ global:
     #     error: 'red.darken4'
     #     warning: 'orange.darken4'
 
-    # gardenctl - configure the default settings for the gardenctl commands
-    gardenctl:
-      legacyCommands: true # false to show gardenctl-v2 commands by default, true to show the legacy gardenctl commands. Can be overwritten by the user.
-
     defaultNodesCIDR: 10.250.0.0/16 # default CIDR used for nodes network when creating new shoots
 
     # serviceAccountDefaultTokenExpiration - is the default requested duration of validity of the token request for garden cluster service accounts.

--- a/frontend/src/components/ShootDetails/GardenctlCommands.vue
+++ b/frontend/src/components/ShootDetails/GardenctlCommands.vue
@@ -28,39 +28,6 @@ SPDX-License-Identifier: Apache-2.0
             <span>{{visibilityTitle(index)}}</span>
           </v-tooltip>
         </v-list-item-action>
-        <v-list-item-action class="mx-0">
-          <g-popper
-            title="Customize Gardenctl Commands"
-            popper-key="gardenctl"
-          >
-            <template v-slot:popperRef>
-              <v-btn icon  color="action-button">
-                <v-tooltip top>
-                  <template v-slot:activator="{ on }">
-                    <v-icon v-on="on">mdi-cog-outline</v-icon>
-                  </template>
-                  <span>Instructions on how to customize the <span class="font-family-monospace">gardenctl</span> commands</span>
-                </v-tooltip>
-              </v-btn>
-            </template>
-            <v-list class="py-0">
-              <v-list-item class="px-0">
-                <v-list-item-icon>
-                  <v-icon>mdi-information-outline</v-icon>
-                </v-list-item-icon>
-                <v-list-item-content>
-                  <span>
-                    Go to
-                    <router-link :to="{ name: 'Settings', query: { namespace: shootNamespace } }">Settings</router-link>
-                    to customize the
-                    <span class="font-family-monospace">gardenctl</span>
-                    command
-                  </span>
-                </v-list-item-content>
-              </v-list-item>
-            </v-list>
-          </g-popper>
-        </v-list-item-action>
       </v-list-item>
       <v-list-item v-if="expansionPanel[index]" :key="'expansion-' + title">
         <v-list-item-icon></v-list-item-icon>
@@ -77,7 +44,6 @@ SPDX-License-Identifier: Apache-2.0
 </template>
 
 <script>
-import GPopper from '@/components/GPopper'
 import CopyBtn from '@/components/CopyBtn'
 import CodeBlock from '@/components/CodeBlock'
 import { shootItem } from '@/mixins/shootItem'
@@ -88,8 +54,7 @@ import Vue from 'vue'
 export default {
   components: {
     CopyBtn,
-    CodeBlock,
-    GPopper
+    CodeBlock
   },
   mixins: [shootItem],
   data () {
@@ -105,9 +70,6 @@ export default {
       'isAdmin',
       'projectFromProjectList'
     ]),
-    ...mapGetters('storage', [
-      'gardenctlOptions'
-    ]),
     projectName () {
       const project = this.projectFromProjectList
       return get(project, 'metadata.name')
@@ -119,11 +81,10 @@ export default {
           .replace(/ &&/g, ' \\\n  &&')
       }
 
-      const gardenctlVersion = this.legacyCommands ? 'Legacy gardenctl' : 'Gardenctl-v2'
       const cmds = [
         {
           title: 'Target Cluster',
-          subtitle: `${gardenctlVersion} command to target the shoot cluster`,
+          subtitle: 'Gardenctl-v2 command to target the shoot cluster',
           value: this.targetShootCommand,
           displayValue: displayValue(this.targetShootCommand)
         }
@@ -132,45 +93,14 @@ export default {
       if (this.isAdmin) {
         cmds.unshift({
           title: 'Target Control Plane',
-          subtitle: `${gardenctlVersion} command to target the control plane of the shoot cluster`,
+          subtitle: 'Gardenctl-v2 command to target the control plane of the shoot cluster',
           value: this.targetControlPlaneCommand,
           displayValue: displayValue(this.targetControlPlaneCommand)
         })
       }
       return cmds
     },
-    legacyCommands () {
-      return get(this.gardenctlOptions, 'legacyCommands', false)
-    },
     targetControlPlaneCommand () {
-      if (this.legacyCommands) {
-        return this.targetControlPlaneCommandV1
-      }
-
-      return this.targetControlPlaneCommandV2
-    },
-    targetShootCommand () {
-      if (this.legacyCommands) {
-        return this.targetShootCommandV1
-      }
-
-      return this.targetShootCommandV2
-    },
-    targetControlPlaneCommandV1 () {
-      const args = []
-      if (this.cfg.apiServerUrl) {
-        args.push(`--server ${this.cfg.apiServerUrl}`)
-      }
-      if (this.shootSeedName) {
-        args.push(`--seed ${this.shootSeedName}`)
-      }
-      if (this.shootTechnicalId) {
-        args.push(`--namespace ${this.shootTechnicalId}`)
-      }
-
-      return `gardenctl target ${args.join(' ')}`
-    },
-    targetControlPlaneCommandV2 () {
       const args = []
       if (this.cfg.clusterIdentity) {
         args.push(`--garden ${this.cfg.clusterIdentity}`)
@@ -186,21 +116,7 @@ export default {
 
       return `gardenctl target ${args.join(' ')}`
     },
-    targetShootCommandV1 () {
-      const args = []
-      if (this.cfg.apiServerUrl) {
-        args.push(`--server ${this.cfg.apiServerUrl}`)
-      }
-      if (this.projectName) {
-        args.push(`--project ${this.projectName}`)
-      }
-      if (this.shootName) {
-        args.push(`--shoot ${this.shootName}`)
-      }
-
-      return `gardenctl target ${args.join(' ')}`
-    },
-    targetShootCommandV2 () {
+    targetShootCommand () {
       const args = []
       if (this.cfg.clusterIdentity) {
         args.push(`--garden ${this.cfg.clusterIdentity}`)

--- a/frontend/src/store/modules/storage.js
+++ b/frontend/src/store/modules/storage.js
@@ -22,16 +22,6 @@ const getters = {
   },
   isDeveloperModeEnabled (state) {
     return state['global/developer-mode'] === 'enabled'
-  },
-  gardenctlOptions (state, getters, rootState) {
-    const options = {
-      legacyCommands: false,
-      ...rootState.cfg?.gardenctl
-    }
-    try {
-      Object.assign(options, JSON.parse(state['global/gardenctl']))
-    } catch (err) { /* ignore error */ }
-    return options
   }
 }
 
@@ -45,10 +35,6 @@ const actions = {
   },
   setDeveloperMode ({ commit }, value) {
     commit('SET_ITEM', ['global/developer-mode', value ? 'enabled' : 'disabled'])
-  },
-  setGardenctlOptions ({ commit }, options) {
-    const value = JSON.stringify(options)
-    commit('SET_ITEM', ['global/gardenctl', value])
   }
 }
 

--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -15,26 +15,6 @@ SPDX-License-Identifier: Apache-2.0
           <v-card-text>
             <v-row>
               <v-col cols="12">
-                <v-radio-group
-                  v-model="legacyCommands"
-                  label="Gardenctl Version"
-                  hint="Choose for which version the commands should be displayed on the cluster details page"
-                  persistent-hint
-                  class="mt-0"
-                >
-                  <v-radio
-                    label="Gardenctl-v2"
-                    :value="false"
-                    color="primary"
-                  ></v-radio>
-                  <v-radio
-                    label="Legacy Gardenctl"
-                    :value="true"
-                    color="primary"
-                  ></v-radio>
-                </v-radio-group>
-              </v-col>
-              <v-col cols="12">
                 <legend class="text-body-2 text--secondary">Color Scheme</legend>
                 <v-btn-toggle v-model="colorSchemeIndex" mandatory dense @click.native.stop class="pt-1">
                   <v-tooltip top>
@@ -106,8 +86,7 @@ export default {
   computed: {
     ...mapGetters('storage', [
       'logLevel',
-      'colorScheme',
-      'gardenctlOptions'
+      'colorScheme'
     ]),
     logLevelIndex: {
       get () {
@@ -128,24 +107,12 @@ export default {
         const colorScheme = this.colorSchemes[index]
         this.setColorScheme(colorScheme)
       }
-    },
-    legacyCommands: {
-      get () {
-        return this.gardenctlOptions.legacyCommands
-      },
-      set (value) {
-        this.setGardenctlOptions({
-          ...this.gardenctlOptions,
-          legacyCommands: value
-        })
-      }
     }
   },
   methods: {
     ...mapActions('storage', [
       'setLogLevel',
-      'setColorScheme',
-      'setGardenctlOptions'
+      'setColorScheme'
     ])
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Gardenctl-v1 is deprecated since long and shouldn't be used anymore. Instead, it's successor gardenctl-v2 should be used.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
Removed the legacy gardenctl-v1 command. Switch to [gardenctl-v2](https://github.com/gardener/gardenctl-v2/#installation) if not already done
```
