### PR TITLE
Handle session expiration gracefully and fix autoLogin redirection 

### DIFF
--- a/backend/lib/auth.js
+++ b/backend/lib/auth.js
@@ -44,9 +44,17 @@ router.route('/logout')
   .get(async (req, res, next) => {
     try {
       clearCookies(res)
-      const { error = {} } = req.query
-      const hash = error.message ? `#error=${encodeURIComponent(error.message)}` : ''
-      res.redirect(`/login${hash}`)
+      const {
+        error = {},
+        redirectPath
+      } = req.query
+      const hash = error.message
+        ? `#error=${encodeURIComponent(error.message)}`
+        : ''
+      const search = redirectPath
+        ? `?redirectPath=${encodeURIComponent(redirectPath)}`
+        : ''
+      res.redirect(`/login${hash || search}`)
     } catch (err) {
       next(err)
     }

--- a/frontend/__tests__/utils/index.spec.js
+++ b/frontend/__tests__/utils/index.spec.js
@@ -12,6 +12,8 @@ import {
   getIssueSince,
   maintenanceWindowWithBeginAndTimezone,
   getDurationInMinutes,
+  getTimeStringTo,
+  getTimeStringFrom,
 } from '@/utils'
 
 import { pick } from '@/lodash'
@@ -368,6 +370,30 @@ describe('utils', () => {
     })
     it('should calculate window size across multiple days', () => {
       expect(getDurationInMinutes('23:00', '01:00')).toBe(120)
+    })
+  })
+
+  describe('getTimeStringTo', () => {
+    it('should calculate the relative time to a future date', () => {
+      const time = Date.now()
+      expect(getTimeStringTo(time, time)).toBe('just now')
+      expect(getTimeStringTo(time, time, true)).toBe('just now')
+      expect(getTimeStringTo(time, time + 7 * 1_000, true)).toBe('7 seconds')
+      expect(getTimeStringTo(time, time + 7 * 1_000)).toBe('in 7 seconds')
+      expect(getTimeStringTo(time, time + 70 * 24 * 3600_000, true)).toBe('2 months')
+      expect(getTimeStringTo(time, time + 70 * 24 * 3600_000)).toBe('in 2 months')
+    })
+  })
+
+  describe('getTimeStringFrom', () => {
+    it('should calculate the relative time to a date in the past', () => {
+      const time = Date.now()
+      expect(getTimeStringFrom(time, time)).toBe('just now')
+      expect(getTimeStringFrom(time, time, true)).toBe('just now')
+      expect(getTimeStringFrom(time, time + 7 * 1_000, true)).toBe('7 seconds')
+      expect(getTimeStringFrom(time, time + 7 * 1_000)).toBe('7 seconds ago')
+      expect(getTimeStringFrom(time, time + 70 * 24 * 3600_000, true)).toBe('2 months')
+      expect(getTimeStringFrom(time, time + 70 * 24 * 3600_000)).toBe('2 months ago')
     })
   })
 })

--- a/frontend/__tests__/utils/moment.spec.js
+++ b/frontend/__tests__/utils/moment.spec.js
@@ -88,5 +88,42 @@ describe('utils', () => {
         expect(toLocalFormat(date)).toMatch(/^Feb \d{2}, 2012 \d{2}:\d{2} (AM|PM)$/)
       })
     })
+
+    describe('relativeTime', () => {
+      it('should return human readable descriptions for durations with suffix/prefix', () => {
+        expect(dayjs.duration(-7, 'seconds').humanize(true)).toBe('7 seconds ago')
+        expect(dayjs.duration(0, 'seconds').humanize(true)).toBe('just now')
+        expect(dayjs.duration(1, 'seconds').humanize(true)).toBe('in a second')
+        expect(dayjs.duration(7, 'seconds').humanize(true)).toBe('in 7 seconds')
+        expect(dayjs.duration(13, 'seconds').humanize(true)).toBe('in a few seconds')
+        expect(dayjs.duration(59, 'seconds').humanize(true)).toBe('in a few seconds')
+        expect(dayjs.duration(60, 'seconds').humanize(true)).toBe('in a minute')
+        expect(dayjs.duration(3, 'minutes').humanize(true)).toBe('in 3 minutes')
+        expect(dayjs.duration(5, 'hours').humanize(true)).toBe('in 5 hours')
+      })
+
+      it('should return human readable descriptions for relative times with suffix/prefix', () => {
+        // to
+        expect(dayjs(time + 7 * 1_000).to(time)).toBe('7 seconds ago')
+        expect(dayjs(time).to(time)).toBe('just now')
+        expect(dayjs(time - 1 * 1_000).to(time)).toBe('in a second')
+        expect(dayjs(time - 7 * 1_000).to(time)).toBe('in 7 seconds')
+        expect(dayjs(time - 13 * 1_000).to(time)).toBe('in a few seconds')
+        expect(dayjs(time - 59 * 1_000).to(time)).toBe('in a few seconds')
+        expect(dayjs(time - 1 * 60_000).to(time)).toBe('in a minute')
+        expect(dayjs(time - 3 * 60_000).to(time)).toBe('in 3 minutes')
+        expect(dayjs(time - 5 * 3600_000).to(time)).toBe('in 5 hours')
+        // from
+        expect(dayjs(time + 7 * 1_000).from(time)).toBe('in 7 seconds')
+        expect(dayjs(time).from(time)).toBe('just now')
+        expect(dayjs(time - 1 * 1_000).from(time)).toBe('a second ago')
+        expect(dayjs(time - 7 * 1_000).from(time)).toBe('7 seconds ago')
+        expect(dayjs(time - 13 * 1_000).from(time)).toBe('a few seconds ago')
+        expect(dayjs(time - 59 * 1_000).from(time)).toBe('a few seconds ago')
+        expect(dayjs(time - 1 * 60_000).from(time)).toBe('a minute ago')
+        expect(dayjs(time - 3 * 60_000).from(time)).toBe('3 minutes ago')
+        expect(dayjs(time - 5 * 3600_000).from(time)).toBe('5 hours ago')
+      })
+    })
   })
 })

--- a/frontend/src/components/GTimeString.vue
+++ b/frontend/src/components/GTimeString.vue
@@ -5,18 +5,16 @@ SPDX-License-Identifier: Apache-2.0
 -->
 
 <template>
-  <v-tooltip
-    location="top"
-    :disabled="noTooltip"
-  >
-    <template #activator="{ props: activatorProps }">
-      <span
-        v-bind="activatorProps"
-        :class="contentClass"
-      >{{ relDateTimeString }}</span>
-    </template>
-    {{ dateTimeString }}
-  </v-tooltip>
+  <span :class="contentClass">
+    {{ relDateTimeString }}
+    <v-tooltip
+      v-if="!noTooltip"
+      activator="parent"
+      location="top"
+    >
+      {{ dateTimeString }}
+    </v-tooltip>
+  </span>
 </template>
 
 <script setup>
@@ -61,7 +59,7 @@ const clockHalfAnHourAccuracy = new Clock(1000 * 60 * 30)
 
 const props = defineProps({
   dateTime: {
-    type: String,
+    type: [String, Number, Date],
   },
   mode: {
     type: String,

--- a/frontend/src/router/guards.js
+++ b/frontend/src/router/guards.js
@@ -51,7 +51,7 @@ export function createGlobalBeforeGuards () {
 
       authnStore.$reset()
 
-      const expiresIn = authnStore.userExpiresAt - Date.now()
+      const expiresIn = authnStore.sessionExpiresAt - Date.now()
       if (expiresIn > 0) {
         clearTimeout(sessionTimeoutId)
         sessionTimeoutId = setTimeout(() => {

--- a/frontend/src/store/authn/helper.js
+++ b/frontend/src/store/authn/helper.js
@@ -18,6 +18,8 @@ import {
   isUnauthorizedError,
   isNoUserError,
   isClockSkewError,
+  createSessionExpiredError,
+  isSessionExpiredError,
 } from '@/utils/errors'
 
 export const COOKIE_HEADER_PAYLOAD = 'gHdrPyl'
@@ -102,6 +104,9 @@ export function useUserManager (options) {
       if (!user) {
         throw createNoUserError()
       }
+      if (isExpired(user)) {
+        throw createSessionExpiredError()
+      }
       if (isRefreshRequired(user)) {
         throw createClockSkewError()
       }
@@ -168,6 +173,9 @@ export function useUserManager (options) {
       if (!user) {
         throw createNoUserError()
       }
+      if (isExpired(user)) {
+        throw createSessionExpiredError()
+      }
       if (!isRefreshRequired(user)) {
         return
       }
@@ -176,6 +184,9 @@ export function useUserManager (options) {
         user = decodeCookie()
         if (!user) {
           throw createNoUserError()
+        }
+        if (isExpired(user)) {
+          throw createSessionExpiredError()
         }
         if (!isRefreshRequired(user)) {
           return
@@ -190,6 +201,8 @@ export function useUserManager (options) {
       let frameRequestCallback
       if (isNoUserError(err)) {
         frameRequestCallback = () => signin()
+      } else if (isSessionExpiredError(err)) {
+        frameRequestCallback = () => signout()
       } else if (isUnauthorizedError(err) || isClockSkewError(err)) {
         frameRequestCallback = () => signout(err)
       }

--- a/frontend/src/store/authn/helper.js
+++ b/frontend/src/store/authn/helper.js
@@ -145,9 +145,12 @@ export function useUserManager (options) {
     unref(location).href = url
   }
 
-  function signout (err) {
+  function signout (err, redirectPath) {
     deleteCookie()
     const url = new URL('/auth/logout', origin)
+    if (redirectPath) {
+      url.searchParams.set('redirectPath', redirectPath)
+    }
     if (err) {
       url.searchParams.set('error[name]', err.name)
       url.searchParams.set('error[message]', err.message)

--- a/frontend/src/store/authn/index.js
+++ b/frontend/src/store/authn/index.js
@@ -73,7 +73,7 @@ export const useAuthnStore = defineStore('authn', () => {
     return user.value?.name ?? getFullDisplayName(user.value?.id) ?? ''
   })
 
-  const userExpiresAt = computed(() => {
+  const sessionExpiresAt = computed(() => {
     return (user.value?.exp ?? 0) * 1000
   })
 
@@ -95,7 +95,7 @@ export const useAuthnStore = defineStore('authn', () => {
     username,
     displayName,
     fullDisplayName,
-    userExpiresAt,
+    sessionExpiresAt,
     avatarUrl,
     avatarTitle,
     isExpired,

--- a/frontend/src/store/authn/index.js
+++ b/frontend/src/store/authn/index.js
@@ -47,7 +47,7 @@ export const useAuthnStore = defineStore('authn', () => {
         try {
           await ensureValidToken()
         } catch (err) {
-          logger.error(err)
+          logger.error('request token invalid: %s', err.message)
           throw createAbortError('Request aborted')
         }
       }

--- a/frontend/src/store/socket/helper.js
+++ b/frontend/src/store/socket/helper.js
@@ -31,6 +31,8 @@ export function createSocket (state, context) {
   const managerOpen = async fn => {
     try {
       await authnStore.ensureValidToken()
+    } catch (err) {
+      logger.error('io token invalid: %s', err.message)
     } finally {
       Manager.prototype.open.call(manager, fn)
     }
@@ -77,6 +79,8 @@ export function createSocket (state, context) {
   const connect = async () => {
     try {
       await authnStore.ensureValidToken()
+    } catch (err) {
+      logger.error('io token invalid: %s', err.message)
     } finally {
       socket.connect()
     }

--- a/frontend/src/utils/errors.js
+++ b/frontend/src/utils/errors.js
@@ -48,6 +48,10 @@ export function createNoUserError (message = 'User not found', ...rest) {
   return createError('NoUser', message, ...rest)
 }
 
+export function createSessionExpiredError (message = 'User session is expired', ...rest) {
+  return createError('SessionExpired', message, ...rest)
+}
+
 export function createAbortError (message, ...rest) {
   return createError('Abort', message, ...rest)
 }
@@ -74,6 +78,10 @@ export function isGatewayTimeoutError (err) {
 
 export function isNoUserError (err) {
   return err.name === 'NoUserError'
+}
+
+export function isSessionExpiredError (err) {
+  return err.name === 'SessionExpired'
 }
 
 export function isClockSkewError (err) {

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -272,9 +272,8 @@ export function routeName (route) {
 export function getDateFormatted (timestamp) {
   if (!timestamp) {
     return undefined
-  } else {
-    return moment(timestamp).format('YYYY-MM-DD')
   }
+  return moment(timestamp).format('YYYY-MM-DD')
 }
 
 export function getTimestampFormatted (timestamp) {
@@ -287,21 +286,15 @@ export function getTimestampFormatted (timestamp) {
 export function getTimeStringFrom (time, fromTime, withoutSuffix = false) {
   if (!time) {
     return undefined
-  } else {
-    return moment(time).from(fromTime, withoutSuffix)
   }
+  return moment(time).from(fromTime, withoutSuffix)
 }
 
 export function getTimeStringTo (time, toTime, withoutPrefix = false) {
   if (!time) {
     return undefined
-  } else {
-    if (time.getTime() === toTime.getTime()) {
-      // Equal dates result in text "a few seconds ago", this is not we want here...
-      toTime.setSeconds(toTime.getSeconds() + 1)
-    }
-    return moment(time).to(toTime, withoutPrefix)
   }
+  return moment(time).to(toTime, withoutPrefix)
 }
 
 export function isOwnSecret (infrastructureSecret) {

--- a/frontend/src/utils/moment.js
+++ b/frontend/src/utils/moment.js
@@ -15,7 +15,7 @@ import updateLocale from 'dayjs/plugin/updateLocale'
 
 const thresholds = [
   { l: 'S', r: 1, d: 'millisecond' },
-  { l: 's', r: 1, d: 'second' },
+  { l: 's', r: 1 },
   { l: 'ss', r: 10, d: 'second' },
   { l: 'sss', r: 59, d: 'second' },
   { l: 'm', r: 1 },

--- a/frontend/src/utils/moment.js
+++ b/frontend/src/utils/moment.js
@@ -11,14 +11,54 @@ import localizedFormat from 'dayjs/plugin/localizedFormat'
 import customParseFormat from 'dayjs/plugin/customParseFormat'
 import utc from 'dayjs/plugin/utc'
 import timezone from 'dayjs/plugin/timezone'
+import updateLocale from 'dayjs/plugin/updateLocale'
 
-dayjs.extend(relativeTime)
+const thresholds = [
+  { l: 'S', r: 1, d: 'millisecond' },
+  { l: 's', r: 1, d: 'second' },
+  { l: 'ss', r: 10, d: 'second' },
+  { l: 'sss', r: 59, d: 'second' },
+  { l: 'm', r: 1 },
+  { l: 'mm', r: 59, d: 'minute' },
+  { l: 'h', r: 1 },
+  { l: 'hh', r: 23, d: 'hour' },
+  { l: 'd', r: 1 },
+  { l: 'dd', r: 29, d: 'day' },
+  { l: 'M', r: 1 },
+  { l: 'MM', r: 11, d: 'month' },
+  { l: 'y', r: 1 },
+  { l: 'yy', d: 'year' },
+]
+
+dayjs.extend(relativeTime, { thresholds })
 dayjs.extend(duration)
 dayjs.extend(localizedFormat)
 dayjs.extend(customParseFormat)
 dayjs.extend(utc)
 dayjs.extend(timezone)
 dayjs.extend(timezoneExtension)
+dayjs.extend(updateLocale)
+
+dayjs.updateLocale('en', {
+  relativeTime: {
+    future: val => val === 'just now' ? val : `in ${val}`,
+    past: val => val === 'just now' ? val : `${val} ago`,
+    S: 'just now',
+    s: 'a second',
+    ss: '%d seconds',
+    sss: 'a few seconds',
+    m: 'a minute',
+    mm: '%d minutes',
+    h: 'an hour',
+    hh: '%d hours',
+    d: 'a day',
+    dd: '%d days',
+    M: 'a month',
+    MM: '%d months',
+    y: 'a year',
+    yy: '%d years',
+  },
+})
 
 function timezoneExtension (option, dayjsClass, dayjsFactory) {
   const locations = [

--- a/frontend/src/views/GAccount.vue
+++ b/frontend/src/views/GAccount.vue
@@ -73,7 +73,11 @@ SPDX-License-Identifier: Apache-2.0
                 Session
               </div>
               <div class="content">
-                Expires {{ expiresAt }}
+                Expires
+                <g-time-string
+                  mode="future"
+                  :date-time="expiresAt"
+                />
               </div>
             </g-list-item>
           </g-list>
@@ -255,8 +259,7 @@ import { useKubeconfigStore } from '@/store/kubeconfig'
 import GCopyBtn from '@/components/GCopyBtn.vue'
 import GCodeBlock from '@/components/GCodeBlock.vue'
 import GAccountAvatar from '@/components/GAccountAvatar.vue'
-
-import moment from '@/utils/moment'
+import GTimeString from '@/components/GTimeString.vue'
 
 import {
   map,
@@ -270,6 +273,7 @@ export default {
     GCopyBtn,
     GCodeBlock,
     GAccountAvatar,
+    GTimeString,
   },
   inject: ['api', 'logger', 'yaml'],
   data () {
@@ -321,7 +325,7 @@ export default {
       return this.user.groups
     },
     expiresAt () {
-      return moment.duration(this.user.exp - Math.floor(Date.now() / 1000), 'seconds').humanize(true)
+      return this.user.exp * 1000
     },
     projectNames () {
       const names = map(this.projectList, 'metadata.name').sort()


### PR DESCRIPTION
**What this PR does / why we need it**:
If the login session in the dasboard expires the user no longer gets an error message `JWT expired`. In case of autoLogin is enabled the user is redirected back to the last visited page.

**Which issue(s) this PR fixes**:
Fixes #1534 #865

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
If the login session in the dasboard expires the user no longer gets an error message `JWT expired`. In case of autoLogin is enabled the user is redirected back to the last visited page.
```
