### PR TITLE
[hotfix-1.70] Remove duplicative tooltip

### DIFF
--- a/frontend/src/components/GShootListRow.vue
+++ b/frontend/src/components/GShootListRow.vue
@@ -118,18 +118,11 @@ SPDX-License-Identifier: Apache-2.0
         </div>
       </template>
       <template v-if="cell.header.key === 'issueSince'">
-        <v-tooltip location="top">
-          <template #activator="{ props }">
-            <div v-bind="props">
-              <g-time-string
-                :date-time="shootIssueSinceTimestamp"
-                mode="past"
-                without-prefix-or-suffix
-              />
-            </div>
-          </template>
-          {{ shootIssueSince }}
-        </v-tooltip>
+        <g-time-string
+          :date-time="shootIssueSinceTimestamp"
+          mode="past"
+          without-prefix-or-suffix
+        />
       </template>
       <template v-if="cell.header.key === 'accessRestrictions'">
         <g-access-restriction-chips :selected-access-restrictions="shootSelectedAccessRestrictions" />

--- a/frontend/src/views/GAdministration.vue
+++ b/frontend/src/views/GAdministration.vue
@@ -159,18 +159,10 @@ SPDX-License-Identifier: Apache-2.0
                     Created At
                   </div>
                   <div class="text-body-1">
-                    <v-tooltip location="right">
-                      <template #activator="{ props }">
-                        <span
-                          v-bind="props"
-                          class="text-subtitle-1"
-                        >{{ createdAt }}</span>
-                      </template>
-                      <g-time-string
-                        :date-time="creationTimestamp"
-                        :point-in-time="-1"
-                      />
-                    </v-tooltip>
+                    <g-time-string
+                      :date-time="creationTimestamp"
+                      :point-in-time="-1"
+                    />
                   </div>
                 </g-list-item>
                 <v-divider inset />


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes a duplicate tooltip on the issue since value. In addition, the created at date on the administration page now directly uses the timestring component, same as we do on the shoot details page.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed duplicative tooltip on issue since value
```
