### PR TITLE
Ensure `timeoutId` is defined before it is accessed in `useCustomColor`

### DIFF
--- a/frontend/__tests__/composables/useCustomColors.spec.js
+++ b/frontend/__tests__/composables/useCustomColors.spec.js
@@ -1,0 +1,79 @@
+//
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import { ref } from 'vue'
+
+import { useCustomColors } from '@/composables/useCustomColors'
+
+describe('composables', () => {
+  describe('useCustomColors', () => {
+    const customThemes = ref(null)
+    const theme = {
+      themes: {
+        dark: {
+          dark: true,
+          colors: null,
+        },
+        light: {
+          dark: false,
+          colors: null,
+        },
+      },
+    }
+
+    beforeEach(() => {
+      customThemes.value = null
+      theme.themes.dark.colors = {
+        background: '#121212',
+        primary: '#0b8062',
+      }
+      theme.themes.light.colors = {
+        background: '#FFFFFF',
+        primary: '#0b8062',
+      }
+    })
+
+    it('should update theme colors with a short delay', async () => {
+      const lightBackground = '#EEEEEE'
+      setTimeout(() => {
+        customThemes.value = {
+          light: {
+            background: lightBackground,
+          },
+        }
+      }, 1)
+      await useCustomColors(customThemes, theme)
+      expect(theme.themes.light.colors.background).toBe(lightBackground)
+    })
+
+    it('should update theme colors immediately', async () => {
+      const lightBackground = '#EEEEEE'
+      customThemes.value = {
+        light: {
+          background: lightBackground,
+        },
+      }
+      await useCustomColors(customThemes, theme)
+      expect(theme.themes.light.colors.background).toBe(lightBackground)
+    })
+
+    describe('when updating theme colors times out', () => {
+      beforeEach(() => {
+        vi.useFakeTimers()
+      })
+
+      afterEach(() => {
+        vi.useRealTimers()
+      })
+
+      it('should throw an error', async () => {
+        const promise = useCustomColors(customThemes, theme)
+        vi.runAllTimers()
+        await expect(promise).rejects.toThrow('Setting custom colors timed out')
+      })
+    })
+  })
+})

--- a/frontend/__tests__/composables/useCustomColors.spec.js
+++ b/frontend/__tests__/composables/useCustomColors.spec.js
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/frontend/src/composables/useCustomColors.js
+++ b/frontend/src/composables/useCustomColors.js
@@ -16,20 +16,29 @@ import { isHtmlColorCode } from '@/utils'
 
 import { get } from '@/lodash'
 
-function patchVuetifyThemeColors (vuetifyThemes = {}, customThemes) {
+function patchThemes (themes, customThemes) {
   for (const colorMode of ['light', 'dark']) {
-    const vuetifyThemeColors = vuetifyThemes[colorMode]?.colors ?? {}
+    const themeColors = themes[colorMode]?.colors ?? {}
     const customThemeColors = customThemes[colorMode] ?? {}
-    for (const [key, value] of Object.entries(customThemeColors)) {
-      if (key in vuetifyThemeColors) {
-        const colorCode = get(vuetifyColors, value)
-        if (colorCode) {
-          vuetifyThemeColors[key] = colorCode
-        } else if (isHtmlColorCode(value)) {
-          vuetifyThemeColors[key] = value
-        }
-      }
-    }
+    patchThemeColors(themeColors, customThemeColors)
+  }
+}
+
+function patchThemeColors (themeColors, customThemeColors) {
+  for (const [key, value] of Object.entries(customThemeColors)) {
+    setThemeColor(themeColors, key, value)
+  }
+}
+
+function setThemeColor (themeColors, key, value) {
+  if (!(key in themeColors)) {
+    return
+  }
+  const colorCode = get(vuetifyColors, value)
+  if (colorCode) {
+    themeColors[key] = colorCode
+  } else if (isHtmlColorCode(value)) {
+    themeColors[key] = value
   }
 }
 
@@ -45,7 +54,8 @@ export const useCustomColors = (customThemes, theme = useTheme()) => {
       }
       clearTimeout(timeoutId)
       nextTick(() => unwatch())
-      patchVuetifyThemeColors(toValue(theme.themes), value)
+      const themes = toValue(theme.themes) ?? {}
+      patchThemes(themes, value)
       resolve()
     }, {
       immediate: true,

--- a/frontend/src/composables/useCustomColors.js
+++ b/frontend/src/composables/useCustomColors.js
@@ -4,7 +4,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { watch } from 'vue'
+import {
+  watch,
+  nextTick,
+} from 'vue'
 import { useTheme } from 'vuetify'
 import vuetifyColors from 'vuetify/lib/util/colors'
 import { toValue } from '@vueuse/core'
@@ -15,10 +18,14 @@ import { get } from '@/lodash'
 
 export const useCustomColors = (customThemes, theme = useTheme()) => {
   return new Promise((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      unwatch()
+      reject(new Error('Setting custom colors timed out'))
+    }, 3000)
     const unwatch = watch(customThemes, value => {
       if (value) {
         clearTimeout(timeoutId)
-        unwatch()
+        nextTick(() => unwatch())
         for (const colorMode of ['light', 'dark']) {
           const vuetifyThemeColors = toValue(theme.themes)?.[colorMode]?.colors ?? {}
           const customThemeColors = value[colorMode] ?? {}
@@ -38,9 +45,5 @@ export const useCustomColors = (customThemes, theme = useTheme()) => {
     }, {
       immediate: true,
     })
-    const timeoutId = setTimeout(() => {
-      unwatch()
-      reject(new Error('Setting custom colors timed out'))
-    }, 3000)
   })
 }

--- a/frontend/src/store/shoot/index.js
+++ b/frontend/src/store/shoot/index.js
@@ -612,6 +612,9 @@ export const useShootStore = defineStore('shoot', () => {
   }
 
   async function closeSubscription () {
+    if (state.subscriptionState === constants.CLOSED) {
+      return
+    }
     const shootStore = this
     shootStore.$patch(({ state }) => {
       state.subscription = null


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Ensure `timeoutId` is defined before it is accessed in `useCustomColor`.
2. Do not try to close the subscription if it is already closed. This avoids the warning `Unexpected subscription state change: 6 --> 5`

**Which issue(s) this PR fixes**:
Fixes #1682 

**Special notes for your reviewer**:
This does not happen in production

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
NONE
```
