### PR TITLE
fix: change contribution link to Contributor Guide on gardener.cloud

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-Please refer to the [Gardener contributor guide](https://github.com/gardener/documentation/blob/master/CONTRIBUTING.md).
+Please refer to the [Gardener contributor guide](https://gardener.cloud/docs/contribute/).


### PR DESCRIPTION
**What this PR does / why we need it**:

The link in CONTRIBUTING.md did not work anymore. This PR changes this link to gardener.cloud (see https://github.com/gardener/gardener/commit/9161a64a6131e7d70708d8bf1b16169fe7a41c3c)

**Which issue(s) this PR fixes**:
-

**Special notes for your reviewer**:
-

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc developer
NONE
```
