### PR TITLE
[master] Do not use lookbehind regex assertions

### DIFF
--- a/frontend/src/store/modules/shoots/helper.js
+++ b/frontend/src/store/modules/shoots/helper.js
@@ -156,7 +156,10 @@ export function getCondition (type) {
   let shortName = ''
   const words = type
     .replace(/(Available|Healthy|Ready|Availability)$/, '')
-    .split(/(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])/)
+    .replace(/([a-z])([A-Z])/g, '$1 $2') // split groups of uppercase letters
+    .replace(/([A-Z])([A-Z][a-z])/g, '$1 $2') // split remaining groups of uppercase letters
+    .split(' ')
+
   for (const word of words) {
     if (name) {
       name += ' '

--- a/frontend/src/store/modules/shoots/helper.js
+++ b/frontend/src/store/modules/shoots/helper.js
@@ -156,8 +156,10 @@ export function getCondition (type) {
   let shortName = ''
   const words = type
     .replace(/(Available|Healthy|Ready|Availability)$/, '')
-    .replace(/([a-z])([A-Z])/g, '$1 $2') // split groups of uppercase letters
-    .replace(/([A-Z])([A-Z][a-z])/g, '$1 $2') // split remaining groups of uppercase letters
+    // Cannot use lookbehind regex as not supported by all browsers (e.g. Safari)
+    // therefore need to do it in two steps
+    .replace(/([a-z])([A-Z])/g, '$1 $2') // split before new words
+    .replace(/([A-Z])([A-Z][a-z])/g, '$1 $2')// split after uppercase only words
     .split(' ')
 
   for (const word of words) {


### PR DESCRIPTION
Do not use lookbehind regex assertions as they are not supported by safari browser

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
