### PR TITLE
[hotfix-1.69] Bug/hotfix error messages

### DIFF
--- a/frontend/src/components/ShootHibernation/HibernationConfiguration.vue
+++ b/frontend/src/components/ShootHibernation/HibernationConfiguration.vue
@@ -60,9 +60,12 @@ export default {
       await this.reset()
       const confirmed = await this.$refs.actionDialog.waitForDialogClosed()
       if (confirmed) {
-        await this.updateConfiguration()
+        if (await this.updateConfiguration()) {
+          this.componentKey = uuidv4() // force re-render
+        }
+      } else {
+        this.componentKey = uuidv4() // force re-render
       }
-      this.componentKey = uuidv4() // force re-render
     },
     async updateConfiguration () {
       try {
@@ -81,12 +84,14 @@ export default {
           name: this.shootName,
           data: noScheduleAnnotation
         })
+        return true
       } catch (err) {
         const errorMessage = 'Could not save hibernation configuration'
         const errorDetails = errorDetailsFromError(err)
         const detailedErrorMessage = errorDetails.detailedMessage
         this.$refs.actionDialog.setError({ errorMessage, detailedErrorMessage })
         console.error(this.errorMessage, errorDetails.errorCode, errorDetails.detailedMessage, err)
+        return false
       }
     },
     async reset () {

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -25,6 +25,7 @@ import {
   defaultCriNameByKubernetesVersion,
   UNKNOWN_EXPIRED_TIMESTAMP
 } from '@/utils'
+import { errorDetailsFromError } from '@/utils/error'
 import { v4 as uuidv4 } from '@/utils/uuid'
 import { hash } from '@/utils/crypto'
 import {
@@ -1543,7 +1544,15 @@ const actions = {
     return state.loading
   },
   setError ({ commit }, value) {
-    commit('SET_ALERT', { message: get(value, 'message', ''), type: 'error' })
+    let message
+    if (value?.response) {
+      const errorDetails = errorDetailsFromError(value)
+      message = errorDetails.detailedMessage
+    } else {
+      message = value?.message
+    }
+
+    commit('SET_ALERT', { message, type: 'error' })
     return state.alert
   },
   setAlert ({ commit }, value) {

--- a/frontend/src/views/NewShootEditor.vue
+++ b/frontend/src/views/NewShootEditor.vue
@@ -96,10 +96,15 @@ export default {
           }
         })
       } catch (err) {
-        const errorDetails = errorDetailsFromError(err)
+        this.errorMessage = errorDetailsFromError(err)
         this.errorMessage = 'Failed to create cluster.'
-        this.detailedErrorMessage = errorDetails.detailedMessage
-        console.error(this.errorMessage, errorDetails.errorCode, errorDetails.detailedMessage, err)
+        if (err.response) {
+          const errorDetails = errorDetailsFromError(err)
+          this.detailedErrorMessage = errorDetails.detailedMessage
+        } else {
+          this.detailedErrorMessage = err.message
+        }
+        this.logger.error(this.errorMessage, this.detailedErrorMessage, err)
       }
     },
     async isShootContentDirty () {

--- a/frontend/src/views/ShootItemEditor.vue
+++ b/frontend/src/views/ShootItemEditor.vue
@@ -33,11 +33,11 @@ SPDX-License-Identifier: Apache-2.0
 import ConfirmDialog from '@/components/dialogs/ConfirmDialog'
 import { mapState, mapGetters } from 'vuex'
 import { replaceShoot } from '@/utils/api'
+import { errorDetailsFromError } from '@/utils/error'
 
 import asyncRef from '@/mixins/asyncRef'
 
 // lodash
-import get from 'lodash/get'
 import pick from 'lodash/pick'
 
 const ShootEditor = () => import('@/components/ShootEditor')
@@ -115,7 +115,14 @@ export default {
         this.snackbarText = 'Cluster specification has been successfully updated'
         this.snackbar = true
       } catch (err) {
-        this.errorMessage = get(err, 'response.data.message', err.message)
+        this.errorMessage = 'Failed to save changes.'
+        if (err.response) {
+          const errorDetails = errorDetailsFromError(err)
+          this.detailedErrorMessage = errorDetails.detailedMessage
+        } else {
+          this.detailedErrorMessage = err.message
+        }
+        this.logger.error(this.errorMessage, this.detailedErrorMessage, err)
       }
     },
     confirmEditorNavigation () {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixed worker & hibernation dialog does not show error and resets to empty dialog
Fixed YAML Exception message sometimes not shown as part of error details
Fixed Snotify alert error message details

**Which issue(s) this PR fixes**:
Fixes #1477
Fixes #1538

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed error handling for manage workers and hibernation dialogs. The dialogs did not show all error messages and resetted to empty broken state on errors
```
```bugfix user
Fixed error handling for manage workers and hibernation dialogs. The dialogs did not show all error messages and resetted to empty broken state on errors
```
```bugfix user
Errors shown as notification alerts sometimes did not contain the failure reason
```
