### PR TITLE
fix link to Azure permission documentation

### DIFF
--- a/frontend/src/components/Secrets/GSecretDialogAzure.vue
+++ b/frontend/src/components/Secrets/GSecretDialogAzure.vue
@@ -73,7 +73,7 @@ SPDX-License-Identifier: Apache-2.0
         </p>
         <p>
           Ensure that the service principal has the permissions defined
-          <g-external-link url="https://github.com/gardener/gardener-extension-provider-azure/blob/master/docs/azure-permissions.md">
+          <g-external-link url="https://github.com/gardener/gardener-extension-provider-azure/blob/master/docs/usage/azure-permissions.md">
             here
           </g-external-link> within your subscription assigned.
           If no fine-grained permissions are required then assign the <strong>Contributor</strong> role.


### PR DESCRIPTION
**What this PR does / why we need it**:

The dashboard help dialog for Azure secrets currently points to a dead location from before the content was moved to the `usage` subfolder with PR https://github.com/gardener/gardener-extension-provider-azure/pull/711. This PR fixes the dead link.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
The broken link to the permission configuration documentation for Azure secrets was fixed.
```
