### PR TITLE
Make cluster access dialog persistent

### DIFF
--- a/frontend/src/views/GShootList.vue
+++ b/frontend/src/views/GShootList.vue
@@ -190,6 +190,7 @@ SPDX-License-Identifier: Apache-2.0
       </v-data-table>
       <v-dialog
         v-model="clusterAccessDialog"
+        persistent
         max-width="850"
       >
         <v-card>


### PR DESCRIPTION
**What this PR does / why we need it**:
The  cluster access dialog should not be closed of a child popover is clicked or closed. This triggers a `click-outside` event on the dialog. 

**Which issue(s) this PR fixes**:
Fixes #1535

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
