### PR TITLE
Fix viewer handling for secret name

### DIFF
--- a/frontend/src/components/GShootSecretName.vue
+++ b/frontend/src/components/GShootSecretName.vue
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 
 <template>
   <v-tooltip
-    v-if="secret"
+    :disabled="!secret"
     location="top"
   >
     <template #activator="{ props }">
@@ -32,8 +32,12 @@ SPDX-License-Identifier: Apache-2.0
 </template>
 
 <script>
-import { mapActions } from 'pinia'
+import {
+  mapActions,
+  mapState,
+} from 'pinia'
 
+import { useAuthzStore } from '@/store/authz'
 import { useSecretStore } from '@/store/secret'
 
 import GTextRouterLink from '@/components/GTextRouterLink.vue'
@@ -53,8 +57,11 @@ export default {
     },
   },
   computed: {
+    ...mapState(useAuthzStore, [
+      'canGetSecrets',
+    ]),
     canLinkToSecret () {
-      return this.secretBindingName && this.namespace
+      return this.canGetSecrets && this.secretBindingName && this.namespace
     },
     secret () {
       return this.getCloudProviderSecretByName({ namespace: this.namespace, name: this.secretBindingName })


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix viewer handling for secret name:
- only link to secret if user can get secrets
- disable tooltip if secret is not available

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
