### PR TITLE
Add plutono URLs in shoots dashboards

### DIFF
--- a/frontend/src/components/ClusterMetrics.vue
+++ b/frontend/src/components/ClusterMetrics.vue
@@ -8,9 +8,9 @@ SPDX-License-Identifier: Apache-2.0
   <v-list>
     <link-list-tile
       icon="mdi-developer-board"
-      app-title="Grafana"
-      :url="grafanaUrl"
-      :url-text="grafanaUrl"
+      app-title="Plutono"
+      :url="plutonoUrl"
+      :url-text="plutonoUrl"
       :is-shoot-status-hibernated="isShootStatusHibernated"
     ></link-list-tile>
     <link-list-tile
@@ -45,8 +45,8 @@ export default {
   },
   mixins: [shootItem],
   computed: {
-    grafanaUrl () {
-      return get(this.shootItem, 'info.grafanaUrl', '')
+    plutonoUrl () {
+      return get(this.shootItem, 'info.plutonoUrl', '')
     },
     prometheusUrl () {
       return get(this.shootItem, 'info.prometheusUrl', '')

--- a/frontend/src/store/modules/shoots/index.js
+++ b/frontend/src/store/modules/shoots/index.js
@@ -176,7 +176,7 @@ const actions = {
 
       if (info.seedShootIngressDomain) {
         const baseHost = info.seedShootIngressDomain
-        info.grafanaUrl = `https://gu-${baseHost}`
+        info.plutonoUrl = `https://pl-${baseHost}`
 
         info.prometheusUrl = `https://p-${baseHost}`
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR add plutono urls as part of the migration of grafana/loki to plutono/vali. After expiring the logs retention period of two weeks we shall remove grafana URLs and remain only with plutono URLs.

**Special notes for your reviewer**:
Adding plutono URLs shall be aligned with the gardener release containing plutono workload.
Later (after the standard log retention period) removing grafana URLs shall be aligned with the gardener release removing grafana and loki workloads

Fixes https://github.com/gardener/backlog/issues/62

**Release note**:

```feature user
This release of gardener dashboards introduces the plutono URLs in the Logging and Monitoring tile.
```
