### PR TITLE
Keep dashboard URL when user session is expired

### DIFF
--- a/frontend/src/router/guards.js
+++ b/frontend/src/router/guards.js
@@ -40,18 +40,13 @@ function ensureUserAuthenticatedForNonPublicRoutes (store, userManager, logger) 
       return next()
     }
     const user = userManager.getUser()
-    if (!user) {
-      logger.info('No user found --> Redirecting to login page')
+    if (!user || userManager.isSessionExpired()) {
+      logger.info('User not found or session has expired --> Redirecting to login page')
       const query = path !== '/' ? { redirectPath: path } : undefined
       return next({
         name: 'Login',
         query
       })
-    }
-    if (userManager.isSessionExpired()) {
-      logger.info('Session is expired --> Redirecting to logout page')
-      userManager.signout()
-      return next(false)
     }
     const storedUser = store.state.user
     if (!storedUser || storedUser.jti !== user.jti) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixed a problem with lost dashboard URL during re-login when the user session was expired. This regression was introduced with release 1.62.0.

**Which issue(s) this PR fixes**:
Fixes #1365 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed a problem with lost dashboard URL during re-login when the user session was expired. This regression was introduced with release 1.62.0.
```
