### PR TITLE
Fixed warnings for machine images

### DIFF
--- a/frontend/src/components/ShootWorkers/MachineImage.vue
+++ b/frontend/src/components/ShootWorkers/MachineImage.vue
@@ -141,7 +141,7 @@ export default {
           severity: 'info'
         })
       }
-      if (this.updateOSMaintenance && this.selectedImageIsNotLatest) {
+      if (this.updateOSMaintenance && this.machineImage.isPreview) {
         hints.push({
           type: 'text',
           hint: 'Preview versions have not yet undergone thorough testing. There is a higher probability of undiscovered issues and are therefore not recommended for production usage',

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -365,12 +365,12 @@ function filterShortcuts ({ getters }, { shortcuts, targetsFilter }) {
 }
 
 function decorateClassificationObject (obj) {
-  const classification = obj.classification
+  const classification = obj.classification ?? 'supported'
   const isExpired = obj.expirationDate && moment().isAfter(obj.expirationDate)
   return {
     ...obj,
     isPreview: classification === 'preview',
-    isSupported: !isExpired && (!classification || classification === 'supported'),
+    isSupported: classification === 'supported' && !isExpired,
     isDeprecated: classification === 'deprecated',
     isExpired,
     expirationDateString: getDateFormatted(obj.expirationDate)

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -584,8 +584,8 @@ export function targetText (target) {
 export function selectedImageIsNotLatest (machineImage, machineImages) {
   const { version: testImageVersion, vendorName: testVendor } = machineImage
 
-  return some(machineImages, ({ version, vendorName, isPreview }) => {
-    return testVendor === vendorName && semver.gt(version, testImageVersion) && !isPreview
+  return some(machineImages, ({ version, vendorName, isSupported }) => {
+    return testVendor === vendorName && semver.gt(version, testImageVersion) && isSupported
   })
 }
 

--- a/frontend/tests/unit/utils.spec.js
+++ b/frontend/tests/unit/utils.spec.js
@@ -366,34 +366,52 @@ describe('utils', () => {
         vendorName: 'Foo',
         icon: 'icon',
         version: '1.1.1',
-        expirationDate: '2119-04-05T01:02:03Z' // not expired
+        expirationDate: '2119-04-05T01:02:03Z', // not expired
+        isSupported: true
       },
       {
         name: 'FooImage2',
         vendorName: 'Foo',
         icon: 'icon',
-        version: '1.2.2'
+        version: '1.2.2',
+        isSupported: true
       },
       {
         name: 'FooImage3',
         vendorName: 'Foo',
         icon: 'icon',
-        version: '1.3.2'
+        version: '1.3.2',
+        isSupported: true
       },
       {
         name: 'FooImage4',
         vendorName: 'Foo',
         icon: 'icon',
         version: '1.3.3',
-        isPreview: true,
-        expirationDate: '2119-04-05T01:02:03Z' // not expired
+        expirationDate: '2119-04-05T01:02:03Z', // not expired
+        isPreview: true
       },
       {
         name: 'BarImage',
         vendorName: 'Bar',
         icon: 'icon',
         version: '3.3.2',
+        isSupported: true,
         expirationDate: '2019-04-05T01:02:03Z' // expired
+      },
+      {
+        name: 'FooImage5',
+        vendorName: 'Foo',
+        icon: 'icon',
+        version: '1.3.4',
+        isDeprecated: true
+      },
+      {
+        name: 'FooImage6',
+        vendorName: 'Foo',
+        icon: 'icon',
+        version: '1.4.4',
+        isPreview: true
       }
     ]
 
@@ -420,19 +438,19 @@ describe('utils', () => {
     })
 
     describe('#selectedImageIsNotLatest', () => {
-      it('selected image should be latest (multiple exist, preview exists)', () => {
+      it('selected image should not be be latest (one newer supported exists)', () => {
+        const result = selectedImageIsNotLatest(sampleMachineImages[1], sampleMachineImages)
+        expect(result).toBe(true)
+      })
+
+      it('selected image should be latest (only newer deprecated, preview and other vendor exists)', () => {
         const result = selectedImageIsNotLatest(sampleMachineImages[2], sampleMachineImages)
         expect(result).toBe(false)
       })
 
-      it('selected image should be latest (one exists)', () => {
-        const result = selectedImageIsNotLatest(sampleMachineImages[3], sampleMachineImages)
+      it('selected image should be latest (only one exists)', () => {
+        const result = selectedImageIsNotLatest(sampleMachineImages[4], sampleMachineImages)
         expect(result).toBe(false)
-      })
-
-      it('selected image should not be latest', () => {
-        const result = selectedImageIsNotLatest(sampleMachineImages[1], sampleMachineImages)
-        expect(result).toBe(true)
       })
     })
 


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed: Preview image warning shown for non `preview` machine images. Also fixed an issue with the not latest image hint sometimes shown even if no newer `supported` image version exists.
```
