### PR TITLE
Remove limits in default values

### DIFF
--- a/charts/__tests__/gardener-dashboard/runtime/bootstrapper/__snapshots__/deployment.spec.js.snap
+++ b/charts/__tests__/gardener-dashboard/runtime/bootstrapper/__snapshots__/deployment.spec.js.snap
@@ -87,10 +87,6 @@ Object {
               "timeoutSeconds": 5,
             },
             "resources": Object {
-              "limits": Object {
-                "cpu": "250m",
-                "memory": "512Mi",
-              },
               "requests": Object {
                 "cpu": "100m",
                 "memory": "100Mi",

--- a/charts/__tests__/gardener-dashboard/runtime/dashboard/__snapshots__/deployment.spec.js.snap
+++ b/charts/__tests__/gardener-dashboard/runtime/dashboard/__snapshots__/deployment.spec.js.snap
@@ -188,10 +188,6 @@ Object {
               "timeoutSeconds": 5,
             },
             "resources": Object {
-              "limits": Object {
-                "cpu": "1.0",
-                "memory": "1Gi",
-              },
               "requests": Object {
                 "cpu": "100m",
                 "memory": "350Mi",

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -53,9 +53,6 @@ global:
     metricsContainerPort: 9050
     servicePort: 8080
     resources:
-      limits:
-        cpu: "1.0"
-        memory: 1Gi
       requests:
         cpu: 100m
         memory: 350Mi
@@ -363,9 +360,6 @@ global:
       requests:
         cpu: 100m
         memory: 100Mi
-      limits:
-        cpu: 250m
-        memory: 512Mi
     nodeOptions: [--max-old-space-size=460]
     readinessProbe:
       initialDelaySeconds: 5

--- a/charts/identity/values.yaml
+++ b/charts/identity/values.yaml
@@ -11,9 +11,6 @@ image:
 containerPort: 5556
 servicePort: 5556
 resources:
-  limits:
-    cpu: 200m
-    memory: 128Mi
   requests:
     cpu: 100m
     memory: 64Mi


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove limit defaults from helm charts for gardener-dashboard and identity

**Which issue(s) this PR fixes**:
Fixes #1448 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Remove limit defaults from helm charts for gardener-dashboard and identity
```
