### PR TITLE
Bug/fix time input safari

### DIFF
--- a/frontend/src/components/GTimeTextField.vue
+++ b/frontend/src/components/GTimeTextField.vue
@@ -1,0 +1,87 @@
+<!--
+SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+<template>
+  <v-text-field
+    v-model="timeValue"
+    :error-messages="errorMessages"
+    :hint="inputHint"
+    :type="textFieldType"
+    @change="v$.timeValue.$touch()"
+  />
+</template>
+
+<script setup>
+
+import { computed } from 'vue'
+import { useVuelidate } from '@vuelidate/core'
+import { useVModel } from '@vueuse/core'
+
+import { getValidationErrors } from '@/utils'
+
+const props = defineProps({
+  modelValue: {
+    type: String,
+  },
+  errorMessages: {
+    type: Array,
+  },
+})
+
+const emit = defineEmits([
+  'update:modelValue',
+])
+
+const timeValue = useVModel(props, 'modelValue', emit)
+
+const isSafari = computed(() => {
+  return /^((?!chrome|android).)*safari/i.test(navigator.userAgent)
+})
+
+const textFieldType = computed(() => {
+  /*
+  Safari browser rendering of text fields with type 'time' is confusing
+  See also https://bugs.webkit.org/show_bug.cgi?id=233215
+  So we use type text for Safari and add hint & error handing to support user input
+  */
+  return isSafari.value ? 'text' : 'time'
+})
+
+const rules = {
+  timeValue: {
+    timeSyntax: (value) => {
+      return !value?.length || /^([01][0-9]|2[0-3]):([0-5][0-9])$/.test(value)
+    },
+  },
+}
+
+const validationErrors = {
+  timeValue: {
+    timeSyntax: 'Input value is not valid 24-hour time format (HH:MM)',
+  },
+}
+
+const inputHint = computed(() => {
+  if (isSafari.value) {
+    return 'Please enter time in 24-hour format (HH:MM)'
+  }
+  return undefined
+})
+
+const errorMessages = computed(() => {
+  return [
+    ...getErrorMessages('timeValue'),
+    ...props.errorMessages,
+  ]
+})
+
+const v$ = useVuelidate(rules, { timeValue })
+
+function getErrorMessages (field) {
+  return getValidationErrors({ v$: v$.value, validators: rules, validationErrors }, field)
+}
+
+</script>

--- a/frontend/src/components/ShootHibernation/GHibernationScheduleEvent.vue
+++ b/frontend/src/components/ShootHibernation/GHibernationScheduleEvent.vue
@@ -39,7 +39,7 @@ SPDX-License-Identifier: Apache-2.0
             clearable
             variant="underlined"
             @blur="touchIfNothingFocused"
-            @input="onInputWakeUpTime"
+            @update:model-value="onInputWakeUpTime"
           />
         </v-col>
         <v-col cols="2">
@@ -52,7 +52,7 @@ SPDX-License-Identifier: Apache-2.0
             clearable
             variant="underlined"
             @blur="touchIfNothingFocused"
-            @input="onInputHibernateTime"
+            @update:model-value="onInputHibernateTime"
           />
         </v-col>
         <v-col cols="3">

--- a/frontend/src/components/ShootHibernation/GHibernationScheduleEvent.vue
+++ b/frontend/src/components/ShootHibernation/GHibernationScheduleEvent.vue
@@ -30,13 +30,12 @@ SPDX-License-Identifier: Apache-2.0
           />
         </v-col>
         <v-col cols="2">
-          <v-text-field
+          <g-time-text-field
             ref="wakeUpTime"
             v-model="wakeUpTime"
             color="primary"
             label="Wake up at"
             :error-messages="getErrorMessages('wakeUpTime')"
-            type="time"
             clearable
             variant="underlined"
             @blur="touchIfNothingFocused"
@@ -44,13 +43,12 @@ SPDX-License-Identifier: Apache-2.0
           />
         </v-col>
         <v-col cols="2">
-          <v-text-field
+          <g-time-text-field
             ref="hibernateTime"
             v-model="hibernateTime"
             color="primary"
             label="Hibernate at"
             :error-messages="getErrorMessages('hibernateTime')"
-            type="time"
             clearable
             variant="underlined"
             @blur="touchIfNothingFocused"
@@ -89,6 +87,8 @@ import {
 } from '@vuelidate/validators'
 import { useVuelidate } from '@vuelidate/core'
 
+import GTimeTextField from '@/components/GTimeTextField.vue'
+
 import { getValidationErrors } from '@/utils'
 import moment from '@/utils/moment'
 
@@ -118,6 +118,9 @@ const validationErrors = {
 }
 
 export default {
+  components: {
+    GTimeTextField,
+  },
   props: {
     scheduleEvent: {
       type: Object,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the Hibernation Schedule time input issue in Safari by falling back to a regular text input field.
This is required because Safari browser rendering of text fields with type 'time' is confusing
See also https://bugs.webkit.org/show_bug.cgi?id=233215
So we use type text for Safari and add hint & error handing to support user input

<img width="895" alt="Screenshot 2023-08-29 at 16 01 23" src="https://github.com/gardener/dashboard/assets/35373687/65964776-ea28-4be8-8379-b83f9b98f370">

**Which issue(s) this PR fixes**:
Fixes #1427

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed hibernation schedule time input for Safari browser
```
