### PR TITLE
Replace `mapGetters` with `mapState`

### DIFF
--- a/frontend/src/components/GShootEditor.vue
+++ b/frontend/src/components/GShootEditor.vue
@@ -163,7 +163,7 @@ SPDX-License-Identifier: Apache-2.0
 
 <script>
 import { markRaw } from 'vue'
-import { mapGetters } from 'pinia'
+import { mapState } from 'pinia'
 import download from 'downloadjs'
 import CodeMirror from 'codemirror'
 import 'codemirror/addon/hint/show-hint.js'
@@ -260,7 +260,7 @@ export default {
     }
   },
   computed: {
-    ...mapGetters(useAuthzStore, ['canPatchShoots']),
+    ...mapState(useAuthzStore, ['canPatchShoots']),
     value () {
       let data = cloneDeep(this.shootItem)
       if (data) {

--- a/frontend/src/components/Members/GMemberDialog.vue
+++ b/frontend/src/components/Members/GMemberDialog.vue
@@ -133,7 +133,6 @@ SPDX-License-Identifier: Apache-2.0
 import {
   mapActions,
   mapState,
-  mapGetters,
 } from 'pinia'
 import { useVuelidate } from '@vuelidate/core'
 import {
@@ -234,8 +233,10 @@ export default {
   },
   computed: {
     ...mapState(useAuthzStore, ['namespace']),
-    ...mapGetters(useMemberStore, { memberList: 'list' }),
-    ...mapGetters(useAuthnStore, ['isAdmin']),
+    ...mapState(useMemberStore, {
+      memberList: 'list',
+    }),
+    ...mapState(useAuthnStore, ['isAdmin']),
     visible: {
       get () {
         return this.modelValue

--- a/frontend/src/components/Secrets/GSecretDialog.vue
+++ b/frontend/src/components/Secrets/GSecretDialog.vue
@@ -119,7 +119,6 @@ SPDX-License-Identifier: Apache-2.0
 import {
   mapActions,
   mapState,
-  mapGetters,
 } from 'pinia'
 import { useVuelidate } from '@vuelidate/core'
 import {
@@ -231,10 +230,13 @@ export default {
   },
   computed: {
     ...mapState(useAuthzStore, ['namespace']),
-    ...mapGetters(useSecretStore, ['infrastructureSecretList', 'dnsSecretList']),
-    ...mapGetters(useCloudProfileStore, ['sortedInfrastructureKindList']),
-    ...mapGetters(useGardenerExtensionStore, ['sortedDnsProviderList']),
-    ...mapGetters(useShootStore, ['shootList']),
+    ...mapState(useSecretStore, [
+      'infrastructureSecretList',
+      'dnsSecretList',
+    ]),
+    ...mapState(useCloudProfileStore, ['sortedInfrastructureKindList']),
+    ...mapState(useGardenerExtensionStore, ['sortedDnsProviderList']),
+    ...mapState(useShootStore, ['shootList']),
     dnsProviderTypes () {
       return map(this.sortedDnsProviderList, 'type')
     },

--- a/frontend/src/components/Secrets/GSecretRowDns.vue
+++ b/frontend/src/components/Secrets/GSecretRowDns.vue
@@ -85,7 +85,7 @@ SPDX-License-Identifier: Apache-2.0
 </template>
 
 <script>
-import { mapGetters } from 'pinia'
+import { mapState } from 'pinia'
 
 import { useAuthzStore } from '@/store/authz'
 
@@ -116,7 +116,7 @@ export default {
     'delete',
   ],
   computed: {
-    ...mapGetters(useAuthzStore, ['canPatchSecrets', 'canDeleteSecrets']),
+    ...mapState(useAuthzStore, ['canPatchSecrets', 'canDeleteSecrets']),
     selectedHeaders () {
       return mapTableHeader(this.headers, 'selected')
     },

--- a/frontend/src/components/Secrets/GSecretRowInfra.vue
+++ b/frontend/src/components/Secrets/GSecretRowInfra.vue
@@ -83,7 +83,7 @@ SPDX-License-Identifier: Apache-2.0
 </template>
 
 <script>
-import { mapGetters } from 'pinia'
+import { mapState } from 'pinia'
 
 import { useAuthzStore } from '@/store/authz'
 
@@ -114,7 +114,7 @@ export default {
     'delete',
   ],
   computed: {
-    ...mapGetters(useAuthzStore, ['canPatchSecrets', 'canDeleteSecrets']),
+    ...mapState(useAuthzStore, ['canPatchSecrets', 'canDeleteSecrets']),
     selectedHeaders () {
       return mapTableHeader(this.headers, 'selected')
     },

--- a/frontend/src/components/ShootAccessRestrictions/GAccessRestrictionsConfiguration.vue
+++ b/frontend/src/components/ShootAccessRestrictions/GAccessRestrictionsConfiguration.vue
@@ -23,7 +23,7 @@ SPDX-License-Identifier: Apache-2.0
 </template>
 
 <script>
-import { mapGetters } from 'pinia'
+import { mapState } from 'pinia'
 
 import { useCloudProfileStore } from '@/store/cloudProfile'
 
@@ -47,7 +47,7 @@ export default {
   mixins: [shootItem],
   inject: ['api', 'logger'],
   computed: {
-    ...mapGetters(useCloudProfileStore, [
+    ...mapState(useCloudProfileStore, [
       'accessRestrictionNoItemsTextForCloudProfileNameAndRegion',
       'accessRestrictionDefinitionsByCloudProfileNameAndRegion',
     ]),

--- a/frontend/src/components/ShootDns/GDnsConfiguration.vue
+++ b/frontend/src/components/ShootDns/GDnsConfiguration.vue
@@ -23,7 +23,7 @@ SPDX-License-Identifier: Apache-2.0
 <script>
 import {
   mapActions,
-  mapGetters,
+  mapState,
 } from 'pinia'
 import { useVuelidate } from '@vuelidate/core'
 
@@ -54,7 +54,7 @@ export default {
     }
   },
   computed: {
-    ...mapGetters(useShootStagingStore, [
+    ...mapState(useShootStagingStore, [
       'getDnsConfiguration',
     ]),
   },

--- a/frontend/src/components/ShootDns/GDnsProviderRow.vue
+++ b/frontend/src/components/ShootDns/GDnsProviderRow.vue
@@ -122,7 +122,6 @@ SPDX-License-Identifier: Apache-2.0
 <script>
 import {
   mapState,
-  mapGetters,
   mapActions,
 } from 'pinia'
 import { required } from '@vuelidate/validators'
@@ -181,7 +180,7 @@ export default {
       'dnsPrimaryProviderId',
       'clusterIsNew',
     ]),
-    ...mapGetters(useGardenerExtensionStore, [
+    ...mapState(useGardenerExtensionStore, [
       'sortedDnsProviderList',
     ]),
     validators () {

--- a/frontend/src/views/GSecrets.vue
+++ b/frontend/src/views/GSecrets.vue
@@ -253,7 +253,7 @@ SPDX-License-Identifier: Apache-2.0
 
 <script>
 import {
-  mapGetters,
+  mapState,
   mapActions,
 } from 'pinia'
 import { useLocalStorage } from '@vueuse/core'
@@ -325,15 +325,15 @@ export default {
     }
   },
   computed: {
-    ...mapGetters(useCloudProfileStore, ['sortedInfrastructureKindList']),
-    ...mapGetters(useGardenerExtensionStore, ['sortedDnsProviderList']),
-    ...mapGetters(useSecretStore,
+    ...mapState(useCloudProfileStore, ['sortedInfrastructureKindList']),
+    ...mapState(useGardenerExtensionStore, ['sortedDnsProviderList']),
+    ...mapState(useSecretStore,
       [
         'infrastructureSecretList',
         'dnsSecretList',
       ]),
-    ...mapGetters(useAuthzStore, ['canCreateSecrets']),
-    ...mapGetters(useShootStore, ['shootList']),
+    ...mapState(useAuthzStore, ['canCreateSecrets']),
+    ...mapState(useShootStore, ['shootList']),
     hasCloudProfileForCloudProviderKind () {
       return (kind) => {
         return !isEmpty(this.cloudProfilesByCloudProviderKind(kind))


### PR DESCRIPTION
**What this PR does / why we need it**:
According to the [pinia documentation](https://pinia.vuejs.org/cookbook/options-api.html) the usage of `mapGetters` should be replaced with `mapState`.

<img width="600" alt="image" src="https://github.com/gardener/dashboard/assets/1574023/d3527e93-6ba1-4b6d-b418-a8ad0f6a15a7">


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
NONE
```
