### PR TITLE
License and reuse adaptions

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,1 +1,202 @@
-LICENSES/Apache-2.0.txt
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,208 +1,202 @@
-Apache License
 
-Version 2.0, January 2004
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-http://www.apache.org/licenses/ TERMS AND CONDITIONS FOR USE, REPRODUCTION,
-AND DISTRIBUTION
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
    1. Definitions.
 
-      
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-"License" shall mean the terms and conditions for use, reproduction, and distribution
-as defined by Sections 1 through 9 of this document.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
-      
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
 
-"Licensor" shall mean the copyright owner or entity authorized by the copyright
-owner that is granting the License.
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
 
-      
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
 
-"Legal Entity" shall mean the union of the acting entity and all other entities
-that control, are controlled by, or are under common control with that entity.
-For the purposes of this definition, "control" means (i) the power, direct
-or indirect, to cause the direction or management of such entity, whether
-by contract or otherwise, or (ii) ownership of fifty percent (50%) or more
-of the outstanding shares, or (iii) beneficial ownership of such entity.
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
 
-      
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
 
-"You" (or "Your") shall mean an individual or Legal Entity exercising permissions
-granted by this License.
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
 
-      
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
 
-"Source" form shall mean the preferred form for making modifications, including
-but not limited to software source code, documentation source, and configuration
-files.
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
 
-      
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
 
-"Object" form shall mean any form resulting from mechanical transformation
-or translation of a Source form, including but not limited to compiled object
-code, generated documentation, and conversions to other media types.
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
 
-      
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
 
-"Work" shall mean the work of authorship, whether in Source or Object form,
-made available under the License, as indicated by a copyright notice that
-is included in or attached to the work (an example is provided in the Appendix
-below).
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
 
-      
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
 
-"Derivative Works" shall mean any work, whether in Source or Object form,
-that is based on (or derived from) the Work and for which the editorial revisions,
-annotations, elaborations, or other modifications represent, as a whole, an
-original work of authorship. For the purposes of this License, Derivative
-Works shall not include works that remain separable from, or merely link (or
-bind by name) to the interfaces of, the Work and Derivative Works thereof.
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
 
-      
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
 
-"Contribution" shall mean any work of authorship, including the original version
-of the Work and any modifications or additions to that Work or Derivative
-Works thereof, that is intentionally submitted to Licensor for inclusion in
-the Work by the copyright owner or by an individual or Legal Entity authorized
-to submit on behalf of the copyright owner. For the purposes of this definition,
-"submitted" means any form of electronic, verbal, or written communication
-sent to the Licensor or its representatives, including but not limited to
-communication on electronic mailing lists, source code control systems, and
-issue tracking systems that are managed by, or on behalf of, the Licensor
-for the purpose of discussing and improving the Work, but excluding communication
-that is conspicuously marked or otherwise designated in writing by the copyright
-owner as "Not a Contribution."
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
 
-      
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
 
-"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
-of whom a Contribution has been received by Licensor and subsequently incorporated
-within the Work.
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
 
-2. Grant of Copyright License. Subject to the terms and conditions of this
-License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive,
-no-charge, royalty-free, irrevocable copyright license to reproduce, prepare
-Derivative Works of, publicly display, publicly perform, sublicense, and distribute
-the Work and such Derivative Works in Source or Object form.
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
 
-3. Grant of Patent License. Subject to the terms and conditions of this License,
-each Contributor hereby grants to You a perpetual, worldwide, non-exclusive,
-no-charge, royalty-free, irrevocable (except as stated in this section) patent
-license to make, have made, use, offer to sell, sell, import, and otherwise
-transfer the Work, where such license applies only to those patent claims
-licensable by such Contributor that are necessarily infringed by their Contribution(s)
-alone or by combination of their Contribution(s) with the Work to which such
-Contribution(s) was submitted. If You institute patent litigation against
-any entity (including a cross-claim or counterclaim in a lawsuit) alleging
-that the Work or a Contribution incorporated within the Work constitutes direct
-or contributory patent infringement, then any patent licenses granted to You
-under this License for that Work shall terminate as of the date such litigation
-is filed.
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
 
-4. Redistribution. You may reproduce and distribute copies of the Work or
-Derivative Works thereof in any medium, with or without modifications, and
-in Source or Object form, provided that You meet the following conditions:
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
 
-(a) You must give any other recipients of the Work or Derivative Works a copy
-of this License; and
+   END OF TERMS AND CONDITIONS
 
-(b) You must cause any modified files to carry prominent notices stating that
-You changed the files; and
+   APPENDIX: How to apply the Apache License to your work.
 
-(c) You must retain, in the Source form of any Derivative Works that You distribute,
-all copyright, patent, trademark, and attribution notices from the Source
-form of the Work, excluding those notices that do not pertain to any part
-of the Derivative Works; and
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
 
-(d) If the Work includes a "NOTICE" text file as part of its distribution,
-then any Derivative Works that You distribute must include a readable copy
-of the attribution notices contained within such NOTICE file, excluding those
-notices that do not pertain to any part of the Derivative Works, in at least
-one of the following places: within a NOTICE text file distributed as part
-of the Derivative Works; within the Source form or documentation, if provided
-along with the Derivative Works; or, within a display generated by the Derivative
-Works, if and wherever such third-party notices normally appear. The contents
-of the NOTICE file are for informational purposes only and do not modify the
-License. You may add Your own attribution notices within Derivative Works
-that You distribute, alongside or as an addendum to the NOTICE text from the
-Work, provided that such additional attribution notices cannot be construed
-as modifying the License.
+   Copyright [yyyy] [name of copyright owner]
 
-You may add Your own copyright statement to Your modifications and may provide
-additional or different license terms and conditions for use, reproduction,
-or distribution of Your modifications, or for any such Derivative Works as
-a whole, provided Your use, reproduction, and distribution of the Work otherwise
-complies with the conditions stated in this License.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
 
-5. Submission of Contributions. Unless You explicitly state otherwise, any
-Contribution intentionally submitted for inclusion in the Work by You to the
-Licensor shall be under the terms and conditions of this License, without
-any additional terms or conditions. Notwithstanding the above, nothing herein
-shall supersede or modify the terms of any separate license agreement you
-may have executed with Licensor regarding such Contributions.
+       http://www.apache.org/licenses/LICENSE-2.0
 
-6. Trademarks. This License does not grant permission to use the trade names,
-trademarks, service marks, or product names of the Licensor, except as required
-for reasonable and customary use in describing the origin of the Work and
-reproducing the content of the NOTICE file.
-
-7. Disclaimer of Warranty. Unless required by applicable law or agreed to
-in writing, Licensor provides the Work (and each Contributor provides its
-Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied, including, without limitation, any warranties
-or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR
-A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness
-of using or redistributing the Work and assume any risks associated with Your
-exercise of permissions under this License.
-
-8. Limitation of Liability. In no event and under no legal theory, whether
-in tort (including negligence), contract, or otherwise, unless required by
-applicable law (such as deliberate and grossly negligent acts) or agreed to
-in writing, shall any Contributor be liable to You for damages, including
-any direct, indirect, special, incidental, or consequential damages of any
-character arising as a result of this License or out of the use or inability
-to use the Work (including but not limited to damages for loss of goodwill,
-work stoppage, computer failure or malfunction, or any and all other commercial
-damages or losses), even if such Contributor has been advised of the possibility
-of such damages.
-
-9. Accepting Warranty or Additional Liability. While redistributing the Work
-or Derivative Works thereof, You may choose to offer, and charge a fee for,
-acceptance of support, warranty, indemnity, or other liability obligations
-and/or rights consistent with this License. However, in accepting such obligations,
-You may act only on Your own behalf and on Your sole responsibility, not on
-behalf of any other Contributor, and only if You agree to indemnify, defend,
-and hold each Contributor harmless for any liability incurred by, or claims
-asserted against, such Contributor by reason of your accepting any such warranty
-or additional liability. END OF TERMS AND CONDITIONS
-
-APPENDIX: How to apply the Apache License to your work.
-
-To apply the Apache License to your work, attach the following boilerplate
-notice, with the fields enclosed by brackets "[]" replaced with your own identifying
-information. (Don't include the brackets!) The text should be enclosed in
-the appropriate comment syntax for the file format. We also recommend that
-a file or class name and description of purpose be included on the same "printed
-page" as the copyright notice for easier identification within third-party
-archives.
-
-Copyright [yyyy] [name of copyright owner]
-
-Licensed under the Apache License, Version 2.0 (the "License");
-
-you may not use this file except in compliance with the License.
-
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-
-distributed under the License is distributed on an "AS IS" BASIS,
-
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-
-See the License for the specific language governing permissions and
-
-limitations under the License.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSES/CC-BY-4.0.txt
+++ b/LICENSES/CC-BY-4.0.txt
@@ -1,11 +1,13 @@
-Creative Commons Attribution 4.0 International Creative Commons Corporation
-("Creative Commons") is not a law firm and does not provide legal services
-or legal advice. Distribution of Creative Commons public licenses does not
-create a lawyer-client or other relationship. Creative Commons makes its licenses
-and related information available on an "as-is" basis. Creative Commons gives
-no warranties regarding its licenses, any material licensed under their terms
-and conditions, or any related information. Creative Commons disclaims all
-liability for damages resulting from their use to the fullest extent possible.
+Creative Commons Attribution 4.0 International
+
+Creative Commons Corporation (“Creative Commons”) is not a law firm and does
+not provide legal services or legal advice. Distribution of Creative Commons
+public licenses does not create a lawyer-client or other relationship. Creative
+Commons makes its licenses and related information available on an “as-is”
+basis. Creative Commons gives no warranties regarding its licenses, any material
+licensed under their terms and conditions, or any related information. Creative
+Commons disclaims all liability for damages resulting from their use to the
+fullest extent possible.
 
 Using Creative Commons Public Licenses
 
@@ -24,11 +26,11 @@ they choose before applying it. Licensors should also secure all rights necessar
 before applying our licenses so that the public can reuse the material as
 expected. Licensors should clearly mark any material not subject to the license.
 This includes other CC-licensed material, or material used under an exception
-or limitation to copyright. More considerations for licensors : wiki.creativecommons.org/Considerations_for_licensors
+or limitation to copyright. More considerations for licensors.
 
 Considerations for the public: By using one of our public licenses, a licensor
 grants the public permission to use the licensed material under specified
-terms and conditions. If the licensor's permission is not necessary for any
+terms and conditions. If the licensor’s permission is not necessary for any
 reason–for example, because of any applicable exception or limitation to copyright–then
 that use is not regulated by the license. Our licenses grant only permissions
 under copyright and certain other rights that a licensor has authority to
@@ -36,9 +38,9 @@ grant. Use of the licensed material may still be restricted for other reasons,
 including because others have copyright or other rights in the material. A
 licensor may make special requests, such as asking that all changes be marked
 or described. Although not required by our licenses, you are encouraged to
-respect those requests where reasonable. More considerations for the public
-: wiki.creativecommons.org/Considerations_for_licensees Creative Commons Attribution
-4.0 International Public License
+respect those requests where reasonable. More considerations for the public.
+
+Creative Commons Attribution 4.0 International Public License
 
 By exercising the Licensed Rights (defined below), You accept and agree to
 be bound by the terms and conditions of this Creative Commons Attribution
@@ -51,7 +53,7 @@ conditions.
 
 Section 1 – Definitions.
 
-a. Adapted Material means material subject to Copyright and Similar Rights
+a.	Adapted Material means material subject to Copyright and Similar Rights
 that is derived from or based upon the Licensed Material and in which the
 Licensed Material is translated, altered, arranged, transformed, or otherwise
 modified in a manner requiring permission under the Copyright and Similar
@@ -60,69 +62,69 @@ Licensed Material is a musical work, performance, or sound recording, Adapted
 Material is always produced where the Licensed Material is synched in timed
 relation with a moving image.
 
-b. Adapter's License means the license You apply to Your Copyright and Similar
+b.	Adapter's License means the license You apply to Your Copyright and Similar
 Rights in Your contributions to Adapted Material in accordance with the terms
 and conditions of this Public License.
 
-c. Copyright and Similar Rights means copyright and/or similar rights closely
+c.	Copyright and Similar Rights means copyright and/or similar rights closely
 related to copyright including, without limitation, performance, broadcast,
 sound recording, and Sui Generis Database Rights, without regard to how the
 rights are labeled or categorized. For purposes of this Public License, the
 rights specified in Section 2(b)(1)-(2) are not Copyright and Similar Rights.
 
-d. Effective Technological Measures means those measures that, in the absence
+d.	Effective Technological Measures means those measures that, in the absence
 of proper authority, may not be circumvented under laws fulfilling obligations
 under Article 11 of the WIPO Copyright Treaty adopted on December 20, 1996,
 and/or similar international agreements.
 
-e. Exceptions and Limitations means fair use, fair dealing, and/or any other
+e.	Exceptions and Limitations means fair use, fair dealing, and/or any other
 exception or limitation to Copyright and Similar Rights that applies to Your
 use of the Licensed Material.
 
-f. Licensed Material means the artistic or literary work, database, or other
+f.	Licensed Material means the artistic or literary work, database, or other
 material to which the Licensor applied this Public License.
 
-g. Licensed Rights means the rights granted to You subject to the terms and
+g.	Licensed Rights means the rights granted to You subject to the terms and
 conditions of this Public License, which are limited to all Copyright and
 Similar Rights that apply to Your use of the Licensed Material and that the
 Licensor has authority to license.
 
-h. Licensor means the individual(s) or entity(ies) granting rights under this
+h.	Licensor means the individual(s) or entity(ies) granting rights under this
 Public License.
 
-i. Share means to provide material to the public by any means or process that
+i.	Share means to provide material to the public by any means or process that
 requires permission under the Licensed Rights, such as reproduction, public
 display, public performance, distribution, dissemination, communication, or
 importation, and to make material available to the public including in ways
 that members of the public may access the material from a place and at a time
 individually chosen by them.
 
-j. Sui Generis Database Rights means rights other than copyright resulting
+j.	Sui Generis Database Rights means rights other than copyright resulting
 from Directive 96/9/EC of the European Parliament and of the Council of 11
 March 1996 on the legal protection of databases, as amended and/or succeeded,
 as well as other essentially equivalent rights anywhere in the world.
 
-k. You means the individual or entity exercising the Licensed Rights under
+k.	You means the individual or entity exercising the Licensed Rights under
 this Public License. Your has a corresponding meaning.
 
 Section 2 – Scope.
 
-   a. License grant.
+     a.	License grant.
 
 1. Subject to the terms and conditions of this Public License, the Licensor
 hereby grants You a worldwide, royalty-free, non-sublicensable, non-exclusive,
 irrevocable license to exercise the Licensed Rights in the Licensed Material
 to:
 
-         A. reproduce and Share the Licensed Material, in whole or in part; and
+A. reproduce and Share the Licensed Material, in whole or in part; and
 
-         B. produce, reproduce, and Share Adapted Material.
+               B. produce, reproduce, and Share Adapted Material.
 
 2. Exceptions and Limitations. For the avoidance of doubt, where Exceptions
 and Limitations apply to Your use, this Public License does not apply, and
 You do not need to comply with its terms and conditions.
 
-      3. Term. The term of this Public License is specified in Section 6(a).
+3. Term. The term of this Public License is specified in Section 6(a).
 
 4. Media and formats; technical modifications allowed. The Licensor authorizes
 You to exercise the Licensed Rights in all media and formats whether now known
@@ -134,7 +136,7 @@ Effective Technological Measures. For purposes of this Public License, simply
 making modifications authorized by this Section 2(a)(4) never produces Adapted
 Material.
 
-      5. Downstream recipients.
+          5. Downstream recipients.
 
 A. Offer from the Licensor – Licensed Material. Every recipient of the Licensed
 Material automatically receives an offer from the Licensor to exercise the
@@ -145,13 +147,13 @@ or different terms or conditions on, or apply any Effective Technological
 Measures to, the Licensed Material if doing so restricts exercise of the Licensed
 Rights by any recipient of the Licensed Material.
 
-6. No endorsement. Nothing in this Public License constitutes or may be construed
+6.  No endorsement. Nothing in this Public License constitutes or may be construed
 as permission to assert or imply that You are, or that Your use of the Licensed
 Material is, connected with, or sponsored, endorsed, or granted official status
 by, the Licensor or others designated to receive attribution as provided in
 Section 3(a)(1)(A)(i).
 
-   b. Other rights.
+b. Other rights.
 
 1. Moral rights, such as the right of integrity, are not licensed under this
 Public License, nor are publicity, privacy, and/or other similar personality
@@ -172,7 +174,7 @@ Section 3 – License Conditions.
 Your exercise of the Licensed Rights is expressly made subject to the following
 conditions.
 
-   a. Attribution.
+     a.	Attribution.
 
 1. If You Share the Licensed Material (including in modified form), You must:
 
@@ -183,11 +185,11 @@ i. identification of the creator(s) of the Licensed Material and any others
 designated to receive attribution, in any reasonable manner requested by the
 Licensor (including by pseudonym if designated);
 
-            ii. a copyright notice;
+                    ii. a copyright notice;
 
-            iii. a notice that refers to this Public License;
+                    iii. a notice that refers to this Public License;
 
-            iv. a notice that refers to the disclaimer of warranties;
+                    iv.	a notice that refers to the disclaimer of warranties;
 
 v. a URI or hyperlink to the Licensed Material to the extent reasonably practicable;
 
@@ -214,25 +216,24 @@ Section 4 – Sui Generis Database Rights.
 Where the Licensed Rights include Sui Generis Database Rights that apply to
 Your use of the Licensed Material:
 
-a. for the avoidance of doubt, Section 2(a)(1) grants You the right to extract,
+a.	for the avoidance of doubt, Section 2(a)(1) grants You the right to extract,
 reuse, reproduce, and Share all or a substantial portion of the contents of
 the database;
 
-b. if You include all or a substantial portion of the database contents in
+b.	if You include all or a substantial portion of the database contents in
 a database in which You have Sui Generis Database Rights, then the database
 in which You have Sui Generis Database Rights (but not its individual contents)
 is Adapted Material; and
 
-c. You must comply with the conditions in Section 3(a) if You Share all or
+c.	You must comply with the conditions in Section 3(a) if You Share all or
 a substantial portion of the contents of the database.
-
 For the avoidance of doubt, this Section 4 supplements and does not replace
 Your obligations under this Public License where the Licensed Rights include
 other Copyright and Similar Rights.
 
 Section 5 – Disclaimer of Warranties and Limitation of Liability.
 
-a. Unless otherwise separately undertaken by the Licensor, to the extent possible,
+a.	Unless otherwise separately undertaken by the Licensor, to the extent possible,
 the Licensor offers the Licensed Material as-is and as-available, and makes
 no representations or warranties of any kind concerning the Licensed Material,
 whether express, implied, statutory, or other. This includes, without limitation,
@@ -241,7 +242,7 @@ absence of latent or other defects, accuracy, or the presence or absence of
 errors, whether or not known or discoverable. Where disclaimers of warranties
 are not allowed in full or in part, this disclaimer may not apply to You.
 
-b. To the extent possible, in no event will the Licensor be liable to You
+b.	To the extent possible, in no event will the Licensor be liable to You
 on any legal theory (including, without limitation, negligence) or otherwise
 for any direct, special, indirect, incidental, consequential, punitive, exemplary,
 or other losses, costs, expenses, or damages arising out of this Public License
@@ -250,75 +251,74 @@ the possibility of such losses, costs, expenses, or damages. Where a limitation
 of liability is not allowed in full or in part, this limitation may not apply
 to You.
 
-c. The disclaimer of warranties and limitation of liability provided above
+c.	The disclaimer of warranties and limitation of liability provided above
 shall be interpreted in a manner that, to the extent possible, most closely
 approximates an absolute disclaimer and waiver of all liability.
 
 Section 6 – Term and Termination.
 
-a. This Public License applies for the term of the Copyright and Similar Rights
+a.	This Public License applies for the term of the Copyright and Similar Rights
 licensed here. However, if You fail to comply with this Public License, then
 Your rights under this Public License terminate automatically.
 
-b. Where Your right to use the Licensed Material has terminated under Section
+b.	Where Your right to use the Licensed Material has terminated under Section
 6(a), it reinstates:
 
 1. automatically as of the date the violation is cured, provided it is cured
 within 30 days of Your discovery of the violation; or
 
-      2. upon express reinstatement by the Licensor.
+          2. upon express reinstatement by the Licensor.
 
-c. For the avoidance of doubt, this Section 6(b) does not affect any right
+c.	For the avoidance of doubt, this Section 6(b) does not affect any right
 the Licensor may have to seek remedies for Your violations of this Public
 License.
 
-d. For the avoidance of doubt, the Licensor may also offer the Licensed Material
+d.	For the avoidance of doubt, the Licensor may also offer the Licensed Material
 under separate terms or conditions or stop distributing the Licensed Material
 at any time; however, doing so will not terminate this Public License.
 
-   e. Sections 1, 5, 6, 7, and 8 survive termination of this Public License.
+     e.	Sections 1, 5, 6, 7, and 8 survive termination of this Public License.
 
 Section 7 – Other Terms and Conditions.
 
-a. The Licensor shall not be bound by any additional or different terms or
+a.	The Licensor shall not be bound by any additional or different terms or
 conditions communicated by You unless expressly agreed.
 
-b. Any arrangements, understandings, or agreements regarding the Licensed
+b.	Any arrangements, understandings, or agreements regarding the Licensed
 Material not stated herein are separate from and independent of the terms
 and conditions of this Public License.
 
 Section 8 – Interpretation.
 
-a. For the avoidance of doubt, this Public License does not, and shall not
+a.	For the avoidance of doubt, this Public License does not, and shall not
 be interpreted to, reduce, limit, restrict, or impose conditions on any use
 of the Licensed Material that could lawfully be made without permission under
 this Public License.
 
-b. To the extent possible, if any provision of this Public License is deemed
+b.	To the extent possible, if any provision of this Public License is deemed
 unenforceable, it shall be automatically reformed to the minimum extent necessary
 to make it enforceable. If the provision cannot be reformed, it shall be severed
 from this Public License without affecting the enforceability of the remaining
 terms and conditions.
 
-c. No term or condition of this Public License will be waived and no failure
+c.	No term or condition of this Public License will be waived and no failure
 to comply consented to unless expressly agreed to by the Licensor.
 
-d. Nothing in this Public License constitutes or may be interpreted as a limitation
+d.	Nothing in this Public License constitutes or may be interpreted as a limitation
 upon, or waiver of, any privileges and immunities that apply to the Licensor
 or You, including from the legal processes of any jurisdiction or authority.
 
 Creative Commons is not a party to its public licenses. Notwithstanding, Creative
 Commons may elect to apply one of its public licenses to material it publishes
-and in those instances will be considered the "Licensor." The text of the
-Creative Commons public licenses is dedicated to the public domain under the
-CC0 Public Domain Dedication. Except for the limited purpose of indicating
-that material is shared under a Creative Commons public license or as otherwise
-permitted by the Creative Commons policies published at creativecommons.org/policies,
-Creative Commons does not authorize the use of the trademark "Creative Commons"
-or any other trademark or logo of Creative Commons without its prior written
-consent including, without limitation, in connection with any unauthorized
-modifications to any of its public licenses or any other arrangements, understandings,
-or agreements concerning use of licensed material. For the avoidance of doubt,
-this paragraph does not form part of the public licenses.
+and in those instances will be considered the “Licensor.” Except for the limited
+purpose of indicating that material is shared under a Creative Commons public
+license or as otherwise permitted by the Creative Commons policies published
+at creativecommons.org/policies, Creative Commons does not authorize the use
+of the trademark “Creative Commons” or any other trademark or logo of Creative
+Commons without its prior written consent including, without limitation, in
+connection with any unauthorized modifications to any of its public licenses
+or any other arrangements, understandings, or agreements concerning use of
+licensed material. For the avoidance of doubt, this paragraph does not form
+part of the public licenses.
 
 Creative Commons may be contacted at creativecommons.org.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Gardener Dashboard
+[![REUSE status](https://api.reuse.software/badge/github.com/gardener/dashboard)](https://api.reuse.software/info/github.com/gardener/dashboard)
+
 
 ![](https://github.com/gardener/dashboard/blob/master/logo/logo_gardener_dashboard.png)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
* Updated `LICENSE` file (no symbolic link so that license is immediately shown in the GitHub sidebar)
![Screenshot 2024-02-15 at 14 59 24](https://github.com/gardener/dashboard/assets/1044005/8cf81b17-f7ed-4892-b7e7-b57efc250c6c)
* Updated `LICENSES` folder (formatting of license texts)
* Added badge for reuse compliance in `README.md` file and registered repo with REUSE API
