### PR TITLE
Show update arrow only for supported versions

### DIFF
--- a/frontend/src/components/ShootVersion/GShootVersion.vue
+++ b/frontend/src/components/ShootVersion/GShootVersion.vue
@@ -21,7 +21,7 @@ SPDX-License-Identifier: Apache-2.0
             @click="showUpdateDialog"
           >
             <v-icon
-              v-if="availableK8sUpdates"
+              v-if="supportedPatchAvailable || supportedUpgradeAvailable"
               icon="mdi-menu-up"
               size="small"
             />


### PR DESCRIPTION
**What this PR does / why we need it**:
For the version update chips, show update arrow only if supported patch or upgrade is available as we do not want to promote preview versions.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
