### PR TITLE
Fix: k8s dashboard not shown on details page

### DIFF
--- a/backend/lib/services/shoots.js
+++ b/backend/lib/services/shoots.js
@@ -361,9 +361,8 @@ exports.info = async function ({ user, namespace, name }) {
         }
       })
       .commit()
-
-    data.dashboardUrlPath = getDashboardUrlPath(shoot.spec.kubernetes.version)
   }
+  data.dashboardUrlPath = getDashboardUrlPath(shoot.spec.kubernetes.version)
 
   /*
     We explicitly use the (privileged) dashboardClient here for fetching the monitoring credentials instead of using the user's token

--- a/frontend/src/components/GShootListRow.vue
+++ b/frontend/src/components/GShootListRow.vue
@@ -309,7 +309,7 @@ export default {
       if (this.shootInfo.dashboardUrl) {
         return false
       }
-      if (this.shootInfo.kubeconfig) {
+      if (this.shootInfo.kubeconfigGardenlogin) {
         return false
       }
 

--- a/frontend/src/components/ShootDetails/GShootAccessCard.vue
+++ b/frontend/src/components/ShootDetails/GShootAccessCard.vue
@@ -62,35 +62,33 @@ SPDX-License-Identifier: Apache-2.0
           />
         </template>
         <g-list-item-content>
-          <template #label>
-            Dashboard
-            <div class="text-caption wrap-text py-2">
-              Access Dashboard using the kubectl command-line tool by running the following command:
-              <code>kubectl proxy</code>.
-              Kubectl will make Dashboard available at:
-            </div>
+          Dashboard
+          <template #description>
+            Access Dashboard using the kubectl command-line tool by running the following command:
+            <code>kubectl proxy</code>.
+            Kubectl will make Dashboard available at:
+            <v-tooltip
+              v-if="isShootStatusHibernated"
+              location="top"
+            >
+              <template #activator="{ props }">
+                <span
+                  v-bind="props"
+                  class="text-grey"
+                >{{ dashboardUrlText }}</span>
+              </template>
+              Dashboard is not running for hibernated clusters
+            </v-tooltip>
+            <a
+              v-else
+              class="text-anchor"
+              :href="dashboardUrl"
+              target="_blank"
+              rel="noopener"
+            >
+              {{ dashboardUrlText }}
+            </a>
           </template>
-          <v-tooltip
-            v-if="isShootStatusHibernated"
-            location="top"
-          >
-            <template #activator="{ props }">
-              <span
-                v-bind="props"
-                class="text-grey"
-              >{{ dashboardUrlText }}</span>
-            </template>
-            Dashboard is not running for hibernated clusters
-          </v-tooltip>
-          <a
-            v-else
-            class="text-anchor"
-            :href="dashboardUrl"
-            target="_blank"
-            rel="noopener"
-          >
-            {{ dashboardUrlText }}
-          </a>
         </g-list-item-content>
       </g-list-item>
       <g-list-item v-if="token">


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an issue where the k8s dashboard was not shown on details page

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fxed issue where the kubernetes dashboard was not shown on cluster details page in case the addon was enabled. The issue occurs when static token kubeconfig is disabled.
```
