### PR TITLE
If provided, use config.clusterIdentity to build the gardenlogin kubeconfig

### DIFF
--- a/backend/lib/services/shoots.js
+++ b/backend/lib/services/shoots.js
@@ -346,6 +346,19 @@ exports.info = async function ({ user, namespace, name }) {
   return data
 }
 
+async function getGardenClusterIdentity () {
+  const configClusterIdentity = _.get(config, 'clusterIdentity')
+
+  if (configClusterIdentity) {
+    return configClusterIdentity
+  }
+
+  const clusterIdentity = await dashboardClient.core.configmaps.get('kube-system', 'cluster-identity')
+
+  return clusterIdentity.data['cluster-identity']
+}
+exports.getGardenClusterIdentity = getGardenClusterIdentity
+
 async function getKubeconfigGardenlogin (client, shoot) {
   if (!shoot.status?.advertisedAddresses?.length) {
     throw new Error('Shoot has no advertised addresses')
@@ -467,14 +480,4 @@ async function assignMonitoringSecret (client, data, namespace, shootName) {
       })
       .commit()
   }
-}
-
-async function getGardenClusterIdentity() {
-  if(_.has(config, 'clusterIdentity')) {
-    return _.get(config, 'clusterIdentity')
-  }
-
-  const clusterIdentity = await dashboardClient.core.configmaps.get('kube-system', 'cluster-identity');
-
-  return clusterIdentity.data['cluster-identity']
 }

--- a/backend/lib/services/shoots.js
+++ b/backend/lib/services/shoots.js
@@ -15,6 +15,7 @@ const authorization = require('./authorization')
 const logger = require('../logger')
 const _ = require('lodash')
 const semver = require('semver')
+const config = require('../config')
 
 const { decodeBase64, getSeedNameFromShoot, getSeedIngressDomain, projectFilter } = utils
 const { getSeed } = cache
@@ -354,13 +355,11 @@ async function getKubeconfigGardenlogin (client, shoot) {
 
   const [
     ca,
-    clusterIdentity
+    gardenClusterIdentity
   ] = await Promise.all([
     client.core.secrets.get(namespace, `${name}.ca-cluster`),
-    dashboardClient.core.configmaps.get('kube-system', 'cluster-identity')
+    getGardenClusterIdentity()
   ])
-
-  const gardenClusterIdentity = clusterIdentity.data['cluster-identity']
 
   const caData = ca.data?.['ca.crt']
 
@@ -468,4 +467,14 @@ async function assignMonitoringSecret (client, data, namespace, shootName) {
       })
       .commit()
   }
+}
+
+async function getGardenClusterIdentity() {
+  if(_.has(config, 'clusterIdentity')) {
+    return _.get(config, 'clusterIdentity')
+  }
+
+  const clusterIdentity = await dashboardClient.core.configmaps.get('kube-system', 'cluster-identity');
+
+  return clusterIdentity.data['cluster-identity']
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
If a clusterIdentity "override" via config.yaml is present, it should be honored in the gardenlogin kubeconfig presented to the user.
**Which issue(s) this PR fixes**:
Fixes #1415 

**Special notes for your reviewer**:

**Release note**:
```
No longer ignores clusterIdentity override when building gardenlogin kubeconfig
```