### PR TITLE
Introduce basic branding functionality

### DIFF
--- a/docs/whitelabeling.md
+++ b/docs/whitelabeling.md
@@ -1,0 +1,42 @@
+# Customization
+This document describes possibilities to customize the gardener dashboard
+as deployed on Kubernetes. This can help in offering whitelabeling features
+to customers.
+
+We assume one deployment of the dashboard for each customized or whitelabeled
+gardener-dashboard. We strive for minimal modifications needed in the source
+code to allow for whitelabeling configurations.
+
+## Theming
+Gardener-Dashboard is using the Vue.js-Framework and allows for using the
+Vue.js Theming options. For documentation see deployment/theming.md
+
+## Logo
+The logo is served at `/static/assets/logo.svg` and can be found in the
+source at `/frontend/public/static/assets/logo.svg`. This is also changed
+with by the theming capabilities.
+
+## Customizing Product Name
+You can customize some values by providing a custom `login-config.json`.
+Available parameters are:
+```json
+{
+  "productName": "John Doe's KE",
+  "productSlogan": "Universal Kubernetes at Scale",
+  "documentationURL": "https://example.org/docs",
+  "supportURL": "https://example.org/support",
+  "customLandingPagePre": "Find out who",
+  "landingPageUrl": "https://example.org/john",
+  "landingPageName": "John Doe",
+  "customLandingPagePost": "really is",
+  "loginTypes": ["token"]
+}
+```
+This file is found at `frontend/public/login-config.json` and served
+as `/login-config-json`. You can see all parameters in the source at
+`frontend/src/views/Login.vue`.
+
+To avoid uneccessary network latency, the `login-config.json` is fetched
+by the Login-Page only and the values are then copied in the Browsers
+sessionStorage. This means that during development you might have to
+logout and login again to see the changes reflected on the rendered pages.

--- a/docs/whitelabeling.md
+++ b/docs/whitelabeling.md
@@ -17,7 +17,7 @@ source at `/frontend/public/static/assets/logo.svg`. This is also changed
 with by the theming capabilities.
 
 ## Customizing Product Name
-You can customize some values by providing a custom `login-config.json`.
+You can customize some values by providing a custom `branding.json`.
 Available parameters are:
 ```json
 {
@@ -32,11 +32,5 @@ Available parameters are:
   "loginTypes": ["token"]
 }
 ```
-This file is found at `frontend/public/login-config.json` and served
-as `/login-config-json`. You can see all parameters in the source at
-`frontend/src/views/Login.vue`.
-
-To avoid uneccessary network latency, the `login-config.json` is fetched
-by the Login-Page only and the values are then copied in the Browsers
-sessionStorage. This means that during development you might have to
-logout and login again to see the changes reflected on the rendered pages.
+This file is found at `frontend/public/branding.json` and served
+as `/branding-json`.

--- a/frontend/public/branding.json
+++ b/frontend/public/branding.json
@@ -1,0 +1,12 @@
+{
+  "productName": "",
+  "productSlogan": "Universal Kubernetes at Scale",
+  "loginDocumentationURL": "https://gardener.cloud/docs",
+  "loginSupportURL": "https://gardener.cloud",
+  "loginLandingPagePre": "Discover what our service is about at the",
+  "loginLandingPageUrl": "https://gardener.cloud",
+  "loginLandingPageName": "Gardener Landing Page",
+  "loginLandingPagePost": "",
+  "mainNavShowVersion": true,
+  "mainNavLogoOnly": false
+}

--- a/frontend/public/login-config.json
+++ b/frontend/public/login-config.json
@@ -1,4 +1,11 @@
 {
-  "landingPageUrl": "https://gardener.cloud/",
-  "loginTypes": ["oidc", "token"]
+  "productName": "",
+  "productSlogan": "Universal Kubernetes at Scale",
+  "documentationURL": "https://gardener.cloud/docs",
+  "supportURL": "https://gardener.cloud",
+  "customLandingPagePre": "Discover what our service is about at the",
+  "landingPageUrl": "https://gardener.cloud",
+  "landingPageName": "Gardener Landing Page",
+  "customLandingPagePost": "",
+  "loginTypes": ["token"]
 }

--- a/frontend/public/login-config.json
+++ b/frontend/public/login-config.json
@@ -1,11 +1,3 @@
 {
-  "productName": "",
-  "productSlogan": "Universal Kubernetes at Scale",
-  "documentationURL": "https://gardener.cloud/docs",
-  "supportURL": "https://gardener.cloud",
-  "customLandingPagePre": "Discover what our service is about at the",
-  "landingPageUrl": "https://gardener.cloud",
-  "landingPageName": "Gardener Landing Page",
-  "customLandingPagePost": "",
   "loginTypes": ["token"]
 }

--- a/frontend/src/components/MainNavigation.vue
+++ b/frontend/src/components/MainNavigation.vue
@@ -19,8 +19,10 @@ SPDX-License-Identifier: Apache-2.0
           </v-btn>
           <a href="/">
             <img src="/static/assets/logo.svg" class="logo" alt="gardener logo">
-            <h1 class="main-navigation-title--text">{{ productName }} <span class="version">{{version}}</span></h1>
-            <h2 class="primary--text">{{ customSubheader }}</h2>
+            <template v-if="!logoOnly">
+              <h1 v-if="productName" class="main-navigation-title--text">{{ productName }} <span v-if="showVersion" class="version">{{version}}</span></h1>
+              <h2 v-if="productSlogan" class="primary--text mt-2">{{ productSlogan }}</h2>
+            </template>
           </a>
         </div>
       </div>
@@ -200,16 +202,23 @@ export default {
     ]),
     ...mapGetters([
       'canCreateProject',
-      'projectList'
+      'projectList',
+      'branding'
     ]),
     version () {
       return get(this.cfg, 'appVersion', process.env.VUE_APP_VERSION)
     },
-    productName () {
-      return sessionStorage.getItem('wl.productName') || 'Gardener'
+    logoOnly () {
+      return this.branding.mainNavLogoOnly
     },
-    customSubheader () {
-      return sessionStorage.getItem('wl.productSlogan') || 'Universal Kubernetes at Scale'
+    showVersion () {
+      return this.branding.mainNavShowVersion
+    },
+    productName () {
+      return this.branding.productName
+    },
+    productSlogan () {
+      return this.branding.productSlogan
     },
     isActive: {
       get () {

--- a/frontend/src/components/MainNavigation.vue
+++ b/frontend/src/components/MainNavigation.vue
@@ -19,8 +19,8 @@ SPDX-License-Identifier: Apache-2.0
           </v-btn>
           <a href="/">
             <img src="/static/assets/logo.svg" class="logo" alt="gardener logo">
-            <h1 class="main-navigation-title--text">Gardener <span class="version">{{version}}</span></h1>
-            <h2 class="primary--text">Universal Kubernetes at Scale</h2>
+            <h1 class="main-navigation-title--text">{{ productName }} <span class="version">{{version}}</span></h1>
+            <h2 class="primary--text">{{ customSubheader }}</h2>
           </a>
         </div>
       </div>
@@ -204,6 +204,12 @@ export default {
     ]),
     version () {
       return get(this.cfg, 'appVersion', process.env.VUE_APP_VERSION)
+    },
+    productName () {
+      return sessionStorage.getItem('wl.productName') || 'Gardener'
+    },
+    customSubheader () {
+      return sessionStorage.getItem('wl.productSlogan') || 'Universal Kubernetes at Scale'
     },
     isActive: {
       get () {

--- a/frontend/src/components/MainToolbar.vue
+++ b/frontend/src/components/MainToolbar.vue
@@ -33,7 +33,7 @@ SPDX-License-Identifier: Apache-2.0
         </template>
         <v-card tile width="300px">
           <v-card-title primary-title>
-            <div class="content text-h6 mb-2">Gardener</div>
+            <div class="content text-h6 mb-2">{{ productName }}</div>
           </v-card-title>
           <v-divider></v-divider>
           <v-card-actions class="px-3">
@@ -242,6 +242,9 @@ export default {
     },
     settingsLink () {
       return this.targetRoute('Settings')
+    },
+    productName () {
+      return sessionStorage.getItem('wl.productName') || 'Gardener'
     },
     colorSchemeIndex: {
       get () {

--- a/frontend/src/components/MainToolbar.vue
+++ b/frontend/src/components/MainToolbar.vue
@@ -221,7 +221,7 @@ export default {
       'colorScheme'
     ]),
     helpMenuItems () {
-      return this.cfg.helpMenuItems || [{}]
+      return this.cfg.helpMenuItems || {}
     },
     tabs () {
       const tabs = get(this.$route, 'meta.tabs')

--- a/frontend/src/components/MainToolbar.vue
+++ b/frontend/src/components/MainToolbar.vue
@@ -213,14 +213,15 @@ export default {
       'username',
       'displayName',
       'avatarUrl',
-      'isAdmin'
+      'isAdmin',
+      'branding'
     ]),
     ...mapGetters('storage', [
       'autoLoginEnabled',
       'colorScheme'
     ]),
     helpMenuItems () {
-      return this.cfg.helpMenuItems || {}
+      return this.cfg.helpMenuItems || [{}]
     },
     tabs () {
       const tabs = get(this.$route, 'meta.tabs')
@@ -244,7 +245,7 @@ export default {
       return this.targetRoute('Settings')
     },
     productName () {
-      return sessionStorage.getItem('wl.productName') || 'Gardener'
+      return this.branding.productName
     },
     colorSchemeIndex: {
       get () {

--- a/frontend/src/components/dialogs/InfoDialog.vue
+++ b/frontend/src/components/dialogs/InfoDialog.vue
@@ -67,10 +67,11 @@ export default {
   computed: {
     ...mapGetters([
       'isAdmin',
-      'gardenerExtensionsList'
+      'gardenerExtensionsList',
+      'branding'
     ]),
     productName () {
-      return sessionStorage.getItem('wl.productName') || 'Gardener'
+      return this.branding.productName
     },
     extensionsList () {
       return sortBy(this.gardenerExtensionsList, 'name')

--- a/frontend/src/components/dialogs/InfoDialog.vue
+++ b/frontend/src/components/dialogs/InfoDialog.vue
@@ -15,9 +15,9 @@ SPDX-License-Identifier: Apache-2.0
     <template v-slot:caption>About</template>
     <template v-slot:message>
       <div class="d-flex flex-row align-center mt-3">
-        <img src="/static/assets/logo.svg" alt="gardener logo" class="logo mr-3">
+        <img src="/static/assets/logo.svg" alt="product logo" class="logo mr-3">
         <div>
-          <h2 class="mb-1">Gardener Dashboard</h2>
+          <h2 class="mb-1">{{ productName }} Dashboard</h2>
         </div>
       </div>
       <v-divider class="my-3"></v-divider>
@@ -25,7 +25,7 @@ SPDX-License-Identifier: Apache-2.0
         <div class="font-weight-bold">Version Information</div>
         <div v-if="!!dashboardVersion">Dashboard<span class="ml-1 font-weight-bold">{{dashboardVersion}}</span></div>
         <template v-if="isAdmin">
-          <div v-if="!!gardenerVersion">API<span class="ml-1 font-weight-bold">{{gardenerVersion}}</span></div>
+          <div v-if="!!gardenerVersion">Gardener API<span class="ml-1 font-weight-bold">{{gardenerVersion}}</span></div>
           <v-divider v-if="extensionsList.length" class="my-3"></v-divider>
           <div v-if="extensionsList.length" class="font-weight-bold">Extensions ({{extensionsList.length}} deployed)</div>
           <div
@@ -69,6 +69,9 @@ export default {
       'isAdmin',
       'gardenerExtensionsList'
     ]),
+    productName () {
+      return sessionStorage.getItem('wl.productName') || 'Gardener'
+    },
     extensionsList () {
       return sortBy(this.gardenerExtensionsList, 'name')
     }

--- a/frontend/src/router/guards.js
+++ b/frontend/src/router/guards.js
@@ -6,12 +6,13 @@
 
 import includes from 'lodash/includes'
 import isEmpty from 'lodash/isEmpty'
-import { getConfiguration } from '@/utils/api'
+import { getBrandingConfiguration, getConfiguration } from '@/utils/api'
 
 export default function createGuards (store, userManager, localStorage, logger) {
   return {
     beforeEach: [
       setLoading(store, true),
+      ensureBrandingLoaded(store),
       ensureUserAuthenticatedForNonPublicRoutes(store, userManager, logger),
       ensureDataLoaded(store, localStorage, logger)
     ],
@@ -154,6 +155,21 @@ function ensureDataLoaded (store, localStorage, logger) {
           break
         }
       }
+      next()
+    } catch (err) {
+      next(err)
+    }
+  }
+}
+
+function ensureBrandingLoaded (store) {
+  return async (to, from, next) => {
+    try {
+      if (!store.state.branding) {
+        const { data } = await getBrandingConfiguration()
+        await store.dispatch('setBranding', data)
+      }
+
       next()
     } catch (err) {
       next(err)

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -346,6 +346,9 @@ function decorateClassificationObject (obj) {
 
 // getters
 const getters = {
+  branding (state) {
+    return get(state, 'branding')
+  },
   apiServerUrl (state) {
     return get(state.cfg, 'apiServerUrl', window.location.origin)
   },
@@ -1473,6 +1476,9 @@ const actions = {
       await dispatch('setError', { message: `Failed to Reset Service Account ${err.message}` })
     }
   },
+  setBranding ({ commit, getters }, value) {
+    commit('SET_BRANDING', value)
+  },
   setConfiguration ({ commit, getters }, value) {
     commit('SET_CONFIGURATION', value)
 
@@ -1561,6 +1567,9 @@ const actions = {
 
 // mutations
 const mutations = {
+  SET_BRANDING (state, value) {
+    state.branding = value
+  },
   SET_CONFIGURATION (state, value) {
     state.cfg = value
   },

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -111,6 +111,7 @@ if (debug) {
 
 // initial state
 const state = {
+  branding: null,
   cfg: null,
   kubeconfigData: null,
   ready: false,

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -1476,7 +1476,7 @@ const actions = {
       await dispatch('setError', { message: `Failed to Reset Service Account ${err.message}` })
     }
   },
-  setBranding ({ commit, getters }, value) {
+  setBranding ({ commit }, value) {
     commit('SET_BRANDING', value)
   },
   setConfiguration ({ commit, getters }, value) {

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -45,6 +45,10 @@ export function getLoginConfiguration () {
   return getResource('/login-config.json')
 }
 
+export function getBrandingConfiguration () {
+  return getResource('/branding.json')
+}
+
 /* CloudProviders Secrets */
 
 export function getCloudProviderSecrets ({ namespace }) {

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -14,8 +14,9 @@ SPDX-License-Identifier: Apache-2.0
             <v-card class="elevation-1">
               <v-card-title class="pa-0">
                 <div class="layout column align-center main-background darken-1 pa-3 pt-6">
-                  <img src="/static/assets/logo.svg" alt="Login to Gardener" width="180" height="180">
-                  <span class="flex my-4 primary--text text-h5 font-weight-light">Universal Kubernetes at Scale</span>
+                  <img src="/static/assets/logo.svg" alt="Product Login Logo" width="180" height="180">
+                  <span v-if="productName" class="flex my-4 primary--text text-h4 font-weight-light">{{ productName }}</span>
+                  <span v-if="productSlogan" class="flex my-4 primary--text text-h5 font-weight-light">{{ productSlogan }}</span>
                 </div>
                 <v-tabs
                   v-show="!loading"
@@ -60,7 +61,13 @@ SPDX-License-Identifier: Apache-2.0
               </v-card-text>
               <v-card-actions v-show="!loading" class="bt-2 pb-4">
                 <div class="d-flex justify-center flex-grow-1">
+                  <a :href="documentationURL" target="_blank" rel="noopener">Docs</a>
+                </div>
+                <div class="d-flex justify-center flex-grow-1">
                   <v-btn @click="handleLogin" color="primary">Login</v-btn>
+                </div>
+                <div class="d-flex justify-center flex-grow-1">
+                  <a :href="supportURL" target="_blank" rel="noopener">Support</a>
                 </div>
               </v-card-actions>
             </v-card>
@@ -68,7 +75,11 @@ SPDX-License-Identifier: Apache-2.0
         </v-row>
       </v-container>
       <div v-if="landingPageUrl" class="footer text-caption">
-        <span class="primary--text">Discover what our service is about at the <a :href="landingPageUrl" target="_blank" rel="noopener">Gardener Landing Page</a></span>
+        <span class="primary--text">
+          {{ customLandingPagePre }}
+          <a :href="landingPageUrl" target="_blank" rel="noopener">{{ landingPageName }}</a>
+          {{ customLandingPagePost }}
+        </span>
       </div>
     </v-main>
     <g-snotify></g-snotify>
@@ -103,8 +114,15 @@ export default {
       token: '',
       loginType: undefined,
       cfg: {
+        productName: undefined,
+        productSlogan: undefined,
+        documentationURL: undefined,
+        supportURL: undefined,
         loginTypes: undefined,
-        landingPageUrl: undefined
+        landingPageUrl: undefined,
+        landingPageName: undefined,
+        customLandingPagePre: undefined,
+        customLandingPagePost: undefined
       },
       loading: false
     }
@@ -119,8 +137,29 @@ export default {
     primaryLoginType () {
       return getPrimaryLoginType(this.cfg)
     },
+    productName () {
+      return this.cfg.productName
+    },
+    productSlogan () {
+      return this.cfg.productSlogan
+    },
+    documentationURL () {
+      return this.cfg.documentationURL
+    },
+    supportURL () {
+      return this.cfg.supportURL
+    },
     landingPageUrl () {
       return this.cfg.landingPageUrl
+    },
+    landingPageName () {
+      return this.cfg.landingPageName
+    },
+    customLandingPagePre () {
+      return this.cfg.customLandingPagePre
+    },
+    customLandingPagePost () {
+      return this.cfg.customLandingPagePost
     }
   },
   beforeRouteEnter (to, from, next) {
@@ -136,6 +175,9 @@ export default {
       try {
         const { data } = await api.getLoginConfiguration()
         cfg = data
+        Object.keys(cfg).forEach(key => {
+          sessionStorage.setItem('wl.' + key, cfg[key])
+        })
       } catch (err) {
         logger.error('Failed to fetch login configuration: %s', err.message)
         cfg = {

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -115,7 +115,7 @@ export default {
       token: '',
       loginType: undefined,
       cfg: {
-        loginTypes: undefined,
+        loginTypes: undefined
       },
       loading: false
     }

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -114,7 +114,9 @@ export default {
       showToken: false,
       token: '',
       loginType: undefined,
-      cfg: {},
+      cfg: {
+        loginTypes: undefined,
+      },
       loading: false
     }
   },

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -15,8 +15,9 @@ SPDX-License-Identifier: Apache-2.0
               <v-card-title class="pa-0">
                 <div class="layout column align-center main-background darken-1 pa-3 pt-6">
                   <img src="/static/assets/logo.svg" alt="Product Login Logo" width="180" height="180">
-                  <span v-if="productName" class="flex my-4 primary--text text-h4 font-weight-light">{{ productName }}</span>
-                  <span v-if="productSlogan" class="flex my-4 primary--text text-h5 font-weight-light">{{ productSlogan }}</span>
+                  <span v-if="productName" class="mt-4 primary--text text-h4 font-weight-light">{{ productName }}</span>
+                  <span v-if="productSlogan" class="mt-4 primary--text text-h5 font-weight-light">{{ productSlogan }}</span>
+                  <span v-if="productName || productSlogan" class="mb-4"></span>
                 </div>
                 <v-tabs
                   v-show="!loading"
@@ -76,9 +77,9 @@ SPDX-License-Identifier: Apache-2.0
       </v-container>
       <div v-if="landingPageUrl" class="footer text-caption">
         <span class="primary--text">
-          {{ customLandingPagePre }}
+          {{ landingPagePre }}
           <a :href="landingPageUrl" target="_blank" rel="noopener">{{ landingPageName }}</a>
-          {{ customLandingPagePost }}
+          {{ landingPagePost }}
         </span>
       </div>
     </v-main>
@@ -113,17 +114,7 @@ export default {
       showToken: false,
       token: '',
       loginType: undefined,
-      cfg: {
-        productName: undefined,
-        productSlogan: undefined,
-        documentationURL: undefined,
-        supportURL: undefined,
-        loginTypes: undefined,
-        landingPageUrl: undefined,
-        landingPageName: undefined,
-        customLandingPagePre: undefined,
-        customLandingPagePost: undefined
-      },
+      cfg: {},
       loading: false
     }
   },
@@ -131,6 +122,7 @@ export default {
     ...mapGetters('storage', [
       'autoLoginEnabled'
     ]),
+    ...mapGetters(['branding']),
     redirectPath () {
       return getRedirectPath(this.$route)
     },
@@ -138,28 +130,28 @@ export default {
       return getPrimaryLoginType(this.cfg)
     },
     productName () {
-      return this.cfg.productName
+      return this.branding.productName
     },
     productSlogan () {
-      return this.cfg.productSlogan
+      return this.branding.productSlogan
     },
     documentationURL () {
-      return this.cfg.documentationURL
+      return this.branding.loginDocumentationURL
     },
     supportURL () {
-      return this.cfg.supportURL
+      return this.branding.loginSupportURL
     },
     landingPageUrl () {
-      return this.cfg.landingPageUrl
+      return this.branding.loginLandingPagePre
     },
     landingPageName () {
-      return this.cfg.landingPageName
+      return this.branding.loginLandingPageUrl
     },
-    customLandingPagePre () {
-      return this.cfg.customLandingPagePre
+    landingPagePre () {
+      return this.branding.loginLandingPageName
     },
-    customLandingPagePost () {
-      return this.cfg.customLandingPagePost
+    landingPagePost () {
+      return this.branding.loginLandingPagePost
     }
   },
   beforeRouteEnter (to, from, next) {
@@ -175,9 +167,6 @@ export default {
       try {
         const { data } = await api.getLoginConfiguration()
         cfg = data
-        Object.keys(cfg).forEach(key => {
-          sessionStorage.setItem('wl.' + key, cfg[key])
-        })
       } catch (err) {
         logger.error('Failed to fetch login configuration: %s', err.message)
         cfg = {

--- a/frontend/tests/unit/MainNavigation.spec.js
+++ b/frontend/tests/unit/MainNavigation.spec.js
@@ -89,7 +89,8 @@ describe('MainNavigation.vue', () => {
     vuetify = new Vuetify()
     getters = {
       canCreateProject: jest.fn().mockReturnValue(true),
-      projectList: jest.fn().mockReturnValue(createProjectList(['foo', 'bar']))
+      projectList: jest.fn().mockReturnValue(createProjectList(['foo', 'bar'])),
+      branding: jest.fn().mockReturnValue({})
     }
     actions = {
       setSidebar: jest.fn()


### PR DESCRIPTION
This introduces a basic branding functionality for the login screen and upper main navigation.
I cherry-picked some of this from [plusserver/gardener-dashboard](https://github.com/plusserver/gardener-dashboard/commit/d3a194c88e2c6c00ad72314e8d76d4f6829580a4#diff-923685d166d604bc207ab4b061a5edd9c1c344fdc2deec6b549569e21d529c4e)

The general idea is to provide means of setting various product-related strings in a non-code way. That would include: 

- customizable product name (login page, main nav, help modal, info modal)
- customizable slogan (login page, main nav)
- docs link (login page)
- support link (login page)
- landing page link's text as well as prefix and suffix (login page)
- showing/hiding version info (main nav)
- hiding anything but the logo (main nav)

The landing page url was loaded from login-config.json before. I moved it to branding.json for consistency.

This branding.json gets you the following look on the login page:
```json
{
  "productName": "John Doe's KE",
  "productSlogan": "100% vegan",
  "loginDocumentationURL": "https://example.org/docs",
  "loginSupportURL": "https://example.org/support",
  "loginLandingPagePre": "Find out who",
  "loginLandingPageUrl": "https://example.org/john",
  "loginLandingPageName": "John Doe",
  "loginLandingPagePost": "really is",
  "mainNavShowVersion": true,
  "mainNavLogoOnly": false
}
```
![image](https://github.com/gardener/dashboard/assets/13417122/256cb034-0511-4246-97a4-a0a61cdd840f)

Let me know what you think.
