### PR TITLE
[hotfix-1.70] Update GShootActionRotateCredentials.vue (#1603)

### DIFF
--- a/frontend/src/components/GShootActionRotateCredentials.vue
+++ b/frontend/src/components/GShootActionRotateCredentials.vue
@@ -236,11 +236,11 @@ export default {
         return 'Unschedule Rotation'
       }
       if (this.maintenance) {
-        return 'Schedule Roatation'
+        return 'Schedule Rotation'
       }
       switch (this.mode) {
         case 'START':
-          return 'Prepare Roatation'
+          return 'Prepare Rotation'
         case 'COMPLETE':
           return 'Complete Rotation'
       }


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherry picked from commit c718d9f4733eef7915a75811ae62341f9dc7f81c (PR #1603)

There is a small typo in the Credential rotation pop-up. "Rotation" was misspelled as "Roatation"

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed a typo in shoot credentials rotation
```
