### PR TITLE
[hotfix-1.71] Fixed navigation to the all projects list for non-admin users

### DIFF
--- a/backend/__fixtures__/shoots.js
+++ b/backend/__fixtures__/shoots.js
@@ -131,6 +131,7 @@ const shoots = {
 }
 
 const matchOptions = { decode: decodeURIComponent }
+const matchListAllNamespaces = pathToRegexp.match('/apis/core.gardener.cloud/v1beta1/shoots', matchOptions)
 const matchList = pathToRegexp.match('/apis/core.gardener.cloud/v1beta1/namespaces/:namespace/shoots', matchOptions)
 const matchItem = pathToRegexp.match('/apis/core.gardener.cloud/v1beta1/namespaces/:namespace/shoots/:name', matchOptions)
 const matchAdminKubeconfig = pathToRegexp.match('/apis/core.gardener.cloud/v1beta1/namespaces/:namespace/shoots/:name/adminkubeconfig', matchOptions)
@@ -139,15 +140,17 @@ const matchBinding = pathToRegexp.match('/apis/core.gardener.cloud/v1beta1/names
 const mocks = {
   list () {
     return headers => {
-      const matchResult = matchList(headers[':path'])
+      const matchResult = matchList(headers[':path']) || matchListAllNamespaces(headers[':path'])
       if (matchResult === false) {
         return Promise.reject(createError(503))
       }
       const { params: { namespace } = {} } = matchResult
-      const payload = getTokenPayload(headers)
-      const project = projects.getByNamespace(namespace)
-      if (!projects.isMember(project, payload)) {
-        return Promise.reject(createError(403))
+      if (namespace) {
+        const payload = getTokenPayload(headers)
+        const project = projects.getByNamespace(namespace)
+        if (!projects.isMember(project, payload)) {
+          return Promise.reject(createError(403))
+        }
       }
       const items = shoots.list(namespace)
       return Promise.resolve({ items })

--- a/backend/lib/services/shoots.js
+++ b/backend/lib/services/shoots.js
@@ -55,7 +55,7 @@ exports.list = async function ({ user, namespace, labelSelector, useCache = fals
             .flatMap(namespace => cache.getShoots(namespace, query))
         }
       }
-      const statuses = await Promise.allSettled(namespaces.map(namespace, client['core.gardener.cloud'].shoots.list(namespace, query)))
+      const statuses = await Promise.allSettled(namespaces.map(namespace => client['core.gardener.cloud'].shoots.list(namespace, query)))
       return {
         apiVersion: 'v1',
         kind: 'List',

--- a/backend/lib/utils/index.js
+++ b/backend/lib/utils/index.js
@@ -163,16 +163,16 @@ function filterBySelectors (selectors) {
 }
 
 function useWatchCacheForListShoots (useCache) {
-  switch (config.experimentalUseWatchCacheForListShoots) {
+  switch ('' + config.experimentalUseWatchCacheForListShoots) {
     case 'never':
       return false
     case 'always':
       return true
     case 'no':
-    case false:
+    case 'false':
       return ['true', 'yes', 'on'].includes(useCache)
     case 'yes':
-    case true:
+    case 'true':
       return !['false', 'no', 'off'].includes(useCache)
     default:
       return false

--- a/backend/lib/utils/index.js
+++ b/backend/lib/utils/index.js
@@ -169,9 +169,13 @@ function useWatchCacheForListShoots (useCache) {
     case 'always':
       return true
     case 'no':
+    case false:
       return ['true', 'yes', 'on'].includes(useCache)
     case 'yes':
+    case true:
       return !['false', 'no', 'off'].includes(useCache)
+    default:
+      return false
   }
 }
 

--- a/backend/test/acceptance/__snapshots__/api.shoots.spec.js.snap
+++ b/backend/test/acceptance/__snapshots__/api.shoots.spec.js.snap
@@ -1122,6 +1122,336 @@ Object {
 }
 `;
 
+exports[`api shoots should return all shoots for a non-admin user 1`] = `
+Array [
+  Array [
+    Object {
+      ":authority": "kubernetes:6443",
+      ":method": "post",
+      ":path": "/apis/authorization.k8s.io/v1/selfsubjectaccessreviews",
+      ":scheme": "https",
+      "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImZvb0BleGFtcGxlLm9yZyIsImlhdCI6MTU3NzgzNjgwMCwiYXVkIjpbImdhcmRlbmVyIl0sImV4cCI6MzE1NTcxNjgwMCwianRpIjoianRpIn0.k3kGjF6AgugJLdwERXEWZPaibFAPFPOnmpT3YM9H0xU",
+    },
+    Object {
+      "apiVersion": "authorization.k8s.io/v1",
+      "kind": "SelfSubjectAccessReview",
+      "spec": Object {
+        "nonResourceAttributes": undefined,
+        "resourceAttributes": Object {
+          "group": "core.gardener.cloud",
+          "namespace": undefined,
+          "resource": "shoots",
+          "verb": "list",
+        },
+      },
+    },
+  ],
+  Array [
+    Object {
+      ":authority": "kubernetes:6443",
+      ":method": "get",
+      ":path": "/apis/core.gardener.cloud/v1beta1/namespaces/garden-foo/shoots",
+      ":scheme": "https",
+      "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImZvb0BleGFtcGxlLm9yZyIsImlhdCI6MTU3NzgzNjgwMCwiYXVkIjpbImdhcmRlbmVyIl0sImV4cCI6MzE1NTcxNjgwMCwianRpIjoianRpIn0.k3kGjF6AgugJLdwERXEWZPaibFAPFPOnmpT3YM9H0xU",
+    },
+  ],
+  Array [
+    Object {
+      ":authority": "kubernetes:6443",
+      ":method": "get",
+      ":path": "/apis/core.gardener.cloud/v1beta1/namespaces/garden-bar/shoots",
+      ":scheme": "https",
+      "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImZvb0BleGFtcGxlLm9yZyIsImlhdCI6MTU3NzgzNjgwMCwiYXVkIjpbImdhcmRlbmVyIl0sImV4cCI6MzE1NTcxNjgwMCwianRpIjoianRpIn0.k3kGjF6AgugJLdwERXEWZPaibFAPFPOnmpT3YM9H0xU",
+    },
+  ],
+]
+`;
+
+exports[`api shoots should return all shoots for a non-admin user 2`] = `
+Object {
+  "apiVersion": "v1",
+  "items": Array [
+    Object {
+      "metadata": Object {
+        "annotations": Object {
+          "gardener.cloud/created-by": "foo@example.org",
+        },
+        "name": "fooShoot",
+        "namespace": "garden-foo",
+        "uid": 1,
+      },
+      "spec": Object {
+        "cloudProfileName": "infra1-profileName",
+        "hibernation": Object {
+          "enabled": false,
+        },
+        "kubernetes": Object {
+          "version": "1.16.0",
+        },
+        "provider": Object {
+          "type": "fooInfra",
+        },
+        "purpose": "fooPurpose",
+        "region": "foo-west",
+        "secretBindingName": "foo-infra1",
+        "seedName": "infra1-seed",
+      },
+      "status": Object {
+        "advertisedAddresses": Array [
+          Object {
+            "name": "external",
+            "url": "https://api.fooShoot.foo.shoot.test",
+          },
+        ],
+        "technicalID": "shoot--foo--fooShoot",
+      },
+    },
+    Object {
+      "metadata": Object {
+        "annotations": Object {
+          "gardener.cloud/created-by": "bar@example.org",
+        },
+        "name": "barShoot",
+        "namespace": "garden-foo",
+        "uid": 2,
+      },
+      "spec": Object {
+        "cloudProfileName": "infra1-profileName",
+        "hibernation": Object {
+          "enabled": false,
+        },
+        "kubernetes": Object {
+          "version": "1.16.0",
+        },
+        "provider": Object {
+          "type": "fooInfra",
+        },
+        "purpose": "barPurpose",
+        "region": "foo-west",
+        "secretBindingName": "foo-infra1",
+        "seedName": "infra1-seed",
+      },
+      "status": Object {
+        "advertisedAddresses": Array [
+          Object {
+            "name": "external",
+            "url": "https://api.barShoot.foo.shoot.test",
+          },
+        ],
+        "technicalID": "shoot--foo--barShoot",
+      },
+    },
+    Object {
+      "metadata": Object {
+        "annotations": Object {
+          "gardener.cloud/created-by": "foo@example.org",
+        },
+        "name": "dummyShoot",
+        "namespace": "garden-foo",
+        "uid": 3,
+      },
+      "spec": Object {
+        "cloudProfileName": "infra1-profileName",
+        "hibernation": Object {
+          "enabled": false,
+        },
+        "kubernetes": Object {
+          "version": "1.16.0",
+        },
+        "provider": Object {
+          "type": "fooInfra",
+        },
+        "purpose": "fooPurpose",
+        "region": "foo-west",
+        "secretBindingName": "barSecretName",
+        "seedName": "infra4-seed-without-secretRef",
+      },
+      "status": Object {
+        "technicalID": "shoot--foo--dummyShoot",
+      },
+    },
+  ],
+  "kind": "List",
+}
+`;
+
+exports[`api shoots should return all shoots for an admin user 1`] = `
+Array [
+  Array [
+    Object {
+      ":authority": "kubernetes:6443",
+      ":method": "post",
+      ":path": "/apis/authorization.k8s.io/v1/selfsubjectaccessreviews",
+      ":scheme": "https",
+      "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImZvb0BleGFtcGxlLm9yZyIsImlhdCI6MTU3NzgzNjgwMCwiYXVkIjpbImdhcmRlbmVyIl0sImV4cCI6MzE1NTcxNjgwMCwianRpIjoianRpIn0.k3kGjF6AgugJLdwERXEWZPaibFAPFPOnmpT3YM9H0xU",
+    },
+    Object {
+      "apiVersion": "authorization.k8s.io/v1",
+      "kind": "SelfSubjectAccessReview",
+      "spec": Object {
+        "nonResourceAttributes": undefined,
+        "resourceAttributes": Object {
+          "group": "core.gardener.cloud",
+          "namespace": undefined,
+          "resource": "shoots",
+          "verb": "list",
+        },
+      },
+    },
+  ],
+  Array [
+    Object {
+      ":authority": "kubernetes:6443",
+      ":method": "get",
+      ":path": "/apis/core.gardener.cloud/v1beta1/shoots",
+      ":scheme": "https",
+      "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImZvb0BleGFtcGxlLm9yZyIsImlhdCI6MTU3NzgzNjgwMCwiYXVkIjpbImdhcmRlbmVyIl0sImV4cCI6MzE1NTcxNjgwMCwianRpIjoianRpIn0.k3kGjF6AgugJLdwERXEWZPaibFAPFPOnmpT3YM9H0xU",
+    },
+  ],
+]
+`;
+
+exports[`api shoots should return all shoots for an admin user 2`] = `
+Object {
+  "items": Array [
+    Object {
+      "metadata": Object {
+        "annotations": Object {
+          "gardener.cloud/created-by": "foo@example.org",
+        },
+        "name": "fooShoot",
+        "namespace": "garden-foo",
+        "uid": 1,
+      },
+      "spec": Object {
+        "cloudProfileName": "infra1-profileName",
+        "hibernation": Object {
+          "enabled": false,
+        },
+        "kubernetes": Object {
+          "version": "1.16.0",
+        },
+        "provider": Object {
+          "type": "fooInfra",
+        },
+        "purpose": "fooPurpose",
+        "region": "foo-west",
+        "secretBindingName": "foo-infra1",
+        "seedName": "infra1-seed",
+      },
+      "status": Object {
+        "advertisedAddresses": Array [
+          Object {
+            "name": "external",
+            "url": "https://api.fooShoot.foo.shoot.test",
+          },
+        ],
+        "technicalID": "shoot--foo--fooShoot",
+      },
+    },
+    Object {
+      "metadata": Object {
+        "annotations": Object {
+          "gardener.cloud/created-by": "bar@example.org",
+        },
+        "name": "barShoot",
+        "namespace": "garden-foo",
+        "uid": 2,
+      },
+      "spec": Object {
+        "cloudProfileName": "infra1-profileName",
+        "hibernation": Object {
+          "enabled": false,
+        },
+        "kubernetes": Object {
+          "version": "1.16.0",
+        },
+        "provider": Object {
+          "type": "fooInfra",
+        },
+        "purpose": "barPurpose",
+        "region": "foo-west",
+        "secretBindingName": "foo-infra1",
+        "seedName": "infra1-seed",
+      },
+      "status": Object {
+        "advertisedAddresses": Array [
+          Object {
+            "name": "external",
+            "url": "https://api.barShoot.foo.shoot.test",
+          },
+        ],
+        "technicalID": "shoot--foo--barShoot",
+      },
+    },
+    Object {
+      "metadata": Object {
+        "annotations": Object {
+          "gardener.cloud/created-by": "foo@example.org",
+        },
+        "name": "dummyShoot",
+        "namespace": "garden-foo",
+        "uid": 3,
+      },
+      "spec": Object {
+        "cloudProfileName": "infra1-profileName",
+        "hibernation": Object {
+          "enabled": false,
+        },
+        "kubernetes": Object {
+          "version": "1.16.0",
+        },
+        "provider": Object {
+          "type": "fooInfra",
+        },
+        "purpose": "fooPurpose",
+        "region": "foo-west",
+        "secretBindingName": "barSecretName",
+        "seedName": "infra4-seed-without-secretRef",
+      },
+      "status": Object {
+        "technicalID": "shoot--foo--dummyShoot",
+      },
+    },
+    Object {
+      "metadata": Object {
+        "annotations": Object {
+          "gardener.cloud/created-by": "admin@example.org",
+        },
+        "name": "infra1-seed",
+        "namespace": "garden",
+        "uid": 4,
+      },
+      "spec": Object {
+        "cloudProfileName": "infra1-profileName",
+        "hibernation": Object {
+          "enabled": false,
+        },
+        "kubernetes": Object {
+          "version": "1.16.0",
+        },
+        "provider": Object {
+          "type": "fooInfra",
+        },
+        "purpose": "foo-purpose",
+        "region": "foo-west",
+        "secretBindingName": "soil-infra1",
+        "seedName": "soil-infra1",
+      },
+      "status": Object {
+        "advertisedAddresses": Array [
+          Object {
+            "name": "external",
+            "url": "https://api.infra1-seed.garden.shoot.test",
+          },
+        ],
+        "technicalID": "shoot--garden--infra1-seed",
+      },
+    },
+  ],
+}
+`;
+
 exports[`api shoots should return shoot info 1`] = `
 Array [
   Array [
@@ -1393,7 +1723,7 @@ Note that the kubeconfig refers to the path of the garden cluster kubeconfig whi
 }
 `;
 
-exports[`api shoots should return three shoots 1`] = `
+exports[`api shoots should return shoots for a single namespace 1`] = `
 Array [
   Array [
     Object {
@@ -1407,7 +1737,7 @@ Array [
 ]
 `;
 
-exports[`api shoots should return three shoots 2`] = `
+exports[`api shoots should return shoots for a single namespace 2`] = `
 Object {
   "items": Array [
     Object {
@@ -1513,7 +1843,43 @@ Object {
 }
 `;
 
-exports[`api shoots when served from cache should return all shoots 1`] = `
+exports[`api shoots when served from cache should be forbidden to list shoots for a single namespace 1`] = `
+Array [
+  Array [
+    Object {
+      ":authority": "kubernetes:6443",
+      ":method": "post",
+      ":path": "/apis/authorization.k8s.io/v1/selfsubjectaccessreviews",
+      ":scheme": "https",
+      "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImZvb0BleGFtcGxlLm9yZyIsImlhdCI6MTU3NzgzNjgwMCwiYXVkIjpbImdhcmRlbmVyIl0sImV4cCI6MzE1NTcxNjgwMCwianRpIjoianRpIn0.k3kGjF6AgugJLdwERXEWZPaibFAPFPOnmpT3YM9H0xU",
+    },
+    Object {
+      "apiVersion": "authorization.k8s.io/v1",
+      "kind": "SelfSubjectAccessReview",
+      "spec": Object {
+        "nonResourceAttributes": undefined,
+        "resourceAttributes": Object {
+          "group": "core.gardener.cloud",
+          "namespace": "garden-foo",
+          "resource": "shoots",
+          "verb": "list",
+        },
+      },
+    },
+  ],
+]
+`;
+
+exports[`api shoots when served from cache should be forbidden to list shoots for a single namespace 2`] = `
+Object {
+  "code": 403,
+  "message": "No authorization to list shoots in namespace garden-foo",
+  "reason": "Forbidden",
+  "status": "Failure",
+}
+`;
+
+exports[`api shoots when served from cache should return all shoots an admin user 1`] = `
 Array [
   Array [
     Object {
@@ -1540,7 +1906,7 @@ Array [
 ]
 `;
 
-exports[`api shoots when served from cache should return all shoots 2`] = `
+exports[`api shoots when served from cache should return all shoots an admin user 2`] = `
 Object {
   "apiVersion": "v1",
   "items": Array [
@@ -1688,6 +2054,194 @@ Object {
           },
         ],
         "technicalID": "shoot--garden--infra1-seed",
+      },
+    },
+  ],
+  "kind": "List",
+}
+`;
+
+exports[`api shoots when served from cache should return all shoots for a non-admin user 1`] = `
+Array [
+  Array [
+    Object {
+      ":authority": "kubernetes:6443",
+      ":method": "post",
+      ":path": "/apis/authorization.k8s.io/v1/selfsubjectaccessreviews",
+      ":scheme": "https",
+      "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImZvb0BleGFtcGxlLm9yZyIsImlhdCI6MTU3NzgzNjgwMCwiYXVkIjpbImdhcmRlbmVyIl0sImV4cCI6MzE1NTcxNjgwMCwianRpIjoianRpIn0.k3kGjF6AgugJLdwERXEWZPaibFAPFPOnmpT3YM9H0xU",
+    },
+    Object {
+      "apiVersion": "authorization.k8s.io/v1",
+      "kind": "SelfSubjectAccessReview",
+      "spec": Object {
+        "nonResourceAttributes": undefined,
+        "resourceAttributes": Object {
+          "group": "core.gardener.cloud",
+          "namespace": undefined,
+          "resource": "shoots",
+          "verb": "list",
+        },
+      },
+    },
+  ],
+  Array [
+    Object {
+      ":authority": "kubernetes:6443",
+      ":method": "post",
+      ":path": "/apis/authorization.k8s.io/v1/selfsubjectaccessreviews",
+      ":scheme": "https",
+      "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImZvb0BleGFtcGxlLm9yZyIsImlhdCI6MTU3NzgzNjgwMCwiYXVkIjpbImdhcmRlbmVyIl0sImV4cCI6MzE1NTcxNjgwMCwianRpIjoianRpIn0.k3kGjF6AgugJLdwERXEWZPaibFAPFPOnmpT3YM9H0xU",
+    },
+    Object {
+      "apiVersion": "authorization.k8s.io/v1",
+      "kind": "SelfSubjectAccessReview",
+      "spec": Object {
+        "nonResourceAttributes": undefined,
+        "resourceAttributes": Object {
+          "group": "core.gardener.cloud",
+          "namespace": "garden-foo",
+          "resource": "shoots",
+          "verb": "list",
+        },
+      },
+    },
+  ],
+  Array [
+    Object {
+      ":authority": "kubernetes:6443",
+      ":method": "post",
+      ":path": "/apis/authorization.k8s.io/v1/selfsubjectaccessreviews",
+      ":scheme": "https",
+      "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImZvb0BleGFtcGxlLm9yZyIsImlhdCI6MTU3NzgzNjgwMCwiYXVkIjpbImdhcmRlbmVyIl0sImV4cCI6MzE1NTcxNjgwMCwianRpIjoianRpIn0.k3kGjF6AgugJLdwERXEWZPaibFAPFPOnmpT3YM9H0xU",
+    },
+    Object {
+      "apiVersion": "authorization.k8s.io/v1",
+      "kind": "SelfSubjectAccessReview",
+      "spec": Object {
+        "nonResourceAttributes": undefined,
+        "resourceAttributes": Object {
+          "group": "core.gardener.cloud",
+          "namespace": "garden-bar",
+          "resource": "shoots",
+          "verb": "list",
+        },
+      },
+    },
+  ],
+]
+`;
+
+exports[`api shoots when served from cache should return all shoots for a non-admin user 2`] = `
+Object {
+  "apiVersion": "v1",
+  "items": Array [
+    Object {
+      "metadata": Object {
+        "annotations": Object {
+          "gardener.cloud/created-by": "foo@example.org",
+        },
+        "labels": Object {
+          "shoot.gardener.cloud/status": "healthy",
+        },
+        "name": "fooShoot",
+        "namespace": "garden-foo",
+        "uid": 1,
+      },
+      "spec": Object {
+        "cloudProfileName": "infra1-profileName",
+        "hibernation": Object {
+          "enabled": false,
+        },
+        "kubernetes": Object {
+          "version": "1.16.0",
+        },
+        "provider": Object {
+          "type": "fooInfra",
+        },
+        "purpose": "fooPurpose",
+        "region": "foo-west",
+        "secretBindingName": "foo-infra1",
+        "seedName": "infra1-seed",
+      },
+      "status": Object {
+        "advertisedAddresses": Array [
+          Object {
+            "name": "external",
+            "url": "https://api.fooShoot.foo.shoot.test",
+          },
+        ],
+        "technicalID": "shoot--foo--fooShoot",
+      },
+    },
+    Object {
+      "metadata": Object {
+        "annotations": Object {
+          "gardener.cloud/created-by": "bar@example.org",
+        },
+        "labels": Object {
+          "shoot.gardener.cloud/status": "healthy",
+        },
+        "name": "barShoot",
+        "namespace": "garden-foo",
+        "uid": 2,
+      },
+      "spec": Object {
+        "cloudProfileName": "infra1-profileName",
+        "hibernation": Object {
+          "enabled": false,
+        },
+        "kubernetes": Object {
+          "version": "1.16.0",
+        },
+        "provider": Object {
+          "type": "fooInfra",
+        },
+        "purpose": "barPurpose",
+        "region": "foo-west",
+        "secretBindingName": "foo-infra1",
+        "seedName": "infra1-seed",
+      },
+      "status": Object {
+        "advertisedAddresses": Array [
+          Object {
+            "name": "external",
+            "url": "https://api.barShoot.foo.shoot.test",
+          },
+        ],
+        "technicalID": "shoot--foo--barShoot",
+      },
+    },
+    Object {
+      "metadata": Object {
+        "annotations": Object {
+          "gardener.cloud/created-by": "foo@example.org",
+        },
+        "labels": Object {
+          "shoot.gardener.cloud/status": "unhealthy",
+        },
+        "name": "dummyShoot",
+        "namespace": "garden-foo",
+        "uid": 3,
+      },
+      "spec": Object {
+        "cloudProfileName": "infra1-profileName",
+        "hibernation": Object {
+          "enabled": false,
+        },
+        "kubernetes": Object {
+          "version": "1.16.0",
+        },
+        "provider": Object {
+          "type": "fooInfra",
+        },
+        "purpose": "fooPurpose",
+        "region": "foo-west",
+        "secretBindingName": "barSecretName",
+        "seedName": "infra4-seed-without-secretRef",
+      },
+      "status": Object {
+        "technicalID": "shoot--foo--dummyShoot",
       },
     },
   ],

--- a/backend/test/acceptance/api.shoots.spec.js
+++ b/backend/test/acceptance/api.shoots.spec.js
@@ -87,7 +87,24 @@ describe('api', function () {
         expect(res.body).toMatchSnapshot()
       })
 
-      it('should return all shoots', async () => {
+      it('should be forbidden to list shoots for a single namespace', async () => {
+        mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess({ allowed: false }))
+
+        const res = await agent
+          .get(`/api/namespaces/${namespace}/shoots`)
+          .query({ useCache })
+          .set('cookie', await user.cookie)
+          .expect('content-type', /json/)
+          .expect(403)
+
+        expect(mockRequest).toBeCalledTimes(1)
+        expect(mockRequest.mock.calls).toMatchSnapshot()
+
+        const { code, reason, message, status } = res.body
+        expect({ code, reason, message, status }).toMatchSnapshot()
+      })
+
+      it('should return all shoots an admin user', async () => {
         mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
 
         const res = await agent
@@ -101,6 +118,25 @@ describe('api', function () {
         expect(mockRequest.mock.calls).toMatchSnapshot()
 
         expect(res.body.items.map(item => item.metadata.uid)).toEqual([1, 2, 3, 4])
+        expect(res.body).toMatchSnapshot()
+      })
+
+      it('should return all shoots for a non-admin user', async () => {
+        mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess({ allowed: false }))
+        mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+        mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess({ allowed: false }))
+
+        const res = await agent
+          .get('/api/namespaces/_all/shoots')
+          .query({ useCache })
+          .set('cookie', await user.cookie)
+          .expect('content-type', /json/)
+          .expect(200)
+
+        expect(mockRequest).toBeCalledTimes(3)
+        expect(mockRequest.mock.calls).toMatchSnapshot()
+
+        expect(res.body.items.map(item => item.metadata.uid)).toEqual([1, 2, 3])
         expect(res.body).toMatchSnapshot()
       })
 
@@ -123,7 +159,7 @@ describe('api', function () {
       })
     })
 
-    it('should return three shoots', async function () {
+    it('should return shoots for a single namespace', async function () {
       mockRequest.mockImplementationOnce(fixtures.shoots.mocks.list())
 
       const res = await agent
@@ -135,6 +171,41 @@ describe('api', function () {
       expect(mockRequest).toBeCalledTimes(1)
       expect(mockRequest.mock.calls).toMatchSnapshot()
 
+      expect(res.body).toMatchSnapshot()
+    })
+
+    it('should return all shoots for an admin user', async () => {
+      mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+      mockRequest.mockImplementationOnce(fixtures.shoots.mocks.list())
+
+      const res = await agent
+        .get('/api/namespaces/_all/shoots')
+        .set('cookie', await user.cookie)
+        .expect('content-type', /json/)
+        .expect(200)
+
+      expect(mockRequest).toBeCalledTimes(2)
+      expect(mockRequest.mock.calls).toMatchSnapshot()
+
+      expect(res.body.items.map(item => item.metadata.uid)).toEqual([1, 2, 3, 4])
+      expect(res.body).toMatchSnapshot()
+    })
+
+    it('should return all shoots for a non-admin user', async () => {
+      mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess({ allowed: false }))
+      mockRequest.mockImplementationOnce(fixtures.shoots.mocks.list())
+      mockRequest.mockImplementationOnce(fixtures.shoots.mocks.list())
+
+      const res = await agent
+        .get('/api/namespaces/_all/shoots')
+        .set('cookie', await user.cookie)
+        .expect('content-type', /json/)
+        .expect(200)
+
+      expect(mockRequest).toBeCalledTimes(3)
+      expect(mockRequest.mock.calls).toMatchSnapshot()
+
+      expect(res.body.items.map(item => item.metadata.uid)).toEqual([1, 2, 3])
       expect(res.body).toMatchSnapshot()
     })
 

--- a/backend/test/utils.spec.js
+++ b/backend/test/utils.spec.js
@@ -219,6 +219,14 @@ describe('utils', function () {
         config.experimentalUseWatchCacheForListShoots = 'no'
         expect(useWatchCacheForListShoots(undefined)).toBe(false)
         expect(useWatchCacheForListShoots('true')).toBe(true)
+        config.experimentalUseWatchCacheForListShoots = true
+        expect(useWatchCacheForListShoots(undefined)).toBe(true)
+        expect(useWatchCacheForListShoots('false')).toBe(false)
+        config.experimentalUseWatchCacheForListShoots = false
+        expect(useWatchCacheForListShoots(undefined)).toBe(false)
+        expect(useWatchCacheForListShoots('true')).toBe(true)
+        config.experimentalUseWatchCacheForListShoots = undefined
+        expect(useWatchCacheForListShoots(true)).toBe(false)
       })
     })
   })

--- a/charts/__tests__/gardener-dashboard/runtime/dashboard/configmap.spec.js
+++ b/charts/__tests__/gardener-dashboard/runtime/dashboard/configmap.spec.js
@@ -857,6 +857,21 @@ describe('gardener-dashboard', function () {
         const config = yaml.load(configMap.data['config.yaml'])
         expect(config.experimentalUseWatchCacheForListShoots).toBe('no')
       })
+
+      it('should render the template with value "true"', async function () {
+        const values = {
+          global: {
+            dashboard: {
+              experimentalUseWatchCacheForListShoots: true
+            }
+          }
+        }
+        const documents = await renderTemplates(templates, values)
+        expect(documents).toHaveLength(1)
+        const [configMap] = documents
+        const config = yaml.load(configMap.data['config.yaml'])
+        expect(config.experimentalUseWatchCacheForListShoots).toBe('true')
+      })
     })
   })
 })

--- a/charts/gardener-dashboard/charts/runtime/templates/dashboard/configmap.yaml
+++ b/charts/gardener-dashboard/charts/runtime/templates/dashboard/configmap.yaml
@@ -35,7 +35,7 @@ data:
     clusterIdentity: {{ .Values.global.dashboard.clusterIdentity }}
     {{- end }}
     maxRequestBodySize: {{ .Values.global.dashboard.maxRequestBodySize | default "100kb" }}
-    experimentalUseWatchCacheForListShoots: "{{ .Values.global.dashboard.experimentalUseWatchCacheForListShoots | default "never" }}"
+    experimentalUseWatchCacheForListShoots: {{ .Values.global.dashboard.experimentalUseWatchCacheForListShoots | default "never" | quote }}
     readinessProbe:
       periodSeconds: {{ .Values.global.dashboard.readinessProbe.periodSeconds }}
     {{- if .Values.global.dashboard.gitHub }}

--- a/charts/gardener-dashboard/charts/runtime/templates/dashboard/configmap.yaml
+++ b/charts/gardener-dashboard/charts/runtime/templates/dashboard/configmap.yaml
@@ -35,7 +35,7 @@ data:
     clusterIdentity: {{ .Values.global.dashboard.clusterIdentity }}
     {{- end }}
     maxRequestBodySize: {{ .Values.global.dashboard.maxRequestBodySize | default "100kb" }}
-    experimentalUseWatchCacheForListShoots: {{ .Values.global.dashboard.experimentalUseWatchCacheForListShoots | default "never" }}
+    experimentalUseWatchCacheForListShoots: "{{ .Values.global.dashboard.experimentalUseWatchCacheForListShoots | default "never" }}"
     readinessProbe:
       periodSeconds: {{ .Values.global.dashboard.readinessProbe.periodSeconds }}
     {{- if .Values.global.dashboard.gitHub }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixed an issue where the error message `_all is not a function` was displayed on the `ALL PROJECTS` page.
![image](https://github.com/gardener/dashboard/assets/1574023/0e191cb4-6da9-48c4-85ce-d969e96c772b)

**Which issue(s) this PR fixes**:
Fixes #1662

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed an issue where the error message `_all is not a function` was displayed on the `ALL PROJECTS` page.
```
