### PR TITLE
Garden Terminal: make rolebinding configurable

### DIFF
--- a/backend/lib/services/terminals/index.js
+++ b/backend/lib/services/terminals/index.js
@@ -214,7 +214,7 @@ async function getTargetCluster ({ user, namespace, name, target, preferredHost,
             roleRef: {
               apiGroup: 'rbac.authorization.k8s.io',
               kind: 'ClusterRole',
-              name: 'cluster-admin'
+              name: 'gardener.cloud:system:administrators'
             },
             bindingKind: 'ClusterRoleBinding'
           }

--- a/backend/lib/services/terminals/index.js
+++ b/backend/lib/services/terminals/index.js
@@ -209,7 +209,7 @@ async function getTargetCluster ({ user, namespace, name, target, preferredHost,
       if (isAdmin) {
         targetCluster.namespace = 'garden'
         targetCluster.credentials = getConfigValue('terminal.garden.operatorCredentials')
-        targetCluster.authorization.roleBindings = [
+        targetCluster.authorization.roleBindings = getConfigValue('terminal.garden.roleBindings', [
           {
             roleRef: {
               apiGroup: 'rbac.authorization.k8s.io',
@@ -218,7 +218,7 @@ async function getTargetCluster ({ user, namespace, name, target, preferredHost,
             },
             bindingKind: 'ClusterRoleBinding'
           }
-        ]
+        ])
       } else {
         const projectName = findProjectByNamespace(namespace).metadata.name
         targetCluster.namespace = namespace

--- a/backend/test/acceptance/__snapshots__/api.terminals.spec.js.snap
+++ b/backend/test/acceptance/__snapshots__/api.terminals.spec.js.snap
@@ -624,7 +624,7 @@ Array [
                 "roleRef": Object {
                   "apiGroup": "rbac.authorization.k8s.io",
                   "kind": "ClusterRole",
-                  "name": "cluster-admin",
+                  "name": "gardener.cloud:system:administrators",
                 },
               },
             ],

--- a/charts/__tests__/gardener-dashboard/runtime/dashboard/__snapshots__/configmap.spec.js.snap
+++ b/charts/__tests__/gardener-dashboard/runtime/dashboard/__snapshots__/configmap.spec.js.snap
@@ -374,6 +374,44 @@ Li4u
 }
 `;
 
+exports[`gardener-dashboard configmap terminal config garden cluster custom rolebBindings should default apiGroup 1`] = `
+Object {
+  "terminal": Object {
+    "garden": Object {
+      "roleBindings": Array [
+        Object {
+          "bindingKind": "ClusterRoleBinding",
+          "roleRef": Object {
+            "apiGroup": "rbac.authorization.k8s.io",
+            "kind": "ClusterRole",
+            "name": "test-role",
+          },
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`gardener-dashboard configmap terminal config garden cluster custom rolebBindings should render the template 1`] = `
+Object {
+  "terminal": Object {
+    "garden": Object {
+      "roleBindings": Array [
+        Object {
+          "bindingKind": "ClusterRoleBinding",
+          "roleRef": Object {
+            "apiGroup": "rbac.authorization.k8s.foo",
+            "kind": "ClusterRole",
+            "name": "test-role",
+          },
+        },
+      ],
+    },
+  },
+}
+`;
+
 exports[`gardener-dashboard configmap terminal config should render the template 1`] = `
 Object {
   "terminal": Object {

--- a/charts/__tests__/gardener-dashboard/runtime/dashboard/configmap.spec.js
+++ b/charts/__tests__/gardener-dashboard/runtime/dashboard/configmap.spec.js
@@ -455,6 +455,59 @@ describe('gardener-dashboard', function () {
         const config = yaml.load(configMap.data['config.yaml'])
         expect(pick(config, ['terminal'])).toMatchSnapshot()
       })
+
+      describe('garden cluster custom rolebBindings', function () {
+        it('should render the template', async function () {
+          const values = {
+            global: {
+              terminal: {
+                garden: {
+                  roleBindings: [
+                    {
+                      roleRef: {
+                        apiGroup: 'rbac.authorization.k8s.foo',
+                        kind: 'ClusterRole',
+                        name: 'test-role'
+                      },
+                      bindingKind: 'ClusterRoleBinding'
+                    }
+                  ]
+                }
+              }
+            }
+          }
+          const documents = await renderTemplates(templates, values)
+          expect(documents).toHaveLength(1)
+          const [configMap] = documents
+          const config = yaml.load(configMap.data['config.yaml'])
+          expect(pick(config, ['terminal.garden.roleBindings'])).toMatchSnapshot()
+        })
+
+        it('should default apiGroup', async function () {
+          const values = {
+            global: {
+              terminal: {
+                garden: {
+                  roleBindings: [
+                    {
+                      roleRef: {
+                        kind: 'ClusterRole',
+                        name: 'test-role'
+                      },
+                      bindingKind: 'ClusterRoleBinding'
+                    }
+                  ]
+                }
+              }
+            }
+          }
+          const documents = await renderTemplates(templates, values)
+          expect(documents).toHaveLength(1)
+          const [configMap] = documents
+          const config = yaml.load(configMap.data['config.yaml'])
+          expect(pick(config, ['terminal.garden.roleBindings'])).toMatchSnapshot()
+        })
+      })
     })
 
     describe('themes', function () {

--- a/charts/gardener-dashboard/charts/runtime/templates/dashboard/configmap.yaml
+++ b/charts/gardener-dashboard/charts/runtime/templates/dashboard/configmap.yaml
@@ -147,6 +147,16 @@ data:
       garden:
         operatorCredentials:
 {{ toYaml .Values.global.terminal.garden.operatorCredentials | trim | indent 10 }}
+        {{- if .Values.global.terminal.garden.roleBindings }}
+        roleBindings:
+        {{- range .Values.global.terminal.garden.roleBindings }}
+        - roleRef:
+            apiGroup: {{ default "rbac.authorization.k8s.io" .roleRef.apiGroup }}
+            kind: {{ required ".Values.global.terminal.garden.roleBindings.roleRef.kind is required" .roleRef.kind }}
+            name: {{ required ".Values.global.terminal.garden.roleBindings.roleRef.name is required" .roleRef.name }}
+          bindingKind: {{ required ".Values.global.terminal.garden.roleBindings.bindingKind is required" .bindingKind }}
+        {{- end }}
+        {{- end }}
     {{- end }}
     frontend:
       {{- if .Values.global.dashboard.frontendConfig.helpMenuItems }}

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -435,6 +435,13 @@ global:
   #       serviceAccountRef: # serviceAccountRef or secretRef
   #         name: dashboard-terminal-admin
   #         namespace: garden
+  #     # role bindings that the access service account within the terminal pod should receive
+  #     roleBindings:
+  #     - roleRef:
+  #         apiGroup: 'rbac.authorization.k8s.io'
+  #         kind: 'ClusterRole'
+  #         name: 'gardener.cloud:system:administrators'
+  #       bindingKind: 'ClusterRoleBinding'
   #   bootstrap:
   #     disabled: true # indicates if bootstrapping resources required for the terminal feature is generally disabled
   #     seedDisabled: false # indicates if bootstrapping resources for seeds is disabled, required for gardener operator terminals


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows the configuration of role bindings to which the access service account within the `garden` terminal pod is bound.

example `values.yaml`
```yaml
global:
  terminal:
    garden:
      # role bindings that the access service account within the terminal pod should receive
      roleBindings:
      - roleRef:
          apiGroup: 'rbac.authorization.k8s.io'
          kind: 'ClusterRole'
          name: 'gardener.cloud:system:administrators'
        bindingKind: 'ClusterRoleBinding'
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Terminal: By default, the access service account within the garden terminal pod is bound to `gardener.cloud:system:administrators`, not `cluster-admin` anymore.
```

```feature operator
Terminal: You can now configure the role bindings to which the access service account within the `garden` terminal pod is bound (`Values.global.terminal.garden.roleBindings`).
```
