### PR TITLE
Drop support for basic auth

### DIFF
--- a/backend/lib/services/shoots.js
+++ b/backend/lib/services/shoots.js
@@ -345,14 +345,13 @@ exports.info = async function ({ user, namespace, name }) {
     _
       .chain(secret)
       .get('data')
-      .pick('kubeconfig', 'username', 'password', 'token')
+      .pick('kubeconfig', 'token')
       .forEach((value, key) => {
         value = decodeBase64(value)
         if (key === 'kubeconfig') {
           try {
             const kubeconfigObject = cleanKubeconfig(value)
             data[key] = kubeconfigObject.toYAML()
-            data.serverUrl = kubeconfigObject.currentCluster.server
           } catch (err) {
             logger.error('failed to clean kubeconfig', err)
           }

--- a/backend/test/acceptance/__snapshots__/api.shoots.spec.js.snap
+++ b/backend/test/acceptance/__snapshots__/api.shoots.spec.js.snap
@@ -1555,14 +1555,11 @@ Array [
 exports[`api shoots should return shoot info without gardenlogin kubeconfig: body 1`] = `
 Object {
   "canLinkToSeed": false,
-  "cluster_password": "pass-foo-dummyShoot",
-  "cluster_username": "user-foo-dummyShoot",
   "dashboardUrlPath": "/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/",
   "kubeconfig": Any<String>,
   "monitoringPassword": "pass-garden-foo-dummyShoot.monitoring",
   "monitoringUsername": "user-garden-foo-dummyShoot.monitoring",
   "seedShootIngressDomain": "foo--dummyShoot.ingress.foo-south.infra1.example.org",
-  "serverUrl": "https://api.dummyShoot.foo.shoot.cluster",
 }
 `;
 
@@ -1604,15 +1601,12 @@ Object {
 exports[`api shoots should return shoot info: body 1`] = `
 Object {
   "canLinkToSeed": false,
-  "cluster_password": "pass-foo-barShoot",
-  "cluster_username": "user-foo-barShoot",
   "dashboardUrlPath": "/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/",
   "kubeconfig": Any<String>,
   "kubeconfigGardenlogin": Any<String>,
   "monitoringPassword": "pass-garden-foo-barShoot.monitoring",
   "monitoringUsername": "user-garden-foo-barShoot.monitoring",
   "seedShootIngressDomain": "foo--barShoot.ingress.foo-east.infra1.example.org",
-  "serverUrl": "https://api.barShoot.foo.shoot.cluster",
 }
 `;
 

--- a/frontend/src/components/ShootDetails/GShootAccessCard.vue
+++ b/frontend/src/components/ShootDetails/GShootAccessCard.vue
@@ -28,7 +28,7 @@ SPDX-License-Identifier: Apache-2.0
     />
 
     <v-divider
-      v-if="isTerminalTileVisible && (isTerminalShortcutsTileVisible || isDashboardTileVisible || isCredentialsTileVisible || isKubeconfigTileVisible || isGardenctlTileVisible)"
+      v-if="isTerminalTileVisible && (isTerminalShortcutsTileVisible || isDashboardTileVisible || isKubeconfigTileVisible || isGardenctlTileVisible)"
       inset
     />
 
@@ -40,20 +40,11 @@ SPDX-License-Identifier: Apache-2.0
     />
 
     <v-divider
-      v-if="isTerminalShortcutsTileVisible && (isDashboardTileVisible || isCredentialsTileVisible || isKubeconfigTileVisible || isGardenctlTileVisible)"
+      v-if="isTerminalShortcutsTileVisible && (isDashboardTileVisible || isKubeconfigTileVisible || isGardenctlTileVisible)"
       inset
     />
 
-    <g-link-list-tile
-      v-if="isDashboardTileVisible && !hasDashboardTokenAuth"
-      icon="mdi-developer-board"
-      app-title="Dashboard"
-      :url="dashboardUrl"
-      :url-text="dashboardUrlText"
-      :is-shoot-status-hibernated="isShootStatusHibernated"
-    />
-
-    <template v-if="isDashboardTileVisible && hasDashboardTokenAuth">
+    <template v-if="isDashboardTileVisible">
       <g-list-item>
         <template #prepend>
           <v-icon
@@ -75,7 +66,7 @@ SPDX-License-Identifier: Apache-2.0
                 <span
                   v-bind="props"
                   class="text-grey"
-                >{{ dashboardUrlText }}</span>
+                >{{ dashboardUrl }}</span>
               </template>
               Dashboard is not running for hibernated clusters
             </v-tooltip>
@@ -86,7 +77,7 @@ SPDX-License-Identifier: Apache-2.0
               target="_blank"
               rel="noopener"
             >
-              {{ dashboardUrlText }}
+              {{ dashboardUrl }}
             </a>
           </template>
         </g-list-item-content>
@@ -107,21 +98,9 @@ SPDX-License-Identifier: Apache-2.0
     </template>
 
     <v-divider
-      v-if="isDashboardTileVisible && (isCredentialsTileVisible || isKubeconfigTileVisible || isGardenctlTileVisible)"
+      v-if="isDashboardTileVisible && (isKubeconfigTileVisible || isGardenctlTileVisible)"
       inset
     />
-
-    <g-username-password
-      v-if="isCredentialsTileVisible"
-      :username="username"
-      :password="password"
-    />
-
-    <v-divider
-      v-if="isCredentialsTileVisible && (isKubeconfigTileVisible || isGardenctlTileVisible)"
-      inset
-    />
-
     <template v-if="isKubeconfigTileVisible">
       <g-shoot-kubeconfig
         :shoot-item="shootItem"
@@ -159,9 +138,7 @@ import GListItem from '@/components/GListItem.vue'
 import GListItemContent from '@/components/GListItemContent.vue'
 import GActionButton from '@/components/GActionButton.vue'
 import GCopyBtn from '@/components/GCopyBtn.vue'
-import GUsernamePassword from '@/components/GUsernamePasswordListTile.vue'
 import GTerminalListTile from '@/components/GTerminalListTile.vue'
-import GLinkListTile from '@/components/GLinkListTile.vue'
 
 import { shootItem } from '@/mixins/shootItem'
 
@@ -180,10 +157,8 @@ export default {
     GListItem,
     GListItemContent,
     GActionButton,
-    GUsernamePassword,
     GCopyBtn,
     GTerminalListTile,
-    GLinkListTile,
     GShootKubeconfig,
     GGardenctlCommands,
     GTerminalShortcutsTile,
@@ -220,9 +195,6 @@ export default {
       if (!this.hasDashboardEnabled) {
         return ''
       }
-      if (!this.hasDashboardTokenAuth) {
-        return this.shootInfo.dashboardUrl || ''
-      }
 
       if (!this.shootInfo.dashboardUrlPath) {
         return ''
@@ -230,23 +202,8 @@ export default {
       const pathname = this.shootInfo.dashboardUrlPath
       return `http://localhost:8001${pathname}`
     },
-    dashboardUrlText () {
-      if (this.hasDashboardTokenAuth) {
-        return this.dashboardUrl
-      }
-      return this.shootInfo.dashboardUrlText || ''
-    },
-    username () {
-      return this.shootInfo.cluster_username || ''
-    },
-    password () {
-      return this.shootInfo.cluster_password || ''
-    },
     hasDashboardEnabled () {
       return get(this.shootItem, 'spec.addons.kubernetesDashboard.enabled', false) === true
-    },
-    hasDashboardTokenAuth () {
-      return get(this.shootItem, 'spec.addons.kubernetesDashboard.authenticationMode', 'basic') === 'token'
     },
     kubeconfig () {
       return get(this.shootInfo, 'kubeconfig')
@@ -267,13 +224,10 @@ export default {
       return this.hasControlPlaneTerminalAccess ? 'Open terminal into cluster or cluster\'s control plane' : 'Open terminal into cluster'
     },
     isAnyTileVisible () {
-      return this.isDashboardTileVisible || this.isCredentialsTileVisible || this.isKubeconfigTileVisible || this.isTerminalTileVisible
+      return this.isDashboardTileVisible || this.isKubeconfigTileVisible || this.isTerminalTileVisible
     },
     isDashboardTileVisible () {
       return !!this.dashboardUrl
-    },
-    isCredentialsTileVisible () {
-      return !!this.username && !!this.password
     },
     isKubeconfigTileVisible () {
       return !!this.kubeconfigGardenlogin || this.canPatchShoots

--- a/frontend/src/store/shoot/helper.js
+++ b/frontend/src/store/shoot/helper.js
@@ -49,8 +49,6 @@ import {
   orderBy,
 } from '@/lodash'
 
-export const uriPattern = /^([^:/?#]+:)?(\/\/[^/?#]*)?([^?#]*)(\?[^#]*)?(#.*)?/
-
 const tokenizePattern = /(-?"([^"]|"")*"|\S+)/g
 
 export function tokenizeSearch (text) {

--- a/frontend/src/store/shoot/index.js
+++ b/frontend/src/store/shoot/index.js
@@ -37,7 +37,6 @@ import { useLocalStorageStore } from '../localStorage'
 import { useShootStagingStore } from '../shootStaging'
 
 import {
-  uriPattern,
   createShootResource,
   constants,
   onlyAllShootsWithIssues,
@@ -52,7 +51,6 @@ import {
   get,
   map,
   pick,
-  replace,
   difference,
   find,
   includes,
@@ -425,13 +423,6 @@ export const useShootStore = defineStore('shoot', () => {
     }
     try {
       const { data: info } = await api.getShootInfo(metadata)
-      if (info.serverUrl) {
-        const [, scheme, host] = uriPattern.exec(info.serverUrl)
-        const authority = `//${replace(host, /^\/\//, '')}`
-        const pathname = info.dashboardUrlPath
-        info.dashboardUrl = [scheme, authority, pathname].join('')
-        info.dashboardUrlText = [scheme, host].join('')
-      }
       if (info.seedShootIngressDomain) {
         const baseHost = info.seedShootIngressDomain
         info.plutonoUrl = `https://gu-${baseHost}`


### PR DESCRIPTION
**What this PR does / why we need it**:
Basic auth is not supported by gardener since long and thus it does not make sense to still support it in the dashboard. See also https://github.com/gardener/gardener/pull/7534

**Which issue(s) this PR fixes**:
Fixes #1659

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
