### PR TITLE
switch GCR -> Artifact-Registry

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -11,6 +11,10 @@ dashboard:
         preprocess:
           'inject-commit-hash'
         inject_effective_version: true
+      component_descriptor:
+        ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
+        ocm_repository_mappings:
+          - repository: europe-docker.pkg.dev/gardener-project/releases
       publish:
         oci-builder: docker-buildx
         platforms:
@@ -21,8 +25,7 @@ dashboard:
             inputs:
               repos:
                 source: ~ # default
-            registry: 'gcr-readwrite'
-            image: 'eu.gcr.io/gardener-project/gardener/dashboard'
+            image: 'europe-docker.pkg.dev/gardener-project/snapshots/gardener/dashboard'
             target: dashboard
             resource_labels:
             - name: 'gardener.cloud/cve-categorisation'
@@ -37,7 +40,6 @@ dashboard:
   jobs:
     head-update:
       traits:
-        component_descriptor: ~
         draft_release: ~
     pull-request:
       traits:
@@ -51,6 +53,8 @@ dashboard:
       traits:
         version:
           preprocess: 'finalize'
+        component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases
         release:
           nextversion: 'bump_minor'
           release_callback: '.ci/bump_version'
@@ -60,8 +64,10 @@ dashboard:
             internal_scp_workspace:
               channel_name: 'C017DNNNENQ' # garden-dashboard channel
               slack_cfg_name: 'scp_workspace'
-        component_descriptor: ~
         publish:
           dockerimages:
             dashboard:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/dashboard
               tag_as_latest: true
+              extra_push_targets: # may be dropped after all users updated to new registry
+                - eu.gcr.io/gardener-project/gardener/dashboard

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-REGISTRY                      := eu.gcr.io/gardener-project/gardener
+REGISTRY                      := europe-docker.pkg.dev/gardener-project/snapshots/gardener
 DASHBOARD_IMAGE_REPOSITORY    := $(REGISTRY)/dashboard
 TAG                           := $(shell cat ./VERSION)-$(shell ./scripts/git-version)
 PUSH_LATEST_TAG               := true

--- a/charts/__tests__/gardener-dashboard/runtime/dashboard/__snapshots__/deployment.spec.js.snap
+++ b/charts/__tests__/gardener-dashboard/runtime/dashboard/__snapshots__/deployment.spec.js.snap
@@ -281,7 +281,7 @@ Object {
                 },
               },
             ],
-            "image": "eu.gcr.io/gardener-project/gardener/dashboard:1.26.0-dev-4d529c1",
+            "image": "europe-docker.pkg.dev/gardener-project/releases/gardener/dashboard:1.26.0-dev-4d529c1",
             "imagePullPolicy": "IfNotPresent",
             "livenessProbe": Object {
               "failureThreshold": 6,

--- a/charts/__tests__/gardener-dashboard/runtime/dashboard/deployment.spec.js
+++ b/charts/__tests__/gardener-dashboard/runtime/dashboard/deployment.spec.js
@@ -56,7 +56,7 @@ describe('gardener-dashboard', function () {
       expect(containers).toHaveLength(1)
       const [container] = containers
       expect(container).toEqual(expect.objectContaining({
-        image: 'eu.gcr.io/gardener-project/gardener/dashboard@' + tag,
+        image: 'europe-docker.pkg.dev/gardener-project/releases/gardener/dashboard@' + tag,
         imagePullPolicy: 'IfNotPresent'
       }))
     })

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -10,7 +10,7 @@ global:
     sessionAffinity: ClientIP
 
     image:
-      repository: eu.gcr.io/gardener-project/gardener/dashboard
+      repository: europe-docker.pkg.dev/gardener-project/releases/gardener/dashboard
       tag: latest
       pullPolicy: IfNotPresent
     # additional labels to add to the dashboard deployment
@@ -226,7 +226,7 @@ global:
       #     description: Using kubectl to watch the pods of the control plane for this cluster
       #     target: cp # possible values: "cp" (Control Plane), "shoot", "garden"
       #     container:
-      #       image: eu.gcr.io/gardener-project/gardener/ops-toolbelt:latest
+      #       image: europe-docker.pkg.dev/gardener-project/releases/gardener/ops-toolbelt:latest
       #       # command: ~
       #       args:
       #       - watch
@@ -388,11 +388,11 @@ global:
   # # Terminal related configuration
   # terminal:
   #   container:
-  #     image: eu.gcr.io/gardener-project/gardener/ops-toolbelt:latest
+  #     image: europe-docker.pkg.dev/gardener-project/releases/gardener/ops-toolbelt:latest
   #   containerOperator:
   #     image: ~ # if not defined, value of terminal.container.image will be used
   #   containerImageDescriptions:
-  #   - image: /eu.gcr.io/gardener-project/gardener/ops-toolbelt:.*/ # regexp must start and end with '/', otherwise it's an exact match
+  #   - image: /europe-docker.pkg.dev/gardener-project/releases/gardener/ops-toolbelt:.*/ # regexp must start and end with '/', otherwise it's an exact match
   #     description: Run `ghelp` to get information about installed tools and packages
   #   # serviceAccountTokenExpiration - is the default requested duration of validity of the token request for the "attach" service account (residing in the terminal host cluster)
   #   # If no value is provided, the default value corresponds to 12 hours

--- a/docs/usage/terminal-shortcuts.md
+++ b/docs/usage/terminal-shortcuts.md
@@ -80,7 +80,7 @@ frontend:
 [...]
 terminal: # is generally required for the terminal feature
   container:
-    image: eu.gcr.io/gardener-project/gardener/ops-toolbelt:0.10.0
+    image: europe-docker.pkg.dev/gardener-project/releases/gardener/ops-toolbelt:0.10.0
   containerImageDescriptions:
     - image: /.*/ops-toolbelt:.*/
       description: Run `ghelp` to get information about installed tools and packages

--- a/docs/usage/terminal-shortcuts.md
+++ b/docs/usage/terminal-shortcuts.md
@@ -80,7 +80,7 @@ frontend:
 [...]
 terminal: # is generally required for the terminal feature
   container:
-    image: europe-docker.pkg.dev/gardener-project/releases/gardener/ops-toolbelt:0.10.0
+    image: europe-docker.pkg.dev/gardener-project/releases/gardener/ops-toolbelt:0.26.0
   containerImageDescriptions:
     - image: /.*/ops-toolbelt:.*/
       description: Run `ghelp` to get information about installed tools and packages


### PR DESCRIPTION
GCR has been deprecated [0] in favour of Artifact-Registry.

Thus, change push-targets for OCI-Images:

- europe-docker.pkg.dev/gardener-project/snapshots for snapshots
- europe-docker.pkg.dev/gardener-project/releases for releases

To allow users for smooth transitioning, keep also publishing to GCR.

[0]
https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr


**Release note**:

```breaking operator
Change OCI Image Registry from GCR (`eu.gcr.io/gardener-project`) to Artifact-Registry (`europe-docker.pkg.dev/gardener-project/releases`)
```
