### PR TITLE
Remove unnecessary component name

### DIFF
--- a/frontend/src/components/GDragNDroppableComponent.vue
+++ b/frontend/src/components/GDragNDroppableComponent.vue
@@ -39,7 +39,6 @@ import GPositionalDropzone from '@/components/GPositionalDropzone.vue'
 import { gDraggable } from '@/lib/g-draggable'
 
 export default {
-  name: 'DraggableComponent',
   directives: {
     gDraggable,
   },

--- a/frontend/src/components/GSeedConfiguration.vue
+++ b/frontend/src/components/GSeedConfiguration.vue
@@ -46,7 +46,6 @@ import {
 } from '@/lodash'
 
 export default {
-  name: 'SeedConfiguration',
   components: {
     GActionButtonDialog,
   },

--- a/frontend/src/components/ShootAccessRestrictions/GAccessRestrictionsConfiguration.vue
+++ b/frontend/src/components/ShootAccessRestrictions/GAccessRestrictionsConfiguration.vue
@@ -39,7 +39,6 @@ import {
 } from '@/lodash'
 
 export default {
-  name: 'AccessRestrictionConfiguration',
   components: {
     GActionButtonDialog,
     GAccessRestrictions,

--- a/frontend/src/components/ShootDetails/GCustomFieldsCard.vue
+++ b/frontend/src/components/ShootDetails/GCustomFieldsCard.vue
@@ -50,7 +50,6 @@ SPDX-License-Identifier: Apache-2.0
 <script>
 
 export default {
-  name: 'CustomFieldsCard',
   props: {
     customFields: {
       type: Array,

--- a/frontend/src/components/dialogs/GUnverifiedTerminalShortcutsDialog.vue
+++ b/frontend/src/components/dialogs/GUnverifiedTerminalShortcutsDialog.vue
@@ -43,7 +43,6 @@ SPDX-License-Identifier: Apache-2.0
 import GDialog from '@/components/dialogs/GDialog.vue'
 
 export default {
-  name: 'UnverifiedTerminalShortcutsDialog',
   components: {
     GDialog,
   },

--- a/frontend/src/components/floating/PopperWrapper.vue
+++ b/frontend/src/components/floating/PopperWrapper.vue
@@ -87,7 +87,6 @@ import {
 const referenceProps = ['class']
 
 export default {
-  name: 'VPopperWrapper',
   components: {
     Popper: Popper(),
     PopperContent,

--- a/frontend/src/components/floating/PopperWrapper.vue
+++ b/frontend/src/components/floating/PopperWrapper.vue
@@ -87,6 +87,7 @@ import {
 const referenceProps = ['class']
 
 export default {
+  name: 'VPopperWrapper',
   components: {
     Popper: Popper(),
     PopperContent,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes the unnecessary component name
GShootItem is not touched as the name will be removed with PR https://github.com/gardener/dashboard/pull/1575

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
