### PR TITLE
fix: navigation home item color for light theme

### DIFF
--- a/frontend/src/components/MainNavigation.vue
+++ b/frontend/src/components/MainNavigation.vue
@@ -132,7 +132,7 @@ SPDX-License-Identifier: Apache-2.0
             <v-icon>mdi-home-outline</v-icon>
           </v-list-item-action>
           <v-list-item-content>
-            <v-list-item-title class="text-subtitle-1">Home</v-list-item-title>
+            <v-list-item-title class="text-subtitle-1 main-navigation-title--text">Home</v-list-item-title>
           </v-list-item-content>
         </v-list-item>
         <template v-if="namespace">

--- a/frontend/src/components/MainNavigation.vue
+++ b/frontend/src/components/MainNavigation.vue
@@ -129,7 +129,7 @@ SPDX-License-Identifier: Apache-2.0
       <v-list ref="mainMenu" class="main-menu" flat>
         <v-list-item :to="{name: 'Home'}" exact v-if="hasNoProjects">
           <v-list-item-action>
-            <v-icon>mdi-home-outline</v-icon>
+            <v-icon small color="main-navigation-title">mdi-home-outline</v-icon>
           </v-list-item-action>
           <v-list-item-content>
             <v-list-item-title class="text-subtitle-1 main-navigation-title--text">Home</v-list-item-title>


### PR DESCRIPTION
**What this PR does / why we need it**:

When changing the theme from dark to light, the text color of the "Home" item changes from white to black which impairs readability. This PR adds the color of the navbar title (white) to the home item.

<table>
  <tr>
    <th>dark</th>
    <th>light</th>
    <th>light (expected)</th>
  </tr>
  <tr>
    <td>
      <img width="223" alt="Screenshot 2023-01-13 at 20 02 58" src="https://user-images.githubusercontent.com/71837281/212398563-3b5997b3-94c1-4487-8dc7-7e6f872d507e.png">
    </td>
    <td>
      <img width="233" alt="Screenshot 2023-01-13 at 20 03 12" src="https://user-images.githubusercontent.com/71837281/212398577-53e47f36-c93e-414d-ab64-774bc9cd21bc.png">
    </td>
    <td>
      <img width="214" alt="Screenshot 2023-01-13 at 20 07 35" src="https://user-images.githubusercontent.com/71837281/212399207-f6d4de8b-369f-4bd3-9f42-c71c9572ce76.png">
    </td>
  </tr>
<table>

**Which issue(s) this PR fixes**:
-

**Special notes for your reviewer**:
-

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
NONE
```
