### PR TITLE
Increase hibernation configuration dialog width

### DIFF
--- a/frontend/src/components/ShootHibernation/GHibernationConfiguration.vue
+++ b/frontend/src/components/ShootHibernation/GHibernationConfiguration.vue
@@ -9,7 +9,7 @@ SPDX-License-Identifier: Apache-2.0
     ref="actionDialog"
     :shoot-item="shootItem"
     :valid="!v$.$invalid"
-    width="900"
+    width="1300"
     caption="Configure Hibernation Schedule"
     @dialog-opened="onConfigurationDialogOpened"
   >


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR increases the hibernation configuration dialog width, so that the input fields do not have to be squished. With the new width, all weekdays can now be displayed in one row.

![Screenshot 2023-09-26 at 10 09 44](https://github.com/gardener/dashboard/assets/5526658/34eee0df-416e-4d58-9610-fd6a0dba9811)


**Which issue(s) this PR fixes**:
Fixes #1573

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
