### PR TITLE
Pin docker node image minor version

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -42,7 +42,7 @@ dashboard:
         pull-request: ~
       steps:
         check:
-          image: 'node:20-alpine3.18'
+          image: 'node:20.5-alpine3.18'
         check-docforge:
           image: 'golang:1.20.2'
     release:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ############# builder #############
-FROM node:20-alpine3.18 as builder
+FROM node:20.5-alpine3.18 as builder
 
 WORKDIR /volume
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Pin node minor version to 20.5 to fix build failure

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
