### PR TITLE
[hotfix-1.68] terminal-bootstrap: Use default/kubernetes service for Seed

### DIFF
--- a/packages/terminal-bootstrap/__fixtures__/clients.js
+++ b/packages/terminal-bootstrap/__fixtures__/clients.js
@@ -128,7 +128,8 @@ const hostClient = {
       mergePatch: jest.fn((...args) => Promise.resolve(args[2]))
     },
     endpoints: {
-      mergePatch: jest.fn((...args) => Promise.resolve(args[2]))
+      mergePatch: jest.fn((...args) => Promise.resolve(args[2])),
+      delete: jest.fn()
     }
   },
   'networking.k8s.io': {
@@ -150,6 +151,9 @@ const soilClient = {
   core: {
     services: {
       mergePatch: jest.fn((...args) => Promise.resolve(args[2]))
+    },
+    endpoints: {
+      delete: jest.fn()
     }
   },
   'networking.k8s.io': {
@@ -190,7 +194,9 @@ const mockShootsListAllNamespaces = gardenClient['core.gardener.cloud'].shoots.l
 const mockManagedSeedsGet = gardenClient['seedmanagement.gardener.cloud'].managedseeds.get
 const mockHostServicesCreate = hostClient.core.services.create
 const mockHostServicesMergePatch = hostClient.core.services.mergePatch
+const mockSoilServicesMergePatch = soilClient.core.services.mergePatch
 const mockHostEndpointsMergePatch = hostClient.core.endpoints.mergePatch
+const mockSoilEndpointsDelete = soilClient.core.endpoints.delete
 const mockHostIngressesCreate = hostClient['networking.k8s.io'].ingresses.create
 const mockHostIngressesMergePatch = hostClient['networking.k8s.io'].ingresses.mergePatch
 const mockSoilIngressesMergePatch = soilClient['networking.k8s.io'].ingresses.mergePatch
@@ -208,7 +214,9 @@ const mocks = {
   mockManagedSeedsGet,
   mockHostServicesCreate,
   mockHostServicesMergePatch,
+  mockSoilServicesMergePatch,
   mockHostEndpointsMergePatch,
+  mockSoilEndpointsDelete,
   mockHostIngressesCreate,
   mockHostIngressesMergePatch,
   mockSoilIngressesMergePatch,

--- a/packages/terminal-bootstrap/__tests__/__snapshots__/terminal.bootstrap.test.js.snap
+++ b/packages/terminal-bootstrap/__tests__/__snapshots__/terminal.bootstrap.test.js.snap
@@ -1061,6 +1061,12 @@ Object {
       "soil-infra1",
     ],
   ],
+  "mockSoilEndpointsDelete": Array [
+    Array [
+      "garden",
+      "dashboard-terminal-kube-apiserver-soil-infra1",
+    ],
+  ],
   "mockSoilIngressesMergePatch": Array [
     Array [
       "garden",
@@ -1108,6 +1114,37 @@ Object {
               "secretName": "dashboard-terminal-kube-apiserver-soil-infra1-tls",
             },
           ],
+        },
+      },
+    ],
+  ],
+  "mockSoilServicesMergePatch": Array [
+    Array [
+      "garden",
+      "dashboard-terminal-kube-apiserver-soil-infra1",
+      Object {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": Object {
+          "annotations": Object {},
+          "labels": Object {
+            "component": "dashboard-terminal",
+          },
+          "name": "dashboard-terminal-kube-apiserver-soil-infra1",
+          "namespace": "garden",
+          "ownerReferences": Array [],
+        },
+        "spec": Object {
+          "clusterIP": undefined,
+          "externalName": "kubernetes.default.svc.cluster.local.",
+          "ports": Array [
+            Object {
+              "port": 443,
+              "protocol": "TCP",
+              "targetPort": 6443,
+            },
+          ],
+          "type": "ExternalName",
         },
       },
     ],

--- a/packages/terminal-bootstrap/__tests__/__snapshots__/terminal.bootstrap.test.js.snap
+++ b/packages/terminal-bootstrap/__tests__/__snapshots__/terminal.bootstrap.test.js.snap
@@ -129,7 +129,7 @@ Object {
         },
         "spec": Object {
           "clusterIP": "None",
-          "externalName": undefined,
+          "externalName": "",
           "ports": Array [
             Object {
               "port": 443,
@@ -137,7 +137,7 @@ Object {
               "targetPort": 6443,
             },
           ],
-          "type": undefined,
+          "type": "ClusterIP",
         },
       },
     ],

--- a/packages/terminal-bootstrap/__tests__/terminal.utils.test.js
+++ b/packages/terminal-bootstrap/__tests__/terminal.utils.test.js
@@ -190,7 +190,9 @@ describe('terminal', () => {
       const {
         gardenClient: client,
         mocks: {
-          mockSoilIngressesMergePatch
+          mockSoilIngressesMergePatch,
+          mockSoilServicesMergePatch,
+          mockSoilEndpointsDelete
         }
       } = fixtures.clients
       const name = 'soil-infra1'
@@ -222,6 +224,8 @@ describe('terminal', () => {
         mockConfigTerminal.mockReturnValue(terminalConfig)
         await expect(ensureTrustedCertForSeedApiServer(client, seed)).resolves.toBeUndefined()
         expect(mockSoilIngressesMergePatch).toBeCalledTimes(1)
+        expect(mockSoilServicesMergePatch).toBeCalledTimes(1)
+        expect(mockSoilEndpointsDelete).toBeCalledTimes(1)
         expect(mockSoilIngressesMergePatch.mock.calls[0]).toEqual([
           'garden',
           `dashboard-terminal-kube-apiserver-${name}`,
@@ -234,6 +238,23 @@ describe('terminal', () => {
                 foo: 'bar',
                 'kubernetes.io/ingress.class': 'test'
               }
+            })
+          })
+        ])
+        expect(mockSoilServicesMergePatch.mock.calls[0]).toEqual([
+          'garden',
+          `dashboard-terminal-kube-apiserver-${name}`,
+          expect.objectContaining({
+            apiVersion: 'v1',
+            kind: 'Service',
+            metadata: expect.objectContaining({
+              name: 'dashboard-terminal-kube-apiserver-soil-infra1',
+              namespace: 'garden'
+            }),
+            spec: expect.objectContaining({
+              clusterIP: undefined,
+              externalName: 'kubernetes.default.svc.cluster.local.',
+              type: 'ExternalName'
             })
           })
         ])

--- a/packages/terminal-bootstrap/lib/terminal/resources.js
+++ b/packages/terminal-bootstrap/lib/terminal/resources.js
@@ -172,8 +172,10 @@ function replaceEndpointApiServer (client, { namespace, name, ip, port, ownerRef
   })
 }
 
-function replaceServiceApiServer (client, { namespace, name, externalName, ownerReferences, clusterIP = 'None', targetPort }) {
-  let type
+function replaceServiceApiServer (client, { namespace, name, externalName = '', ownerReferences, targetPort }) {
+  let type = 'ClusterIP'
+  let clusterIP = 'None'
+
   if (externalName) {
     type = 'ExternalName'
     clusterIP = undefined
@@ -188,7 +190,7 @@ function replaceServiceApiServer (client, { namespace, name, externalName, owner
         targetPort
       }
     ],
-    type, // optional
+    type,
     externalName // optional
   }
 

--- a/packages/terminal-bootstrap/lib/terminal/resources.js
+++ b/packages/terminal-bootstrap/lib/terminal/resources.js
@@ -202,6 +202,21 @@ function replaceServiceApiServer (client, { namespace, name, externalName, owner
   })
 }
 
+async function deleteEndpointApiServer (client, { namespace, name }) {
+  if (client[kDryRun] === true) {
+    logger.info('Deleting resource v1, Kind=Endpoint was skipped in dry run mode')
+    return
+  }
+
+  try {
+    await client.core.endpoints.delete(namespace, name)
+  } catch (err) {
+    if (!isHttpError(err, 404)) {
+      throw err
+    }
+  }
+}
+
 module.exports = {
   TERMINAL_KUBE_APISERVER,
   toResource,
@@ -211,5 +226,6 @@ module.exports = {
   replaceResource,
   replaceIngressApiServer,
   replaceServiceApiServer,
-  replaceEndpointApiServer
+  replaceEndpointApiServer,
+  deleteEndpointApiServer
 }

--- a/packages/terminal-bootstrap/lib/terminal/utils.js
+++ b/packages/terminal-bootstrap/lib/terminal/utils.js
@@ -22,7 +22,8 @@ const {
   TERMINAL_KUBE_APISERVER,
   replaceIngressApiServer,
   replaceServiceApiServer,
-  replaceEndpointApiServer
+  replaceEndpointApiServer,
+  deleteEndpointApiServer
 } = require('./resources')
 
 const { kDryRun } = require('./symbols')
@@ -345,6 +346,8 @@ async function ensureTrustedCertForApiServer (client, options) {
 
     service = await replaceServiceApiServer(client, { namespace, name, targetPort: port })
   } else {
+    await deleteEndpointApiServer(client, { namespace, name })
+
     const externalName = apiServerHostname
     service = await replaceServiceApiServer(client, { namespace, name, externalName, targetPort: port })
   }

--- a/packages/terminal-bootstrap/lib/terminal/utils.js
+++ b/packages/terminal-bootstrap/lib/terminal/utils.js
@@ -317,12 +317,20 @@ async function ensureTrustedCertForSeedApiServer (client, seed) {
     name: `${TERMINAL_KUBE_APISERVER}-${seedName}`,
     apiServerIngressHost,
     tlsHost: seedWildcardIngressDomain,
-    ingressAnnotations
+    ingressAnnotations,
+    apiServerHostname: 'kubernetes.default.svc.cluster.local.'
   })
 }
 
-async function ensureTrustedCertForApiServer (client, { namespace, name, apiServerIngressHost, tlsHost, ingressAnnotations }) {
-  const apiServerHostname = client.cluster.server.hostname
+async function ensureTrustedCertForApiServer (client, options) {
+  const {
+    namespace,
+    name,
+    apiServerIngressHost,
+    tlsHost,
+    ingressAnnotations,
+    apiServerHostname = client.cluster.server.hostname
+  } = options
 
   let port = parseInt(client.cluster.server.port)
   if (isNaN(port)) {


### PR DESCRIPTION
**What this PR does / why we need it**:
The `dashboard-terminal-kube-apiserver-${seedName}` `Service` points to the `default/kubernetes` `Service`, instead of the external URL of the kube apiserver

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The `dashboard-terminal-kube-apiserver-${seedName}` `Service` now points to the `default/kubernetes` `Service`, instead of the external URL of the kube apiserver
```
