### PR TITLE
Projects viewer should see all projects

### DIFF
--- a/backend/__fixtures__/auth.js
+++ b/backend/__fixtures__/auth.js
@@ -131,6 +131,9 @@ const mocks = {
           case 'secrets':
             allowed = id === 'admin@example.org'
             break
+          case 'projects':
+            allowed = id === 'projects-viewer@example.org'
+            break
         }
       }
       if (nonResourceAttributes) {

--- a/backend/lib/services/authorization.js
+++ b/backend/lib/services/authorization.js
@@ -41,6 +41,16 @@ exports.isAdmin = function (user) {
   })
 }
 
+exports.canListProjects = function (user) {
+  return hasAuthorization(user, {
+    resourceAttributes: {
+      verb: 'list',
+      group: 'core.gardener.cloud',
+      resource: 'projects'
+    }
+  })
+}
+
 exports.canGetOpenAPI = function (user) {
   return hasAuthorization(user, {
     nonResourceAttributes: {

--- a/backend/lib/services/projects.js
+++ b/backend/lib/services/projects.js
@@ -118,10 +118,10 @@ function getProjectName (namespace) {
 }
 
 exports.list = async function ({ user }) {
-  const isAdmin = await authorization.isAdmin(user)
+  const canListProjects = await authorization.canListProjects(user)
   return _
     .chain(cache.getProjects())
-    .filter(projectFilter(user, isAdmin))
+    .filter(projectFilter(user, canListProjects))
     .map(fromResource)
     .value()
 }

--- a/backend/lib/services/shoots.js
+++ b/backend/lib/services/shoots.js
@@ -29,7 +29,7 @@ exports.list = async function ({ user, namespace, labelSelector, shootsWithIssue
     query.labelSelector = 'shoot.gardener.cloud/status!=healthy'
   }
   if (namespace === '_all') {
-    if (await authorization.isAdmin(user)) {
+    if (await authorization.canListShoots(user)) {
       return client['core.gardener.cloud'].shoots.listAllNamespaces(query)
     } else {
       const promises = _

--- a/backend/lib/utils/index.js
+++ b/backend/lib/utils/index.js
@@ -24,7 +24,7 @@ function encodeBase64 (value) {
   return Buffer.from(value, 'utf8').toString('base64')
 }
 
-function projectFilter (user, isAdmin = false) {
+function projectFilter (user, canListProjects = false) {
   const isMemberOf = project => {
     return _
       .chain(project)
@@ -60,7 +60,7 @@ function projectFilter (user, isAdmin = false) {
     if (isPending(project)) {
       return false
     }
-    return isAdmin || isMemberOf(project)
+    return canListProjects || isMemberOf(project)
   }
 }
 

--- a/backend/test/acceptance/__snapshots__/api.projects.spec.js.snap
+++ b/backend/test/acceptance/__snapshots__/api.projects.spec.js.snap
@@ -200,7 +200,7 @@ Array [
       ":method": "post",
       ":path": "/apis/authorization.k8s.io/v1/selfsubjectaccessreviews",
       ":scheme": "https",
-      "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFkbWluQGV4YW1wbGUub3JnIiwiaWF0IjoxNTc3ODM2ODAwLCJhdWQiOlsiZ2FyZGVuZXIiXSwiZXhwIjozMTU1NzE2ODAwLCJqdGkiOiJqdGkifQ.PwFHRt9M8dJf8YcCVlbyH4xu2QpL3jBI1oEC_Zdmtzk",
+      "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6InByb2plY3RzLXZpZXdlckBleGFtcGxlLm9yZyIsImlhdCI6MTU3NzgzNjgwMCwiYXVkIjpbImdhcmRlbmVyIl0sImV4cCI6MzE1NTcxNjgwMCwianRpIjoianRpIn0.mdL_IwTCaUnb2Yzua4Z54bS85BXKeAU3O1ioUfs7MeI",
     },
     Object {
       "apiVersion": "authorization.k8s.io/v1",
@@ -208,9 +208,9 @@ Array [
       "spec": Object {
         "nonResourceAttributes": undefined,
         "resourceAttributes": Object {
-          "group": "",
-          "resource": "secrets",
-          "verb": "get",
+          "group": "core.gardener.cloud",
+          "resource": "projects",
+          "verb": "list",
         },
       },
     },
@@ -366,9 +366,9 @@ Array [
       "spec": Object {
         "nonResourceAttributes": undefined,
         "resourceAttributes": Object {
-          "group": "",
-          "resource": "secrets",
-          "verb": "get",
+          "group": "core.gardener.cloud",
+          "resource": "projects",
+          "verb": "list",
         },
       },
     },

--- a/backend/test/acceptance/api.projects.spec.js
+++ b/backend/test/acceptance/api.projects.spec.js
@@ -56,7 +56,7 @@ describe('api', function () {
     })
 
     it('should return all projects', async function () {
-      const user = fixtures.auth.createUser({ id: 'admin@example.org' })
+      const user = fixtures.auth.createUser({ id: 'projects-viewer@example.org' })
 
       mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
 

--- a/backend/test/services.projects.spec.js
+++ b/backend/test/services.projects.spec.js
@@ -78,12 +78,12 @@ describe('services', function () {
 
     beforeEach(function () {
       jest.spyOn(cache, 'getProjects').mockReturnValue(projectList)
-      jest.spyOn(authorization, 'isAdmin').mockImplementation(user => Promise.resolve(user.id === 'admin@bar.com'))
+      jest.spyOn(authorization, 'canListProjects').mockImplementation(user => Promise.resolve(user.id === 'projects-viewer@bar.com'))
     })
 
     describe('#list', function () {
-      it('should return all projects if user is admin, including not ready projects', async function () {
-        const userProjects = await projects.list({ user: createUser('admin@bar.com') })
+      it('should return all projects if user can list all projects, including not ready projects', async function () {
+        const userProjects = await projects.list({ user: createUser('projects-viewer@bar.com') })
         expect(userProjects).toHaveLength(2)
       })
 


### PR DESCRIPTION
**What this PR does / why we need it**:
If a user has the permission to `list` all `projects` (e.g. having the ClusterRole `gardener.cloud:viewer` https://github.com/gardener/gardener/blob/ad64150e76a4b1c7dd2e474332db73e4bc391d7b/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml#L96-L207`, the user should be able to see them in the dashboard.
Previously, the user required the permission to `get` `secrets` across all namespaces. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Users with permission to `list` all `projects` can see them now in the dashboard. Previously the permission to `get` `secrets` across all namespaces was required.
```
