### PR TITLE
Add github app-auth chart test for `secret-github.yaml` template

### DIFF
--- a/charts/__tests__/gardener-dashboard/runtime/dashboard/__snapshots__/secrets.spec.js.snap
+++ b/charts/__tests__/gardener-dashboard/runtime/dashboard/__snapshots__/secrets.spec.js.snap
@@ -1,6 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`gardener-dashboard secret-github should render the template 1`] = `
+exports[`gardener-dashboard secret-github app-auth should render the template 1`] = `
+Object {
+  "authentication.appId": "1",
+  "authentication.clientId": "clientId",
+  "authentication.clientSecret": "clientSecret",
+  "authentication.installationId": "123",
+  "authentication.privateKey": "privateKey",
+  "webhookSecret": "webhook-secret",
+}
+`;
+
+exports[`gardener-dashboard secret-github token-auth should render the template 1`] = `
 Object {
   "apiVersion": "v1",
   "data": Object {

--- a/charts/__tests__/gardener-dashboard/runtime/dashboard/secrets.spec.js
+++ b/charts/__tests__/gardener-dashboard/runtime/dashboard/secrets.spec.js
@@ -116,18 +116,7 @@ describe('gardener-dashboard', function () {
     })
 
     it('should render the template', async function () {
-      const values = {
-        global: {
-          dashboard: {
-            gitHub: {
-              authentication: {
-                token: 'token'
-              },
-              webhookSecret: 'webhook-secret'
-            }
-          }
-        }
-      }
+      const values = {}
       const documents = await renderTemplates(templates, values)
       expect(documents).toHaveLength(1)
       const [oidcSecret] = documents

--- a/charts/__tests__/gardener-dashboard/runtime/dashboard/secrets.spec.js
+++ b/charts/__tests__/gardener-dashboard/runtime/dashboard/secrets.spec.js
@@ -6,8 +6,13 @@
 
 'use strict'
 
+const { mapValues } = require('lodash')
 const { helm, helper } = fixtures
-const { getPrivateKey, getCertificate } = helper
+const {
+  getPrivateKey,
+  getCertificate,
+  decodeBase64
+} = helper
 
 const renderTemplates = helm.renderDashboardRuntimeTemplates
 
@@ -21,23 +26,51 @@ describe('gardener-dashboard', function () {
       ]
     })
 
-    it('should render the template', async function () {
-      const values = {
-        global: {
-          dashboard: {
-            gitHub: {
-              authentication: {
-                token: 'token'
-              },
-              webhookSecret: 'webhook-secret'
+    describe('token-auth', function () {
+      it('should render the template', async function () {
+        const values = {
+          global: {
+            dashboard: {
+              gitHub: {
+                authentication: {
+                  token: 'token'
+                },
+                webhookSecret: 'webhook-secret'
+              }
             }
           }
         }
-      }
-      const documents = await renderTemplates(templates, values)
-      expect(documents).toHaveLength(1)
-      const [githubSecret] = documents
-      expect(githubSecret).toMatchSnapshot()
+        const documents = await renderTemplates(templates, values)
+        expect(documents).toHaveLength(1)
+        const [githubSecret] = documents
+        expect(githubSecret).toMatchSnapshot()
+      })
+    })
+
+    describe('app-auth', function () {
+      it('should render the template', async function () {
+        const values = {
+          global: {
+            dashboard: {
+              gitHub: {
+                authentication: {
+                  appId: 1,
+                  clientId: 'clientId',
+                  clientSecret: 'clientSecret',
+                  installationId: 123,
+                  privateKey: 'privateKey'
+                },
+                webhookSecret: 'webhook-secret'
+              }
+            }
+          }
+        }
+        const documents = await renderTemplates(templates, values)
+        expect(documents).toHaveLength(1)
+        const [githubSecret] = documents
+        const data = mapValues(githubSecret.data, decodeBase64)
+        expect(data).toMatchSnapshot()
+      })
     })
   })
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a github app-auth chart test for the `secret-github.yaml `template

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
