### PR TITLE
Add assets checksum annotation on deployment

### DIFF
--- a/charts/__tests__/gardener-dashboard/runtime/dashboard/deployment.spec.js
+++ b/charts/__tests__/gardener-dashboard/runtime/dashboard/deployment.spec.js
@@ -125,6 +125,26 @@ describe('gardener-dashboard', function () {
       expect(deployment.metadata.labels).toEqual(expect.objectContaining(values.global.dashboard.deploymentLabels))
     })
 
+    it('should render the template with assets checksum annotation', async function () {
+      const values = {
+        global: {
+          dashboard: {
+            frontendConfig: {
+              assets: {
+                foo: 'bar'
+              }
+            }
+          }
+        }
+      }
+      const documents = await renderTemplates(templates, values)
+      expect(documents).toHaveLength(1)
+      const [deployment] = documents
+      expect(deployment.spec.template.metadata.annotations).toEqual(expect.objectContaining({
+        'checksum/configmap-gardener-dashboard-assets': expect.stringMatching(/[0-9a-f]{64}/)
+      }))
+    })
+
     it('should render the template with deployment annotations', async function () {
       const values = {
         global: {

--- a/charts/gardener-dashboard/charts/runtime/templates/dashboard/deployment.yaml
+++ b/charts/gardener-dashboard/charts/runtime/templates/dashboard/deployment.yaml
@@ -28,6 +28,9 @@ spec:
     metadata:
       annotations:
         checksum/configmap-gardener-dashboard-config: {{ include (print .Template.BasePath "/dashboard/configmap.yaml") . | sha256sum }}
+        {{- if .Values.global.dashboard.frontendConfig.assets }}
+        checksum/configmap-gardener-dashboard-assets: {{ include (print .Template.BasePath "/dashboard/configmap-assets.yaml") . | sha256sum }}
+        {{- end }}
         checksum/secret-gardener-dashboard-sessionSecret: {{ include (print .Template.BasePath "/dashboard/secret-sessionSecret.yaml") . | sha256sum }}
         {{- if .Values.global.dashboard.oidc }}
         checksum/secret-gardener-dashboard-oidc: {{ include (print .Template.BasePath "/dashboard/secret-oidc.yaml") . | sha256sum }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixed issue where Dashboard pods were not recreated after assets have been changed

**Which issue(s) this PR fixes**:
Fixes #1626 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Dashboard pods were not recreated after assets have been changed
```
