### PR TITLE
Allow configuration of the service `sessionAffinity` 

### DIFF
--- a/charts/__tests__/gardener-dashboard/runtime/dashboard/deployment.spec.js
+++ b/charts/__tests__/gardener-dashboard/runtime/dashboard/deployment.spec.js
@@ -95,6 +95,20 @@ describe('gardener-dashboard', function () {
       expect(container.args).toBeUndefined()
     })
 
+    it('should render the template with three replicas', async function () {
+      const values = {
+        global: {
+          dashboard: {
+            replicaCount: 3
+          }
+        }
+      }
+      const documents = await renderTemplates(templates, values)
+      expect(documents).toHaveLength(1)
+      const [deployment] = documents
+      expect(deployment.spec.replicas).toBe(values.global.dashboard.replicaCount)
+    })
+
     describe('kubeconfig', function () {
       it('should render the template', async function () {
         const values = {

--- a/charts/__tests__/gardener-dashboard/runtime/dashboard/service.spec.js
+++ b/charts/__tests__/gardener-dashboard/runtime/dashboard/service.spec.js
@@ -27,5 +27,19 @@ describe('gardener-dashboard', function () {
       const [service] = documents
       expect(service).toMatchSnapshot()
     })
+
+    it('should render the template with sessionAffinity None', async function () {
+      const values = {
+        global: {
+          dashboard: {
+            sessionAffinity: 'None'
+          }
+        }
+      }
+      const documents = await renderTemplates(templates, values)
+      expect(documents).toHaveLength(1)
+      const [service] = documents
+      expect(service.spec.sessionAffinity).toBe(values.global.dashboard.sessionAffinity)
+    })
   })
 })

--- a/charts/gardener-dashboard/charts/runtime/templates/dashboard/service.yaml
+++ b/charts/gardener-dashboard/charts/runtime/templates/dashboard/service.yaml
@@ -20,5 +20,5 @@ spec:
     app.kubernetes.io/name: gardener-dashboard
     app.kubernetes.io/component: dashboard
   type: ClusterIP
-  sessionAffinity: ClientIP
+  sessionAffinity: {{ .Values.global.dashboard.sessionAffinity }}
 {{- end }}

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -6,6 +6,8 @@ global:
   dashboard:
     enabled: true
     replicaCount: 1
+    # If connections from a particular client should not be passed to the same Pod each time, set the session affinity to "None".
+    sessionAffinity: ClientIP
 
     image:
       repository: eu.gcr.io/gardener-project/gardener/dashboard


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow configuration of the service `sessionAffinity` 

**Which issue(s) this PR fixes**:
Fixes #1458 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```enh operator
The `sessionAffinity` of the dashboard service can now be configured via the property `.values.global.dashboard.sessionAffinity`. The default is still `"ClientIP"` but will be changed to `"None"` in future dashboard versions. If you want sticky session in the future you should explicitly configure it and not rely on the default anymore.
```
