### PR TITLE
Removed force delete feature flag from dashboard configuration

### DIFF
--- a/charts/__tests__/gardener-dashboard/runtime/dashboard/__snapshots__/configmap.spec.js.snap
+++ b/charts/__tests__/gardener-dashboard/runtime/dashboard/__snapshots__/configmap.spec.js.snap
@@ -424,7 +424,6 @@ Object {
     ],
     "features": Object {
       "projectTerminalShortcutsEnabled": false,
-      "shootForceDeletionEnabled": false,
       "terminalEnabled": false,
     },
     "helpMenuItems": Array [

--- a/charts/gardener-dashboard/charts/runtime/templates/dashboard/configmap.yaml
+++ b/charts/gardener-dashboard/charts/runtime/templates/dashboard/configmap.yaml
@@ -212,7 +212,6 @@ data:
       features:
         terminalEnabled: {{ .Values.global.dashboard.frontendConfig.features.terminalEnabled | default false }}
         projectTerminalShortcutsEnabled: {{ .Values.global.dashboard.frontendConfig.features.projectTerminalShortcutsEnabled | default false }}
-        shootForceDeletionEnabled: {{ .Values.global.dashboard.frontendConfig.features.shootForceDeletionEnabled | default false }}
       experimental:
         throttleDelayPerCluster: {{ .Values.global.dashboard.frontendConfig.experimental.throttleDelayPerCluster | default 10 }}
       {{- if .Values.global.dashboard.frontendConfig.terminal }}

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -232,7 +232,6 @@ global:
       features:
         terminalEnabled: false
         projectTerminalShortcutsEnabled: false
-        shootForceDeletionEnabled: false
 
       shootAdminKubeconfig:
         enabled: false

--- a/frontend/__tests__/mixins/shootItem.spec.js
+++ b/frontend/__tests__/mixins/shootItem.spec.js
@@ -9,7 +9,6 @@ import { shallowMount } from '@vue/test-utils'
 import { createTestingPinia } from '@pinia/testing'
 
 import { useShootStore } from '@/store/shoot'
-import { useConfigStore } from '@/store/config'
 
 import shootItem from '@/mixins/shootItem'
 
@@ -302,26 +301,14 @@ describe('mixins', () => {
           }],
         },
       })
-      const pinia = createTestingPinia({
-        stubActions: false,
-      })
-      const configStore = useConfigStore(pinia)
-      configStore.isShootForceDeletionEnabled = true
       const wrapper = shallowMount(Component, {
         propsData: {
           shootItem,
-        },
-        global: {
-          plugins: [pinia],
         },
       })
 
       expect(wrapper.vm.canForceDeleteShoot).toBe(true)
 
-      configStore.isShootForceDeletionEnabled = false
-      expect(wrapper.vm.canForceDeleteShoot).toBe(false)
-
-      configStore.isShootForceDeletionEnabled = true
       delete shootItem.metadata.deletionTimestamp
       expect(wrapper.vm.canForceDeleteShoot).toBe(false)
 

--- a/frontend/src/mixins/shootItem.js
+++ b/frontend/src/mixins/shootItem.js
@@ -4,12 +4,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import {
-  mapActions,
-  mapState,
-} from 'pinia'
+import { mapActions } from 'pinia'
 
-import { useConfigStore } from '@/store/config'
 import { useShootStore } from '@/store/shoot'
 import { useCloudProfileStore } from '@/store/cloudProfile'
 import { useProjectStore } from '@/store/project'
@@ -52,9 +48,6 @@ export const shootItem = {
     },
   },
   computed: {
-    ...mapState(useConfigStore, [
-      'isShootForceDeletionEnabled',
-    ]),
     shootMetadata () {
       return get(this.shootItem, 'metadata', {})
     },
@@ -293,9 +286,6 @@ export const shootItem = {
       return !this.isShootActive(this.shootMetadata.uid)
     },
     canForceDeleteShoot () {
-      if (!this.isShootForceDeletionEnabled) {
-        return false
-      }
       if (!this.shootDeletionTimestamp) {
         return false
       }


### PR DESCRIPTION
**What this PR does / why we need it**:
Removed force delete feature flag from dashboard configuration.
It is not required in most cases, as the feature will be enabled in most landscapes and the feature gate will be removed in future gardener versions. Moreover, it is acceptable to run into an error in those rare situations where the feature is disabled as this feature is only available in edge error scenarios anyway

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
No release note as PR feature has not yet been released
Adjusted release note in original PR: https://github.com/gardener/dashboard/pull/1665

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
NONE
```
