### PR TITLE
Replaced absolute links with relative

### DIFF
--- a/docs/development/local-setup.md
+++ b/docs/development/local-setup.md
@@ -9,8 +9,8 @@
 Develop new feature and fix bug on the Gardener Dashboard.
 
 ## Requirements
-- Yarn. For the required version, refer to `.engines.yarn` in [package.json](https://github.com/gardener/dashboard/blob/master/package.json).
-- Node.js. For the required version, refer to `.engines.node` in [package.json](https://github.com/gardener/dashboard/blob/master/package.json).
+- Yarn. For the required version, refer to `.engines.yarn` in [package.json](../../package.json).
+- Node.js. For the required version, refer to `.engines.node` in [package.json](../../package.json).
 
 ## Steps
 
@@ -54,13 +54,13 @@ frontend:
 ```
 
 ### 5. Run it locally
-The Gardener Dashboard [`backend`](https://github.com/gardener/dashboard/tree/master/backend) server requires a kubeconfig for the Garden cluster. You can set it e.g. by using the `KUBECONFIG` environment variable.
+The Gardener Dashboard [`backend`](../../backend) server requires a kubeconfig for the Garden cluster. You can set it e.g. by using the `KUBECONFIG` environment variable.
 
 If you want to run the Garden cluster locally, follow the [getting started locally](https://github.com/gardener/gardener/blob/master/docs/development/getting_started_locally.md) documentation.
 Gardener Dashboard supports the `local` infrastructure provider that comes with the local Gardener cluster setup.
 See [6. Login to the dashboard](#6-login-to-the-dashboard) for more information on how to use the Dashboard with a local gardener or any other Gardener landscape.
 
-Concurrently run the `backend` server (port `3030`) and the [`frontend`](https://github.com/gardener/dashboard/tree/master/frontend) server (port `8080`) with hot reload enabled.
+Concurrently run the `backend` server (port `3030`) and the [`frontend`](../../frontend) server (port `8080`) with hot reload enabled.
 
 ```sh
 cd backend

--- a/docs/operations/customization.md
+++ b/docs/operations/customization.md
@@ -4,7 +4,7 @@
 Gardener landscape administrators should have the possibility to change the appearance and the branding of the Gardener Dashboard via configuration without the need to touch the code.
 
 ## Branding
-It is possible to change the branding of the Gardener Dashboard when using the [helm chart](https://github.com/gardener/dashboard/blob/master/charts/gardener-dashboard) in the `frontendConfig.branding` map. The following configuration properties are supported:
+It is possible to change the branding of the Gardener Dashboard when using the [helm chart](../../charts/gardener-dashboard) in the `frontendConfig.branding` map. The following configuration properties are supported:
 
 | name | description | default |
 | ---- | ----------- | ------- |
@@ -14,12 +14,12 @@ It is possible to change the branding of the Gardener Dashboard when using the [
 | `productTitleSuperscript` | Superscript next to the product title. To supress the superscript set to `false` | Production version (e.g 1.73.1) |
 | `productSlogan` | Slogan that is displayed under the product title and on the login page| `Universal Kubernetes at Scale` |
 | `productLogoUrl` | URL for the product logo. You can also use [data:](https://developer.mozilla.org/en-US/docs/web/http/basics_of_http/data_urls) scheme for development. For production it is recommended to provide static assets | `/static/assets/logo.svg` |
-| `teaserHeight` | Height of the teaser in the [GMainNavigation](https://github.com/gardener/dashboard/blob/master/frontend/src/components/GMainNavigation.vue) component | `200` |
-| `teaserTemplate` | Custom HTML template to replace to teaser content | refer to [GTeaser](https://github.com/gardener/dashboard/blob/master/frontend/src/components/GTeaser.vue) |
-| `loginTeaserHeight` | Height of the login teaser in the [GLogin](https://github.com/gardener/dashboard/blob/master/frontend/src/layouts/GLogin.vue) component | `260` |
-| `loginTeaserTemplate` | Custom HTML template to replace to login teaser content | refer to [GLoginTeaser](https://github.com/gardener/dashboard/blob/master/frontend/src/components/GLoginTeaser.vue) |
-| `loginFooterHeight` | Height of the login footer in the [GLogin](https://github.com/gardener/dashboard/blob/master/frontend/src/layouts/GLogin.vue) component | `24` |
-| `loginFooterTemplate` | Custom HTML template to replace to login footer content | refer to [GLoginFooter](https://github.com/gardener/dashboard/blob/master/frontend/src/components/GLoginFooter.vue) |
+| `teaserHeight` | Height of the teaser in the [GMainNavigation](../../frontend/src/components/GMainNavigation.vue) component | `200` |
+| `teaserTemplate` | Custom HTML template to replace to teaser content | refer to [GTeaser](../../frontend/src/components/GTeaser.vue) |
+| `loginTeaserHeight` | Height of the login teaser in the [GLogin](../../frontend/src/layouts/GLogin.vue) component | `260` |
+| `loginTeaserTemplate` | Custom HTML template to replace to login teaser content | refer to [GLoginTeaser](../../frontend/src/components/GLoginTeaser.vue) |
+| `loginFooterHeight` | Height of the login footer in the [GLogin](../../frontend/src/layouts/GLogin.vue) component | `24` |
+| `loginFooterTemplate` | Custom HTML template to replace to login footer content | refer to [GLoginFooter](../../frontend/src/components/GLoginFooter.vue) |
 | `loginHints` | Links [`{ title: string; href: string; }`](https://vuetifyjs.com/en/api/v-breadcrumbs/#props-items) to product related sites shown below the login button  | `undefined` |
 | `oidcLoginTitle` | Title of tabstrip for loginType OIDC | `OIDC` |
 | `oidcLoginText` | Text show above the login button on the OIDC tabstrip | `Press Login to be redirected to`<br> `configured OpenID Connect Provider.` |
@@ -50,7 +50,7 @@ If you use the helm chart, you can configure those with `frontendConfig.themes.l
 
 ## Logos and Icons
 
-It is also possible to exchange the Dashboard logo and icons. You can replace the [assets](https://github.com/gardener/dashboard/tree/master/frontend/public/static/assets) folder when using the [helm chart](https://github.com/gardener/dashboard/blob/master/charts/gardener-dashboard) in the `frontendConfig.assets` map.
+It is also possible to exchange the Dashboard logo and icons. You can replace the [assets](../../frontend/public/static/assets) folder when using the [helm chart](../../charts/gardener-dashboard) in the `frontendConfig.assets` map.
 
 Attention: You need to set values for all files as mapping the volume will overwrite all files. It is not possible to exchange single files.
 

--- a/docs/usage/custom-fields.md
+++ b/docs/usage/custom-fields.md
@@ -37,7 +37,7 @@ Custom fields can be shown in a dedicated card (`Custom Fields`) on the cluster 
 | searchable | Bool | true | | Indicates if column is searchable on the cluster list |
 | showDetails | Bool | true | | Indicates if field shall appear in a dedicated card (`Custom Fields`) on the cluster details page |
 
-As there is currently no way to configure the custom shoot fields for a project in the gardener dashboard, you have to use `kubectl` to update the `project` resource. See https://github.com/gardener/dashboard/blob/master/docs/usage/project-operations.md#download-kubeconfig-for-a-user on how to get a `kubeconfig` for the `garden` cluster in order to edit the `project`.
+As there is currently no way to configure the custom shoot fields for a project in the gardener dashboard, you have to use `kubectl` to update the `project` resource. See [Project Operations](../usage/project-operations.md#download-kubeconfig-for-a-user) on how to get a `kubeconfig` for the `garden` cluster in order to edit the `project`.
 
 ### Example
 

--- a/docs/usage/custom-fields.md
+++ b/docs/usage/custom-fields.md
@@ -37,7 +37,7 @@ Custom fields can be shown in a dedicated card (`Custom Fields`) on the cluster 
 | searchable | Bool | true | | Indicates if column is searchable on the cluster list |
 | showDetails | Bool | true | | Indicates if field shall appear in a dedicated card (`Custom Fields`) on the cluster details page |
 
-As there is currently no way to configure the custom shoot fields for a project in the gardener dashboard, you have to use `kubectl` to update the `project` resource. See [Project Operations](../usage/project-operations.md#download-kubeconfig-for-a-user) on how to get a `kubeconfig` for the `garden` cluster in order to edit the `project`.
+As there is currently no way to configure the custom shoot fields for a project in the gardener dashboard, you have to use `kubectl` to update the `project` resource. See [Project Operations](./project-operations.md#download-kubeconfig-for-a-user) on how to get a `kubeconfig` for the `garden` cluster in order to edit the `project`.
 
 ### Example
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR replaces all absolute links pointing to the gardener/dashboard repository with relative links in order to prevent possible docforge conflicts.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc developer
NONE
```
