### PR TITLE
Reset filter on Secrets, Members and Shoot list page

### DIFF
--- a/frontend/src/views/GMembers.vue
+++ b/frontend/src/views/GMembers.vue
@@ -289,6 +289,7 @@ import {
   computed,
   markRaw,
   inject,
+  watch,
 } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useRouter } from 'vue-router'
@@ -554,6 +555,17 @@ const serviceAccountTableHeaders = computed(() => {
 const visibleServiceAccountTableHeaders = computed(() => {
   return filter(serviceAccountTableHeaders.value, ['selected', true])
 })
+
+watch(namespace, () => {
+  reset()
+})
+
+function reset () {
+  userFilter.value = ''
+  serviceAccountFilter.value = ''
+  userPage.value = 1
+  serviceAccountPage.value = 1
+}
 
 function setKubeconfigError (err) {
   appStore.alert = {

--- a/frontend/src/views/GMembers.vue
+++ b/frontend/src/views/GMembers.vue
@@ -373,11 +373,11 @@ const userPage = ref(1)
 const serviceAccountPage = ref(1)
 
 const {
-  namespace,
   project,
   projectList,
 } = storeToRefs(projectStore)
 const {
+  namespace,
   canManageMembers,
   canManageServiceAccountMembers,
   canCreateServiceAccounts,

--- a/frontend/src/views/GSecrets.vue
+++ b/frontend/src/views/GSecrets.vue
@@ -332,7 +332,10 @@ export default {
         'infrastructureSecretList',
         'dnsSecretList',
       ]),
-    ...mapState(useAuthzStore, ['canCreateSecrets']),
+    ...mapState(useAuthzStore, [
+      'canCreateSecrets',
+      'namespace',
+    ]),
     ...mapState(useShootStore, ['shootList']),
     hasCloudProfileForCloudProviderKind () {
       return (kind) => {
@@ -484,6 +487,11 @@ export default {
       }))
     },
   },
+  watch: {
+    namespace () {
+      this.reset()
+    },
+  },
   mounted () {
     if (!get(this.$route.params, 'name')) {
       return
@@ -533,6 +541,12 @@ export default {
     },
     setSelectedInfraHeader (header) {
       this.infraSecretSelectedColumns[header.key] = !header.selected
+    },
+    reset () {
+      this.infraSecretFilter = ''
+      this.dnsSecretFilter = ''
+      this.infraSecretPage = 1
+      this.dnsSecretPage = 1
     },
     resetInfraTableSettings () {
       this.infraSecretSelectedColumns = mapTableHeader(this.infraSecretTableHeaders, 'defaultSelected')

--- a/frontend/src/views/GSecrets.vue
+++ b/frontend/src/views/GSecrets.vue
@@ -333,8 +333,8 @@ export default {
         'dnsSecretList',
       ]),
     ...mapState(useAuthzStore, [
-      'canCreateSecrets',
       'namespace',
+      'canCreateSecrets',
     ]),
     ...mapState(useShootStore, ['shootList']),
     hasCloudProfileForCloudProviderKind () {

--- a/frontend/src/views/GShootList.vue
+++ b/frontend/src/views/GShootList.vue
@@ -73,7 +73,7 @@ SPDX-License-Identifier: Apache-2.0
             <template #activator="{ props }">
               <v-text-field
                 v-bind="props"
-                v-model="shootSearch"
+                :model-value="shootSearch"
                 prepend-inner-icon="mdi-magnify"
                 color="primary"
                 label="Search"
@@ -85,7 +85,7 @@ SPDX-License-Identifier: Apache-2.0
                 clear-icon="mdi-close"
                 density="compact"
                 class="g-table-search-field mr-3"
-                @update:model-value="onInputSearch"
+                @update:model-value="onUpdateShootSearch"
                 @keyup.esc="resetShootSearch"
               />
             </template>
@@ -296,7 +296,7 @@ export default {
   data () {
     return {
       shootSearch: '',
-      delayedShootSearch: '',
+      debouncedShootSearch: '',
       dialog: null,
       itemsPerPage: useLocalStorage('projects/shoot-list/itemsPerPage', 10),
       page: 1,
@@ -694,7 +694,7 @@ export default {
     },
     sortedAndFilteredItems () {
       const items = this.sortItems(this.items, this.sortByInternal)
-      return filter(items, item => this.searchItems(this.delayedShootSearch, toRaw(item)))
+      return filter(items, item => this.searchItems(this.debouncedShootSearch, toRaw(item)))
     },
   },
   watch: {
@@ -719,7 +719,7 @@ export default {
     ]),
     resetShootSearch () {
       this.shootSearch = null
-      this.delayedShootSearch = null
+      this.debouncedShootSearch = null
     },
     async showDialog (args) {
       switch (args.action) {
@@ -804,8 +804,13 @@ export default {
       const filters = this.shootListFilters
       return get(filters, key, false)
     },
-    onInputSearch: debounce(function (value) {
-      this.delayedShootSearch = value
+    onUpdateShootSearch (value) {
+      this.shootSearch = value
+
+      this.setDebouncedShootSearch()
+    },
+    setDebouncedShootSearch: debounce(function () {
+      this.debouncedShootSearch = this.shootSearch
     }, 500),
     disableCustomKeySort (tableHeaders) {
       const sortableTableHeaders = filter(tableHeaders, ['sortable', true])

--- a/frontend/src/views/GShootList.vue
+++ b/frontend/src/views/GShootList.vue
@@ -73,6 +73,7 @@ SPDX-License-Identifier: Apache-2.0
             <template #activator="{ props }">
               <v-text-field
                 v-bind="props"
+                v-model="shootSearch"
                 prepend-inner-icon="mdi-magnify"
                 color="primary"
                 label="Search"
@@ -85,7 +86,7 @@ SPDX-License-Identifier: Apache-2.0
                 density="compact"
                 class="g-table-search-field mr-3"
                 @update:model-value="onInputSearch"
-                @keyup.esc="shootSearch = ''"
+                @keyup.esc="resetShootSearch"
               />
             </template>
             Search terms are <span class="font-weight-bold">ANDed</span>.<br>
@@ -281,20 +282,21 @@ export default {
     })
   },
   beforeRouteUpdate (to, from, next) {
-    this.shootSearch = null
+    this.resetShootSearch()
     this.updateTableSettings()
     this.focusModeInternal = false
     next()
   },
   beforeRouteLeave (to, from, next) {
     this.cachedItems = this.shootList.slice(0)
-    this.shootSearch = null
+    this.resetShootSearch()
     this.focusModeInternal = false
     next()
   },
   data () {
     return {
       shootSearch: '',
+      delayedShootSearch: '',
       dialog: null,
       itemsPerPage: useLocalStorage('projects/shoot-list/itemsPerPage', 10),
       page: 1,
@@ -692,7 +694,7 @@ export default {
     },
     sortedAndFilteredItems () {
       const items = this.sortItems(this.items, this.sortByInternal)
-      return filter(items, item => this.searchItems(this.shootSearch, toRaw(item)))
+      return filter(items, item => this.searchItems(this.delayedShootSearch, toRaw(item)))
     },
   },
   watch: {
@@ -715,6 +717,10 @@ export default {
       'setFocusMode',
       'setSortBy',
     ]),
+    resetShootSearch () {
+      this.shootSearch = null
+      this.delayedShootSearch = null
+    },
     async showDialog (args) {
       switch (args.action) {
         case 'access':
@@ -799,7 +805,7 @@ export default {
       return get(filters, key, false)
     },
     onInputSearch: debounce(function (value) {
-      this.shootSearch = value
+      this.delayedShootSearch = value
     }, 500),
     disableCustomKeySort (tableHeaders) {
       const sortableTableHeaders = filter(tableHeaders, ['sortable', true])


### PR DESCRIPTION
**What this PR does / why we need it**:
Reset filter on Secrets, Members and Shoot list page when switching the Project

**Which issue(s) this PR fixes**:
Fixes #1524

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed an issue where the filter on the `Secrets`, `Members` and `Clusters` page was not reset when switching the Project
```
