### PR TITLE
Add kubelogin plugin for connecting kubectl.

### DIFF
--- a/docs/usage/connect-kubectl.md
+++ b/docs/usage/connect-kubectl.md
@@ -30,6 +30,7 @@ On this page:
 3. If `gardenlogin` is not installed or configured, click on the *show gardenlogin info* action to follow the installation and configuration hints.
 
    <img width="700" src="../images/03-gardenlogin-info.png">
+4. You might also need to install [kubelogin](https://github.com/int128/kubelogin#setup)
 
 ### Connecting to the cluster
 


### PR DESCRIPTION
**What this PR does / why we need it**:

`gardenlogin` was not enough for me. I also add to install `kubelogin` to be able to connect to my clusters.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
NONE
```
