### PR TITLE
Added configuration parameter that specifies the maximum size of the request body

### DIFF
--- a/backend/lib/api.js
+++ b/backend/lib/api.js
@@ -11,6 +11,7 @@ const bodyParser = require('body-parser')
 const cookieParser = require('cookie-parser')
 const zlib = require('zlib')
 const compression = require('compression')
+const config = require('./config')
 const routes = require('./routes')
 const hooks = require('./hooks')()
 const { authenticate } = require('./security')
@@ -27,7 +28,9 @@ router.use(compression({
 router.use(requestLogger)
 router.use(monitorResponseTimes())
 router.use(cookieParser())
-router.use(bodyParser.json())
+router.use(bodyParser.json({
+  limit: config.maxRequestBodySize
+}))
 router.use(authenticate({ createClient }))
 for (const [key, value] of Object.entries(routes)) {
   router.use(key, value)

--- a/charts/__tests__/gardener-dashboard/runtime/dashboard/__snapshots__/configmap.spec.js.snap
+++ b/charts/__tests__/gardener-dashboard/runtime/dashboard/__snapshots__/configmap.spec.js.snap
@@ -437,7 +437,7 @@ Object {
   },
   "logFormat": "text",
   "logLevel": "debug",
-  "maxRequestBodySize": "200kb",
+  "maxRequestBodySize": "100kb",
   "oidc": Object {
     "ca": "-----BEGIN CERTIFICATE-----
 Li4u

--- a/charts/__tests__/gardener-dashboard/runtime/dashboard/__snapshots__/configmap.spec.js.snap
+++ b/charts/__tests__/gardener-dashboard/runtime/dashboard/__snapshots__/configmap.spec.js.snap
@@ -437,6 +437,7 @@ Object {
   },
   "logFormat": "text",
   "logLevel": "debug",
+  "maxRequestBodySize": "200kb",
   "oidc": Object {
     "ca": "-----BEGIN CERTIFICATE-----
 Li4u

--- a/charts/__tests__/gardener-dashboard/runtime/dashboard/configmap.spec.js
+++ b/charts/__tests__/gardener-dashboard/runtime/dashboard/configmap.spec.js
@@ -713,6 +713,25 @@ describe('gardener-dashboard', function () {
       })
     })
 
+    describe('maxRequestBodySize', function () {
+      it('should render the template', async function () {
+        const limit = '1mb'
+        const values = {
+          global: {
+            dashboard: {
+              maxRequestBodySize: limit
+            }
+          }
+        }
+
+        const documents = await renderTemplates(templates, values)
+        expect(documents).toHaveLength(1)
+        const [configMap] = documents
+        const config = yaml.load(configMap.data['config.yaml'])
+        expect(config.maxRequestBodySize).toBe(limit)
+      })
+    })
+
     describe('grantTypes', function () {
       it('should render the template', async function () {
         const values = {

--- a/charts/gardener-dashboard/charts/runtime/templates/dashboard/configmap.yaml
+++ b/charts/gardener-dashboard/charts/runtime/templates/dashboard/configmap.yaml
@@ -34,6 +34,7 @@ data:
     {{- if .Values.global.dashboard.clusterIdentity }}
     clusterIdentity: {{ .Values.global.dashboard.clusterIdentity }}
     {{- end }}
+    maxRequestBodySize: {{ .Values.global.dashboard.maxRequestBodySize | default "100kb" }}
     experimentalUseWatchCacheForListShoots: {{ .Values.global.dashboard.experimentalUseWatchCacheForListShoots | default "never" }}
     readinessProbe:
       periodSeconds: {{ .Values.global.dashboard.readinessProbe.periodSeconds }}

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -65,6 +65,12 @@ global:
     # # the identifier of the gardener landscape (defaults to the name stored in kube-system/cluster-identity configmap)
     # clusterIdentity: my-landscape-dev
 
+    # Maximum Request Body Size
+    # This configuration parameter specifies the maximum size of the request body.
+    # It is used to limit the size of data that the server will accept in a single request.
+    # (see https://expressjs.com/en/resources/middleware/body-parser.html#bodyparserjsonoptions)
+    maxRequestBodySize: 100kb
+
     # Experimental Feature: Control of Watch Cache for List Shoots Requests
     # This feature allows fine-tuning the behavior of how list shoots requests are handled in terms of caching.
     # Note: As this is an experimental feature, it is subject to change and may not be stable.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new configuration parameter `Values.global.dashboard.maxRequestBodySize` that specifies the maximum size of the request body. The default value is `100kb`. For more information please refer to the documentation of [express.json](https://expressjs.com/en/api.html#express.json) middleware.
**Which issue(s) this PR fixes**:
Fixes #1648 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Added a configuration parameter `Values.global.dashboard.maxRequestBodySize` that specifies the maximum size of the request body. It's value defaults to `100kb`.
```
