### PR TITLE
Fix member dialog validation

### DIFF
--- a/frontend/src/components/dialogs/MemberDialog.vue
+++ b/frontend/src/components/dialogs/MemberDialog.vue
@@ -173,25 +173,21 @@ export default {
     },
     validators () {
       const validators = {
-        internalRoles: {},
+        internalRoles: {
+          required: requiredIf(function () {
+            return this.isForeignServiceAccount || this.isUserDialog
+          })
+        },
         internalName: {}
       }
       if (!this.isUpdateDialog) {
         if (this.isUserDialog) {
-          validators.internalRoles = {
-            required
-          }
           validators.internalName = {
             required,
             unique: unique('projectUsernames'),
             isNoServiceAccount: value => !isServiceAccountUsername(value)
           }
         } else if (this.isServiceDialog) {
-          validators.internalRoles = {
-            required: requiredIf(function () {
-              return this.isForeignServiceAccount
-            })
-          }
           validators.internalName = {
             required,
             serviceAccountResource: value => {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix member dialog validation. A User and foreign service account should always have roles assigned. Otherwise they have to be removed from the project membership.

**Which issue(s) this PR fixes**:
Fixes #1356

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed roles validation for invited service accounts and user project member
```
