### PR TITLE
Chart: Increase default resource limits and requests

### DIFF
--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -57,11 +57,11 @@ global:
   servicePort: 8080
   resources:
     limits:
-      cpu: 250m
-      memory: 300Mi
+      cpu: 1.0
+      memory: 1G
     requests:
       cpu: 100m
-      memory: 120Mi
+      memory: 350Mi
 
   # If dashboard is running in an environment with less than 1.5GB of available memory
   # you should cap the maximum available "old space". In a Docker-512MB-Container,


### PR DESCRIPTION
**What this PR does / why we need it**:
The default resource limits and requests weren't touched since ~4 years. Meanwhile the dashboard has evolved and we cache several resources (shoots, seeds, cloudprofiles, projects etc). Even on a initially set-up kind cluster ([ref](https://github.com/gardener/gardener/blob/master/docs/development/getting_started_locally.md)) it shows that the dashboard requires more than 300Mi memory.

**Which issue(s) this PR fixes**:
Fixes #1287

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`gardener-dashboard` helm chart: Increased default resource limits and requests to adapt to increased resource requests due to caching of several resources
```
