### PR TITLE
Spinner: ensure interval is started only once

### DIFF
--- a/frontend/src/lib/terminal.js
+++ b/frontend/src/lib/terminal.js
@@ -452,6 +452,10 @@ export class Spinner {
   }
 
   start () {
+    if (this.#intervalId) {
+      return
+    }
+
     const frames = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
     let i = 0
     this._clearTerminal()
@@ -465,6 +469,7 @@ export class Spinner {
 
   stop () {
     clearInterval(this.#intervalId)
+    this.#intervalId = undefined
     this._eraseLine()
     this._showCursor()
   }

--- a/frontend/src/router/routes.js
+++ b/frontend/src/router/routes.js
@@ -56,7 +56,7 @@ const GShootItem = () => import('@/views/GShootItem.vue')
 const GShootItemTerminal = () => import('@/views/GShootItemTerminal.vue')
 
 export function createRoutes () {
-  const appStore = useAppStore
+  const appStore = useAppStore()
   const authnStore = useAuthnStore()
   const authzStore = useAuthzStore()
   const projectStore = useProjectStore()
@@ -327,7 +327,7 @@ export function createRoutes () {
       beforeEnter (to, from) {
         if (!authzStore.hasShootTerminalAccess) {
           appStore.setError(new Error('Access to cluster terminal is not allowed'))
-          return false
+          return from
         }
       },
     }
@@ -410,7 +410,7 @@ export function createRoutes () {
       beforeEnter (to, from) {
         if (!authzStore.hasGardenTerminalAccess) {
           appStore.setError(new Error('Access to garden terminal is not allowed'))
-          return false
+          return from
         }
         to.params.target = 'garden'
       },


### PR DESCRIPTION
**What this PR does / why we need it**:
There is a case where the spinner is started twice and one interval leaks https://github.com/gardener/dashboard/blob/5c69e731ea0d7f7f3b41dfbc7e9496e21a12b128/frontend/src/lib/terminal.js#L219
This PR ensures that only one spinner interval runs at a time.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Terminal: fixed an issue where the loading spinner would not disappear, even though the terminal pod is `running` and the terminal connection shows as `connected`
```
