### PR TITLE
Add HA config to dashboard deployment

### DIFF
--- a/charts/__tests__/gardener-dashboard/runtime/dashboard/__snapshots__/deployment.spec.js.snap
+++ b/charts/__tests__/gardener-dashboard/runtime/dashboard/__snapshots__/deployment.spec.js.snap
@@ -190,6 +190,7 @@ Object {
       "app.kubernetes.io/managed-by": "Helm",
       "app.kubernetes.io/name": "gardener-dashboard",
       "helm.sh/chart": "gardener-dashboard-runtime-0.1.0",
+      "high-availability-config.resources.gardener.cloud/type": "server",
     },
     "name": "gardener-dashboard",
     "namespace": "garden",

--- a/charts/gardener-dashboard/charts/runtime/templates/dashboard/deployment.yaml
+++ b/charts/gardener-dashboard/charts/runtime/templates/dashboard/deployment.yaml
@@ -14,6 +14,7 @@ metadata:
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+    high-availability-config.resources.gardener.cloud/type: server
     {{- if .Values.global.dashboard.deploymentLabels }}
     {{- toYaml .Values.global.dashboard.deploymentLabels | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds high availability config to the `gardener-dashboard` deployment.
More information can be found here https://github.com/gardener/gardener/blob/master/docs/concepts/resource-manager.md#high-availability-config


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The `gardener-dashboard` `Deployment` now runs with high availability config (with label `high-availability-config.resources.gardener.cloud/type=server`). For more information about the HA config see https://github.com/gardener/gardener/blob/master/docs/concepts/resource-manager.md#high-availability-config
```
