### PR TITLE
Secret Page: Fixed accessing property of possible undefined object

### DIFF
--- a/frontend/src/views/Secrets.vue
+++ b/frontend/src/views/Secrets.vue
@@ -527,7 +527,7 @@ export default {
     },
     relatedShootCountDns (secret) {
       const shootsByDnsSecret = filter(this.shootList, shoot => {
-        return find(shoot.spec.dns.providers, { type: secret.metadata.dnsProviderName, secretName: secret.metadata.name })
+        return find(shoot.spec.dns?.providers, { type: secret.metadata.dnsProviderName, secretName: secret.metadata.name })
       })
       return shootsByDnsSecret.length
     },

--- a/frontend/src/views/Secrets.vue
+++ b/frontend/src/views/Secrets.vue
@@ -181,7 +181,7 @@ import InfraIcon from '@/components/VendorIcon'
 import isEmpty from 'lodash/isEmpty'
 import map from 'lodash/map'
 import filter from 'lodash/filter'
-import find from 'lodash/find'
+import some from 'lodash/some'
 import includes from 'lodash/includes'
 
 export default {
@@ -527,7 +527,10 @@ export default {
     },
     relatedShootCountDns (secret) {
       const shootsByDnsSecret = filter(this.shootList, shoot => {
-        return find(shoot.spec.dns?.providers, { type: secret.metadata.dnsProviderName, secretName: secret.metadata.name })
+        return some(shoot.spec.dns?.providers, {
+          type: secret.metadata.dnsProviderName,
+          secretName: secret.metadata.name
+        })
       })
       return shootsByDnsSecret.length
     },


### PR DESCRIPTION
**What this PR does / why we need it**:
Not yet created clusters may not have a `dns` object. This caused an error on the secret page which stopped the page rendering.

<img width="632" alt="Screenshot 2022-12-13 at 16 18 37" src="https://user-images.githubusercontent.com/35373687/207372827-3999c1e8-da10-4532-85f5-966e9df58abd.png">

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed broken secret page if a project contains a cluster with creation pending
```
