### PR TITLE
The author of a github comment can be `null`

### DIFF
--- a/backend/lib/github/index.js
+++ b/backend/lib/github/index.js
@@ -84,13 +84,14 @@ async function getComments ({ number }) {
   return repository.issue.comments.nodes
     .filter(node => !node.isMinimized)
     .map(node => {
+      const author = node.author ?? {}
       return {
         id: node.databaseId,
         node_id: node.id,
         html_url: node.url,
         user: {
-          login: node.author.login,
-          avatar_url: node.author.avatarUrl
+          login: author.login ?? 'ghost',
+          avatar_url: author.avatarUrl
         },
         created_at: node.createdAt,
         updated_at: node.updatedAt,


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request addresses a specific behavior observed in the GitHub GraphQL API, where the author field is set to null for comments with an author_association value of 'NONE'. To maintain consistency with the GitHub REST API, which defaults to a user login of 'ghost' under similar circumstances, this change implements a similar fallback mechanism in the GraphQL API. Notably, this update focuses solely on the user login aspect and does not include a fallback for the avatar_url, as our dashboard does not utilize this information.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
NONE
```
