### PR TITLE
[hotfix-1.69] Remove `kubernetes.io/ingress.class` annotation in values.yaml

### DIFF
--- a/charts/__fixtures__/gardener-dashboard.js
+++ b/charts/__fixtures__/gardener-dashboard.js
@@ -26,8 +26,7 @@ const defaults = {
       ingress: {
         annotations: {
           'nginx.ingress.kubernetes.io/ssl-redirect': 'true',
-          'nginx.ingress.kubernetes.io/use-port-in-redirects': 'true',
-          'kubernetes.io/ingress.class': 'nginx'
+          'nginx.ingress.kubernetes.io/use-port-in-redirects': 'true'
         },
         hosts: [
           'dashboard.garden.example.org',

--- a/charts/__tests__/gardener-dashboard/runtime/dashboard/__snapshots__/ingress.spec.js.snap
+++ b/charts/__tests__/gardener-dashboard/runtime/dashboard/__snapshots__/ingress.spec.js.snap
@@ -6,7 +6,6 @@ Object {
   "kind": "Ingress",
   "metadata": Object {
     "annotations": Object {
-      "kubernetes.io/ingress.class": "nginx",
       "nginx.ingress.kubernetes.io/ssl-redirect": "true",
       "nginx.ingress.kubernetes.io/use-port-in-redirects": "true",
     },

--- a/charts/__tests__/gardener-dashboard/runtime/dashboard/ingress.spec.js
+++ b/charts/__tests__/gardener-dashboard/runtime/dashboard/ingress.spec.js
@@ -95,5 +95,24 @@ describe('gardener-dashboard', function () {
 
       expect(tlsSecret).toBe(null)
     })
+
+    it('should render the template nginx class', async function () {
+      templates = ['ingress']
+
+      const ingressClassName = 'my-class'
+      const values = {
+        global: {
+          dashboard: {
+            ingress: {
+              ingressClassName
+            }
+          }
+        }
+      }
+      const documents = await renderTemplates(templates, values)
+      expect(documents).toHaveLength(1)
+      const [ingress] = documents
+      expect(ingress.spec.ingressClassName).toBe(ingressClassName)
+    })
   })
 })

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -73,7 +73,6 @@ global:
       annotations:
         nginx.ingress.kubernetes.io/ssl-redirect: "true"
         nginx.ingress.kubernetes.io/use-port-in-redirects: "true"
-        kubernetes.io/ingress.class: nginx
       # # configuration of hosts used for rules and tls
       # hosts:
       # - dashboard.ingress.example.org


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue where the helm deployment failed with the error 
```
Helm upgrade failed: failed to create resource: Ingress.extensions "gardener-dashboard-ingress" is invalid: annotations.kubernetes.io/ingress.class: Invalid value: "nginx": can not be set when the class field is also set
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed an issue where the helm deployment failed with the error `annotations.kubernetes.io/ingress.class: Invalid value: "nginx": can not be set when the class field is also set`
```
```breaking operator
The default ingress class annotation under `Values.global.dashboard.ingress.annotations['kubernetes.io/ingress.class']` will not be set anymore. Instead, the ingress class name will be set using `Values.global.dashboard.ingress.ingressClassName`
```