### PR TITLE
Fix vendor icon size

### DIFF
--- a/frontend/src/components/GVendorIcon.vue
+++ b/frontend/src/components/GVendorIcon.vue
@@ -119,8 +119,8 @@ const mdiIcon = computed(() => {
 const iconStyle = computed(() => {
   const maxIconSize = props.size - 4
   return {
-    maxHeight: `${maxIconSize}px`,
-    maxWidth: `${maxIconSize}px`,
+    height: `${maxIconSize}px`,
+    width: `${maxIconSize}px`,
   }
 })
 

--- a/frontend/src/components/GVendorIcon.vue
+++ b/frontend/src/components/GVendorIcon.vue
@@ -119,6 +119,8 @@ const mdiIcon = computed(() => {
 const iconStyle = computed(() => {
   const maxIconSize = props.size - 4
   return {
+    maxHeight: `${maxIconSize}px`,
+    maxWidth: `${maxIconSize}px`,
     height: `${maxIconSize}px`,
     width: `${maxIconSize}px`,
   }


### PR DESCRIPTION
use `height`, `width` instead of `maxHeight`, `maxWidth` to ensure correct vendor icon sizes

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #1521

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
