### PR TITLE
Remove the use of the enableBasicAuthentication field

### DIFF
--- a/docs/usage/project-operations.md
+++ b/docs/usage/project-operations.md
@@ -252,8 +252,6 @@ To create a new cluster using the command line, you need a YAML definition of th
             location: Europe/Kiev
       kubernetes:
         allowPrivilegedContainers: true
-        kubeAPIServer:
-          enableBasicAuthentication: false
         kubeControllerManager:
           nodeCIDRMaskSize: 24
         kubeProxy:

--- a/docs/usage/shoot.yaml
+++ b/docs/usage/shoot.yaml
@@ -54,8 +54,6 @@ spec:
         location: Europe/Kiev
   kubernetes:
     allowPrivilegedContainers: true
-    kubeAPIServer:
-      enableBasicAuthentication: false
     kubeControllerManager:
       nodeCIDRMaskSize: 24
     kubeProxy:
@@ -66,4 +64,3 @@ spec:
       enabled: false
     kubernetesDashboard:
       enabled: false
-      


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove the use of the enableBasicAuthentication field

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/6911

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
NONE
```
