### PR TITLE
Readiness sorting improvements

### DIFF
--- a/frontend/src/components/StatusTags.vue
+++ b/frontend/src/components/StatusTags.vue
@@ -10,8 +10,8 @@ SPDX-License-Identifier: Apache-2.0
       <status-tag
         v-for="condition in conditions"
         :condition="condition"
-        :popper-key="condition.id"
-        :key="condition.id"
+        :popper-key="condition.type"
+        :key="condition.type"
         :popper-placement="popperPlacement"
         :secret-binding-name="shootSecretBindingName"
         :namespace="shootNamespace"
@@ -66,15 +66,12 @@ export default {
     ]),
     conditions () {
       const shootConditions = filter(this.shootReadiness, condition => !!condition.lastTransitionTime)
-      const conditions = map(shootConditions, condition => {
-        const { lastTransitionTime, message, status, type, codes } = condition
-        const id = type
-        const { displayName: name, shortName, description, showAdminOnly } = this.getCondition(condition.type)
-
-        return { id, name, shortName, description, message, lastTransitionTime, status, codes, showAdminOnly }
+      const conditions = map(shootConditions, conditionStatus => {
+        const condition = this.getCondition(conditionStatus.type)
+        return { ...condition, ...conditionStatus }
       })
 
-      return sortBy(conditions, 'shortName')
+      return sortBy(conditions, 'sort', 'shortName')
     },
     errorCodeObjects () {
       const allErrorCodes = errorCodesFromArray(this.conditions)
@@ -104,9 +101,9 @@ export default {
         conditionComponents = dropRight(conditionComponents)
       }
 
-      const displayName = join(conditionComponents, ' ')
+      const name = join(conditionComponents, ' ')
       const shortName = join(map(conditionComponents, first), '')
-      const conditionMetaData = { displayName, shortName }
+      const conditionMetaData = { name, shortName }
       this.setCondition({ conditionKey: type, conditionValue: conditionMetaData })
 
       return conditionMetaData

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -134,33 +134,41 @@ const state = {
   projectTerminalShortcuts: null,
   conditionCache: {
     APIServerAvailable: {
-      displayName: 'API Server',
+      name: 'API Server',
       shortName: 'API',
-      description: 'Indicates whether the shoot\'s kube-apiserver is healthy and available. If this is in error state then no interaction with the cluster is possible. The workload running on the cluster is most likely not affected.'
+      description: 'Indicates whether the shoot\'s kube-apiserver is healthy and available. If this is in error state then no interaction with the cluster is possible. The workload running on the cluster is most likely not affected.',
+      sort: '0'
     },
     ControlPlaneHealthy: {
-      displayName: 'Control Plane',
+      name: 'Control Plane',
       shortName: 'CP',
       description: 'Indicates whether all control plane components are up and running.',
-      showAdminOnly: true
+      showAdminOnly: true,
+      sort: '1'
     },
     EveryNodeReady: {
-      displayName: 'Nodes',
+      name: 'Nodes',
       shortName: 'N',
       description: 'Indicates whether all nodes registered to the cluster are healthy and up-to-date. If this is in error state there then there is probably an issue with the cluster nodes. In worst case there is currently not enough capacity to schedule all the workloads/pods running in the cluster and that might cause a service disruption of your applications.'
     },
     SystemComponentsHealthy: {
-      displayName: 'System Components',
+      name: 'System Components',
       shortName: 'SC',
-      description: 'Indicates whether all system components in the kube-system namespace are up and running. Gardener manages these system components and should automatically take care that the components become healthy again.'
+      description: 'Indicates whether all system components in the kube-system namespace are up and running. Gardener manages these system components and should automatically take care that the components become healthy again.',
+      sort: '2'
+    },
+    ObservabilityComponentsHealthy: {
+      name: 'Observability Components',
+      shortName: 'OC',
+      description: 'Indicates whether all observability components like Prometheus, Loki, Grafana, etc. are up and running. Gardener manages these system components and should automatically take care that the components become healthy again.'
     },
     MaintenancePreconditionsSatisfied: {
-      displayName: 'Maintenance Preconditions Satisfied',
+      name: 'Maintenance Preconditions Satisfied',
       shortName: 'M',
       description: 'Indicates whether Gardener is able to perform required actions during maintenance. If you do not resolve this issue your cluster will eventually turn into an error state.'
     },
     HibernationPossible: {
-      displayName: 'Hibernation Preconditions Satisfied',
+      name: 'Hibernation Preconditions Satisfied',
       shortName: 'H',
       description: 'Indicates whether Gardener is able to hibernate this cluster. If you do not resolve this issue your hibernation schedule may not have any effect.'
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
- Added sort value for known conditions
- Group readiness columns by error condition
- Added `Observability Components` to known conditions
- Fixed missing case for `technicalId` in `getRawVal` method

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed: Sort cluster list by `technical id` did not work
```

```other user
Cluster list: Known conditions now have a defined order in the readiness column. If the list is sorted by the readiness column, the clusters are now grouped by the conditions with error state. Please use the recently introduced `issue since` to sort the list without grouping
```

