### PR TITLE
Adapt `NetworkPolicy`s

### DIFF
--- a/charts/__tests__/gardener-dashboard/runtime/bootstrapper/__snapshots__/deployment.spec.js.snap
+++ b/charts/__tests__/gardener-dashboard/runtime/bootstrapper/__snapshots__/deployment.spec.js.snap
@@ -35,6 +35,9 @@ Object {
           "app.kubernetes.io/managed-by": "Helm",
           "app.kubernetes.io/name": "gardener-dashboard",
           "helm.sh/chart": "gardener-dashboard-runtime-0.1.0",
+          "networking.gardener.cloud/to-dns": "allowed",
+          "networking.gardener.cloud/to-public-networks": "allowed",
+          "networking.resources.gardener.cloud/to-virtual-garden-kube-apiserver-tcp-443": "allowed",
         },
       },
       "spec": Object {

--- a/charts/__tests__/gardener-dashboard/runtime/dashboard/__snapshots__/deployment.spec.js.snap
+++ b/charts/__tests__/gardener-dashboard/runtime/dashboard/__snapshots__/deployment.spec.js.snap
@@ -105,6 +105,9 @@ Object {
           "app.kubernetes.io/managed-by": "Helm",
           "app.kubernetes.io/name": "gardener-dashboard",
           "helm.sh/chart": "gardener-dashboard-runtime-0.1.0",
+          "networking.gardener.cloud/to-dns": "allowed",
+          "networking.gardener.cloud/to-public-networks": "allowed",
+          "networking.resources.gardener.cloud/to-virtual-garden-kube-apiserver-tcp-443": "allowed",
         },
       },
       "spec": Object {

--- a/charts/gardener-dashboard/charts/runtime/templates/bootstrapper/deployment.yaml
+++ b/charts/gardener-dashboard/charts/runtime/templates/bootstrapper/deployment.yaml
@@ -24,6 +24,9 @@ spec:
         helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
         app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+        networking.gardener.cloud/to-dns: allowed
+        networking.gardener.cloud/to-public-networks: allowed
+        networking.resources.gardener.cloud/to-virtual-garden-kube-apiserver-tcp-443: allowed
         {{- if .Values.global.bootstrapper.podLabels }}
         {{- toYaml .Values.global.bootstrapper.podLabels | nindent 8 }}
         {{- end }}

--- a/charts/gardener-dashboard/charts/runtime/templates/dashboard/deployment.yaml
+++ b/charts/gardener-dashboard/charts/runtime/templates/dashboard/deployment.yaml
@@ -39,6 +39,9 @@ spec:
         helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
         app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+        networking.gardener.cloud/to-dns: allowed
+        networking.gardener.cloud/to-public-networks: allowed
+        networking.resources.gardener.cloud/to-virtual-garden-kube-apiserver-tcp-443: allowed
         {{- if .Values.global.dashboard.podLabels }}
         {{- toYaml .Values.global.dashboard.podLabels | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security networking
/kind enhancement

**What this PR does / why we need it**:
This PR adapts the `NetworkPolicy`s as following:

- egress traffic to DNS and to the virtual garden kube-apiserver is allowed
- egress to public networks is allowed (to reach GitHub API and seed/shoot API server)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The Helm chart are now adapted such that they work well in garden cluster with enabled `NetworkPolicy` protection (default since `gardener/gardener@v1.71` when garden cluster is managed by `gardener-operator`).
```
