### PR TITLE
Small typo fix for names that are too long

### DIFF
--- a/frontend/src/components/NewShoot/NewShootDetails.vue
+++ b/frontend/src/components/NewShoot/NewShootDetails.vue
@@ -92,7 +92,7 @@ const Purpose = () => import('@/components/Purpose')
 const validationErrors = {
   name: {
     required: 'Name is required',
-    maxLength: 'Name ist too long',
+    maxLength: 'Name is too long',
     resourceName: 'Name must only be lowercase letters, numbers and hyphens',
     unique: 'Cluster name must be unique',
     noConsecutiveHyphen: 'Cluster name must not contain consecutive hyphens',

--- a/frontend/src/components/ShootWorkers/WorkerInputGeneric.vue
+++ b/frontend/src/components/ShootWorkers/WorkerInputGeneric.vue
@@ -162,7 +162,7 @@ const validationErrors = {
   worker: {
     name: {
       required: 'Name is required',
-      maxLength: 'Name ist too long',
+      maxLength: 'Name is too long',
       resourceName: 'Name must only be lowercase letters, numbers and hyphens',
       uniqueWorkerName: 'Name is taken. Try another.',
       noStartEndHyphen: 'Name must not start or end with a hyphen'


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a typo for when user input of names is too long.

**Which issue(s) this PR fixes**:
Fixes #1404 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
