### PR TITLE
Rename prometheus metric for monitoring HTTP request durations in seconds

### DIFF
--- a/backend/lib/api.js
+++ b/backend/lib/api.js
@@ -16,6 +16,7 @@ const hooks = require('./hooks')()
 const { authenticate } = require('./security')
 const { createClient } = require('@gardener-dashboard/kube-client')
 const { notFound, sendError, requestLogger } = require('./middleware')
+const { monitorResponseTimes } = require('@gardener-dashboard/monitor')
 // configure router
 const router = express.Router()
 
@@ -24,6 +25,7 @@ router.use(compression({
   level: zlib.constants.Z_DEFAULT_COMPRESSION
 }))
 router.use(requestLogger)
+router.use(monitorResponseTimes())
 router.use(cookieParser())
 router.use(bodyParser.json())
 router.use(authenticate({ createClient }))

--- a/backend/lib/app.js
+++ b/backend/lib/app.js
@@ -16,7 +16,6 @@ const { notFound, renderError, historyFallback, noCache } = require('./middlewar
 const helmet = require('helmet')
 const api = require('./api')
 const auth = require('./auth')
-const { monitorResponseTimes } = require('@gardener-dashboard/monitor')
 const githubWebhook = require('./github/webhook')
 
 const { healthCheck } = require('./healthz')
@@ -58,9 +57,7 @@ app.use(helmet.noSniff())
 app.use(helmet.hsts())
 app.use(noCache(['/js', '/css', '/fonts', '/img', '/static']))
 app.use('/auth', auth.router)
-app.use('/webhook', monitorResponseTimes())
 app.use('/webhook', githubWebhook.router)
-app.use('/api', monitorResponseTimes())
 app.use('/api', api.router)
 
 app.use(helmet.xssFilter())

--- a/backend/lib/github/webhook/router.js
+++ b/backend/lib/github/webhook/router.js
@@ -9,6 +9,7 @@
 const express = require('express')
 const bodyParser = require('body-parser')
 const { requestLogger } = require('../../middleware')
+const { monitorResponseTimes } = require('@gardener-dashboard/monitor')
 const handleGithubEvent = require('./handler')
 const verify = require('./verify')
 
@@ -18,6 +19,7 @@ const router = express.Router()
 // under a different path or before other (auth) middlewares and handlers.
 const middlewares = [
   requestLogger,
+  monitorResponseTimes(),
   bodyParser.json({ verify })
 ]
 

--- a/packages/monitor/lib/metrics.js
+++ b/packages/monitor/lib/metrics.js
@@ -10,19 +10,23 @@ const promClient = require('prom-client')
 
 const connectionsCount = new promClient.Gauge({
   name: 'tcp_connections_count',
-  labelNames: ['type'],
-  help: 'dashboard currently open connections'
+  help: 'Number of currently open TCP connections',
+  labelNames: ['type']
 })
 const connectionsTotal = new promClient.Counter({
   name: 'tcp_connections_total',
-  labelNames: ['type'],
-  help: 'dashboard total opened connections'
+  help: 'Total number of opened TCP connections',
+  labelNames: ['type']
 })
 const responseTime = new promClient.Histogram({
-  name: 'http_response_duration_seconds',
-  help: 'Time to first byte for requests served in seconds',
+  name: 'http_request_duration_seconds',
+  help: 'HTTP request duration in seconds',
   labelNames: ['method', 'route', 'status_code'],
-  buckets: [0.1, 0.2, 0.3, 0.5, 1.0, 1.5, 2.0, 3.0, 5.0, 10.0, 15.0]
+  buckets: [
+    1e-1, 2e-1, 3e-1, 5e-1,
+    1e+0, 2e+0, 3e+0, 5e+0,
+    1e+1, 2e+1
+  ]
 })
 
 module.exports = {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR renames the prometheus metric for monitoring HTTP request durations in seconds to the commonly used name
```
http_request_duration_seconds
```
The buckets were adjusted so that they correspond more to a logarithmic scale.
The usage of the metrics middleware has been moved from the backend app into the individual router implementations.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
NONE
```
