### PR TITLE
Added support for `gke-gcloud-auth-plugin`

### DIFF
--- a/packages/kube-config/lib/Config.js
+++ b/packages/kube-config/lib/Config.js
@@ -25,6 +25,18 @@ class Config {
       .pick(PROPERTY_NAMES)
       .cloneDeep()
       .value()
+    for (const { user } of input.users) {
+      if (user.exec?.command === 'gke-gcloud-auth-plugin') {
+        delete user.exec
+        user['auth-provider'] = {
+          name: 'gcp',
+          config: {
+            'access-token': undefined,
+            expiry: '1970-01-01T00:00:00.000Z'
+          }
+        }
+      }
+    }
     Object.assign(this, {
       apiVersion: 'v1',
       kind: 'Config'
@@ -123,6 +135,7 @@ class Config {
           await gToken.getToken()
           authProvider.config['access-token'] = gToken.accessToken
           authProvider.config.expiry = new Date(gToken.expiresAt).toISOString()
+          break
         }
       }
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for kubeconfigs with an exec command `gke-gcloud-auth-plugin`. This case is handled in the same way as a gcp `auth-provider`. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
NONE
```
