### PR TITLE
Use text-medium-emphasis

### DIFF
--- a/frontend/src/components/ShootAccessRestrictions/GAccessRestrictions.vue
+++ b/frontend/src/components/ShootAccessRestrictions/GAccessRestrictions.vue
@@ -151,7 +151,7 @@ export default {
     },
     textClass (definition) {
       return this.enabled(definition)
-        ? 'text-secondary'
+        ? 'text-medium-emphasis'
         : 'text-disabled'
     },
     applyTo (shootResource) {

--- a/frontend/src/components/ShootAddons/GManageAddons.vue
+++ b/frontend/src/components/ShootAddons/GManageAddons.vue
@@ -102,7 +102,7 @@ export default {
     textClass (addonDefinition) {
       return !this.createMode && addonDefinition.forbidDisable && this.addons[addonDefinition.name].enabled
         ? 'text-disabled'
-        : 'text-secondary'
+        : 'text-medium-emphasis'
     },
   },
 }

--- a/frontend/src/views/GSettings.vue
+++ b/frontend/src/views/GSettings.vue
@@ -25,7 +25,7 @@ SPDX-License-Identifier: Apache-2.0
           <v-card-text>
             <v-row>
               <v-col cols="12">
-                <legend class="text-secondary">
+                <legend class="text-medium-emphasis">
                   Color Scheme
                 </legend>
                 <v-btn-toggle
@@ -79,7 +79,7 @@ SPDX-License-Identifier: Apache-2.0
                 </v-btn-toggle>
               </v-col>
               <v-col cols="12">
-                <legend class="text-secondary">
+                <legend class="text-medium-emphasis">
                   Log Level
                 </legend>
                 <v-btn-toggle


### PR DESCRIPTION
**What this PR does / why we need it**:
https://vuetifyjs.com/en/styles/text-and-typography/#opacity
> Opacity helper classes allow you to easily adjust the emphasis of text. text-high-emphasis has the same opacity as default text. text-medium-emphasis is used for hints and helper text. De-emphasize text with text-disabled.

On dark mode, the texts with text-secondary are too dark, even darker than `text-disabled` and thus look disabled in comparison.

left window: `text-secondary`
right window: `text-medium-emphasis`


![Screenshot 2023-09-25 at 16 47 32](https://github.com/gardener/dashboard/assets/5526658/509b4e38-f876-4cf9-bf77-7da1df292da1)
![Screenshot 2023-09-25 at 16 48 10](https://github.com/gardener/dashboard/assets/5526658/62fd5941-da53-498c-bb52-fe22151c1503)
![Screenshot 2023-09-25 at 16 48 39](https://github.com/gardener/dashboard/assets/5526658/cf141989-1501-4f2b-82d6-027db486d497)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
