### PR TITLE
Fix console error when navigating to All Projects page

### DIFF
--- a/frontend/src/components/ShootDetails/GGardenctlCommands.vue
+++ b/frontend/src/components/ShootDetails/GGardenctlCommands.vue
@@ -91,12 +91,8 @@ export default {
       'isAdmin',
     ]),
     ...mapState(useProjectStore, [
-      'project',
+      'projectName',
     ]),
-    projectName () {
-      const project = this.project
-      return get(project, 'metadata.name')
-    },
     commands () {
       const displayValue = command => {
         return '$ ' + command

--- a/frontend/src/components/ShootDetails/GGardenctlCommands.vue
+++ b/frontend/src/components/ShootDetails/GGardenctlCommands.vue
@@ -91,10 +91,10 @@ export default {
       'isAdmin',
     ]),
     ...mapState(useProjectStore, [
-      'projectFromProjectList',
+      'project',
     ]),
     projectName () {
-      const project = this.projectFromProjectList
+      const project = this.project
       return get(project, 'metadata.name')
     },
     commands () {

--- a/frontend/src/components/ShootDetails/GGardenctlCommands.vue
+++ b/frontend/src/components/ShootDetails/GGardenctlCommands.vue
@@ -66,8 +66,6 @@ import GGardenctlInfo from '@/components/GGardenctlInfo.vue'
 
 import { shootItem } from '@/mixins/shootItem'
 
-import { get } from '@/lodash'
-
 export default {
   components: {
     GListItem,

--- a/frontend/src/components/dialogs/GProjectDialog.vue
+++ b/frontend/src/components/dialogs/GProjectDialog.vue
@@ -219,7 +219,7 @@ export default {
   computed: {
     ...mapState(useMemberStore, ['memberList']),
     ...mapState(useAuthnStore, ['username']),
-    ...mapState(useProjectStore, ['projectNamesFromProjectList']),
+    ...mapState(useProjectStore, ['projectNames']),
     ...mapState(useConfigStore, ['costObjectSettings']),
     visible: {
       get () {
@@ -228,9 +228,6 @@ export default {
       set (value) {
         this.$emit('update:modelValue', value)
       },
-    },
-    projectNames () {
-      return this.projectNamesFromProjectList
     },
     projectDetails () {
       return getProjectDetails(this.project)

--- a/frontend/src/store/project.js
+++ b/frontend/src/store/project.js
@@ -211,7 +211,6 @@ export const useProjectStore = defineStore('project', () => {
     list.value = null
   }
 
-  const projectFromProjectList = project // TODO: deprecated - use project instead
   const projectNamesFromProjectList = projectNames // TODO: deprecated - use projectNames instead
 
   return {
@@ -224,7 +223,6 @@ export const useProjectStore = defineStore('project', () => {
     projectName,
     projectList,
     project,
-    projectFromProjectList,
     projectNames,
     projectNamesFromProjectList,
     shootCustomFields,

--- a/frontend/src/store/project.js
+++ b/frontend/src/store/project.js
@@ -211,8 +211,6 @@ export const useProjectStore = defineStore('project', () => {
     list.value = null
   }
 
-  const projectNamesFromProjectList = projectNames // TODO: deprecated - use projectNames instead
-
   return {
     list,
     isInitial,
@@ -224,7 +222,6 @@ export const useProjectStore = defineStore('project', () => {
     projectList,
     project,
     projectNames,
-    projectNamesFromProjectList,
     shootCustomFields,
     shootCustomFieldList,
     isCurrentNamespace,

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -328,7 +328,7 @@ export function getIssueSince (shootStatus) {
   return head(issueTimestamps.sort())
 }
 
-export function getProjectDetails (project) {
+export function getProjectDetails (project = {}) {
   const projectData = project.data || {}
   const projectMetadata = project.metadata || {}
   const projectName = projectMetadata.name || ''

--- a/frontend/src/views/GAdministration.vue
+++ b/frontend/src/views/GAdministration.vue
@@ -578,7 +578,7 @@ export default {
     ]),
     ...mapState(useProjectStore, [
       'projectList',
-      'projectFromProjectList',
+      'project',
       'shootCustomFieldList',
     ]),
     ...mapState(useMemberStore, [
@@ -590,9 +590,6 @@ export default {
     ...mapState(useQuotaStore, [
       'projectQuotaStatus',
     ]),
-    project () {
-      return this.projectFromProjectList
-    },
     projectDetails () {
       return getProjectDetails(this.project)
     },

--- a/frontend/src/views/GMembers.vue
+++ b/frontend/src/views/GMembers.vue
@@ -373,7 +373,7 @@ const serviceAccountPage = ref(1)
 
 const {
   namespace,
-  projectFromProjectList: project,
+  project,
   projectList,
 } = storeToRefs(projectStore)
 const {

--- a/frontend/src/views/GShootList.vue
+++ b/frontend/src/views/GShootList.vue
@@ -324,7 +324,6 @@ export default {
     }),
     ...mapState(useProjectStore, [
       'projectName',
-      'projectFromProjectList',
       'shootCustomFieldList',
       'shootCustomFields',
     ]),


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously, the getter made sure that always an object is returned https://github.com/gardener/dashboard/blob/e9d0d79776bd89a613fb2f7d7e599d2e7990c378/frontend/src/store/index.js#L598C49-L598C54
However I changed the utils function to default the project
I also removed deprecated computed properties

**Which issue(s) this PR fixes**:
Fixes #1528

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
