### PR TITLE
Clarify misleading wording on potential updates during maintenance

### DIFF
--- a/frontend/src/components/ShootMaintenance/GShootActionMaintenanceStart.vue
+++ b/frontend/src/components/ShootMaintenance/GShootActionMaintenanceStart.vue
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
     </div>
     <g-maintenance-components
       ref="maintenanceComponents"
-      title="The following updates will be performed"
+      title="The following updates might be performed"
       :selectable="false"
     />
     <v-alert


### PR DESCRIPTION
**What this PR does / why we need it**:
Clarifies a misleading wording on potential updates during maintenance.
When hitting the maintenance button, a dialog currently reads "The following updates will be performed...".
However the dashboard has no idea that such updates will definitely be performed (and in most cases they won't), hence change it to "might be performed".

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
