### PR TITLE
Refresh rules

### DIFF
--- a/frontend/src/components/Members/GMemberDialog.vue
+++ b/frontend/src/components/Members/GMemberDialog.vue
@@ -403,7 +403,7 @@ export default {
   },
   methods: {
     ...mapActions(useAuthzStore, [
-      'fetchRules',
+      'refreshRules',
     ]),
     ...mapActions(useMemberStore, [
       'addMember',
@@ -448,7 +448,7 @@ export default {
           await this.updateMember(name, { roles, description: this.internalDescription })
 
           if (this.isCurrentUser && !this.isAdmin) {
-            await this.fetchRules(this.namespace, true)
+            await this.refreshRules()
           }
           this.hide()
         } catch (err) {

--- a/frontend/src/components/Members/GMemberDialog.vue
+++ b/frontend/src/components/Members/GMemberDialog.vue
@@ -402,10 +402,12 @@ export default {
     },
   },
   methods: {
+    ...mapActions(useAuthzStore, [
+      'fetchRules',
+    ]),
     ...mapActions(useMemberStore, [
       'addMember',
       'updateMember',
-      'refreshSubjectRules',
     ]),
     hide () {
       this.visible = false
@@ -446,7 +448,7 @@ export default {
           await this.updateMember(name, { roles, description: this.internalDescription })
 
           if (this.isCurrentUser && !this.isAdmin) {
-            await this.refreshSubjectRules()
+            await this.fetchRules(this.namespace, true)
           }
           this.hide()
         } catch (err) {

--- a/frontend/src/store/authz.js
+++ b/frontend/src/store/authz.js
@@ -135,13 +135,22 @@ export const useAuthzStore = defineStore('authz', () => {
       canCreateTerminals.value
   })
 
-  async function fetchRules (namespace, force) {
-    if (force || (namespace && spec.value?.namespace !== namespace)) {
-      const body = { namespace }
-      const response = await api.getSubjectRules(body)
+  // reuse function not exported
+  async function getRules (namespace) {
+    const body = { namespace }
+    const response = await api.getSubjectRules(body)
+    status.value = response.data
+  }
+
+  async function fetchRules (namespace) {
+    if (namespace && spec.value?.namespace !== namespace) {
+      await getRules(namespace)
       this.setNamespace(namespace)
-      status.value = response.data
     }
+  }
+
+  function refreshRules () {
+    return getRules(spec.value?.namespace)
   }
 
   function setNamespace (namespace) {
@@ -181,6 +190,7 @@ export const useAuthzStore = defineStore('authz', () => {
     hasControlPlaneTerminalAccess,
     hasShootTerminalAccess,
     fetchRules,
+    refreshRules,
     $reset,
   }
 })

--- a/frontend/src/store/authz.js
+++ b/frontend/src/store/authz.js
@@ -135,8 +135,8 @@ export const useAuthzStore = defineStore('authz', () => {
       canCreateTerminals.value
   })
 
-  async function fetchRules (namespace) {
-    if (namespace && spec.value?.namespace !== namespace) {
+  async function fetchRules (namespace, force) {
+    if (force || (namespace && spec.value?.namespace !== namespace)) {
       const body = { namespace }
       const response = await api.getSubjectRules(body)
       this.setNamespace(namespace)


### PR DESCRIPTION
**What this PR does / why we need it**:
Refresh subject rules when changing the permissions of your own (non-admin) user. E.g. you make yourself a viewer instead of project admin. The rules should be updated accordingly

This PR fixed an issue where the wrong function was used (`refreshSubjectRules`), which was a leftover of the pre-vue3 code.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
