### PR TITLE
fix: deleting just created comment was not propagated to UI

### DIFF
--- a/backend/lib/github/webhook/router.js
+++ b/backend/lib/github/webhook/router.js
@@ -25,9 +25,8 @@ router.route('/')
   .post(middlewares, async (req, res, next) => {
     try {
       const eventName = req.headers['x-github-event']
-      const eventData = req.body
 
-      await handleGithubEvent(eventName, eventData)
+      await handleGithubEvent(eventName)
       res.status(204).end()
     } catch (err) {
       next(err)

--- a/backend/lib/utils/index.js
+++ b/backend/lib/utils/index.js
@@ -95,11 +95,6 @@ function isSeedUnreachable (seed) {
   return _.isMatch(seed, { metadata: { labels: matchLabels } })
 }
 
-function isDateValid (dateOrDateString) {
-  const date = dateOrDateString instanceof Date ? dateOrDateString : new Date(dateOrDateString)
-  return !isNaN(date.getTime())
-}
-
 module.exports = {
   decodeBase64,
   encodeBase64,
@@ -108,6 +103,5 @@ module.exports = {
   getSeedNameFromShoot,
   shootHasIssue,
   isSeedUnreachable,
-  getSeedIngressDomain,
-  isDateValid
+  getSeedIngressDomain
 }

--- a/backend/test/acceptance/webhook.spec.js
+++ b/backend/test/acceptance/webhook.spec.js
@@ -90,9 +90,7 @@ describe('github', function () {
         .set('x-hub-signature-256', fixtures.github.createHubSignature(body))
         .type('application/json')
         .send(body)
-        .expect((res) => {
-          expect(res.status).toEqual(422)
-        })
+        .expect(422)
 
       expect(mockRequest).toBeCalledTimes(0)
     })

--- a/backend/test/github.spec.js
+++ b/backend/test/github.spec.js
@@ -19,8 +19,6 @@ const actualNextTick = jest.requireActual('process').nextTick
 
 const { UnprocessableEntity, InternalServerError } = createError
 
-jest.useFakeTimers().setSystemTime(new Date('2023-01-01 00:00:00Z'))
-
 const flushPromises = () => new Promise(actualNextTick)
 // NOTE: if during an advance action a new timeout with a delay of 0(ms)
 // shall be triggered we need to call this fn again but with 1ms as param.
@@ -29,29 +27,32 @@ const advanceTimersAndFlushPromises = async (ms) => {
   await flushPromises()
 }
 
-describe('github webhook', function () {
+describe('github webhook', () => {
+  const now = new Date('2006-01-02T15:04:05.000Z')
+
   describe('handler', () => {
     const namespace = fixtures.env.POD_NAMESPACE
     const holderIdentity = fixtures.env.POD_NAME
     const leaseName = 'gardener-dashboard-github-webhook'
-    const microDateStr = '2006-01-02T15:04:05.000000Z'
+    const microDateStr = now.toISOString().replace(/Z$/, '000Z')
     const dateStr = new Date(microDateStr).toISOString()
     let mergePatchStub
+
+    beforeAll(() => {
+      jest.useFakeTimers().setSystemTime(now)
+    })
 
     beforeEach(() => {
       mergePatchStub = jest.spyOn(dashboardClient['coordination.k8s.io'].leases, 'mergePatch')
       mergePatchStub.mockResolvedValue({})
     })
 
-    it('should throw an error in case of unknown event', async () => {
-      await expect(handleGithubEvent('unknown', null)).rejects.toThrow(UnprocessableEntity)
+    afterAll(() => {
+      jest.useRealTimers()
     })
 
-    it('should error in case of missing properties in payload', async () => {
-      let data = { issue: {} }
-      await expect(handleGithubEvent('issues', data)).rejects.toThrow(UnprocessableEntity)
-      data = { comment: {} }
-      await expect(handleGithubEvent('issue_comment', data)).rejects.toThrow(UnprocessableEntity)
+    it('should throw an error in case of unknown event', async () => {
+      await expect(handleGithubEvent('unknown', null)).rejects.toThrow(UnprocessableEntity)
     })
 
     it('should update the lease object for an issue event', async () => {
@@ -150,11 +151,10 @@ describe('github webhook', function () {
     const loadTicketsDuration = 500
 
     beforeAll(() => {
-      jest.setSystemTime(new Date('2023-01-01 00:00:00Z'))
+      jest.useFakeTimers().setSystemTime(now)
     })
 
     beforeEach(() => {
-      jest.resetAllMocks()
       abortController = new AbortController()
       loadTicketsStub = jest.fn().mockImplementation(() => {
         return new Promise((resolve) => {

--- a/backend/test/github.spec.js
+++ b/backend/test/github.spec.js
@@ -42,13 +42,13 @@ describe('github webhook', () => {
       jest.useFakeTimers().setSystemTime(now)
     })
 
+    afterAll(() => {
+      jest.useRealTimers()
+    })
+
     beforeEach(() => {
       mergePatchStub = jest.spyOn(dashboardClient['coordination.k8s.io'].leases, 'mergePatch')
       mergePatchStub.mockResolvedValue({})
-    })
-
-    afterAll(() => {
-      jest.useRealTimers()
     })
 
     it('should throw an error in case of unknown event', async () => {


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes an issue with the previously merged [PR#1400](https://github.com/gardener/dashboard/pull/1400).
Previously the `updated_at` field, provided in the data from the GitHub webhook, from the the issue/comment was used as value for the `renewTime` field in the patch operation of the k8s Lease-object. If an issue (or comment) is created and deleted immediatly after the `updated_at` field remains the same. Hence the data in the patch call is identical to the data of the resource which does not trigger our change listener on the lease object.

So we now always use the current system time instead to ensure that there always is a change when patching the resource.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
