### PR TITLE
Replace references to Grafana and Loki with Plutono and Vali

### DIFF
--- a/backend/lib/services/shoots.js
+++ b/backend/lib/services/shoots.js
@@ -339,7 +339,7 @@ exports.info = async function ({ user, namespace, name }) {
     as we agreed that also project viewers should be able to see the monitoring credentials.
     Usually project viewers do not have the permission to read the <shootName>.monitoring credential.
     Our assumption: if the user can read the shoot resource, the user can be considered as project viewer.
-    This is only a temporary workaround until a Grafana SSO solution is implemented https://github.com/gardener/monitoring/issues/11.
+    This is only a temporary workaround until a Plutono SSO solution is implemented https://github.com/gardener/monitoring/issues/11.
   */
   await assignMonitoringSecret(dashboardClient, data, namespace, name)
 

--- a/frontend/src/components/ClusterMetrics.vue
+++ b/frontend/src/components/ClusterMetrics.vue
@@ -8,9 +8,9 @@ SPDX-License-Identifier: Apache-2.0
   <v-list>
     <link-list-tile
       icon="mdi-developer-board"
-      app-title="Grafana"
-      :url="grafanaUrl"
-      :url-text="grafanaUrl"
+      app-title="Plutono"
+      :url="plutonoUrl"
+      :url-text="plutonoUrl"
       :is-shoot-status-hibernated="isShootStatusHibernated"
     ></link-list-tile>
     <link-list-tile
@@ -45,8 +45,8 @@ export default {
   },
   mixins: [shootItem],
   computed: {
-    grafanaUrl () {
-      return get(this.shootItem, 'info.grafanaUrl', '')
+    plutonoUrl () {
+      return get(this.shootItem, 'info.plutonoUrl', '')
     },
     prometheusUrl () {
       return get(this.shootItem, 'info.prometheusUrl', '')

--- a/frontend/src/store/modules/shoots/helper.js
+++ b/frontend/src/store/modules/shoots/helper.js
@@ -130,7 +130,7 @@ const wellKnownConditions = {
   ObservabilityComponentsHealthy: {
     name: 'Observability Components',
     shortName: 'OC',
-    description: 'Indicates whether all observability components like Prometheus, Loki, Grafana, etc. are up and running. Gardener manages these system components and should automatically take care that the components become healthy again.',
+    description: 'Indicates whether all observability components like Prometheus, Vali, Plutono, etc. are up and running. Gardener manages these system components and should automatically take care that the components become healthy again.',
     sortOrder: '4'
   },
   MaintenancePreconditionsSatisfied: {

--- a/frontend/src/store/modules/shoots/index.js
+++ b/frontend/src/store/modules/shoots/index.js
@@ -176,7 +176,7 @@ const actions = {
 
       if (info.seedShootIngressDomain) {
         const baseHost = info.seedShootIngressDomain
-        info.grafanaUrl = `https://gu-${baseHost}`
+        info.plutonoUrl = `https://gu-${baseHost}`
 
         info.prometheusUrl = `https://p-${baseHost}`
 


### PR DESCRIPTION
**What this PR does / why we need it**:

In https://github.com/gardener/gardener/pull/7318 we replaced Grafana and Loki with Plutono/Vali. These changes should be reflected in the dashboard. The ingress URL is unchanged for now, because there is a separate migration planned for that. This PR is about textual consistency and does not change any functionality or behavior. It therefore does not require a simultaneous release with the g/g changes.

If you want to learn more about the motivation for this change, please refer to the PR above and the associated issues.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
/cc @istvanballok 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
The terms Grafana and Loki are replaced with Plutono and Vali to reflect the change in gardener/gardener v1.71.0.
```
