### PR TITLE
`terminal-bootstrap`: Use default/kubernetes service for `Seed` - Ingress in `default` namespace

### DIFF
--- a/backend/lib/services/terminals/utils.js
+++ b/backend/lib/services/terminals/utils.js
@@ -110,7 +110,7 @@ function getKubeApiServerHostForShoot (shoot, seed) {
 
 function getKubeApiServerHostForSeed (seed) {
   const ingressDomain = getSeedIngressDomain(seed)
-  return `k-g.${ingressDomain}`
+  return `k-d.${ingressDomain}`
 }
 
 function getGardenTerminalHostClusterRefType () {

--- a/backend/test/acceptance/__snapshots__/api.terminals.spec.js.snap
+++ b/backend/test/acceptance/__snapshots__/api.terminals.spec.js.snap
@@ -649,7 +649,7 @@ Array [
 exports[`api terminals garden should create a terminal resource 2`] = `
 Object {
   "hostCluster": Object {
-    "kubeApiServer": "k-g.ingress.foo-west.infra1.example.org",
+    "kubeApiServer": "k-d.ingress.foo-west.infra1.example.org",
     "namespace": "term-host-21",
   },
   "imageHelpText": "Dummy Image Description",
@@ -953,7 +953,7 @@ Array [
 exports[`api terminals garden should reuse a terminal session 2`] = `
 Object {
   "hostCluster": Object {
-    "kubeApiServer": "k-g.ingress.foo-west.infra1.example.org",
+    "kubeApiServer": "k-d.ingress.foo-west.infra1.example.org",
     "namespace": "term-host-1",
   },
   "imageHelpText": "Foo Image Description",

--- a/backend/test/services.terminals.spec.js
+++ b/backend/test/services.terminals.spec.js
@@ -415,7 +415,7 @@ describe('services', function () {
           }
           terminalStub.mockReturnValue(createTerminalConfig({ gardenTerminalHost }))
           const kubeApiServer = await getGardenHostClusterKubeApiServer(client)
-          const expectedKubeApiServer = `k-g.${ingressDomain}`
+          const expectedKubeApiServer = `k-d.${ingressDomain}`
           expect(kubeApiServer).toBe(expectedKubeApiServer)
         })
 

--- a/packages/terminal-bootstrap/__tests__/__snapshots__/terminal.bootstrap.test.js.snap
+++ b/packages/terminal-bootstrap/__tests__/__snapshots__/terminal.bootstrap.test.js.snap
@@ -1063,7 +1063,7 @@ Object {
   ],
   "mockSoilIngressesMergePatch": Array [
     Array [
-      "garden",
+      "default",
       "dashboard-terminal-kube-apiserver-soil-infra1",
       Object {
         "apiVersion": "networking.k8s.io/v1",
@@ -1081,13 +1081,13 @@ Object {
         "spec": Object {
           "rules": Array [
             Object {
-              "host": "k-g.ingress.foo-east.infra1.example.org",
+              "host": "k-d.ingress.foo-east.infra1.example.org",
               "http": Object {
                 "paths": Array [
                   Object {
                     "backend": Object {
                       "service": Object {
-                        "name": "dashboard-terminal-kube-apiserver-soil-infra1",
+                        "name": "kubernetes",
                         "port": Object {
                           "number": 443,
                         },

--- a/packages/terminal-bootstrap/__tests__/__snapshots__/terminal.bootstrap.test.js.snap
+++ b/packages/terminal-bootstrap/__tests__/__snapshots__/terminal.bootstrap.test.js.snap
@@ -766,7 +766,6 @@ Object {
         "metadata": Object {
           "annotations": Object {
             "foo": "bar",
-            "kubernetes.io/ingress.class": "bar",
           },
           "labels": Object {
             "component": "dashboard-terminal",
@@ -775,6 +774,7 @@ Object {
           "ownerReferences": Array [],
         },
         "spec": Object {
+          "ingressClassName": "bar",
           "rules": Array [
             Object {
               "host": "k-178qqdk.ingress.foo-east.infra1.example.org",
@@ -846,7 +846,6 @@ Object {
         "metadata": Object {
           "annotations": Object {
             "foo": "bar",
-            "kubernetes.io/ingress.class": "bar",
           },
           "labels": Object {
             "component": "dashboard-terminal",

--- a/packages/terminal-bootstrap/__tests__/terminal.utils.test.js
+++ b/packages/terminal-bootstrap/__tests__/terminal.utils.test.js
@@ -206,7 +206,7 @@ describe('terminal', () => {
         expect(logger.info).toBeCalledWith(`Bootstrapping Seed ${name} aborted as 'spec.secretRef' on the seed is missing`)
       })
 
-      it('should set the ingress class annotations', async () => {
+      it('should set the ingress class', async () => {
         const terminalConfig = fixtures.helper.createTerminalConfig({
           gardenTerminalHost: {
             seedRef: name
@@ -229,11 +229,10 @@ describe('terminal', () => {
             apiVersion: 'networking.k8s.io/v1',
             kind: 'Ingress',
             metadata: expect.objectContaining({
-              name: `dashboard-terminal-kube-apiserver-${name}`,
-              annotations: {
-                foo: 'bar',
-                'kubernetes.io/ingress.class': 'test'
-              }
+              name: `dashboard-terminal-kube-apiserver-${name}`
+            }),
+            spec: expect.objectContaining({
+              ingressClassName: 'test'
             })
           })
         ])

--- a/packages/terminal-bootstrap/__tests__/terminal.utils.test.js
+++ b/packages/terminal-bootstrap/__tests__/terminal.utils.test.js
@@ -223,7 +223,7 @@ describe('terminal', () => {
         await expect(ensureTrustedCertForSeedApiServer(client, seed)).resolves.toBeUndefined()
         expect(mockSoilIngressesMergePatch).toBeCalledTimes(1)
         expect(mockSoilIngressesMergePatch.mock.calls[0]).toEqual([
-          'garden',
+          'default',
           `dashboard-terminal-kube-apiserver-${name}`,
           expect.objectContaining({
             apiVersion: 'networking.k8s.io/v1',

--- a/packages/terminal-bootstrap/lib/terminal/resources.js
+++ b/packages/terminal-bootstrap/lib/terminal/resources.js
@@ -98,7 +98,7 @@ async function replaceResource (resource, { namespace, name, body, dryRun }) {
   }
 }
 
-function replaceIngressApiServer (client, { namespace, name, host, tlsHost, serviceName, ownerReferences, annotations, secretName }) {
+function replaceIngressApiServer (client, { namespace, name, host, tlsHost, serviceName, ownerReferences, annotations, secretName, ingressClassName }) {
   if (!secretName) {
     secretName = `${name}-tls`
   }
@@ -133,6 +133,10 @@ function replaceIngressApiServer (client, { namespace, name, host, tlsHost, serv
         secretName
       }
     ]
+  }
+
+  if (ingressClassName) {
+    spec.ingressClassName = ingressClassName
   }
 
   const body = toIngressResource({ name, annotations, spec, ownerReferences })

--- a/packages/terminal-bootstrap/lib/terminal/utils.js
+++ b/packages/terminal-bootstrap/lib/terminal/utils.js
@@ -245,10 +245,7 @@ async function ensureTrustedCertForShootApiServer (client, shoot, seed) {
   const serviceName = 'kube-apiserver'
   const annotations = _.get(config, 'terminal.bootstrap.apiServerIngress.annotations')
 
-  const ingressClass = _.get(seed, 'metadata.annotations["seed.gardener.cloud/ingress-class"]')
-  if (ingressClass && annotations) {
-    annotations['kubernetes.io/ingress.class'] = ingressClass
-  }
+  const ingressClassName = _.get(seed, 'metadata.annotations["seed.gardener.cloud/ingress-class"]')
 
   await replaceIngressApiServer(seedClient, {
     name: TERMINAL_KUBE_APISERVER,
@@ -256,7 +253,8 @@ async function ensureTrustedCertForShootApiServer (client, shoot, seed) {
     serviceName,
     host: apiServerIngressHost,
     tlsHost: seedWildcardIngressDomain,
-    annotations
+    annotations,
+    ingressClassName
   })
 }
 
@@ -306,10 +304,7 @@ async function ensureTrustedCertForSeedApiServer (client, seed) {
   const seedWildcardIngressDomain = getWildcardIngressDomainForSeed(seed)
   const annotations = _.get(config, 'terminal.bootstrap.apiServerIngress.annotations')
 
-  const ingressClass = _.get(seed, 'metadata.annotations["seed.gardener.cloud/ingress-class"]')
-  if (ingressClass && annotations) {
-    annotations['kubernetes.io/ingress.class'] = ingressClass
-  }
+  const ingressClassName = _.get(seed, 'metadata.annotations["seed.gardener.cloud/ingress-class"]')
 
   await replaceIngressApiServer(seedClient, {
     name: `${TERMINAL_KUBE_APISERVER}-${seedName}`,
@@ -317,7 +312,8 @@ async function ensureTrustedCertForSeedApiServer (client, seed) {
     serviceName: 'kubernetes',
     host: apiServerIngressHost,
     tlsHost: seedWildcardIngressDomain,
-    annotations
+    annotations,
+    ingressClassName
   })
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Instead of managing the `Service` (and `Endpoint`) for the kube-apiserver of the `Seed`, use the `kubernetes` `Service` in the default namespace. This requires the `Ingress` to be created in the `default` namespace.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
