### PR TITLE
Remove grantType `authcode-keyboard`, add `device-code`

### DIFF
--- a/charts/__tests__/gardener-dashboard/runtime/dashboard/__snapshots__/configmap.spec.js.snap
+++ b/charts/__tests__/gardener-dashboard/runtime/dashboard/__snapshots__/configmap.spec.js.snap
@@ -103,6 +103,18 @@ Object {
 }
 `;
 
+exports[`gardener-dashboard configmap grantTypes should render the template 1`] = `
+Object {
+  "frontend": Object {
+    "grantTypes": Array [
+      "a",
+      "b",
+      "c",
+    ],
+  },
+}
+`;
+
 exports[`gardener-dashboard configmap knownConditions should render the template with knownConditions markdown 1`] = `
 Object {
   "frontend": Object {

--- a/charts/__tests__/gardener-dashboard/runtime/dashboard/configmap.spec.js
+++ b/charts/__tests__/gardener-dashboard/runtime/dashboard/configmap.spec.js
@@ -547,6 +547,26 @@ describe('gardener-dashboard', function () {
       })
     })
 
+    describe('grantTypes', function () {
+      it('should render the template', async function () {
+        const values = {
+          global: {
+            dashboard: {
+              frontendConfig: {
+                grantTypes: ['a', 'b', 'c']
+              }
+            }
+          }
+        }
+
+        const documents = await renderTemplates(templates, values)
+        expect(documents).toHaveLength(1)
+        const [configMap] = documents
+        const config = yaml.load(configMap.data['config.yaml'])
+        expect(pick(config, ['frontend.grantTypes'])).toMatchSnapshot()
+      })
+    })
+
     describe('resourceQuotaHelp', function () {
       it('should render the template with resourceQuotaHelp markdown', async function () {
         const values = {

--- a/charts/gardener-dashboard/charts/runtime/templates/dashboard/configmap.yaml
+++ b/charts/gardener-dashboard/charts/runtime/templates/dashboard/configmap.yaml
@@ -158,6 +158,12 @@ data:
         target: {{ .target }}{{- end }}
       {{- end }}
       {{- end }}
+      {{- if .Values.global.dashboard.frontendConfig.grantTypes }}
+      grantTypes:
+      {{- range .Values.global.dashboard.frontendConfig.grantTypes }}
+      - {{ . }}
+      {{- end }}
+      {{- end }}
       {{- if .Values.global.dashboard.frontendConfig.externalTools }}
       externalTools:
       {{- range .Values.global.dashboard.frontendConfig.externalTools }}

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -139,6 +139,11 @@ global:
       - title: Issues
         icon: bug_report
         url: https://github.com/gardener/gardener/issues
+      # # supported grantTypes of the garden cluster oidc issuer. See https://github.com/int128/kubelogin/blob/master/docs/usage.md for possible values.
+      # grantTypes:
+      # - auto
+      # - authcode
+      # - device-code
       # ticket:
       #   avatarSource: github # Define from which source the avatar is fetched. For enterprise github instances it is recommended to use gravatar or none. Possible values: github, gravatar, none
       #   gitHubRepoUrl: https://foo-github.com/dummyorg/dummyrepo

--- a/frontend/src/store/config.js
+++ b/frontend/src/store/config.js
@@ -127,7 +127,7 @@ export const useConfigStore = defineStore('config', () => {
   })
 
   const grantTypes = computed(() => {
-    return state.value?.grantTypes || ['auto', 'authcode', 'device-code']
+    return state.value?.grantTypes ?? ['auto', 'authcode', 'device-code']
   })
 
   const knownConditions = computed(() => {

--- a/frontend/src/store/config.js
+++ b/frontend/src/store/config.js
@@ -126,6 +126,10 @@ export const useConfigStore = defineStore('config', () => {
     return state.value?.features
   })
 
+  const grantTypes = computed(() => {
+    return state.value?.grantTypes || ['auto', 'authcode', 'device-code']
+  })
+
   const knownConditions = computed(() => {
     return state.value?.knownConditions
   })
@@ -296,6 +300,7 @@ export const useConfigStore = defineStore('config', () => {
     sla,
     costObject,
     features,
+    grantTypes,
     knownConditions,
     resourceQuotaHelp,
     resourceQuotaHelpText,

--- a/frontend/src/views/GAccount.vue
+++ b/frontend/src/views/GAccount.vue
@@ -243,11 +243,13 @@ SPDX-License-Identifier: Apache-2.0
 </template>
 
 <script>
+import { ref } from 'vue'
 import download from 'downloadjs'
 import { mapState } from 'pinia'
 
 import { useAuthnStore } from '@/store/authn'
 import { useAuthzStore } from '@/store/authz'
+import { useConfigStore } from '@/store/config'
 import { useProjectStore } from '@/store/project'
 import { useKubeconfigStore } from '@/store/kubeconfig'
 
@@ -261,6 +263,7 @@ import {
   map,
   find,
   get,
+  head,
 } from '@/lodash'
 
 export default {
@@ -270,14 +273,23 @@ export default {
     GAccountAvatar,
   },
   inject: ['api', 'logger', 'yaml'],
+  setup () {
+    const configStore = useConfigStore()
+    const grantTypes = configStore.grantTypes
+
+    const grantType = ref(head(grantTypes))
+
+    return {
+      grantType,
+      grantTypes,
+    }
+  },
   data () {
     return {
       kubeconfigExpansionPanel: false,
       kubeconfigTab: 'configure',
       projectName: undefined,
       skipOpenBrowser: false,
-      grantType: 'auto',
-      grantTypes: ['auto', 'authcode', 'authcode-keyboard'],
       idToken: undefined,
       showToken: false,
       showMessage: false,

--- a/frontend/src/views/GAccount.vue
+++ b/frontend/src/views/GAccount.vue
@@ -243,7 +243,6 @@ SPDX-License-Identifier: Apache-2.0
 </template>
 
 <script>
-import { ref } from 'vue'
 import download from 'downloadjs'
 import { mapState } from 'pinia'
 
@@ -273,17 +272,6 @@ export default {
     GAccountAvatar,
   },
   inject: ['api', 'logger', 'yaml'],
-  setup () {
-    const configStore = useConfigStore()
-    const grantTypes = configStore.grantTypes
-
-    const grantType = ref(head(grantTypes))
-
-    return {
-      grantType,
-      grantTypes,
-    }
-  },
   data () {
     return {
       kubeconfigExpansionPanel: false,
@@ -294,9 +282,13 @@ export default {
       showToken: false,
       showMessage: false,
       kubeconfigYaml: '',
+      grantType: undefined,
     }
   },
   computed: {
+    ...mapState(useConfigStore, [
+      'grantTypes',
+    ]),
     ...mapState(useAuthnStore, [
       'user',
       'username',
@@ -425,6 +417,9 @@ export default {
     kubeconfig (value) {
       this.updateKubeconfigYaml(value)
     },
+  },
+  created () {
+    this.grantType = head(this.grantTypes)
   },
   async mounted () {
     try {


### PR DESCRIPTION
**What this PR does / why we need it**:
The Grant type `authcode-keyboard` is not supported by SAP ID service and also [Google](https://developers.google.com/identity/protocols/oauth2/resources/oob-migration) is stopping the support. It is removed by default but can enabled by configuration.
In addition, `device-code` grant type was added.
This applies for the garden cluster kubeconfig that can be downloaded on the `My Account` page.

![Grant Types](https://github.com/gardener/dashboard/assets/5526658/b8701a78-db8f-4372-ab0b-a3794918bca3)


The new default is:
```yaml
# charts/gardener-dashboard/values.yaml
global:
  dashboard:
    frontendConfig:
      grantTypes:
      - auto
      - authcode
      - device-code
```

If you want to restore the old behavior, set
```yaml
# charts/gardener-dashboard/values.yaml
global:
  dashboard:
    frontendConfig:
      grantTypes:
      - auto
      - authcode
      - authcode-keyboard
```
**Which issue(s) this PR fixes**:
Fixes #1511

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The default grant types for the garden cluster OIDC kubeconfig have changed to `auto`, `authcode` and `device-code`. `authcode-keyboard` was removed and `device-code` grant type was added. The default grant types can be overridden by setting `Values.global.dashboard.frontendConfig.grantTypes` in the `gardener-dashboard` helm chart.
```
