### PR TITLE
Fixed member validation

### DIFF
--- a/frontend/src/components/Members/GMemberDialog.vue
+++ b/frontend/src/components/Members/GMemberDialog.vue
@@ -240,6 +240,7 @@ export default {
     rules.internalRoles = withFieldName('Member Roles', internalRolesRules)
 
     if (this.isUpdateDialog) {
+      rules.internalName = {}
       return rules
     }
 

--- a/frontend/src/components/Members/GMemberDialog.vue
+++ b/frontend/src/components/Members/GMemberDialog.vue
@@ -230,7 +230,9 @@ export default {
     }
   },
   validations () {
-    const rules = {}
+    const rules = {
+      internalName: {},
+    }
     const internalRolesRules = {
       required: withMessage(() => this.isUserDialog
         ? 'Users need to have at least one assigned role'
@@ -240,7 +242,7 @@ export default {
     rules.internalRoles = withFieldName('Member Roles', internalRolesRules)
 
     if (this.isUpdateDialog) {
-      rules.internalName = {}
+      // must not add name rules as unique check would fail for existing members
       return rules
     }
 

--- a/frontend/src/plugins/vuetify.js
+++ b/frontend/src/plugins/vuetify.js
@@ -68,8 +68,8 @@ const variations = {
     'main-background',
     'toolbar-background',
   ],
-  lighten: 1,
-  darken: 2,
+  lighten: 3,
+  darken: 3,
 }
 
 export default createVuetify({


### PR DESCRIPTION
**What this PR does / why we need it**:
We need to ensure that there is at least an empty validation defined as the fields are visible but disabled in case of `update` dialog.
We also cannot just remove the return as we must not use the `add`  validations for `update` dialog. In this case, the dialog would always return errors upon save like 'user foo already exists'

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed an issue on the member management page. Update members and service account dialog did not render correctly because of an issue with the input validation
```
