### PR TITLE
Support viewer to download `gardenlogin` kubeconfig by fetching cluster CA via `ConfigMap`

### DIFF
--- a/backend/__fixtures__/configmaps.js
+++ b/backend/__fixtures__/configmaps.js
@@ -6,7 +6,7 @@
 
 'use strict'
 
-const { cloneDeep, find, filter, split, isEmpty } = require('lodash')
+const { cloneDeep, endsWith, find, filter, split, isEmpty } = require('lodash')
 const createError = require('http-errors')
 const pathToRegexp = require('path-to-regexp')
 const { createUrl } = require('./helper')
@@ -54,6 +54,18 @@ const configMaps = {
   },
   createClusterIdentityConfigMap (identity) {
     return getClusterIdentitConfigMap({ identity })
+  },
+  getCaClusterConfigMap (namespace, name) {
+    return getConfigMap({
+      name,
+      namespace,
+      labels: {
+        'gardener.cloud/role': 'ca-cluster'
+      },
+      data: {
+        'ca.crt': 'ca.crt'
+      }
+    })
   }
 }
 
@@ -90,6 +102,10 @@ const mocks = {
       if (namespace === 'kube-system' && name === 'cluster-identity') {
         const [hostname] = split(headers[':authority'], ':')
         const item = configMaps.createClusterIdentityConfigMap(hostname)
+        return Promise.resolve(item)
+      }
+      if (endsWith(name, '.ca-cluster')) {
+        const item = configMaps.getCaClusterConfigMap(namespace, name)
         return Promise.resolve(item)
       }
 

--- a/backend/__fixtures__/secrets.js
+++ b/backend/__fixtures__/secrets.js
@@ -161,18 +161,6 @@ const secrets = {
       }
     })
   },
-  getCaClusterSecret (namespace, name) {
-    return getSecret({
-      name,
-      namespace,
-      labels: {
-        'gardener.cloud/role': 'ca-cluster'
-      },
-      data: {
-        'ca.crt': 'ca.crt'
-      }
-    })
-  },
   getSeedSecret (namespace, name) {
     const seedName = name.substring(11)
     const seed = seeds.get(seedName)
@@ -261,10 +249,6 @@ const mocks = {
         }
         if (endsWith(name, '.kubeconfig')) {
           const item = secrets.getShootSecret(namespace, name)
-          return Promise.resolve(item)
-        }
-        if (endsWith(name, '.ca-cluster')) {
-          const item = secrets.getCaClusterSecret(namespace, name)
           return Promise.resolve(item)
         }
         if (/-token-[a-f0-9]{5}$/.test(name)) {

--- a/backend/lib/services/terminals/index.js
+++ b/backend/lib/services/terminals/index.js
@@ -10,7 +10,7 @@ const _ = require('lodash')
 const hash = require('object-hash')
 const yaml = require('js-yaml')
 const config = require('../../config')
-const { encodeBase64 } = require('../../utils')
+const { getClusterCaData } = require('../shoots')
 const { cleanKubeconfig } = require('@gardener-dashboard/kube-config')
 const { Resources } = require('@gardener-dashboard/kube-client')
 
@@ -336,21 +336,6 @@ async function getTargetCluster ({ user, namespace, name, target, preferredHost,
     }
   }
   return targetCluster
-}
-
-async function getClusterCaData (client, { namespace, name }) {
-  try {
-    const configmap = await client.core.configmaps.get(namespace, `${name}.ca-cluster`)
-    return encodeBase64(configmap.data?.['ca.crt'])
-  } catch (err) {
-    // TODO(petersutter): Remove this fallback of reading the `<shoot-name>.ca-cluster` Secret when Gardener no longer reconciles it, presumably with Gardener v1.97.
-    if (isHttpError(err, 404)) {
-      const caCluster = await client.core.secrets.get(namespace, `${name}.ca-cluster`)
-      return caCluster.data['ca.crt']
-    } else {
-      throw err
-    }
-  }
 }
 
 async function getGardenTerminalHostCluster (client, { body }) {

--- a/backend/lib/services/terminals/index.js
+++ b/backend/lib/services/terminals/index.js
@@ -10,6 +10,7 @@ const _ = require('lodash')
 const hash = require('object-hash')
 const yaml = require('js-yaml')
 const config = require('../../config')
+const { encodeBase64 } = require('../../utils')
 const { cleanKubeconfig } = require('@gardener-dashboard/kube-config')
 const { Resources } = require('@gardener-dashboard/kube-client')
 
@@ -250,8 +251,7 @@ async function getTargetCluster ({ user, namespace, name, target, preferredHost,
       break
     }
     case TargetEnum.SHOOT: {
-      const caCluster = await client.core.secrets.get(namespace, `${name}.ca-cluster`)
-      const caData = caCluster.data['ca.crt']
+      const caData = await getClusterCaData(client, { namespace, name })
 
       targetCluster.apiServer.serviceRef = {}
       targetCluster.apiServer.caData = caData
@@ -296,8 +296,7 @@ async function getTargetCluster ({ user, namespace, name, target, preferredHost,
         const shootRef = getShootRef(managedSeed)
         credentials = { shootRef }
 
-        const caCluster = await client.core.secrets.get(shootRef.namespace, `${shootRef.name}.ca-cluster`)
-        caData = caCluster.data['ca.crt']
+        caData = await getClusterCaData(client, { namespace: shootRef.namespace, name: shootRef.name })
       } else {
         const seed = getSeed(seedName)
         const secretRef = seed.spec?.secretRef
@@ -337,6 +336,21 @@ async function getTargetCluster ({ user, namespace, name, target, preferredHost,
     }
   }
   return targetCluster
+}
+
+async function getClusterCaData (client, { namespace, name }) {
+  try {
+    const configmap = await client.core.configmaps.get(namespace, `${name}.ca-cluster`)
+    return encodeBase64(configmap.data?.['ca.crt'])
+  } catch (err) {
+    // TODO(petersutter): Remove this fallback of reading the `<shoot-name>.ca-cluster` Secret when Gardener no longer reconciles it, presumably with Gardener v1.97.
+    if (isHttpError(err, 404)) {
+      const caCluster = await client.core.secrets.get(namespace, `${name}.ca-cluster`)
+      return caCluster.data['ca.crt']
+    } else {
+      throw err
+    }
+  }
 }
 
 async function getGardenTerminalHostCluster (client, { body }) {

--- a/backend/test/acceptance/__snapshots__/api.shoots.spec.js.snap
+++ b/backend/test/acceptance/__snapshots__/api.shoots.spec.js.snap
@@ -1535,7 +1535,7 @@ Array [
     Object {
       ":authority": "kubernetes:6443",
       ":method": "get",
-      ":path": "/api/v1/namespaces/garden-foo/secrets/barShoot.ca-cluster",
+      ":path": "/api/v1/namespaces/garden-foo/configmaps/barShoot.ca-cluster",
       ":scheme": "https",
       "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImZvb0BleGFtcGxlLm9yZyIsImlhdCI6MTU3NzgzNjgwMCwiYXVkIjpbImdhcmRlbmVyIl0sImV4cCI6MzE1NTcxNjgwMCwianRpIjoianRpIn0.k3kGjF6AgugJLdwERXEWZPaibFAPFPOnmpT3YM9H0xU",
     },

--- a/backend/test/acceptance/__snapshots__/api.terminals.spec.js.snap
+++ b/backend/test/acceptance/__snapshots__/api.terminals.spec.js.snap
@@ -133,7 +133,7 @@ Array [
     Object {
       ":authority": "kubernetes:6443",
       ":method": "get",
-      ":path": "/api/v1/namespaces/garden/secrets/infra1-seed.ca-cluster",
+      ":path": "/api/v1/namespaces/garden/configmaps/infra1-seed.ca-cluster",
       ":scheme": "https",
       "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFkbWluQGV4YW1wbGUub3JnIiwiaWF0IjoxNTc3ODM2ODAwLCJhdWQiOlsiZ2FyZGVuZXIiXSwiZXhwIjozMTU1NzE2ODAwLCJqdGkiOiJqdGkifQ.PwFHRt9M8dJf8YcCVlbyH4xu2QpL3jBI1oEC_Zdmtzk",
     },
@@ -1028,7 +1028,7 @@ Array [
     Object {
       ":authority": "kubernetes:6443",
       ":method": "get",
-      ":path": "/api/v1/namespaces/garden-foo/secrets/fooShoot.ca-cluster",
+      ":path": "/api/v1/namespaces/garden-foo/configmaps/fooShoot.ca-cluster",
       ":scheme": "https",
       "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFkbWluQGV4YW1wbGUub3JnIiwiaWF0IjoxNTc3ODM2ODAwLCJhdWQiOlsiZ2FyZGVuZXIiXSwiZXhwIjozMTU1NzE2ODAwLCJqdGkiOiJqdGkifQ.PwFHRt9M8dJf8YcCVlbyH4xu2QpL3jBI1oEC_Zdmtzk",
     },
@@ -1264,7 +1264,7 @@ Array [
     Object {
       ":authority": "kubernetes:6443",
       ":method": "get",
-      ":path": "/api/v1/namespaces/garden-foo/secrets/fooShoot.ca-cluster",
+      ":path": "/api/v1/namespaces/garden-foo/configmaps/fooShoot.ca-cluster",
       ":scheme": "https",
       "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFkbWluQGV4YW1wbGUub3JnIiwiaWF0IjoxNTc3ODM2ODAwLCJhdWQiOlsiZ2FyZGVuZXIiXSwiZXhwIjozMTU1NzE2ODAwLCJqdGkiOiJqdGkifQ.PwFHRt9M8dJf8YcCVlbyH4xu2QpL3jBI1oEC_Zdmtzk",
     },

--- a/backend/test/acceptance/api.shoots.spec.js
+++ b/backend/test/acceptance/api.shoots.spec.js
@@ -270,7 +270,7 @@ describe('api', function () {
     it('should return shoot info', async function () {
       mockRequest.mockImplementationOnce(fixtures.shoots.mocks.get())
       mockRequest.mockImplementationOnce(fixtures.secrets.mocks.get())
-      mockRequest.mockImplementationOnce(fixtures.secrets.mocks.get())
+      mockRequest.mockImplementationOnce(fixtures.configmaps.mocks.get())
       mockRequest.mockImplementationOnce(fixtures.configmaps.mocks.get())
       mockRequest.mockImplementationOnce(fixtures.shoots.mocks.get())
       mockRequest.mockImplementationOnce(fixtures.secrets.mocks.get())

--- a/backend/test/acceptance/api.terminals.spec.js
+++ b/backend/test/acceptance/api.terminals.spec.js
@@ -353,7 +353,7 @@ describe('api', function () {
         mockRequest.mockImplementationOnce(fixtures.managedseeds.mocks.get())
         mockRequest.mockImplementationOnce(fixtures.managedseeds.mocks.get())
         mockRequest.mockImplementationOnce(fixtures.shoots.mocks.get())
-        mockRequest.mockImplementationOnce(fixtures.secrets.mocks.get())
+        mockRequest.mockImplementationOnce(fixtures.configmaps.mocks.get())
         mockRequest.mockImplementationOnce(fixtures.terminals.mocks.create())
 
         const res = await agent
@@ -445,7 +445,7 @@ describe('api', function () {
         mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
         mockRequest.mockImplementationOnce(fixtures.terminals.mocks.list())
         mockRequest.mockImplementationOnce(fixtures.shoots.mocks.get())
-        mockRequest.mockImplementationOnce(fixtures.secrets.mocks.get())
+        mockRequest.mockImplementationOnce(fixtures.configmaps.mocks.get())
         mockRequest.mockImplementationOnce(fixtures.terminals.mocks.create())
 
         const res = await agent
@@ -479,7 +479,7 @@ describe('api', function () {
         mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
         mockRequest.mockImplementationOnce(fixtures.terminals.mocks.list())
         mockRequest.mockImplementationOnce(fixtures.shoots.mocks.get())
-        mockRequest.mockImplementationOnce(fixtures.secrets.mocks.get())
+        mockRequest.mockImplementationOnce(fixtures.configmaps.mocks.get())
         mockRequest.mockImplementationOnce(fixtures.terminals.mocks.patch())
 
         const res = await agent

--- a/frontend/src/components/ShootDetails/GShootAccessCard.vue
+++ b/frontend/src/components/ShootDetails/GShootAccessCard.vue
@@ -191,6 +191,7 @@ export default {
     ...mapState(useAuthzStore, [
       'hasShootTerminalAccess',
       'canCreateShootsAdminkubeconfig',
+      'canCreateShootsViewerkubeconfig',
       'hasControlPlaneTerminalAccess',
       'canPatchShoots',
     ]),
@@ -231,7 +232,7 @@ export default {
       return this.hasControlPlaneTerminalAccess ? 'Open terminal into cluster or cluster\'s control plane' : 'Open terminal into cluster'
     },
     isAnyTileVisible () {
-      return this.isDashboardTileVisible || this.isKubeconfigTileVisible || this.isTerminalTileVisible
+      return this.isDashboardTileVisible || this.isKubeconfigTileVisible || this.isTerminalTileVisible || this.isGardenctlTileVisible
     },
     isDashboardTileVisible () {
       return !!this.dashboardUrl
@@ -240,7 +241,7 @@ export default {
       return !!this.kubeconfigGardenlogin || this.canPatchShoots
     },
     isGardenctlTileVisible () {
-      return this.canCreateShootsAdminkubeconfig
+      return this.canCreateShootsViewerkubeconfig || this.canCreateShootsAdminkubeconfig
     },
     isTerminalTileVisible () {
       return !isEmpty(this.shootItem) && this.hasShootTerminalAccess && !this.isSeedUnreachable && (this.hasShootWorkerGroups || this.isAdmin)

--- a/frontend/src/components/ShootDetails/GShootAdminKubeconfig.vue
+++ b/frontend/src/components/ShootDetails/GShootAdminKubeconfig.vue
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 -->
 
 <template>
-  <template v-if="isEnabled">
+  <template v-if="isEnabled && canCreateShootsAdminkubeconfig">
     <g-list-item>
       <g-list-item-content>
         Kubeconfig - Time-Limited Access
@@ -79,10 +79,14 @@ SPDX-License-Identifier: Apache-2.0
 </template>
 
 <script>
-import { mapActions } from 'pinia'
+import {
+  mapActions,
+  mapState,
+} from 'pinia'
 import download from 'downloadjs'
 
 import { useAppStore } from '@/store/app'
+import { useAuthzStore } from '@/store/authz'
 
 import GListItem from '@/components/GListItem.vue'
 import GListItemContent from '@/components/GListItemContent.vue'
@@ -126,6 +130,9 @@ export default {
     }
   },
   computed: {
+    ...mapState(useAuthzStore, [
+      'canCreateShootsAdminkubeconfig',
+    ]),
     visibilityIcon () {
       return this.expansionPanel ? 'mdi-eye-off' : 'mdi-eye'
     },

--- a/frontend/src/components/ShootDetails/GShootDetails.vue
+++ b/frontend/src/components/ShootDetails/GShootDetails.vue
@@ -27,10 +27,7 @@ SPDX-License-Identifier: Apache-2.0
         cols="12"
         md="6"
       >
-        <v-card
-          v-if="canGetSecrets"
-          class="mb-4"
-        >
+        <v-card class="mb-4">
           <g-toolbar title="Access" />
           <g-shoot-access-card
             :shoot-item="shootItem"
@@ -49,7 +46,6 @@ SPDX-License-Identifier: Apache-2.0
 import { defineAsyncComponent } from 'vue'
 import { mapState } from 'pinia'
 
-import { useAuthzStore } from '@/store/authz'
 import { useProjectStore } from '@/store/project'
 
 import GShootDetailsCard from '@/components/ShootDetails/GShootDetailsCard'
@@ -87,7 +83,6 @@ export default {
     'addTerminalShortcut',
   ],
   computed: {
-    ...mapState(useAuthzStore, ['canGetSecrets']),
     ...mapState(useProjectStore, ['shootCustomFieldList']),
     customFields () {
       const customFields = filter(this.shootCustomFieldList, ['showDetails', true])

--- a/frontend/src/components/ShootDetails/GShootKubeconfig.vue
+++ b/frontend/src/components/ShootDetails/GShootKubeconfig.vue
@@ -5,7 +5,9 @@ SPDX-License-Identifier: Apache-2.0
 -->
 
 <template>
-  <g-list-item>
+  <g-list-item
+    v-if="isGardenloginType || canGetSecrets"
+  >
     <template #prepend>
       <v-icon
         :icon="icon"
@@ -27,7 +29,7 @@ SPDX-License-Identifier: Apache-2.0
         </span>
       </template>
     </g-list-item-content>
-    <g-list-item-content v-else>
+    <g-list-item-content v-else-if="canGetSecrets">
       Kubeconfig - Static Token
       <template #description>
         <span v-if="!shootEnableStaticTokenKubeconfig">
@@ -86,6 +88,9 @@ SPDX-License-Identifier: Apache-2.0
 
 <script>
 import download from 'downloadjs'
+import { mapState } from 'pinia'
+
+import { useAuthzStore } from '@/store/authz'
 
 import GListItem from '@/components/GListItem.vue'
 import GListItemContent from '@/components/GListItemContent.vue'
@@ -124,6 +129,9 @@ export default {
     }
   },
   computed: {
+    ...mapState(useAuthzStore, [
+      'canGetSecrets',
+    ]),
     icon () {
       return this.showListIcon ? 'mdi-file' : ''
     },

--- a/frontend/src/store/authz.js
+++ b/frontend/src/store/authz.js
@@ -66,6 +66,10 @@ export const useAuthzStore = defineStore('authz', () => {
     return canI(status.value, 'create', 'core.gardener.cloud', 'shoots/adminkubeconfig')
   })
 
+  const canCreateShootsViewerkubeconfig = computed(() => {
+    return canI(status.value, 'create', 'core.gardener.cloud', 'shoots/viewerkubeconfig')
+  })
+
   const canPatchSecrets = computed(() => {
     return canI(status.value, 'patch', '', 'secrets')
   })
@@ -185,6 +189,7 @@ export const useAuthzStore = defineStore('authz', () => {
     canGetSecrets,
     canCreateSecrets,
     canCreateShootsAdminkubeconfig,
+    canCreateShootsViewerkubeconfig,
     canPatchSecrets,
     canDeleteSecrets,
     canCreateTokenRequest,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables users with the `Project` `viewer` role to download the `gardenlogin` kubeconfig by fetching the cluster CA via the `<shoot-name>.ca-cluster` `ConfigMap`.

To build the `gardenlogin` kubeconfig when targeting a `Shoot` cluster, the Dashboard needs to read the cluster CA. In earlier versions, this was obtained from a `.ca-cluster` `Secret`. However, starting from Gardener `v1.89`, the cluster CA is also reconciled as a `ConfigMap`. This update allows users with the `viewer` role to read the `ConfigMap`, thereby facilitating the generation of the `gardenlogin` kubeconfig.

Side note:
`gardenlogin` `v0.5` or higher is designed to fetch credentials from two subresources: `shoots/adminkubeconfig` and `shoots/viewerkubeconfig`. By default, it retrieves credentials from the `shoots/adminkubeconfig` subresource, providing full administrative access. Alternatively, it can fetch credentials from the `shoots/viewerkubeconfig` subresource for read-only access.

The plugin automatically adjusts the level of access for the fetched credentials. It first attempts to fetch admin-level credentials and, if unsuccessful, falls back to viewer-level credentials. This feature makes the `gardenlogin` kubeconfig versatile, as it can be used by both project admins and viewers without the need to specify the access level.


**Which issue(s) this PR fixes**:
Fixes #1709, fixes #1710

**Special notes for your reviewer**:
ref https://github.com/gardener/gardener/issues/9091

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Users with the `Project` `viewer` role are now able to to download the `gardenlogin` kubeconfig by fetching the cluster CA via `ConfigMap`. This feature is supported with Gardener `v1.89` and requires `gardenlogin` `v0.5` or higher.
```
