### PR TITLE
Added machine type filters

### DIFF
--- a/frontend/src/components/ShootWorkers/MachineType.vue
+++ b/frontend/src/components/ShootWorkers/MachineType.vue
@@ -71,7 +71,7 @@ SPDX-License-Identifier: Apache-2.0
 <script>
 import HintColorizer from '@/components/HintColorizer'
 import { required } from 'vuelidate/lib/validators'
-import { getValidationErrors } from '@/utils'
+import { getValidationErrors, sizeStringToBytes } from '@/utils'
 import find from 'lodash/find'
 import uniq from 'lodash/uniq'
 import map from 'lodash/map'
@@ -177,22 +177,11 @@ export default {
     },
     memoryItems () {
       const memoryItems = uniq(map(this.machineTypes, 'memory'))
-      return ['all', ...memoryItems.sort((a, b) => this.rawMemoryValue(a) - this.rawMemoryValue(b))]
+      return ['all', ...memoryItems.sort((a, b) => sizeStringToBytes(a) - sizeStringToBytes(b))]
     }
   },
   validations,
   methods: {
-    rawMemoryValue (memoryString) {
-      let memoryVal = memoryString.replace(/\D/g, '')
-      if (memoryString.includes('Gi')) {
-        memoryVal = memoryVal * 1024
-      }
-      if (memoryString.includes('Ti')) {
-        memoryVal = memoryVal * 1024 * 1024
-      }
-
-      return memoryVal
-    },
     getErrorMessages (field) {
       return getValidationErrors(this, field)
     },

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -609,3 +609,34 @@ export function mapTableHeader (headers, valueKey) {
 export function isHtmlColorCode (value) {
   return /^#([a-f0-9]{6}|[a-f0-9]{3})$/i.test(value)
 }
+
+const units = {
+  m: 0.001,
+  k: 1024,
+  Ki: 1000,
+  M: 1024 * 1024,
+  Mi: 1000 * 1000,
+  G: 1024 * 1024 * 1024,
+  Gi: 1000 * 1000 * 1000,
+  T: 1024 * 1024 * 1024 * 1024,
+  Ti: 1000 * 1000 * 1000 * 1000,
+  P: 1024 * 1024 * 1024 * 1024 * 1024,
+  Pi: 1000 * 1000 * 1000 * 1000 * 1000,
+  E: 1024 * 1024 * 1024 * 1024 * 1024 * 1024,
+  Ei: 1000 * 1000 * 1000 * 1000 * 1000 * 1000
+}
+
+const sizeRegex = new RegExp('^(\\d+[e\\d]*)(' + Object.keys(units).join('|') + ')?$')
+
+export function sizeStringToBytes (sizeStr) {
+  const [ok, value, unit] = sizeRegex.exec(sizeStr) || []
+  if (!ok) {
+    return sizeStr
+  }
+
+  if (!unit) {
+    return parseFloat(value)
+  }
+
+  return parseFloat(value) * units[unit]
+}

--- a/frontend/tests/unit/utils.spec.js
+++ b/frontend/tests/unit/utils.spec.js
@@ -11,6 +11,7 @@ import {
   canI,
   selectedImageIsNotLatest,
   isHtmlColorCode,
+  sizeStringToBytes,
   defaultCriNameByKubernetesVersion
 } from '@/utils'
 
@@ -542,6 +543,32 @@ describe('utils', () => {
 
     it('should return false on non-html color code', () => {
       expect(isHtmlColorCode('foo')).toBe(false)
+    })
+  })
+
+  describe('string to bytes', () => {
+    it('should not convert without unit', () => {
+      expect(sizeStringToBytes('5000')).toBe(5000)
+    })
+
+    it('should not convert with unknown unit', () => {
+      expect(sizeStringToBytes('5000a')).toBe('5000a')
+    })
+
+    it('should convert with m unit (increase)', () => {
+      expect(sizeStringToBytes('5000m')).toBe(5)
+    })
+
+    it('should convert with G unit (increase)', () => {
+      expect(sizeStringToBytes('5G')).toBe(5368709120)
+    })
+
+    it('should convert with Gi unit (increase)', () => {
+      expect(sizeStringToBytes('5Gi')).toBe(5000000000)
+    })
+
+    it('should convert with exponent', () => {
+      expect(sizeStringToBytes('5e3G')).toBe(5368709120000)
     })
   })
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow-up of #1353
Added additional dropdown filters for machine types

<img width="415" alt="Screenshot 2023-01-09 at 12 54 00" src="https://user-images.githubusercontent.com/35373687/211324757-73e48197-9a23-404c-b91d-b74a62fbb9b5.png">

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Machine types can be filtered for CPU, GPU and memory via dropdown selection
```
