### PR TITLE
Use openapi v3

### DIFF
--- a/backend/lib/openapi/index.js
+++ b/backend/lib/openapi/index.js
@@ -36,12 +36,13 @@ async function getSchemaDefinitions (user) {
 
   if (_.isEmpty(schemaDefinitions)) {
     // Do not use client of user as the result gets cached and returned to other users
-    const swaggerApi = await dashboardClient.openapi.get()
-    const dereferencedSwaggerApi = await SwaggerParser.dereference(swaggerApi)
+    const openAPIRaw = await dashboardClient.openapi.getGardenerV1Beta1()
+    const dereferencedOpenApi = await SwaggerParser.dereference(openAPIRaw)
 
     const selectedSchemaDefinitions = _
-      .chain(dereferencedSwaggerApi)
-      .get('definitions')
+      .chain(dereferencedOpenApi)
+      .get('components')
+      .get('schemas')
       .pick([
         'com.github.gardener.gardener.pkg.apis.core.v1beta1.Shoot'
       ])

--- a/backend/lib/services/authorization.js
+++ b/backend/lib/services/authorization.js
@@ -55,7 +55,7 @@ exports.canGetOpenAPI = function (user) {
   return hasAuthorization(user, {
     nonResourceAttributes: {
       verb: 'get',
-      path: '/openapi/v2'
+      path: '/openapi/v3'
     }
   })
 }

--- a/backend/test/acceptance/openapi.spec.js
+++ b/backend/test/acceptance/openapi.spec.js
@@ -37,10 +37,12 @@ describe('openapi', function () {
 
     mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
     mockRequest.mockResolvedValueOnce({
-      definitions: {
-        ...shootDefinitions,
-        foo: {
-          type: 'object'
+      components: {
+        schemas: {
+          ...shootDefinitions,
+          foo: {
+            type: 'object'
+          }
         }
       }
     })
@@ -66,7 +68,7 @@ describe('openapi', function () {
         spec: expect.objectContaining({
           nonResourceAttributes: {
             verb: 'get',
-            path: '/openapi/v2'
+            path: '/openapi/v3'
           }
         })
       }
@@ -74,7 +76,7 @@ describe('openapi', function () {
     expect(mockRequest.mock.calls[1]).toEqual([{
       ...pick(fixtures.kube, [':scheme', ':authority', 'authorization']),
       ':method': 'get',
-      ':path': '/openapi/v2'
+      ':path': '/openapi/v3/apis/core.gardener.cloud/v1beta1'
     }])
 
     expect(dereferenceStub).toBeCalledTimes(1)

--- a/frontend/__tests__/utils/shootEditorCompletions.spec.js
+++ b/frontend/__tests__/utils/shootEditorCompletions.spec.js
@@ -13,45 +13,62 @@ const shootCompletions = {
   spec: {
     type: 'object',
     description: 'spec description',
-    properties: {
-      apiVersion: {
-        type: 'string',
-      },
-      kind: {
-        type: 'string',
-      },
-      metadata: {
-        type: 'object',
+    allOf: [
+      {
         properties: {
-          annotations: {
-            type: 'object',
+          apiVersion: {
+            type: 'string',
           },
-          managedFields: {
-            description: 'Demo Array',
-            type: 'array',
-            items: {
-              type: 'object',
-              properties: {
-                apiVersion: {
-                  type: 'string',
-                },
-                fieldsType: {
-                  type: 'string',
-                },
-                managedObjects: {
-                  type: 'object',
-                  properties: {
-                    foo: {
-                      type: 'string',
+          kind: {
+            type: 'string',
+          },
+          metadata: {
+            type: 'object',
+            allOf: [
+              {
+                type: 'object',
+                properties: {
+                  annotations: {
+                    type: 'object',
+                  },
+                  managedFields: {
+                    description: 'Demo Array',
+                    type: 'array',
+                    items: {
+                      allOf: [
+                        {
+                          type: 'object',
+                          properties: {
+                            apiVersion: {
+                              type: 'string',
+                            },
+                            fieldsType: {
+                              type: 'string',
+                            },
+                            managedObjects: {
+                              type: 'object',
+                              allOf: [
+                                {
+                                  properties: {
+                                    foo: {
+                                      type: 'string',
+                                    },
+                                  },
+                                },
+                              ],
+                            },
+                          },
+                        },
+                      ],
                     },
                   },
                 },
               },
-            },
+            ],
           },
         },
       },
-    },
+    ],
   },
 }
 

--- a/frontend/src/components/ShootWorkers/GWorkerConfiguration.vue
+++ b/frontend/src/components/ShootWorkers/GWorkerConfiguration.vue
@@ -54,7 +54,7 @@ SPDX-License-Identifier: Apache-2.0
             <g-shoot-editor
               ref="workerEditorRef"
               :shoot-item="editorData"
-              :completion-paths="['spec.properties.provider.properties.workers', 'spec.properties.provider.properties.infrastructureConfig']"
+              :completion-paths="['spec.allOf[0].properties.provider.allOf[0].properties.workers', 'spec.allOf[0].properties.provider.allOf[0].properties.infrastructureConfig']"
               hide-toolbar
               animate-on-appear
               alert-banner-identifier="workerEditorWarning"

--- a/frontend/src/utils/shootEditorCompletions.js
+++ b/frontend/src/utils/shootEditorCompletions.js
@@ -96,8 +96,7 @@ export class ShootEditorCompletions {
   _getYamlCompletions (token, cur, cm, exactMatch = false) {
     const completionPath = this._getTokenCompletionPath(token, cur, cm)
     if (this.supportedPaths?.length) {
-      const currentPath = completionPath.join('.')
-      if (!this.supportedPaths.some(path => currentPath.startsWith(path))) {
+      if (!this.supportedPaths.some(path => completionPath.startsWith(path))) {
         return []
       }
     }
@@ -244,25 +243,25 @@ export class ShootEditorCompletions {
           }
           if (isLeafContextToken && token.type === 'firstArrayItem') {
             // leaf context token is array, so list properties of its items
-            return [pathToken.propertyName, 'items', 'properties']
+            return [pathToken.propertyName, 'items', 'allOf[0]', 'properties']
           }
           // regular property token
-          return [pathToken.propertyName, 'properties']
+          return [pathToken.propertyName, 'allOf[0]', 'properties']
         }
         case 'firstArrayItem': {
           const isTokenIndentIndicatingObjectStart = token.start === pathToken.indent + this.indentUnit + this.arrayBulletIndent
           if (pathToken.propertyName !== undefined && isLeafContextToken && isTokenIndentIndicatingObjectStart) {
             // firstArrayItem line can also start new object, so list properties of item object
-            return ['items', 'properties', pathToken.propertyName, 'properties']
+            return ['items', 'allOf[0]', 'properties', pathToken.propertyName, 'allOf[0]', 'properties']
           }
           // path token is array, so list properties of its items
-          return ['items', 'properties']
+          return ['items', 'allOf[0]', 'properties']
         }
       }
       return []
     })
 
-    return tokenPath
+    return tokenPath.join('.')
   }
 
   // Utils

--- a/packages/kube-client/__tests__/non-resource-endpoints.test.js
+++ b/packages/kube-client/__tests__/non-resource-endpoints.test.js
@@ -73,8 +73,8 @@ describe('kube-client', () => {
     })
 
     describe('openapi', () => {
-      it('should fetch the openapi/v2 endpoint', async () => {
-        await expect(endpoints.openapi.get()).resolves.toEqual(['openapi/v2', { method: 'get' }])
+      it('should fetch the openapi/v3 endpoint', async () => {
+        await expect(endpoints.openapi.getGardenerV1Beta1()).resolves.toEqual(['openapi/v3/apis/core.gardener.cloud/v1beta1', { method: 'get' }])
       })
     })
 

--- a/packages/kube-client/lib/nonResourceEndpoints/OpenAPI.js
+++ b/packages/kube-client/lib/nonResourceEndpoints/OpenAPI.js
@@ -10,8 +10,8 @@ const HttpClient = require('../HttpClient')
 const { http } = require('../symbols')
 
 class OpenAPI extends HttpClient {
-  get () {
-    return this[http.request]('openapi/v2', { method: 'get' })
+  getGardenerV1Beta1 () {
+    return this[http.request]('openapi/v3/apis/core.gardener.cloud/v1beta1', { method: 'get' })
   }
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Since OpenAPI v2 has been deprecated, we need to switch to OpenAPI v3 to be able to show shot resource editor hints and code completion.

**Which issue(s) this PR fixes**:
Fixes #1578

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed code completion and tooltips in cluster editor: Recent Gardener releases dropped support for OpenAPI v2. Dashboard now uses OpenAPI v3 to fetch shoot resource information
```
