### PR TITLE
Default to verbose logging if nothing is defined in localStorage

### DIFF
--- a/frontend/src/store/modules/storage.js
+++ b/frontend/src/store/modules/storage.js
@@ -22,16 +22,6 @@ const getters = {
   },
   autoLoginEnabled (state) {
     return state['global/auto-login'] === 'enabled'
-  },
-  gardenctlOptions (state, getters, rootState) {
-    const options = {
-      legacyCommands: false,
-      ...rootState.cfg?.gardenctl
-    }
-    try {
-      Object.assign(options, JSON.parse(state['global/gardenctl']))
-    } catch (err) { /* ignore error */ }
-    return options
   }
 }
 
@@ -45,10 +35,6 @@ const actions = {
   },
   setAutoLogin ({ commit }, value) {
     commit('SET_ITEM', ['global/auto-login', value ? 'enabled' : 'disabled'])
-  },
-  setGardenctlOptions ({ commit }, options) {
-    const value = JSON.stringify(options)
-    commit('SET_ITEM', ['global/gardenctl', value])
   }
 }
 

--- a/frontend/src/utils/logger.js
+++ b/frontend/src/utils/logger.js
@@ -17,7 +17,7 @@ const levels = {
 export class Logger {
   #level
 
-  constructor (level = 'error') {
+  constructor (level = 'debug') {
     this.#level = level
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Show all log messages (LogLevel: verbose) if the user has not yet defined anything in his settings

**Which issue(s) this PR fixes**:
Fixes #1367

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Show all log messages (LogLevel: verbose) if the user has not yet defined anything in his settings
```