### PR TITLE
Set dashboard ingress.spec.ingressClassName to nginx

### DIFF
--- a/charts/__tests__/gardener-dashboard/runtime/dashboard/__snapshots__/ingress.spec.js.snap
+++ b/charts/__tests__/gardener-dashboard/runtime/dashboard/__snapshots__/ingress.spec.js.snap
@@ -21,6 +21,7 @@ Object {
     "namespace": "garden",
   },
   "spec": Object {
+    "ingressClassName": "nginx",
     "rules": Array [
       Object {
         "host": "dashboard.garden.example.org",

--- a/charts/gardener-dashboard/charts/runtime/templates/dashboard/ingress.yaml
+++ b/charts/gardener-dashboard/charts/runtime/templates/dashboard/ingress.yaml
@@ -13,6 +13,7 @@ metadata:
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
   annotations: {{ toYaml .Values.global.dashboard.ingress.annotations | nindent 4 }}
 spec:
+  ingressClassName: {{ .Values.global.dashboard.ingress.ingressClassName }}
 {{- if .Values.global.dashboard.ingress.tls }}
   tls:
   - secretName: {{ required ".Values.global.dashboard.ingress.tls.secretName is required" .Values.global.dashboard.ingress.tls.secretName }}

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -65,6 +65,7 @@ global:
     nodeOptions: [--max-old-space-size=920]
 
     ingress:
+      ingressClassName: nginx
       annotations:
         nginx.ingress.kubernetes.io/ssl-redirect: "true"
         nginx.ingress.kubernetes.io/use-port-in-redirects: "true"


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds `ingressClassName: nginx` to the Dashboard ingress.

With https://github.com/gardener/gardener/pull/7945 we want to install nginx-ingress-controller through gardener-operator.

The currently deployed runtime nginx-ingress-controller uses the following argument `--watch-ingress-without-class=true` which reads the Class through deprecated kubernetes.io/ingress.class annotation.

With that change `--watch-ingress-without-class=true` argument is not needed when the nginx-controller is installed through the gardener-operator. Will leave the old annotation for now.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Set dashboard ingress.spec.ingressClassName to nginx
```
