### PR TITLE
Enh/remove deprecated annotations

### DIFF
--- a/backend/lib/services/members/SubjectList.js
+++ b/backend/lib/services/members/SubjectList.js
@@ -20,9 +20,8 @@ class SubjectList {
     } = project
     const createServiceAccountItem = ({ metadata, secrets }) => {
       const { namespace, name, annotations = {}, creationTimestamp, deletionTimestamp } = metadata
-      const createdByLegacy = annotations['garden.sapcloud.io/createdBy']
       const createdByTerminal = annotations['terminal.dashboard.gardener.cloud/created-by']
-      const createdBy = annotations['dashboard.gardener.cloud/created-by'] || createdByLegacy || createdByTerminal
+      const createdBy = annotations['dashboard.gardener.cloud/created-by'] || createdByTerminal
       const description = annotations['dashboard.gardener.cloud/description']
       const item = SubjectListItem.create({
         kind: 'ServiceAccount',

--- a/frontend/src/components/GAccountAvatar.vue
+++ b/frontend/src/components/GAccountAvatar.vue
@@ -16,7 +16,7 @@ SPDX-License-Identifier: Apache-2.0
       />
     </v-avatar>
     <a
-      v-if="mailTo && isEmail"
+      v-if="mailTo && isAccountNameEmail"
       :href="`mailto:${accountName}`"
       class="text-anchor"
     >{{ accountName }}</a>
@@ -58,5 +58,9 @@ const { accountName, mailTo, size } = toRefs(props)
 
 const avatarUrl = computed(() => {
   return gravatarUrlGeneric(accountName.value, size.value * 2)
+})
+
+const isAccountNameEmail = computed(() => {
+  return isEmail(accountName.value)
 })
 </script>

--- a/frontend/src/mixins/shootItem.js
+++ b/frontend/src/mixins/shootItem.js
@@ -49,8 +49,7 @@ export const shootItem = {
       return this.shootMetadata.namespace
     },
     isShootMarkedForDeletion () {
-      const confirmationDeprecated = get(this.shootAnnotations, ['confirmation.garden.sapcloud.io/deletion'], 'false')
-      const confirmation = get(this.shootAnnotations, ['confirmation.gardener.cloud/deletion'], confirmationDeprecated)
+      const confirmation = get(this.shootAnnotations, ['confirmation.gardener.cloud/deletion'])
       const deletionTimestamp = this.shootDeletionTimestamp
 
       return !!deletionTimestamp && isTruthyValue(confirmation)

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -330,8 +330,7 @@ export function isShootStatusHibernated (status) {
 }
 
 export function isReconciliationDeactivated (metadata) {
-  const ignoreDeprecated = get(metadata, ['annotations', 'shoot.garden.sapcloud.io/ignore'])
-  const ignore = get(metadata, ['annotations', 'shoot.gardener.cloud/ignore'], ignoreDeprecated)
+  const ignore = get(metadata, ['annotations', 'shoot.gardener.cloud/ignore'])
   return isTruthyValue(ignore)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
removed support for deprecated annotations
- garden.sapcloud.io/createdBy
- confirmation.garden.sapcloud.io/deletion
- shoot.garden.sapcloud.io/ignore

Fixed isEmail check for account names.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
Removed support for deprecated created by annotation `garden.sapcloud.io/createdBy`. This annotation has been deprecated long time ago. If you still have a cluster using this annotation, you can migrate it manually to `dashboard.gardener.cloud/created-by` if you need to
```
```breaking user
Removed support for deprecated ignore annotation `shoot.garden.sapcloud.io/ignore`. This annotation has been deprecated long time ago. If you still have a cluster using this annotation, you can migrate it manually to `shoot.gardener.cloud/ignore` if you need to
```

```bugfix user
Fixed email check for account names: Non email user accounts are no longer converted to a `mailto` link
```
