### PR TITLE
Support generic cloud providers

### DIFF
--- a/frontend/src/components/dialogs/SecretDialogGeneric.vue
+++ b/frontend/src/components/dialogs/SecretDialogGeneric.vue
@@ -1,0 +1,154 @@
+<!--
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+ -->
+
+ <template>
+  <secret-dialog
+    :value=value
+    :data="secretData"
+    :data-valid="valid"
+    :secret="secret"
+    :vendor="vendor"
+    :create-title="`Add new ${vendor} Secret`"
+    :replace-title="`Replace ${vendor} Secret`"
+    @input="onInput">
+
+    <template v-slot:secret-slot>
+      <div>
+        <v-textarea
+          ref="data"
+          color="primary"
+          filled
+          v-model="data"
+          label="Secret Data"
+          :error-messages="getErrorMessages('data')"
+          @input="$v.data.$touch()"
+          @blur="$v.data.$touch()"
+        ></v-textarea>
+      </div>
+    </template>
+    <template v-slot:help-slot>
+      <div class="help-content">
+        <p>
+          This is a generic provider service account dialog.
+        </p>
+        <p>
+          Please enter data required for this provider type.
+        </p>
+      </div>
+    </template>
+
+  </secret-dialog>
+
+</template>
+
+<script>
+import SecretDialog from '@/components/dialogs/SecretDialog'
+import { required } from 'vuelidate/lib/validators'
+import { getValidationErrors, setDelayedInputFocus } from '@/utils'
+
+const validationErrors = {
+  data: {
+    required: 'You can\'t leave this empty.',
+    isJSON: 'You need to enter secret data as JSON Object'
+  }
+}
+
+export default {
+  components: {
+    SecretDialog
+  },
+  props: {
+    value: {
+      type: Boolean,
+      required: true
+    },
+    secret: {
+      type: Object
+    },
+    vendor: {
+      type: String
+    }
+  },
+  data () {
+    return {
+      data: undefined,
+      validationErrors
+    }
+  },
+  validations () {
+    // had to move the code to a computed property so that the getValidationErrors method can access it
+    return this.validators
+  },
+  computed: {
+    valid () {
+      return !this.$v.$invalid
+    },
+    validators () {
+      const validators = {
+        data: {
+          required,
+          isJSON: () => { return this.secretJSON !== undefined }
+        }
+      }
+      return validators
+    },
+    isCreateMode () {
+      return !this.secret
+    },
+    secretJSON () {
+      try {
+        return JSON.parse(this.data)
+      } catch (err) {
+        return undefined
+      }
+    },
+    secretData () {
+      return this.secretJSON ?? {}
+    }
+  },
+  methods: {
+    onInput (value) {
+      this.$emit('input', value)
+    },
+    reset () {
+      this.$v.$reset()
+
+      this.data = ''
+
+      if (!this.isCreateMode) {
+        setDelayedInputFocus(this, 'data')
+      }
+    },
+    getErrorMessages (field) {
+      return getValidationErrors(this, field)
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+
+  ::v-deep .v-input__control textarea {
+    font-family: monospace;
+    font-size: 14px;
+  }
+
+    .help-content {
+    ul {
+      margin-top: 20px;
+      margin-bottom: 20px;
+      list-style-type: none;
+      border-left: 4px solid #318334 !important;
+      margin-left: 20px;
+      padding-left: 24px;
+      li {
+        font-weight: 300;
+        font-size: 16px;
+      }
+    }
+  }
+
+</style>

--- a/frontend/src/components/dialogs/SecretDialogWrapper.vue
+++ b/frontend/src/components/dialogs/SecretDialogWrapper.vue
@@ -21,26 +21,30 @@ import InfobloxDialog from '@/components/dialogs/SecretDialogInfoblox'
 import NetlifyDialog from '@/components/dialogs/SecretDialogNetlify'
 import DeleteDialog from '@/components/dialogs/SecretDialogDelete'
 import HcloudDialog from '@/components/dialogs/SecretDialogHCloud'
+import GenericDialog from '@/components/dialogs/SecretDialogGeneric'
 
 import upperFirst from 'lodash/upperFirst'
 import split from 'lodash/split'
 import head from 'lodash/head'
 
+const components = {
+  GcpDialog,
+  AzureDialog,
+  AwsDialog,
+  OpenstackDialog,
+  AlicloudDialog,
+  MetalDialog,
+  VsphereDialog,
+  CloudflareDialog,
+  InfobloxDialog,
+  NetlifyDialog,
+  HcloudDialog,
+  GenericDialog,
+  DeleteDialog
+}
+
 export default {
-  components: {
-    GcpDialog,
-    AzureDialog,
-    AwsDialog,
-    OpenstackDialog,
-    AlicloudDialog,
-    MetalDialog,
-    VsphereDialog,
-    CloudflareDialog,
-    InfobloxDialog,
-    NetlifyDialog,
-    HcloudDialog,
-    DeleteDialog
-  },
+  components,
   data () {
     return {
       visibleDialogState: false
@@ -63,7 +67,12 @@ export default {
           return 'GcpDialog'
         default: {
           const name = upperFirst(head(split(this.visibleDialog, '-')))
-          return `${name}Dialog`
+          const componentName = `${name}Dialog`
+          const componentNames = Object.keys(components)
+          if (componentNames.includes(componentName)) {
+            return componentName
+          }
+          return 'GenericDialog'
         }
       }
     }

--- a/frontend/src/mixins/shootItem.js
+++ b/frontend/src/mixins/shootItem.js
@@ -11,6 +11,7 @@ import cloneDeep from 'lodash/cloneDeep'
 import find from 'lodash/find'
 import some from 'lodash/some'
 import filter from 'lodash/filter'
+import compact from 'lodash/compact'
 import { mapGetters } from 'vuex'
 
 import {
@@ -129,7 +130,7 @@ export const shootItem = {
       return this.shootSpec.region
     },
     shootZones () {
-      return uniq(flatMap(get(this.shootSpec, 'provider.workers'), 'zones'))
+      return compact(uniq(flatMap(get(this.shootSpec, 'provider.workers'), 'zones')))
     },
     podsCidr () {
       return get(this.shootSpec, 'networking.pods')

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -740,7 +740,7 @@ const getters = {
     return uniq(map(state.cloudProfiles.all, 'metadata.cloudProviderKind'))
   },
   sortedCloudProviderKindList (state, getters) {
-    return intersection(['aws', 'azure', 'gcp', 'openstack', 'alicloud', 'metal', 'vsphere', 'hcloud'], getters.cloudProviderKindList)
+    return intersection(['aws', 'azure', 'gcp', 'openstack', 'alicloud', 'metal', 'vsphere', 'hcloud', 'local'], getters.cloudProviderKindList)
   },
   sortedDnsProviderList (state, getters) {
     const supportedProviderTypes = ['aws-route53', 'azure-dns', 'azure-private-dns', 'google-clouddns', 'openstack-designate', 'alicloud-dns', 'infoblox-dns', 'netlify-dns']

--- a/frontend/src/store/modules/shoots/index.js
+++ b/frontend/src/store/modules/shoots/index.js
@@ -228,6 +228,11 @@ const actions = {
       }
     }
 
+    if (!rootGetters.sortedCloudProviderKindList.length) {
+      Vue.logger.warn('Could not reset new shoot resource as there is no supported cloud profile')
+      return
+    }
+
     const infrastructureKind = head(rootGetters.sortedCloudProviderKindList)
     set(shootResource, 'spec', getSpecTemplate(infrastructureKind, rootGetters.nodesCIDR))
 

--- a/frontend/src/utils/createShoot.js
+++ b/frontend/src/utils/createShoot.js
@@ -180,6 +180,10 @@ function getProviderTemplate (infrastructureKind, defaultWorkerCIDR) {
           kind: 'ControlPlaneConfig'
         }
       }
+    default:
+      return {
+        type: infrastructureKind
+      }
   }
 }
 

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -533,6 +533,8 @@ export function isZonedCluster ({ cloudProviderKind, shootSpec, isNewCluster }) 
       return get(shootSpec, 'provider.infrastructureConfig.zoned', false)
     case 'metal':
       return false // metal clusters do not support zones for worker groups
+    case 'local':
+      return false // local development provider does not support zones
     default:
       return true
   }

--- a/frontend/src/views/Secrets.vue
+++ b/frontend/src/views/Secrets.vue
@@ -57,7 +57,13 @@ SPDX-License-Identifier: Apache-2.0
         ></table-column-selection>
       </v-toolbar>
 
-      <v-card-text v-if="!infrastructureSecretItems.length">
+      <v-card-text v-if="!sortedCloudProviderKindList.length">
+        <v-alert class="ma-3" type="warning">
+          No supported cloud profile found.
+          Ensure that you have confiugred at least one cloud profile supported by the dashboard as well as a corresponding seed.
+        </v-alert>
+      </v-card-text>
+      <v-card-text v-else-if="!infrastructureSecretItems.length">
         <div class="text-h6 grey--text text--darken-1 my-4">Add Infrastructure Secrets to your project</div>
         <p class="text-body-1">
           Before you can provision and access a Kubernetes cluster, you need to add infrastructure account credentials. The Gardener needs the credentials to provision and operate the infrastructure for your Kubernetes cluster.

--- a/frontend/src/views/Secrets.vue
+++ b/frontend/src/views/Secrets.vue
@@ -457,6 +457,13 @@ export default {
               value: secretData.hcloudToken
             }
           ]
+        default:
+          return [
+            {
+              label: 'Secret Data',
+              value: JSON.stringify(secretData)
+            }
+          ]
       }
     },
     getSecretDetailsDns (secret) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR has several improvements regarding unsupported cloud providers.

***If no (valid) cloud provider is configured that the dashboard supports, this will no longer result in an fatal error 500. Instead this will be rendered as an information in the dashboard***
<img width="989" alt="Screenshot 2023-02-28 at 14 47 42" src="https://user-images.githubusercontent.com/35373687/222105210-e607239c-5e44-455d-9771-970416a59888.png">
<img width="993" alt="Screenshot 2023-02-28 at 14 48 04" src="https://user-images.githubusercontent.com/35373687/222105219-90f27f07-2fc9-450a-85a6-f985ae0821e1.png">

***Added a generic secret dialog as well as fallback implementation for all required code parts. Start implementing support for a new cloud provider is now as simple as adding the name of the new provider to the list of supported providers***

***Added support for Gardener `local` infrastructure provider***
<img width="1178" alt="Screenshot 2023-03-01 at 10 48 36" src="https://user-images.githubusercontent.com/35373687/222106912-be2e745e-8375-4bcd-a5ea-7e904e573f08.png">
<img width="741" alt="Screenshot 2023-03-01 at 10 54 44" src="https://user-images.githubusercontent.com/35373687/222106916-918e3721-7d8b-4870-86be-c76be2727805.png">

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
If no (valid) cloud provider is configured that the dashboard supports, this will no longer result in an fatal error 500. Instead this will be rendered as an information in the dashboard
```
```feature developer
Added a generic secret dialog as well as fallback implementation for all required code parts. Start implementing support for a new cloud provider is now as simple as adding the name of the new provider to the list of supported providers (`supportedProviderTypes` in store/index.js)
```
```feature developer
Added support for `local` infrastructure provider. This allows to use the dashboard with local gardener installations. See also: [Deploying Gardener locally](https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally.md)
```