### PR TITLE
Adjust the shoot ingress domain calculation

### DIFF
--- a/backend/lib/services/shoots.js
+++ b/backend/lib/services/shoots.js
@@ -293,7 +293,7 @@ exports.info = async function ({ user, namespace, name }) {
 
   if (shoot.spec.seedName) {
     const seed = getSeed(getSeedNameFromShoot(shoot))
-    const prefix = _.replace(shoot.status.technicalID, /^shoot--/, '')
+    const prefix = _.replace(shoot.status.technicalID, /^shoot-{1,2}/, '')
     if (prefix) {
       const ingressDomain = getSeedIngressDomain(seed)
       if (ingressDomain) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Adjust the shoot ingress domain calculation

With Gardener 1.64, a bug was fixed that affected technical IDs and the ingress calculations.

In older shoot clusters with a single `-` in the technical ID, the ingress domain contained the prefix `shoot-` (this was a bug), because Gardener tried to remove `shoot--` and that was not found so the `shoot-` prefix stayed in the ingress domain.

Now that the bug is fixed, the `shoot-` prefix will be removed and the logic in the Gardener Dashboard has to be adjusted as well.

See https://github.com/gardener/gardener/pull/7454

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/cc @holgerkoser @petersutter 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Adjust the shoot ingress domain calculation to a bugfix in Gardener 1.64
```
