### PR TITLE
Support default node CIDR from cloud profile

### DIFF
--- a/frontend/__tests__/stores/cloudProfile.spec.js
+++ b/frontend/__tests__/stores/cloudProfile.spec.js
@@ -795,7 +795,7 @@ describe('stores', () => {
       const cloudProfileName = 'foo'
 
       it('should return default node cidr from config', async () => {
-        const defaultNodesCIDR = cloudProfileStore.defaultNodesCIDRByCloudProfileName({ cloudProfileName })
+        const defaultNodesCIDR = cloudProfileStore.getDefaultNodesCIDR({ cloudProfileName })
         expect(defaultNodesCIDR).toBe('10.10.0.0/16')
       })
 
@@ -805,7 +805,7 @@ describe('stores', () => {
             defaultNodesCIDR: '1.2.3.4/16',
           },
         })
-        const defaultNodesCIDR = cloudProfileStore.defaultNodesCIDRByCloudProfileName({ cloudProfileName })
+        const defaultNodesCIDR = cloudProfileStore.getDefaultNodesCIDR({ cloudProfileName })
         expect(defaultNodesCIDR).toBe('1.2.3.4/16')
       })
     })

--- a/frontend/__tests__/stores/cloudProfile.spec.js
+++ b/frontend/__tests__/stores/cloudProfile.spec.js
@@ -791,7 +791,7 @@ describe('stores', () => {
       })
     })
 
-    describe('providerConfig.defaultNodeCIDRRange', () => {
+    describe('providerConfig.defaultNodesCIDR', () => {
       const cloudProfileName = 'foo'
 
       it('should return default node cidr from config', async () => {
@@ -802,7 +802,7 @@ describe('stores', () => {
       it('should return default node cidr from cloud profile', () => {
         setData({
           providerConfig: {
-            defaultNodeCIDRRange: '1.2.3.4/16',
+            defaultNodesCIDR: '1.2.3.4/16',
           },
         })
         const defaultNodesCIDR = cloudProfileStore.defaultNodesCIDRByCloudProfileName({ cloudProfileName })

--- a/frontend/__tests__/stores/cloudProfile.spec.js
+++ b/frontend/__tests__/stores/cloudProfile.spec.js
@@ -58,11 +58,13 @@ describe('stores', () => {
       authzStore.setNamespace(namespace)
       configStore = useConfigStore()
       mockGetConfiguration = vi.spyOn(api, 'getConfiguration').mockResolvedValue({
-        vendorHints: [{
-          type: 'warning',
-          message: 'test',
-          matchNames: ['suse-jeos', 'suse-chost'],
-        }],
+        data: {
+          vendorHints: [{
+            type: 'warning',
+            message: 'test',
+            matchNames: ['suse-jeos', 'suse-chost'],
+          }],
+        },
       })
       await configStore.fetchConfig()
       cloudProfileStore = useCloudProfileStore()
@@ -130,6 +132,7 @@ describe('stores', () => {
         expect(suseImage.expirationDateString).toBeDefined()
         expect(suseImage.vendorName).toBe('suse-chost')
         expect(suseImage.icon).toBe('suse-chost')
+        expect(suseImage.vendorHint).toBeDefined()
         expect(suseImage.vendorHint).toEqual(configStore.vendorHints[0])
         expect(suseImage.classification).toBe('supported')
         expect(suseImage.isSupported).toBe(true)

--- a/frontend/__tests__/stores/cloudProfile.spec.js
+++ b/frontend/__tests__/stores/cloudProfile.spec.js
@@ -59,6 +59,7 @@ describe('stores', () => {
       configStore = useConfigStore()
       mockGetConfiguration = vi.spyOn(api, 'getConfiguration').mockResolvedValue({
         data: {
+          defaultNodesCIDR: '10.10.0.0/16',
           vendorHints: [{
             type: 'warning',
             message: 'test',
@@ -787,6 +788,25 @@ describe('stores', () => {
         dashboardLoadBalancerProviderNames = cloudProfileStore.loadBalancerProviderNamesByCloudProfileNameAndRegion({ cloudProfileName, region })
         expect(dashboardLoadBalancerProviderNames).toHaveLength(1)
         expect(dashboardLoadBalancerProviderNames[0]).toBe('other regional LB')
+      })
+    })
+
+    describe('providerConfig.defaultNodeCIDRRange', () => {
+      const cloudProfileName = 'foo'
+
+      it('should return default node cidr from config', async () => {
+        const defaultNodesCIDR = cloudProfileStore.defaultNodesCIDRByCloudProfileName({ cloudProfileName })
+        expect(defaultNodesCIDR).toBe('10.10.0.0/16')
+      })
+
+      it('should return default node cidr from cloud profile', () => {
+        setData({
+          providerConfig: {
+            defaultNodeCIDRRange: '1.2.3.4/16',
+          },
+        })
+        const defaultNodesCIDR = cloudProfileStore.defaultNodesCIDRByCloudProfileName({ cloudProfileName })
+        expect(defaultNodesCIDR).toBe('1.2.3.4/16')
       })
     })
     describe('helper', () => {

--- a/frontend/src/components/NewShoot/GNewShootInfrastructureDetails.vue
+++ b/frontend/src/components/NewShoot/GNewShootInfrastructureDetails.vue
@@ -465,7 +465,7 @@ export default {
       'firewallImagesByCloudProfileName',
       'firewallNetworksByCloudProfileNameAndPartitionId',
       'firewallSizesByCloudProfileNameAndRegion',
-      'defaultNodesCIDRByCloudProfileName',
+      'getDefaultNodesCIDR',
     ]),
     ...mapActions(useSecretStore, [
       'infrastructureSecretsByCloudProfileName',
@@ -501,7 +501,7 @@ export default {
       this.projectID = undefined
 
       const cloudProfileName = this.cloudProfileName
-      this.defaultNodesCIDR = this.defaultNodesCIDRByCloudProfileName({ cloudProfileName })
+      this.defaultNodesCIDR = this.getDefaultNodesCIDR({ cloudProfileName })
     },
     setDefaultCloudProfile () {
       this.cloudProfileName = get(head(this.cloudProfiles), 'metadata.name')

--- a/frontend/src/components/NewShoot/GNewShootInfrastructureDetails.vue
+++ b/frontend/src/components/NewShoot/GNewShootInfrastructureDetails.vue
@@ -273,6 +273,7 @@ export default {
       firewallSize: undefined,
       firewallNetworks: undefined,
       projectID: undefined,
+      defaultNodesCIDR: undefined,
     }
   },
   validations () {
@@ -464,6 +465,7 @@ export default {
       'firewallImagesByCloudProfileName',
       'firewallNetworksByCloudProfileNameAndPartitionId',
       'firewallSizesByCloudProfileNameAndRegion',
+      'defaultNodesCIDRByCloudProfileName',
     ]),
     ...mapActions(useSecretStore, [
       'infrastructureSecretsByCloudProfileName',
@@ -497,6 +499,9 @@ export default {
       this.firewallImage = head(this.firewallImages)
       this.onInputFirewallImage()
       this.projectID = undefined
+
+      const cloudProfileName = this.cloudProfileName
+      this.defaultNodesCIDR = this.defaultNodesCIDRByCloudProfileName({ cloudProfileName })
     },
     setDefaultCloudProfile () {
       this.cloudProfileName = get(head(this.cloudProfiles), 'metadata.name')
@@ -568,6 +573,7 @@ export default {
         firewallImage: this.firewallImage,
         firewallSize: this.firewallSize,
         firewallNetworks: this.firewallNetworks,
+        defaultNodesCIDR: this.defaultNodesCIDR,
       }
     },
     setInfrastructureData ({

--- a/frontend/src/store/cloudProfile/index.js
+++ b/frontend/src/store/cloudProfile/index.js
@@ -166,7 +166,7 @@ export const useCloudProfileStore = defineStore('cloudProfile', () => {
     return max(map(seedsMatchingCloudProfileAndRegion, 'volume.minimumSize')) || defaultMinimumSize
   }
 
-  function defaultNodesCIDRByCloudProfileName ({ cloudProfileName }) {
+  function getDefaultNodesCIDR ({ cloudProfileName }) {
     const cloudProfile = cloudProfileByName(cloudProfileName)
     return get(cloudProfile, 'data.providerConfig.defaultNodesCIDR', configStore.defaultNodesCIDR)
   }
@@ -634,7 +634,7 @@ export const useCloudProfileStore = defineStore('cloudProfile', () => {
     regionsWithSeedByCloudProfileName,
     regionsWithoutSeedByCloudProfileName,
     loadBalancerProviderNamesByCloudProfileNameAndRegion,
-    defaultNodesCIDRByCloudProfileName,
+    getDefaultNodesCIDR,
     floatingPoolNamesByCloudProfileNameAndRegionAndDomain,
     floatingPoolsByCloudProfileNameAndRegionAndDomain,
     loadBalancerClassNamesByCloudProfileName,

--- a/frontend/src/store/cloudProfile/index.js
+++ b/frontend/src/store/cloudProfile/index.js
@@ -168,7 +168,7 @@ export const useCloudProfileStore = defineStore('cloudProfile', () => {
 
   function defaultNodesCIDRByCloudProfileName ({ cloudProfileName }) {
     const cloudProfile = cloudProfileByName(cloudProfileName)
-    return get(cloudProfile, 'data.providerConfig.defaultNodeCIDRRange', configStore.defaultNodesCIDR)
+    return get(cloudProfile, 'data.providerConfig.defaultNodesCIDR', configStore.defaultNodesCIDR)
   }
 
   function floatingPoolsByCloudProfileNameAndRegionAndDomain ({ cloudProfileName, region, secretDomain }) {

--- a/frontend/src/store/cloudProfile/index.js
+++ b/frontend/src/store/cloudProfile/index.js
@@ -166,6 +166,11 @@ export const useCloudProfileStore = defineStore('cloudProfile', () => {
     return max(map(seedsMatchingCloudProfileAndRegion, 'volume.minimumSize')) || defaultMinimumSize
   }
 
+  function defaultNodesCIDRByCloudProfileName ({ cloudProfileName }) {
+    const cloudProfile = cloudProfileByName(cloudProfileName)
+    return get(cloudProfile, 'data.providerConfig.defaultNodeCIDRRange', configStore.defaultNodesCIDR)
+  }
+
   function floatingPoolsByCloudProfileNameAndRegionAndDomain ({ cloudProfileName, region, secretDomain }) {
     const cloudProfile = cloudProfileByName(cloudProfileName)
     const floatingPools = get(cloudProfile, 'data.providerConfig.constraints.floatingPools')
@@ -629,6 +634,7 @@ export const useCloudProfileStore = defineStore('cloudProfile', () => {
     regionsWithSeedByCloudProfileName,
     regionsWithoutSeedByCloudProfileName,
     loadBalancerProviderNamesByCloudProfileNameAndRegion,
+    defaultNodesCIDRByCloudProfileName,
     floatingPoolNamesByCloudProfileNameAndRegionAndDomain,
     floatingPoolsByCloudProfileNameAndRegionAndDomain,
     loadBalancerClassNamesByCloudProfileName,

--- a/frontend/src/store/config.js
+++ b/frontend/src/store/config.js
@@ -293,8 +293,6 @@ export const useConfigStore = defineStore('config', () => {
     return get(knownConditions.value, type, getCondition(type))
   }
 
-  const nodesCIDR = defaultNodesCIDR // TODO: remove one later
-
   return {
     isInitial,
     appVersion,
@@ -318,7 +316,6 @@ export const useConfigStore = defineStore('config', () => {
     helpMenuItems,
     externalTools,
     defaultNodesCIDR,
-    nodesCIDR,
     apiServerUrl,
     clusterIdentity,
     seedCandidateDeterminationStrategy,

--- a/frontend/src/store/shoot/helper.js
+++ b/frontend/src/store/shoot/helper.js
@@ -148,7 +148,7 @@ export function createShootResource (context) {
 
   const infrastructureKind = head(cloudProfileStore.sortedInfrastructureKindList)
   const cloudProfileName = get(head(cloudProfileStore.cloudProfilesByCloudProviderKind(infrastructureKind)), 'metadata.name')
-  const defaultNodesCIDR = cloudProfileStore.defaultNodesCIDRByCloudProfileName({ cloudProfileName })
+  const defaultNodesCIDR = cloudProfileStore.getDefaultNodesCIDR({ cloudProfileName })
 
   set(shootResource, 'spec', getSpecTemplate(infrastructureKind, defaultNodesCIDR))
   set(shootResource, 'spec.cloudProfileName', cloudProfileName)

--- a/frontend/src/store/shoot/helper.js
+++ b/frontend/src/store/shoot/helper.js
@@ -147,9 +147,10 @@ export function createShootResource (context) {
   }
 
   const infrastructureKind = head(cloudProfileStore.sortedInfrastructureKindList)
-  set(shootResource, 'spec', getSpecTemplate(infrastructureKind, configStore.nodesCIDR))
-
   const cloudProfileName = get(head(cloudProfileStore.cloudProfilesByCloudProviderKind(infrastructureKind)), 'metadata.name')
+  const defaultNodesCIDR = cloudProfileStore.defaultNodesCIDRByCloudProfileName({ cloudProfileName })
+
+  set(shootResource, 'spec', getSpecTemplate(infrastructureKind, defaultNodesCIDR))
   set(shootResource, 'spec.cloudProfileName', cloudProfileName)
 
   const secret = head(secretStore.infrastructureSecretsByCloudProfileName(cloudProfileName))
@@ -221,7 +222,7 @@ export function createShootResource (context) {
 
   const allZones = cloudProfileStore.zonesByCloudProfileNameAndRegion({ cloudProfileName, region })
   const zones = allZones.length ? [sample(allZones)] : undefined
-  const zonesNetworkConfiguration = getDefaultZonesNetworkConfiguration(zones, infrastructureKind, allZones.length, configStore.defaultNodesCIDR)
+  const zonesNetworkConfiguration = getDefaultZonesNetworkConfiguration(zones, infrastructureKind, allZones.length, defaultNodesCIDR)
   if (zonesNetworkConfiguration) {
     set(shootResource, 'spec.provider.infrastructureConfig.networks.zones', zonesNetworkConfiguration)
   }

--- a/frontend/src/views/GNewShoot.vue
+++ b/frontend/src/views/GNewShoot.vue
@@ -311,7 +311,7 @@ export default {
     ]),
     ...mapActions(useCloudProfileStore, [
       'zonesByCloudProfileNameAndRegion',
-      'defaultNodesCIDRByCloudProfileName',
+      'getDefaultNodesCIDR',
     ]),
     async isShootContentDirty () {
       const shootResource = await this.shootResourceFromUIComponents()
@@ -536,7 +536,7 @@ export default {
 
       const zonedCluster = isZonedCluster({ cloudProviderKind: infrastructureKind, isNewCluster: true })
 
-      const defaultNodesCIDR = this.defaultNodesCIDRByCloudProfileName({ cloudProfileName })
+      const defaultNodesCIDR = this.getDefaultNodesCIDR({ cloudProfileName })
       const newShootWorkerCIDR = get(shootResource, 'spec.networking.nodes', defaultNodesCIDR)
       await this.manageWorkers.dispatch('setWorkersData', { workers, cloudProfileName, region, updateOSMaintenance: osUpdates, zonedCluster, kubernetesVersion, newShootWorkerCIDR })
 

--- a/frontend/src/views/GNewShoot.vue
+++ b/frontend/src/views/GNewShoot.vue
@@ -271,7 +271,7 @@ export default {
   },
   computed: {
     ...mapState(useAuthzStore, ['namespace']),
-    ...mapState(useConfigStore, ['accessRestriction', 'defaultNodesCIDR']),
+    ...mapState(useConfigStore, ['accessRestriction']),
     ...mapState(useShootStagingStore, ['controlPlaneFailureToleranceType']),
     ...mapState(useShootStagingStore, [
       'workerless',
@@ -311,6 +311,7 @@ export default {
     ]),
     ...mapActions(useCloudProfileStore, [
       'zonesByCloudProfileNameAndRegion',
+      'defaultNodesCIDRByCloudProfileName',
     ]),
     async isShootContentDirty () {
       const shootResource = await this.shootResourceFromUIComponents()
@@ -333,11 +334,12 @@ export default {
         firewallImage,
         firewallSize,
         firewallNetworks,
+        defaultNodesCIDR,
       } = this.$refs.infrastructureDetails.getInfrastructureData()
       const oldInfrastructureKind = get(shootResource, 'spec.provider.type')
       if (oldInfrastructureKind !== infrastructureKind) {
         // Infrastructure changed
-        set(shootResource, 'spec', getSpecTemplate(infrastructureKind, this.defaultNodesCIDR))
+        set(shootResource, 'spec', getSpecTemplate(infrastructureKind, defaultNodesCIDR))
       }
       set(shootResource, 'spec.cloudProfileName', cloudProfileName)
       set(shootResource, 'spec.region', region)
@@ -400,7 +402,7 @@ export default {
 
         const allZones = this.zonesByCloudProfileNameAndRegion({ cloudProfileName, region })
         const oldZoneConfiguration = get(shootResource, 'spec.provider.infrastructureConfig.networks.zones', [])
-        const nodeCIDR = get(shootResource, 'spec.networking.nodes', this.defaultNodesCIDR)
+        const nodeCIDR = get(shootResource, 'spec.networking.nodes', defaultNodesCIDR)
         const zonesNetworkConfiguration = getZonesNetworkConfiguration(oldZoneConfiguration, workers, infrastructureKind, allZones.length, undefined, nodeCIDR)
         if (zonesNetworkConfiguration) {
           set(shootResource, 'spec.provider.infrastructureConfig.networks.zones', zonesNetworkConfiguration)
@@ -534,7 +536,8 @@ export default {
 
       const zonedCluster = isZonedCluster({ cloudProviderKind: infrastructureKind, isNewCluster: true })
 
-      const newShootWorkerCIDR = get(shootResource, 'spec.networking.nodes', this.defaultNodesCIDR)
+      const defaultNodesCIDR = this.defaultNodesCIDRByCloudProfileName({ cloudProfileName })
+      const newShootWorkerCIDR = get(shootResource, 'spec.networking.nodes', defaultNodesCIDR)
       await this.manageWorkers.dispatch('setWorkersData', { workers, cloudProfileName, region, updateOSMaintenance: osUpdates, zonedCluster, kubernetesVersion, newShootWorkerCIDR })
 
       const addons = cloneDeep(get(shootResource, 'spec.addons', {}))


### PR DESCRIPTION
**What this PR does / why we need it**:
In addition to the `defaultNodesCIDR` config (`Values.global.dashboard.frontendConfig.defaultNodesCIDR`) of the `gardener-dashboard` which applies for all new Shoots, you can now have a configuration per cloud profile, by setting `.spec.providerConfig.defaultNodesCIDR` on the respective `CloudProfile`.

**Which issue(s) this PR fixes**:
Fixes #1567

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
In addition to the `defaultNodesCIDR` config (`Values.global.dashboard.frontendConfig.defaultNodesCIDR`) of the `gardener-dashboard` which applies for all new Shoots, you can now have a configuration per cloud profile, by setting `.spec.providerConfig.defaultNodesCIDR` on the respective `CloudProfile`.
```
