### PR TITLE
Imporve focus mode tooltip formatting and tooltip background

### DIFF
--- a/frontend/src/sass/settings.scss
+++ b/frontend/src/sass/settings.scss
@@ -14,6 +14,7 @@
   $color-pack: true !default,
   $utilities: false !default,
   $alert-padding: 8px 4px 8px 8px,
+  $tooltip-background-color: rgba(var(--v-theme-surface-variant), 0.87),
 );
 
 @forward './variables.scss';

--- a/frontend/src/views/GShootList.vue
+++ b/frontend/src/views/GShootList.vue
@@ -54,7 +54,7 @@ SPDX-License-Identifier: Apache-2.0
               </div>
             </template>
             <span class="font-weight-bold">Focus Mode</span>
-            <ul>
+            <ul class="ml-3">
               <li>Cluster list sorting is freezed</li>
               <li>Items in the list will still be updated</li>
               <li>New clusters will not be added to the list until you disable focus mode</li>


### PR DESCRIPTION
**What this PR does / why we need it**:
Reduce tooltip opacity and indent focus mode list items.

##### Dark mode
<img width="600" alt="Screenshot 2023-09-12 at 14 08 11" src="https://github.com/gardener/dashboard/assets/1574023/ad8e7bfa-cb3a-49d6-ae28-134758be97e4">

#### Light mode
<img width="600" alt="Screenshot 2023-09-12 at 14 08 26" src="https://github.com/gardener/dashboard/assets/1574023/46f0a6fa-fcb1-4f4b-a859-aeae0e5ad7c0">


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
