### PR TITLE
Some minor fixes

### DIFF
--- a/frontend/src/components/ShootDetails/GCustomFieldsCard.vue
+++ b/frontend/src/components/ShootDetails/GCustomFieldsCard.vue
@@ -5,7 +5,10 @@ SPDX-License-Identifier: Apache-2.0
 -->
 
 <template>
-  <v-card v-if="customFields && customFields.length">
+  <v-card
+    v-if="customFields && customFields.length"
+    class="mb-4"
+  >
     <g-toolbar title="Custom Fields" />
     <g-list>
       <template

--- a/frontend/src/components/ShootWorkers/GWorkerGroup.vue
+++ b/frontend/src/components/ShootWorkers/GWorkerGroup.vue
@@ -51,7 +51,10 @@ SPDX-License-Identifier: Apache-2.0
           <v-container class="pa-2">
             <v-row dense>
               <v-col cols="6">
-                <v-card outlined>
+                <v-card
+                  variant="outlined"
+                  class="border"
+                >
                   <v-toolbar
                     height="28"
                     class="text-medium-emphasis"
@@ -125,7 +128,7 @@ SPDX-License-Identifier: Apache-2.0
                 </v-card>
                 <v-card
                   variant="outlined"
-                  class="mt-2"
+                  class="border mt-2"
                 >
                   <v-toolbar
                     height="28"
@@ -168,7 +171,10 @@ SPDX-License-Identifier: Apache-2.0
                 </v-card>
               </v-col>
               <v-col cols="6">
-                <v-card outlined>
+                <v-card
+                  variant="outlined"
+                  class="border"
+                >
                   <v-toolbar
                     height="28"
                     class="text-medium-emphasis"
@@ -228,7 +234,7 @@ SPDX-License-Identifier: Apache-2.0
                 </v-card>
                 <v-card
                   variant="outlined"
-                  class="mt-2"
+                  class="border mt-2"
                 >
                   <v-toolbar
                     height="28"
@@ -277,7 +283,7 @@ SPDX-License-Identifier: Apache-2.0
                 </v-card>
                 <v-card
                   variant="outlined"
-                  class="mt-2"
+                  class="border mt-2"
                 >
                   <v-toolbar
                     height="28"
@@ -452,3 +458,9 @@ export default {
   },
 }
 </script>
+
+<style>
+  .border {
+    border-color: rgba(var(--v-border-color), var(--v-border-opacity)) !important;
+  }
+</style>

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -166,6 +166,7 @@ export default defineConfig(({ command, mode }) => {
   if (process.env.NODE_ENV === 'test') {
     const coverage = {
       provider: 'v8',
+      exclude: ['**/__fixtures__/**'],
       statements: 73,
       branches: 80,
       functions: 48,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR contains the following fixes:
1. Exclude the folder `__fixtures__` from vitest coverage reports.
2. Added the missing bottom margin for the Custom Fields Card on the Shoot Details page. 
<img width="600" alt="image" src="https://github.com/gardener/dashboard/assets/1574023/6e98fa10-9d14-48e2-9e08-b854833f68a4">

3. All cards of the WorkerGroup Details popover should be outlined with a light grey border.
<img width="600" alt="image" src="https://github.com/gardener/dashboard/assets/1574023/1371d0f9-15f4-4103-8942-0387abfa582e">

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
