### PR TITLE
Fetch subject rules when the user is not assigned to any project yet

### DIFF
--- a/frontend/src/composables/useApi/api.js
+++ b/frontend/src/composables/useApi/api.js
@@ -273,7 +273,8 @@ export function createTokenReview (data) {
   return createResource('/auth', data)
 }
 
-export function getSubjectRules ({ namespace = 'default' }) {
+export function getSubjectRules (options) {
+  const namespace = options?.namespace ?? 'default'
   return callResourceMethod('/api/user/subjectrules', {
     namespace,
   })

--- a/frontend/src/store/authz.js
+++ b/frontend/src/store/authz.js
@@ -143,7 +143,16 @@ export const useAuthzStore = defineStore('authz', () => {
   }
 
   async function fetchRules (namespace) {
-    if (namespace && spec.value?.namespace !== namespace) {
+    /**
+     * The value of `spec.value?.namespace` is:
+     * - undefined if no rules have been fetched yet
+     * - null if only cluster scoped rules have been fetched
+     * - a non-empty string if both cluster scoped rules and the rules for the namespace have been fetched
+     */
+    if (!namespace) {
+      namespace = null
+    }
+    if (spec.value?.namespace !== namespace) {
       await getRules(namespace)
       this.setNamespace(namespace)
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fetch subject rules when the user is not assigned to any project yet.

**Which issue(s) this PR fixes**:
Fixes #1560

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
