### PR TITLE
Fixed some shoot item navigation issues

### DIFF
--- a/frontend/src/components/GMainContent.vue
+++ b/frontend/src/components/GMainContent.vue
@@ -15,7 +15,7 @@ SPDX-License-Identifier: Apache-2.0
       ref="wrapRef"
       class="g-main__wrap"
     >
-      <router-view :key="routerViewKey" />
+      <router-view />
     </div>
   </v-main>
 </template>
@@ -53,13 +53,6 @@ function setElementOverflowY (element, value) {
     element.style.overflowY = value
   }
 }
-
-const routerViewKey = computed(() => {
-  if (route.name !== 'ShootItemTerminal') {
-    return undefined
-  }
-  return route.path
-})
 
 const mainContainer = computed(() => {
   return mainRef.value?.$el.querySelector(':scope > div[class$=\'wrap\']')

--- a/frontend/src/components/GMainContent.vue
+++ b/frontend/src/components/GMainContent.vue
@@ -29,7 +29,6 @@ import {
   watch,
 } from 'vue'
 import { useLayout } from 'vuetify'
-import { useRoute } from 'vue-router'
 import { storeToRefs } from 'pinia'
 
 import { useConfigStore } from '@/store/config'
@@ -39,7 +38,6 @@ import GAlertBanner from '@/components/GAlertBanner.vue'
 import { useLogger } from '@/composables/useLogger'
 
 const layout = useLayout()
-const route = useRoute()
 const logger = useLogger()
 const configStore = useConfigStore()
 const { alertBannerMessage, alertBannerType, alertBannerIdentifier } = storeToRefs(configStore)

--- a/frontend/src/components/GNotify.vue
+++ b/frontend/src/components/GNotify.vue
@@ -32,6 +32,7 @@ import {
   watch,
   toRef,
   toRefs,
+  nextTick,
 } from 'vue'
 
 import { useAppStore } from '@/store/app'
@@ -87,14 +88,19 @@ watch(alert, value => {
     const duration = type === 'success'
       ? 3000
       : props.duration
-    notify({
+    const options = {
       group: props.group,
-      type: getType(value),
+      type,
       title: value.title,
       text: value.message,
       duration,
+    }
+    nextTick(() => {
+      notify(options)
+      alert.value = null
     })
-    alert.value = null
   }
+}, {
+  immediate: true,
 })
 </script>

--- a/frontend/src/components/GNotify.vue
+++ b/frontend/src/components/GNotify.vue
@@ -95,10 +95,8 @@ watch(alert, value => {
       text: value.message,
       duration,
     }
-    nextTick(() => {
-      notify(options)
-      alert.value = null
-    })
+    alert.value = null
+    nextTick(() => notify(options))
   }
 }, {
   immediate: true,

--- a/frontend/src/components/GSplitpane.vue
+++ b/frontend/src/components/GSplitpane.vue
@@ -35,6 +35,7 @@ SPDX-License-Identifier: Apache-2.0
 </template>
 
 <script>
+import { mapActions } from 'pinia'
 import {
   Splitpanes,
   Pane,
@@ -62,11 +63,13 @@ export default {
     },
   },
   methods: {
+    ...mapActions(useAppStore, [
+      'updateSplitpaneResize',
+    ]),
     resize () {
-      const store = useAppStore()
       // use nextTick as splitpanes library needs to be finished with rendering because fitAddon relies on
       // dynamic dimensions calculated via css, which do not return correct values before rendering is complete
-      this.$nextTick(store.updateSplitpaneResize)
+      this.$nextTick(() => this.updateSplitpaneResize())
     },
     hasChildren (item) {
       const isSplitpaneTree = Reflect.has(item, 'horizontal')

--- a/frontend/src/store/app.js
+++ b/frontend/src/store/app.js
@@ -4,7 +4,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { defineStore } from 'pinia'
+import {
+  defineStore,
+  acceptHMRUpdate,
+} from 'pinia'
 import { ref } from 'vue'
 
 import moment from '@/utils/moment'
@@ -82,3 +85,7 @@ export const useAppStore = defineStore('app', () => {
     setRouterError,
   }
 })
+
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useAppStore, import.meta.hot))
+}

--- a/frontend/src/store/app.js
+++ b/frontend/src/store/app.js
@@ -19,12 +19,12 @@ export const useAppStore = defineStore('app', () => {
   const location = ref(moment.tz.guess())
   const timezone = ref(moment().format('Z'))
   const focusedElementId = ref(null)
-  const splitpaneResize = ref(null)
+  const splitpaneResize = ref(0)
   const fromRoute = ref(null)
   const routerError = ref(null)
 
   function updateSplitpaneResize () {
-    splitpaneResize.value = new Date()
+    splitpaneResize.value = Date.now()
   }
 
   function setAlert (value) {

--- a/frontend/src/store/authn/index.js
+++ b/frontend/src/store/authn/index.js
@@ -4,7 +4,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { defineStore } from 'pinia'
+import {
+  defineStore,
+  acceptHMRUpdate,
+} from 'pinia'
 import {
   ref,
   computed,
@@ -103,3 +106,7 @@ export const useAuthnStore = defineStore('authn', () => {
     $reset,
   }
 })
+
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useAuthnStore, import.meta.hot))
+}

--- a/frontend/src/store/authz.js
+++ b/frontend/src/store/authz.js
@@ -4,7 +4,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { defineStore } from 'pinia'
+import {
+  defineStore,
+  acceptHMRUpdate,
+} from 'pinia'
 import {
   ref,
   computed,
@@ -203,3 +206,7 @@ export const useAuthzStore = defineStore('authz', () => {
     $reset,
   }
 })
+
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useAuthzStore, import.meta.hot))
+}

--- a/frontend/src/store/cloudProfile/index.js
+++ b/frontend/src/store/cloudProfile/index.js
@@ -4,7 +4,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { defineStore } from 'pinia'
+import {
+  defineStore,
+  acceptHMRUpdate,
+} from 'pinia'
 import {
   ref,
   computed,
@@ -660,3 +663,7 @@ export const useCloudProfileStore = defineStore('cloudProfile', () => {
     machineImagesByCloudProfileName,
   }
 })
+
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useCloudProfileStore, import.meta.hot))
+}

--- a/frontend/src/store/config.js
+++ b/frontend/src/store/config.js
@@ -4,7 +4,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { defineStore } from 'pinia'
+import {
+  defineStore,
+  acceptHMRUpdate,
+} from 'pinia'
 import {
   ref,
   computed,
@@ -333,3 +336,7 @@ export const useConfigStore = defineStore('config', () => {
     $reset,
   }
 })
+
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useConfigStore, import.meta.hot))
+}

--- a/frontend/src/store/gardenerExtension.js
+++ b/frontend/src/store/gardenerExtension.js
@@ -4,7 +4,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { defineStore } from 'pinia'
+import {
+  defineStore,
+  acceptHMRUpdate,
+} from 'pinia'
 import {
   ref,
   computed,
@@ -80,3 +83,7 @@ export const useGardenerExtensionStore = defineStore('gardenerExtension', () => 
     networkingTypeList,
   }
 })
+
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useGardenerExtensionStore, import.meta.hot))
+}

--- a/frontend/src/store/kubeconfig.js
+++ b/frontend/src/store/kubeconfig.js
@@ -4,7 +4,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { defineStore } from 'pinia'
+import {
+  defineStore,
+  acceptHMRUpdate,
+} from 'pinia'
 import {
   ref,
   computed,
@@ -39,3 +42,7 @@ export const useKubeconfigStore = defineStore('kubeconfig', () => {
     fetchKubeconfig,
   }
 })
+
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useKubeconfigStore, import.meta.hot))
+}

--- a/frontend/src/store/localStorage.js
+++ b/frontend/src/store/localStorage.js
@@ -4,7 +4,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { defineStore } from 'pinia'
+import {
+  defineStore,
+  acceptHMRUpdate,
+} from 'pinia'
 import {
   computed,
   toRef,
@@ -255,3 +258,7 @@ export const useLocalStorageStore = defineStore('localStorage', () => {
     terminalSplitpaneTree,
   }
 })
+
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useLocalStorageStore, import.meta.hot))
+}

--- a/frontend/src/store/login.js
+++ b/frontend/src/store/login.js
@@ -8,7 +8,10 @@ import {
   ref,
   watch,
 } from 'vue'
-import { defineStore } from 'pinia'
+import {
+  defineStore,
+  acceptHMRUpdate,
+} from 'pinia'
 
 import { useLogger } from '@/composables/useLogger'
 
@@ -65,3 +68,7 @@ export const useLoginStore = defineStore('login', () => {
     isNotFetching,
   }
 })
+
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useLoginStore, import.meta.hot))
+}

--- a/frontend/src/store/member.js
+++ b/frontend/src/store/member.js
@@ -4,7 +4,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { defineStore } from 'pinia'
+import {
+  defineStore,
+  acceptHMRUpdate,
+} from 'pinia'
 import {
   ref,
   computed,
@@ -91,3 +94,7 @@ export const useMemberStore = defineStore('member', () => {
     $reset,
   }
 })
+
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useMemberStore, import.meta.hot))
+}

--- a/frontend/src/store/project.js
+++ b/frontend/src/store/project.js
@@ -4,7 +4,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { defineStore } from 'pinia'
+import {
+  defineStore,
+  acceptHMRUpdate,
+} from 'pinia'
 import {
   ref,
   computed,
@@ -234,3 +237,7 @@ export const useProjectStore = defineStore('project', () => {
     $reset,
   }
 })
+
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useProjectStore, import.meta.hot))
+}

--- a/frontend/src/store/quota/index.js
+++ b/frontend/src/store/quota/index.js
@@ -4,7 +4,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { defineStore } from 'pinia'
+import {
+  defineStore,
+  acceptHMRUpdate,
+} from 'pinia'
 import {
   ref,
   computed,
@@ -46,3 +49,7 @@ export const useQuotaStore = defineStore('quota', () => {
     fetchQuotas,
   }
 })
+
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useQuotaStore, import.meta.hot))
+}

--- a/frontend/src/store/secret.js
+++ b/frontend/src/store/secret.js
@@ -4,7 +4,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { defineStore } from 'pinia'
+import {
+  defineStore,
+  acceptHMRUpdate,
+} from 'pinia'
 import {
   ref,
   computed,
@@ -146,3 +149,7 @@ export const useSecretStore = defineStore('secret', () => {
     $reset,
   }
 })
+
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useSecretStore, import.meta.hot))
+}

--- a/frontend/src/store/seed.js
+++ b/frontend/src/store/seed.js
@@ -4,7 +4,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { defineStore } from 'pinia'
+import {
+  defineStore,
+  acceptHMRUpdate,
+} from 'pinia'
 import {
   ref,
   computed,
@@ -68,3 +71,7 @@ export const useSeedStore = defineStore('seed', () => {
     isSeedUnreachableByName,
   }
 })
+
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useSeedStore, import.meta.hot))
+}

--- a/frontend/src/store/shoot/index.js
+++ b/frontend/src/store/shoot/index.js
@@ -4,7 +4,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { defineStore } from 'pinia'
+import {
+  defineStore,
+  acceptHMRUpdate,
+} from 'pinia'
 import {
   computed,
   reactive,
@@ -633,3 +636,7 @@ export const useShootStore = defineStore('shoot', () => {
     setSubscriptionError,
   }
 })
+
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useShootStore, import.meta.hot))
+}

--- a/frontend/src/store/shootStaging.js
+++ b/frontend/src/store/shootStaging.js
@@ -4,7 +4,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { defineStore } from 'pinia'
+import {
+  defineStore,
+  acceptHMRUpdate,
+} from 'pinia'
 import {
   computed,
   reactive,
@@ -363,3 +366,7 @@ export const useShootStagingStore = defineStore('shootStaging', () => {
     setWorkerless,
   }
 })
+
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useShootStagingStore, import.meta.hot))
+}

--- a/frontend/src/store/socket/index.js
+++ b/frontend/src/store/socket/index.js
@@ -4,7 +4,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { defineStore } from 'pinia'
+import {
+  defineStore,
+  acceptHMRUpdate,
+} from 'pinia'
 import {
   computed,
   reactive,
@@ -141,3 +144,7 @@ export const useSocketStore = defineStore('socket', () => {
     emitUnsubscribe,
   }
 })
+
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useSocketStore, import.meta.hot))
+}

--- a/frontend/src/store/terminal.js
+++ b/frontend/src/store/terminal.js
@@ -4,7 +4,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { defineStore } from 'pinia'
+import {
+  defineStore,
+  acceptHMRUpdate,
+} from 'pinia'
 import {
   ref,
   computed,
@@ -101,3 +104,7 @@ export const useTerminalStore = defineStore('terminal', () => {
     isTerminalShortcutsFeatureEnabled,
   }
 })
+
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useTerminalStore, import.meta.hot))
+}

--- a/frontend/src/store/ticket.js
+++ b/frontend/src/store/ticket.js
@@ -4,7 +4,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { defineStore } from 'pinia'
+import {
+  defineStore,
+  acceptHMRUpdate,
+} from 'pinia'
 import {
   ref,
   computed,
@@ -186,3 +189,7 @@ export const useTicketStore = defineStore('ticket', () => {
     clearComments,
   }
 })
+
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useTicketStore, import.meta.hot))
+}

--- a/frontend/src/views/GProjectPlaceholder.vue
+++ b/frontend/src/views/GProjectPlaceholder.vue
@@ -18,15 +18,27 @@ import { useProjectStore } from '@/store/project'
 
 import GProjectError from '@/views/GProjectError.vue'
 
+import { isEqual } from '@/lodash'
+
+function isLoadRequired (route, to) {
+  return route.name !== to.name || !isEqual(route.params, to.params)
+}
+
 export default {
   components: {
     GProjectError,
   },
   beforeRouteEnter (to, from, next) {
-    next(vm => vm.load(to))
+    next(vm => {
+      if (isLoadRequired(vm.$route, to)) {
+        vm.load(to)
+      }
+    })
   },
-  async beforeRouteUpdate (to, from) {
-    this.load(to)
+  beforeRouteUpdate (to, from) {
+    if (isLoadRequired(this.$route, to)) {
+      this.load(to)
+    }
   },
   data () {
     return {
@@ -69,12 +81,15 @@ export default {
       }
     },
   },
+  mounted () {
+    this.load(this.$route)
+  },
   methods: {
     load (route) {
-      const routeName = route.name
-      const routeParams = route.params
       this.error = null
       this.fallbackRoute = null
+      const routeName = route.name
+      const routeParams = route.params
       if (this.namespace !== routeParams.namespace) {
         this.error = new Error('An unexpected error occurred')
         this.fallbackRoute = {

--- a/frontend/src/views/GShootItem.vue
+++ b/frontend/src/views/GShootItem.vue
@@ -34,7 +34,6 @@ import { useTerminalSplitpanes } from '@/composables/useTerminalSplitpanes'
 import { PositionEnum } from '@/lib/g-symbol-tree'
 
 export default {
-  name: 'ShootItem',
   components: {
     GShootDetails,
     GTerminalSplitpanes,

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -167,10 +167,10 @@ export default defineConfig(({ command, mode }) => {
     const coverage = {
       provider: 'v8',
       exclude: ['**/__fixtures__/**'],
-      statements: 73,
+      statements: 76,
       branches: 80,
-      functions: 48,
-      lines: 73,
+      functions: 47,
+      lines: 76,
     }
 
     config.test = {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR addresses inconsistencies in component initialization when using Vue Router's [_Fetching Before Navigation_](https://router.vuejs.org/guide/advanced/data-fetching.html#Fetching-Before-Navigation) approach. In development scenarios with Hot Module Replacement (HMR), the `beforeRouteEnter` and `beforeRouteUpdate` guards are not consistently invoked. However, Vue's [Component Lifecycle Hooks](https://vuejs.org/guide/essentials/lifecycle.html#lifecycle-diagram) are still triggered.

Our placeholder components rely on Vue's built-in [Meta Component](https://vuejs.org/api/built-in-special-elements.html#component) to dynamically render child components based on navigation or loading states.
```vue
<template>
  <component
    :is="component"
    v-bind="componentProperties"
  />
</template>
```
During this process, the component displays a loading indicator, error components for failures, or `<router-view/>` when navigation completes successfully.

##### Key Changes:

1. **Single Initialization**: 
   Ensures that component initialization only occurs once, either upon route change or initial page load.
   
2. **State Management**: 
  Manages the release of previous states (unsubscriptions and data resets) when navigating to new routes.

3. **Conditional Rendering**: 
  Ensures that `<router-view/>` is only displayed once navigation is complete to prevent rendering issues, such as brief flashes of old route components that get immediately deleted.

By implementing these changes, we aim to provide a more consistent and error-free navigation experience. This is crucial because any inconsistencies could lead to a range of issues, from rendering problems to violation of component property constraints.
 


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
