### PR TITLE
Stop setting the `.spec.provider.providerConfig.zone` field for OpenStack Shoots

### DIFF
--- a/frontend/src/utils/createShoot.js
+++ b/frontend/src/utils/createShoot.js
@@ -321,7 +321,6 @@ export function getControlPlaneZone (workers, infrastructureKind, oldControlPlan
   switch (infrastructureKind) {
     case 'gcp':
     case 'hcloud':
-    case 'openstack':
       if (includes(workerZones, oldControlPlaneZone)) {
         return oldControlPlaneZone
       }


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:
See https://github.com/gardener/dashboard/issues/1378

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/dashboard/issues/1378

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```cleanup operator
The dashboard does no longer sets the deprecated and no-op `.spec.provider.providerConfig.zone` field for new OpenStack Shoots.
```
