### PR TITLE
Map pinia functions with mapActions

### DIFF
--- a/frontend/src/components/GSeedConfiguration.vue
+++ b/frontend/src/components/GSeedConfiguration.vue
@@ -28,7 +28,10 @@ SPDX-License-Identifier: Apache-2.0
 </template>
 
 <script>
-import { mapState } from 'pinia'
+import {
+  mapState,
+  mapActions,
+} from 'pinia'
 
 import { useSeedStore } from '@/store/seed'
 
@@ -58,7 +61,6 @@ export default {
   },
   computed: {
     ...mapState(useSeedStore, [
-      'seedByName',
       'seedList',
     ]),
     seedNames () {
@@ -69,6 +71,9 @@ export default {
     },
   },
   methods: {
+    ...mapActions(useSeedStore, [
+      'seedByName',
+    ]),
     async onConfigurationDialogOpened () {
       await this.reset()
       const confirmed = await this.$refs.actionDialog.waitForDialogClosed()

--- a/frontend/src/components/ShootAccessRestrictions/GAccessRestrictionsConfiguration.vue
+++ b/frontend/src/components/ShootAccessRestrictions/GAccessRestrictionsConfiguration.vue
@@ -23,7 +23,7 @@ SPDX-License-Identifier: Apache-2.0
 </template>
 
 <script>
-import { mapState } from 'pinia'
+import { mapActions } from 'pinia'
 
 import { useCloudProfileStore } from '@/store/cloudProfile'
 
@@ -47,10 +47,6 @@ export default {
   mixins: [shootItem],
   inject: ['api', 'logger'],
   computed: {
-    ...mapState(useCloudProfileStore, [
-      'accessRestrictionNoItemsTextForCloudProfileNameAndRegion',
-      'accessRestrictionDefinitionsByCloudProfileNameAndRegion',
-    ]),
     disabled () {
       const accessRestrictionDefinitions = this.accessRestrictionDefinitionsByCloudProfileNameAndRegion({ cloudProfileName: this.shootCloudProfileName, region: this.shootRegion })
       return isEmpty(accessRestrictionDefinitions)
@@ -66,6 +62,10 @@ export default {
     },
   },
   methods: {
+    ...mapActions(useCloudProfileStore, [
+      'accessRestrictionNoItemsTextForCloudProfileNameAndRegion',
+      'accessRestrictionDefinitionsByCloudProfileNameAndRegion',
+    ]),
     async onConfigurationDialogOpened () {
       this.reset()
       const confirmed = await this.$refs.actionDialog.waitForDialogClosed()

--- a/frontend/src/components/ShootDns/GDnsConfiguration.vue
+++ b/frontend/src/components/ShootDns/GDnsConfiguration.vue
@@ -21,10 +21,7 @@ SPDX-License-Identifier: Apache-2.0
 </template>
 
 <script>
-import {
-  mapActions,
-  mapState,
-} from 'pinia'
+import { mapActions } from 'pinia'
 import { useVuelidate } from '@vuelidate/core'
 
 import { useShootStagingStore } from '@/store/shootStaging'
@@ -53,13 +50,9 @@ export default {
       componentKey: uuidv4(),
     }
   },
-  computed: {
-    ...mapState(useShootStagingStore, [
-      'getDnsConfiguration',
-    ]),
-  },
   methods: {
     ...mapActions(useShootStagingStore, [
+      'getDnsConfiguration',
       'setClusterConfiguration',
     ]),
     async onConfigurationDialogOpened () {

--- a/frontend/src/views/GNewShoot.vue
+++ b/frontend/src/views/GNewShoot.vue
@@ -265,19 +265,14 @@ export default {
     ...mapState(useAuthzStore, ['namespace']),
     ...mapState(useConfigStore, ['accessRestriction', 'defaultNodesCIDR']),
     ...mapState(useShootStagingStore, ['controlPlaneFailureToleranceType']),
-    ...mapState(useShootStagingStore, [
-      'getDnsConfiguration',
-    ]),
     ...mapState(useShootStore, [
       'newShootResource',
       'initialNewShootResource',
     ]),
     ...mapState(useSecretStore, [
-      'infrastructureSecretsByCloudProfileName',
       'sortedInfrastructureKindList',
     ]),
     ...mapState(useCloudProfileStore, [
-      'zonesByCloudProfileNameAndRegion',
       'sortedInfrastructureKindList',
     ]),
   },
@@ -297,7 +292,14 @@ export default {
       'setNewShootResource',
     ]),
     ...mapActions(useShootStagingStore, [
+      'getDnsConfiguration',
       'setClusterConfiguration',
+    ]),
+    ...mapActions(useSecretStore, [
+      'infrastructureSecretsByCloudProfileName',
+    ]),
+    ...mapActions(useCloudProfileStore, [
+      'zonesByCloudProfileNameAndRegion',
     ]),
     async isShootContentDirty () {
       const shootResource = await this.shootResourceFromUIComponents()


### PR DESCRIPTION
**What this PR does / why we need it**:
Map pinia functions with `mapActions` and not with `mapState`. Mapping functions to methods works also by using mapState under computed but it is more clear and cleaner if functions are mapped into methods with mapActions. The pinia implementation could also change in the future.

**Which issue(s) this PR fixes**:
Fixes #1564 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
