### PR TITLE
Support alpine architecture `x86_64` and `aarch64`

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -12,6 +12,10 @@ dashboard:
           'inject-commit-hash'
         inject_effective_version: true
       publish:
+        oci-builder: docker-buildx
+        platforms:
+        - linux/amd64
+        - linux/arm64
         dockerimages:
           dashboard:
             inputs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,9 @@ RUN apk add --no-cache tini \
     && chown 1000:1000 ./home/node \
     # libc, libgcc and libstdc++ libraries
     && mkdir -p ./lib ./usr/lib \
-    && cp -d /lib/ld-musl-x86_64.so.* ./lib \
-    && cp -d /lib/libc.musl-x86_64.so.* ./lib \
+    && alpineArch="$(apk --print-arch)" \
+    && cp -d /lib/ld-musl-$alpineArch.so.* ./lib \
+    && cp -d /lib/libc.musl-$alpineArch.so.* ./lib \
     && cp -d /usr/lib/libgcc_s.so.* ./usr/lib \
     && cp -d /usr/lib/libstdc++.so.* ./usr/lib
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Support alpine architecture `x86_64` and `aarch64`

**Which issue(s) this PR fixes**:
Fixes #1437

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
The make build command now also works for new macbooks with ARM processor
```
