### PR TITLE
[DRAFT] Add cloud providers via configuration

### DIFF
--- a/backend/lib/routes/config.js
+++ b/backend/lib/routes/config.js
@@ -57,7 +57,8 @@ function sanitizeFrontendConfig (frontendConfig) {
     } = {},
     vendorHints = [],
     resourceQuotaHelp = '',
-    controlPlaneHighAvailabilityHelp = ''
+    controlPlaneHighAvailabilityHelp = '',
+    customCloudProviders = {}
   } = sanitizedFrontendConfig
 
   convertAndSanitize(alert, 'message')
@@ -87,6 +88,13 @@ function sanitizeFrontendConfig (frontendConfig) {
 
   for (const vendorHint of vendorHints) {
     convertAndSanitize(vendorHint, 'message')
+  }
+
+  for (const key of Object.keys(customCloudProviders)) {
+    const secret = customCloudProviders[key]?.secret
+    if (secret) {
+      convertAndSanitize(secret, 'help')
+    }
   }
 
   return sanitizedFrontendConfig

--- a/charts/__tests__/gardener-dashboard/runtime/dashboard/configmap.spec.js
+++ b/charts/__tests__/gardener-dashboard/runtime/dashboard/configmap.spec.js
@@ -696,6 +696,111 @@ describe('gardener-dashboard', function () {
       })
     })
 
+    describe('cloudProviderList', function () {
+      it('should render the template with cloudProviderList', async function () {
+        const values = {
+          global: {
+            dashboard: {
+              frontendConfig: {
+                cloudProviderList: [
+                  'foo',
+                  'bar'
+                ]
+              }
+            }
+          }
+        }
+        const documents = await renderTemplates(templates, values)
+        expect(documents).toHaveLength(1)
+        const [configMap] = documents
+        const config = yaml.load(configMap.data['config.yaml'])
+        expect(pick(config, ['frontend.cloudProviderList'])).toMatchSnapshot()
+      })
+    })
+
+    describe('customCloudProviders', function () {
+      it('should render the template with customCloudProviders', async function () {
+        const values = {
+          global: {
+            dashboard: {
+              frontendConfig: {
+                customCloudProviders: {
+                  foo: {
+                    zoned: true,
+                    shoot: {
+                      provider: {
+                        type: 'foo'
+                      }
+                    },
+                    secret: {
+                      fields: [
+                        {
+                          key: 'user',
+                          type: 'text'
+                        },
+                        {
+                          key: 'password',
+                          type: 'password'
+                        }
+                      ]
+                    }
+                  },
+                  bar: {
+                    zoned: false,
+                    shoot: {
+                      provider: {
+                        type: 'bar'
+                      }
+                    },
+                    secret: {
+                      fields: [
+                        {
+                          key: 'user',
+                          type: 'text'
+                        },
+                        {
+                          key: 'password',
+                          type: 'password'
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        const documents = await renderTemplates(templates, values)
+        expect(documents).toHaveLength(1)
+        const [configMap] = documents
+        const config = yaml.load(configMap.data['config.yaml'])
+        expect(pick(config, ['frontend.customCloudProviders'])).toMatchSnapshot()
+      })
+    })
+
+    describe('vendors', function () {
+      it('should render the template with vendors', async function () {
+        const values = {
+          global: {
+            dashboard: {
+              frontendConfig: {
+                vendors: {
+                  foo: {
+                    icon: 'foo_icon.svg'
+                  }
+                }
+              }
+            }
+          }
+        }
+        const documents = await renderTemplates(templates, values)
+        expect(documents).toHaveLength(1)
+        const [configMap] = documents
+        const config = yaml.load(configMap.data['config.yaml'])
+        expect(pick(config, ['frontend.vendors'])).toMatchSnapshot()
+      })
+    })
+
     describe('knownConditions', function () {
       it('should render the template with knownConditions markdown', async function () {
         const values = {

--- a/charts/gardener-dashboard/charts/runtime/templates/dashboard/configmap-vendor-assets.yaml
+++ b/charts/gardener-dashboard/charts/runtime/templates/dashboard/configmap-vendor-assets.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.global.dashboard.enabled }}
+{{- if .Values.global.dashboard.frontendConfig.vendorAssets }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dashboard-vendor-assets
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: gardener-dashboard
+    app.kubernetes.io/component: dashboard
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+binaryData:
+{{- range $file, $content := .Values.global.dashboard.frontendConfig.vendorAssets }}
+  {{ $file }}: |
+    {{ $content }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/gardener-dashboard/charts/runtime/templates/dashboard/configmap.yaml
+++ b/charts/gardener-dashboard/charts/runtime/templates/dashboard/configmap.yaml
@@ -341,6 +341,18 @@ data:
       {{- if .Values.global.dashboard.frontendConfig.serviceAccountDefaultTokenExpiration }}
       serviceAccountDefaultTokenExpiration: {{ .Values.global.dashboard.frontendConfig.serviceAccountDefaultTokenExpiration }}
       {{- end }}
+      {{- if .Values.global.dashboard.frontendConfig.cloudProviderList }}
+      cloudProviderList:
+        {{- range .Values.global.dashboard.frontendConfig.cloudProviderList }}
+        - {{ . }}
+        {{- end }}
+      {{- end }}
+      {{- if .Values.global.dashboard.frontendConfig.customCloudProviders }}
+      customCloudProviders: {{ toYaml .Values.global.dashboard.frontendConfig.customCloudProviders | nindent 8 }}
+      {{- end }}
+      {{- if .Values.global.dashboard.frontendConfig.vendors }}
+      vendors: {{ toYaml .Values.global.dashboard.frontendConfig.vendors | nindent 8  }}
+      {{- end }}
       {{- if .Values.global.dashboard.frontendConfig.knownConditions }}
       knownConditions: {{ toYaml .Values.global.dashboard.frontendConfig.knownConditions | nindent 8 }}
       {{- end }}

--- a/charts/gardener-dashboard/charts/runtime/templates/dashboard/deployment.yaml
+++ b/charts/gardener-dashboard/charts/runtime/templates/dashboard/deployment.yaml
@@ -75,6 +75,12 @@ spec:
           name: dashboard-assets
           defaultMode: 0444
       {{- end }}
+      {{- if .Values.global.dashboard.frontendConfig.vendorAssets }}
+      - name: vendor-assets
+        configMap:
+          name: dashboard-vendor-assets
+          defaultMode: 0444
+      {{- end }}
       {{- if .Values.global.dashboard.serviceAccountTokenVolumeProjection.enabled }}
       - name: service-account-token
         projected:
@@ -229,6 +235,10 @@ spec:
           {{- if .Values.global.dashboard.frontendConfig.assets }}
           - name: assets
             mountPath: /app/public/static/assets
+          {{- end }}
+          {{- if .Values.global.dashboard.frontendConfig.vendorAssets }}
+          - name: vendor-assets
+            mountPath: /app/public/static/vendor-assets
           {{- end }}
           {{- if .Values.global.dashboard.serviceAccountTokenVolumeProjection.enabled }}
           - name: service-account-token

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -310,6 +310,43 @@ global:
       # resourceQuotaHelp:
       #   text: Help text
 
+       # # cloudProviderList - configure available cloud providers. This allows to change order and to add additional (not built-in providers), see also customCloudProviders
+      # cloudProviderList:
+      # - aws
+      # - custom-provider
+
+      # # customCloudProviders - configure additional cloud providers
+      # customCloudProviders:
+      #   custom-provider:
+      #     zoned: true
+      #     shoot: # shoot template for this provider
+      #       specTemplate:
+      #         provider:
+      #           type: custom-provider
+      #         networking:
+      #           nodes: ${workerCIDR}
+      #     secret: # secret dialog
+      #       fields:
+      #       - key: user
+      #         hint: Enter a valid user
+      #         label: User
+      #         type: text
+      #         validators:
+      #           required:
+      #             type: required
+      #         validationErrors:
+      #           required: User is required
+      #       help: | # help text for secret dialog
+      #         #Foo Cloud Provider
+
+      # # vendors - configure additional or overwrite built-in vendor icons
+      # vendors:
+      #   custom-provider:
+      #     icon: custom-provider.svg
+      #
+      # vendorAssets:
+      #   custom-provider.svg: |
+
       # # controlPlaneHighAvailabilityHelp - configure help text for control plane high availability, control plane pricing etc.
       # controlPlaneHighAvailabilityHelp:
       #   text: Help text

--- a/frontend/src/components/GVendor.vue
+++ b/frontend/src/components/GVendor.vue
@@ -33,7 +33,7 @@ SPDX-License-Identifier: Apache-2.0
               :icon="cloudProviderKind"
               class="mr-2"
             />
-            {{ cloudProviderKind }}
+            {{ vendorName }}
           </v-list-item-title>
         </v-list-item>
         <v-list-item v-if="cloudProfileName">
@@ -54,9 +54,16 @@ SPDX-License-Identifier: Apache-2.0
 </template>
 
 <script>
+import { mapState } from 'pinia'
+
+import { useConfigStore } from '@/store/config'
+
 import GVendorIcon from '@/components/GVendorIcon'
 
-import { join } from '@/lodash'
+import {
+  join,
+  get,
+} from '@/lodash'
 
 export default {
   components: {
@@ -86,6 +93,9 @@ export default {
     },
   },
   computed: {
+    ...mapState(useConfigStore, [
+      'vendors',
+    ]),
     zoneText () {
       return join(this.zones, ', ')
     },
@@ -98,7 +108,7 @@ export default {
     description () {
       const description = []
       if (this.extended && this.cloudProviderKind) {
-        description.push(this.cloudProviderKind)
+        description.push(this.vendorName)
       }
       if (this.cloudProfileName) {
         description.push(this.cloudProfileName)
@@ -127,6 +137,9 @@ export default {
         titles.push(this.zoneTitle)
       }
       return join(titles, ' / ')
+    },
+    vendorName () {
+      return get(this.vendors, [this.cloudProviderKind, 'name'], this.cloudProviderKind)
     },
   },
 }

--- a/frontend/src/components/GVendorIcon.vue
+++ b/frontend/src/components/GVendorIcon.vue
@@ -63,9 +63,9 @@ const configStore = useConfigStore()
 const { vendors } = storeToRefs(configStore)
 
 const iconSrc = computed(() => {
-  const customCloudProviderIcon = get(vendors, [props.icon, 'icon'])
+  const customCloudProviderIcon = get(vendors, ['value', props.icon, 'icon'])
   if (customCloudProviderIcon) {
-    return new URL(`/static/vendor-assets/${customCloudProviderIcon}`, import.meta.url)
+    return `/static/vendor-assets/${customCloudProviderIcon}`
   }
 
   switch (props.icon) {

--- a/frontend/src/components/GVendorIcon.vue
+++ b/frontend/src/components/GVendorIcon.vue
@@ -28,12 +28,19 @@ SPDX-License-Identifier: Apache-2.0
 </template>
 
 <script setup>
+
 import {
   computed,
   toRef,
 } from 'vue'
+import { storeToRefs } from 'pinia'
 
-import { startsWith } from '@/lodash'
+import { useConfigStore } from '@/store/config'
+
+import {
+  startsWith,
+  get,
+} from '@/lodash'
 
 const props = defineProps({
   icon: {
@@ -52,7 +59,15 @@ const props = defineProps({
 
 const noBackground = toRef(props, 'noBackground')
 
+const configStore = useConfigStore()
+const { vendors } = storeToRefs(configStore)
+
 const iconSrc = computed(() => {
+  const customCloudProviderIcon = get(vendors, [props.icon, 'icon'])
+  if (customCloudProviderIcon) {
+    return new URL(`/static/vendor-assets/${customCloudProviderIcon}`, import.meta.url)
+  }
+
   switch (props.icon) {
     // infrastructures
     case 'azure':

--- a/frontend/src/components/NewShoot/GNewShootSelectInfrastructure.vue
+++ b/frontend/src/components/NewShoot/GNewShootSelectInfrastructure.vue
@@ -26,7 +26,7 @@ SPDX-License-Identifier: Apache-2.0
           />
         </div>
         <div class="mt-2">
-          <span class="text-subtitle-1">{{ infrastructureKind }}</span>
+          <span class="text-subtitle-1">{{ vendorName(infrastructureKind) }}</span>
         </div>
       </div>
     </v-card>
@@ -40,9 +40,11 @@ import {
 } from 'pinia'
 
 import { useCloudProfileStore } from '@/store/cloudProfile'
+import { useConfigStore } from '@/store/config'
 
 import GVendorIcon from '@/components/GVendorIcon'
 
+import { get } from '@/lodash'
 export default {
   components: {
     GVendorIcon,
@@ -62,6 +64,9 @@ export default {
     ...mapState(useCloudProfileStore, [
       'sortedInfrastructureKindList',
     ]),
+    ...mapState(useConfigStore, [
+      'vendors',
+    ]),
   },
   methods: {
     ...mapActions(useCloudProfileStore, ['cloudProfilesByCloudProviderKind']),
@@ -71,6 +76,9 @@ export default {
     },
     setSelectedInfrastructure (infrastructure) {
       this.selectedInfrastructure = infrastructure
+    },
+    vendorName (infrastructureKind) {
+      return get(this.vendors, [infrastructureKind, 'name'], infrastructureKind)
     },
   },
 }

--- a/frontend/src/components/Secrets/GSecretDialogGeneric.vue
+++ b/frontend/src/components/Secrets/GSecretDialogGeneric.vue
@@ -208,7 +208,7 @@ export default {
       return transformHtml(this.customCloudProvider?.secret?.help)
     },
     valid () {
-      return !this.$v.$invalid
+      return !this.v$.$invalid
     },
     isCreateMode () {
       return !this.secret
@@ -228,7 +228,7 @@ export default {
       set(this.customCloudProviderParsedData, key, {})
       try {
         if (type === 'yaml') {
-          this.customCloudProviderParsedData[key] = await this.$yaml.load(this.customCloudProviderData[key])
+          this.customCloudProviderParsedData[key] = await this.yaml.load(this.customCloudProviderData[key])
         } else if (type === 'json') {
           this.customCloudProviderParsedData[key] = JSON.parse(this.customCloudProviderData[key])
         }
@@ -239,7 +239,7 @@ export default {
           this.customCloudProviderParsedData[key] = {}
         }
       }
-      this.$v.customCloudProviderData[key].$touch()
+      this.v$.customCloudProviderData[key].$touch()
     },
     reset () {
       this.v$.$reset()

--- a/frontend/src/components/ShootWorkers/GMachineImage.vue
+++ b/frontend/src/components/ShootWorkers/GMachineImage.vue
@@ -28,7 +28,7 @@ SPDX-License-Identifier: Apache-2.0
         <template #prepend>
           <g-vendor-icon :icon="item.raw.icon" />
         </template>
-        <v-list-item-title>Name: {{ item.raw.name }} | Version: {{ item.raw.version }}</v-list-item-title>
+        <v-list-item-title>Name: {{ item.raw.displayName }} | Version: {{ item.raw.version }}</v-list-item-title>
         <v-list-item-subtitle v-if="itemDescription(item).length">
           {{ itemDescription(item.raw) }}
         </v-list-item-subtitle>
@@ -37,7 +37,7 @@ SPDX-License-Identifier: Apache-2.0
     <template #selection="{ item }">
       <g-vendor-icon :icon="item.raw.icon" />
       <span class="ml-2">
-        {{ item.raw.name }} [{{ item.raw.version }}]
+        {{ item.raw.displayName }} [{{ item.raw.version }}]
       </span>
     </template>
     <template #message="{ message }">

--- a/frontend/src/components/ShootWorkers/GManageWorkers.vue
+++ b/frontend/src/components/ShootWorkers/GManageWorkers.vue
@@ -63,9 +63,13 @@ SPDX-License-Identifier: Apache-2.0
 </template>
 
 <script>
-import { mapActions } from 'pinia'
+import {
+  mapActions,
+  mapState,
+} from 'pinia'
 
 import { useCloudProfileStore } from '@/store/cloudProfile'
+import { useConfigStore } from '@/store/config'
 
 import GWorkerInputGeneric from '@/components/ShootWorkers/GWorkerInputGeneric'
 import GExpandTransitionGroup from '@/components/GExpandTransitionGroup'
@@ -128,6 +132,9 @@ export default {
     }
   },
   computed: {
+    ...mapState(useConfigStore, [
+      'customCloudProviders',
+    ]),
     allMachineTypes () {
       return this.machineTypesByCloudProfileName({ cloudProfileName: this.cloudProfileName })
     },
@@ -208,7 +215,11 @@ export default {
          * do not pass shootspec as we do not have it available in this component and it is (currently) not required to determine isZoned for new clusters. This event handler is only called for new clusters, as the
          * userInterActionBus is only set for the create cluster use case
          */
-        this.zonedCluster = isZonedCluster({ cloudProviderKind: this.cloudProviderKind, isNewCluster: this.isNewCluster })
+        this.zonedCluster = isZonedCluster({
+          cloudProviderKind: this.cloudProviderKind,
+          isNewCluster: this.isNewCluster,
+          customCloudProviders: this.customCloudProviders,
+        })
         this.setDefaultWorker()
       })
       this.userInterActionBus.on('updateRegion', region => {

--- a/frontend/src/components/ShootWorkers/GWorkerConfiguration.vue
+++ b/frontend/src/components/ShootWorkers/GWorkerConfiguration.vue
@@ -97,6 +97,9 @@ SPDX-License-Identifier: Apache-2.0
 <script>
 import { defineAsyncComponent } from 'vue'
 import { useVuelidate } from '@vuelidate/core'
+import { mapState } from 'pinia'
+
+import { useConfigStore } from '@/store/config'
 
 import GActionButtonDialog from '@/components/dialogs/GActionButtonDialog'
 import GCodeBlock from '@/components/GCodeBlock'
@@ -145,6 +148,9 @@ export default {
     }
   },
   computed: {
+    ...mapState(useConfigStore, [
+      'customCloudProviders',
+    ]),
     tab: {
       get () {
         return this.tabValue
@@ -211,7 +217,11 @@ export default {
       const zonesNetworkConfiguration = get(this.shootItem, 'spec.provider.infrastructureConfig.networks.zones')
       const cloudProfileName = this.shootCloudProfileName
       const region = this.shootRegion
-      const zonedCluster = isZonedCluster({ cloudProviderKind: this.shootCloudProviderKind, shootSpec: this.shootSpec })
+      const zonedCluster = isZonedCluster({
+        cloudProviderKind: this.shootCloudProviderKind,
+        shootSpec: this.shootSpec,
+        customCloudProviders: this.customCloudProviders,
+      })
       const existingWorkerCIDR = get(this.shootItem, 'spec.networking.nodes')
 
       await this.manageWorkers.dispatch('setWorkersData', { workers, cloudProfileName, region, zonesNetworkConfiguration, zonedCluster, existingWorkerCIDR, kubernetesVersion: this.shootK8sVersion })

--- a/frontend/src/components/ShootWorkers/GWorkerGroup.vue
+++ b/frontend/src/components/ShootWorkers/GWorkerGroup.vue
@@ -197,7 +197,7 @@ SPDX-License-Identifier: Apache-2.0
                         <legend class="text-caption text-medium-emphasis">
                           Name
                         </legend>
-                        <span class="text-body-2">{{ workerGroup.machine.image.name }}</span>
+                        <span class="text-body-2">{{ machineImage ? machineImage.displayName : workerGroup.machine.image.name }}</span>
                       </v-col>
                       <v-col>
                         <legend class="text-caption text-medium-emphasis">

--- a/frontend/src/store/cloudProfile/index.js
+++ b/frontend/src/store/cloudProfile/index.js
@@ -379,6 +379,7 @@ export const useCloudProfileStore = defineStore('cloudProfile', () => {
 
       const name = machineImage.name
       const vendorName = vendorNameFromImageName(machineImage.name)
+      const displayName = get(configStore, ['vendors', vendorName, 'name'], vendorName)
       const vendorHint = findVendorHint(configStore.vendorHints, vendorName)
 
       return map(versions, ({ version, expirationDate, cri, classification, architectures }) => {
@@ -388,6 +389,7 @@ export const useCloudProfileStore = defineStore('cloudProfile', () => {
         return decorateClassificationObject({
           key: name + '/' + version,
           name,
+          displayName,
           version,
           cri,
           classification,

--- a/frontend/src/store/cloudProfile/index.js
+++ b/frontend/src/store/cloudProfile/index.js
@@ -103,7 +103,7 @@ export const useCloudProfileStore = defineStore('cloudProfile', () => {
   })
 
   const sortedInfrastructureKindList = computed(() => {
-    return intersection(['aws', 'azure', 'gcp', 'openstack', 'alicloud', 'metal', 'vsphere', 'hcloud', 'onmetal', 'local'], infrastructureKindList.value)
+    return intersection(configStore.cloudProviderList ?? ['aws', 'azure', 'gcp', 'openstack', 'alicloud', 'metal', 'vsphere', 'hcloud', 'onmetal', 'local'], infrastructureKindList.value)
   })
 
   function cloudProfilesByCloudProviderKind (cloudProviderKind) {

--- a/frontend/src/store/config.js
+++ b/frontend/src/store/config.js
@@ -243,6 +243,18 @@ export const useConfigStore = defineStore('config', () => {
     }
   })
 
+  const customCloudProviders = computed(() => {
+    return state.value?.customCloudProviders
+  })
+
+  const vendors = computed(() => {
+    return state.value?.vendors
+  })
+
+  const cloudProviderList = computed(() => {
+    return state.value?.cloudProviderList
+  })
+
   const appVersion = computed(() => {
     return state.value?.appVersion ?? import.meta.env.VITE_APP_VERSION
   })
@@ -330,6 +342,9 @@ export const useConfigStore = defineStore('config', () => {
     isShootHasNoHibernationScheduleWarning,
     fetchConfig,
     conditionForType,
+    customCloudProviders,
+    vendors,
+    cloudProviderList,
     $reset,
   }
 })

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -547,7 +547,11 @@ export function defaultCriNameByKubernetesVersion (criNames, kubernetesVersion) 
     ? criName
     : head(criNames)
 }
-export function isZonedCluster ({ cloudProviderKind, shootSpec, isNewCluster }) {
+export function isZonedCluster ({ cloudProviderKind, shootSpec, isNewCluster, customCloudProviders }) {
+  const customCloudProviderZone = get(customCloudProviders, [cloudProviderKind, 'zoned'])
+  if (customCloudProviderZone !== undefined) {
+    return customCloudProviderZone
+  }
   switch (cloudProviderKind) {
     case 'azure':
       if (isNewCluster) {

--- a/frontend/src/views/GNewShoot.vue
+++ b/frontend/src/views/GNewShoot.vue
@@ -263,7 +263,10 @@ export default {
   },
   computed: {
     ...mapState(useAuthzStore, ['namespace']),
-    ...mapState(useConfigStore, ['accessRestriction', 'defaultNodesCIDR']),
+    ...mapState(useConfigStore, [
+      'accessRestriction',
+      'defaultNodesCIDR',
+      'customCloudProviders']),
     ...mapState(useShootStagingStore, ['controlPlaneFailureToleranceType']),
     ...mapState(useShootStagingStore, [
       'getDnsConfiguration',
@@ -324,7 +327,7 @@ export default {
       const oldInfrastructureKind = get(shootResource, 'spec.provider.type')
       if (oldInfrastructureKind !== infrastructureKind) {
         // Infrastructure changed
-        set(shootResource, 'spec', getSpecTemplate(infrastructureKind, this.defaultNodesCIDR))
+        set(shootResource, 'spec', getSpecTemplate(infrastructureKind, this.defaultNodesCIDR, this.customCloudProviders))
       }
       set(shootResource, 'spec.cloudProfileName', cloudProfileName)
       set(shootResource, 'spec.region', region)
@@ -500,7 +503,7 @@ export default {
       })
 
       const workers = get(shootResource, 'spec.provider.workers')
-      const zonedCluster = isZonedCluster({ cloudProviderKind: infrastructureKind, isNewCluster: true })
+      const zonedCluster = isZonedCluster({ cloudProviderKind: infrastructureKind, isNewCluster: true, customCloudProviders: this.customCloudProviders })
 
       const newShootWorkerCIDR = get(shootResource, 'spec.networking.nodes', this.defaultNodesCIDR)
       await this.manageWorkers.dispatch('setWorkersData', { workers, cloudProfileName, region, updateOSMaintenance: osUpdates, zonedCluster, kubernetesVersion, newShootWorkerCIDR })


### PR DESCRIPTION
**What this PR does / why we need it**:
On top of PR #1434 this PR adds logic to define additional cloud providers via configuration (`customCloudProviders`).
It is possible to define a custom secret dialog including (simple) validation and help texts.
Current possible validations:
- required
- requiredIf (ref to other field) // TODO add example
- regex validation
- isJSON
- isYAML

A custom cloud provider icon can be defined using an image resource mounted via asset configuration.
This way it is also possible to overwrite icons as well as names for build-in cloud providers (like aws, gpc, etc)
It is possible to provide additional required data for the shoot template.

This PR also adds a configuration option for the available cloud providers (`cloudProviderList`). This allows to add additional cloud providers as well as configure their order in the Dashboard. It is possible to add cloud providers without additional configuration, the secret dialog and logo will fallback to generic input / icon.

***Current Limitations:***
No additional input fields on create cluster page, see #1445

***Example dashboard configuration for a cloud provider with name `custom`***
```yaml
cloudProviderList:
  - gcp
  - aws
  - custom
customCloudProviders:
  custom:
    zoned: false
    shoot:
      specTemplate:
        provider:
          type: custom
          infrastructureConfig:
            apiVersion: custom.provider.extensions.gardener.cloud/v1alpha1
            kind: InfrastructureConfig
            networks:
              vpc:
                cidr: ${workerCIDR}
          controlPlaneConfig:
            apiVersion: custom.provider.extensions.gardener.cloud/v1alpha1
            kind: ControlPlaneConfig
        networking:
          nodes: ${workerCIDR}
          foo: bar
    secret:
      fields:
      - key: namespace
        hint: Enter a valid namespace
        label: Namespace
        validators:
          required: .+
          isNamespace: .+--.+
        validationErrors:
          required: Namespace is required
          isNamespace: Must be a valid namespace with format a--b
      - key: token 
        hint: Enter a valid token
        label: token
        password: true
        validators:
          required: .+
          isToken: ^.{10}$
        validationErrors:
          required: token is required
          isToken: Must be a valid token with length 10
      help: |
        #Custom Cloud Provider
        <br />
        <img src="/static/vendor_assets/custom.png" width="100px" />
        <br />
        ## Namespace
        Please enter a valid namespace with format a--b
        <br />
        ## Token
        Please enter a valid token with exactly 10 chars
vendors:
    aws:
      icon: amazon.svg
      name: Amazon
    custom:
      name: Custom CC
      icon: custom.png
```

Icons can be provided as base64 encoded values when using the [helm chart](https://github.com/gardener/dashboard/blob/master/charts/gardener-dashboard) in the frontendConfig.vendorAssets map. Those icons can then be refrenced in the vendor configurations as well as the help html as shown above.

***Cloud provider `custom` rendered in the Dashboard***
<img width="304" alt="Screenshot 2023-03-06 at 16 51 34" src="https://user-images.githubusercontent.com/35373687/223168470-fa0c68e7-d846-447d-8572-a131d288a541.png">
<img width="864" alt="Screenshot 2023-03-06 at 16 53 47" src="https://user-images.githubusercontent.com/35373687/223168477-792a9289-3691-42b3-b6cf-ce7842dc23a4.png">
<img width="1351" alt="Screenshot 2023-03-06 at 16 54 20" src="https://user-images.githubusercontent.com/35373687/223168485-02b6ef63-6a29-4220-8706-592921f064e7.png">

**Which issue(s) this PR fixes**:
Fixes 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Define order of cloud providers in dashboard configuration
```
```feature operator
Define additional cloud providers in dashboard configuration
```
