### PR TITLE
Run the helm chart unit tests as part of the pipeline check step.

### DIFF
--- a/.ci/check
+++ b/.ci/check
@@ -23,16 +23,12 @@ yarn install --immutable --immutable-cache --check-cache
 # Install helm
 VERSION="3.11.1"
 BASE_URL="https://get.helm.sh"
-case `uname -m` in
-  x86_64) ARCH=amd64; ;;
-  aarch64) ARCH=arm64; ;;
-  *) echo "un-supported arch, exit ..."; exit 1; ;;
-esac
-apk add --update --no-cache wget
-wget ${BASE_URL}/helm-v${VERSION}-linux-${ARCH}.tar.gz -O - | tar -xz
-mv linux-${ARCH}/helm /usr/bin/helm
-chmod +x /usr/bin/helm
-rm -rf linux-${ARCH}
+ARCH="$(uname -m | sed 's/x86_64/amd64/')"
+mkdir -p "${SOURCE_PATH}/bin"
+curl -sSL "${BASE_URL}/helm-v${VERSION}-linux-${ARCH}.tar.gz" | tar -xz -C "${SOURCE_PATH}/bin" --strip-components=1 "linux-${ARCH}/helm"
+chmod +x "${SOURCE_PATH}/bin/helm"
+# Add the bin directory to the PATH
+export PATH="${SOURCE_PATH}/bin:$PATH"
 
 # Run the helm chart unit tests
 yarn workspace @gardener-dashboard/charts run test

--- a/.ci/check
+++ b/.ci/check
@@ -20,16 +20,19 @@ cd "${SOURCE_PATH}"
 # the checksums of the packages are not consistent
 yarn install --immutable --immutable-cache --check-cache
 
-# Install helm
-VERSION="3.11.1"
-BASE_URL="https://get.helm.sh"
-ARCH="$(uname -m | sed 's/x86_64/amd64/')"
-mkdir -p "${SOURCE_PATH}/bin"
-curl -sSL "${BASE_URL}/helm-v${VERSION}-linux-${ARCH}.tar.gz" | tar -xz -C "${SOURCE_PATH}/bin" --strip-components=1 "linux-${ARCH}/helm"
-chmod +x "${SOURCE_PATH}/bin/helm"
-
 # Add the bin directory to the PATH
+mkdir -p "${SOURCE_PATH}/bin"
 export PATH="${SOURCE_PATH}/bin:$PATH"
+
+# Install helm if it does not exist
+if [ ! -f "${SOURCE_PATH}/bin/helm" ]; then
+  VERSION="3.11.1"
+  BASE_URL="https://get.helm.sh"
+  ARCH="$(uname -m | sed 's/x86_64/amd64/')"
+  KERNEL="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  wget ${BASE_URL}/helm-v${VERSION}-${KERNEL}-${ARCH}.tar.gz -O - | tar -xz -C "${SOURCE_PATH}/bin" --strip-components=1 "${KERNEL}-${ARCH}/helm"
+  chmod +x "${SOURCE_PATH}/bin/helm"
+fi
 
 # Run the helm chart unit tests
 yarn workspace @gardener-dashboard/charts run test

--- a/.ci/check
+++ b/.ci/check
@@ -20,5 +20,19 @@ cd "${SOURCE_PATH}"
 # the checksums of the packages are not consistent
 yarn install --immutable --immutable-cache --check-cache
 
+# Install helm
+VERSION="3.11.1"
+BASE_URL="https://get.helm.sh"
+case `uname -m` in
+  x86_64) ARCH=amd64; ;;
+  aarch64) ARCH=arm64; ;;
+  *) echo "un-supported arch, exit ..."; exit 1; ;;
+esac
+apk add --update --no-cache wget
+wget ${BASE_URL}/helm-v${VERSION}-linux-${ARCH}.tar.gz -O - | tar -xz
+mv linux-${ARCH}/helm /usr/bin/helm
+chmod +x /usr/bin/helm
+rm -rf linux-${ARCH}
+
 # Run the helm chart unit tests
 yarn workspace @gardener-dashboard/charts run test

--- a/.ci/check
+++ b/.ci/check
@@ -27,6 +27,7 @@ ARCH="$(uname -m | sed 's/x86_64/amd64/')"
 mkdir -p "${SOURCE_PATH}/bin"
 curl -sSL "${BASE_URL}/helm-v${VERSION}-linux-${ARCH}.tar.gz" | tar -xz -C "${SOURCE_PATH}/bin" --strip-components=1 "linux-${ARCH}/helm"
 chmod +x "${SOURCE_PATH}/bin/helm"
+
 # Add the bin directory to the PATH
 export PATH="${SOURCE_PATH}/bin:$PATH"
 

--- a/.ci/check
+++ b/.ci/check
@@ -19,3 +19,6 @@ cd "${SOURCE_PATH}"
 # the cache folder was to be modified or
 # the checksums of the packages are not consistent
 yarn install --immutable --immutable-cache --check-cache
+
+# Run the helm chart unit tests
+yarn workspace @gardener-dashboard/charts run test

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -44,7 +44,7 @@ dashboard:
         check:
           image: 'node:18-alpine3.17'
         check-docforge:
-          image: 'eu.gcr.io/gardener-project/3rd/golang:1.16.7'
+          image: 'golang:1.20.2'
     release:
       traits:
         version:

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -42,7 +42,7 @@ dashboard:
         pull-request: ~
       steps:
         check:
-          image: 'eu.gcr.io/gardener-project/3rd/node:16-alpine3.15'
+          image: 'node:18-alpine3.17'
         check-docforge:
           image: 'eu.gcr.io/gardener-project/3rd/golang:1.16.7'
     release:

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ scripts/bin
 # other files to ignore
 .DS_Store
 node_modules/
+bin/
 dist/
 tmp/
 coverage/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -43,6 +43,7 @@
     ".pre-commit-config.yaml": true,
     ".secrets.baseline": true,
     ".docforge": true,
+    "bin": true,
     "logo": true,
     "LICENSES": true,
     "**/node_modules": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -38,12 +38,7 @@
   "files.exclude": {
     ".pnp.*": true,
     ".yarn": true,
-    ".vscode": false,
-    "yarn.lock": true,
-    ".pre-commit-config.yaml": true,
-    ".secrets.baseline": true,
     ".docforge": true,
-    "bin": true,
     "logo": true,
     "LICENSES": true,
     "**/node_modules": true,

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ############# builder #############
-FROM node:18-alpine3.16 as builder
+FROM node:18-alpine3.17 as builder
 
 WORKDIR /volume
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Run the helm chart unit tests as part of the pipeline check step. This ensures that the master branch contains chart templates with failing unit tests.

<img width="640" alt="image" src="https://user-images.githubusercontent.com/1574023/227041596-5ed626ce-edb5-44eb-bd3b-87fd27a8b4ce.png">

**Which issue(s) this PR fixes**:
Fixes #1450 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Run the helm chart unit tests as part of the pipeline check step.
```
