### PR TITLE
parse numerical abbreviations

### DIFF
--- a/frontend/__tests__/utils/index.spec.js
+++ b/frontend/__tests__/utils/index.spec.js
@@ -14,6 +14,7 @@ import {
   getDurationInMinutes,
   getTimeStringTo,
   getTimeStringFrom,
+  parseNumericalAbbreviation,
 } from '@/utils'
 
 import { pick } from '@/lodash'
@@ -394,6 +395,36 @@ describe('utils', () => {
       expect(getTimeStringFrom(time, time + 7 * 1_000)).toBe('7 seconds ago')
       expect(getTimeStringFrom(time, time + 70 * 24 * 3600_000, true)).toBe('2 months')
       expect(getTimeStringFrom(time, time + 70 * 24 * 3600_000)).toBe('2 months ago')
+    })
+  })
+
+  describe('parseNumericalAbbreviation', () => {
+    it('should convert k to thousands', () => {
+      expect(parseNumericalAbbreviation('1k')).toBe(1000)
+      expect(parseNumericalAbbreviation('1K')).toBe(1000)
+    })
+
+    it('should convert M to millions', () => {
+      expect(parseNumericalAbbreviation('1M')).toBe(1000000)
+      expect(parseNumericalAbbreviation('1m')).toBe(1000000)
+    })
+
+    it('should convert B to billions', () => {
+      expect(parseNumericalAbbreviation('1B')).toBe(1000000000)
+      expect(parseNumericalAbbreviation('1b')).toBe(1000000000)
+    })
+
+    it('should handle decimal values correctly', () => {
+      expect(parseNumericalAbbreviation('1.5k')).toBe(1500)
+      expect(parseNumericalAbbreviation('2.5M')).toBe(2500000)
+    })
+
+    it('should return the original number if no suffix', () => {
+      expect(parseNumericalAbbreviation('500')).toBe(500)
+    })
+
+    test('returns null for invalid input', () => {
+      expect(parseNumericalAbbreviation('abc')).toBeNull()
     })
   })
 })

--- a/frontend/__tests__/utils/index.spec.js
+++ b/frontend/__tests__/utils/index.spec.js
@@ -14,7 +14,7 @@ import {
   getDurationInMinutes,
   getTimeStringTo,
   getTimeStringFrom,
-  parseNumericalAbbreviation,
+  parseNumberWithMagnitudeSuffix,
 } from '@/utils'
 
 import { pick } from '@/lodash'
@@ -398,33 +398,42 @@ describe('utils', () => {
     })
   })
 
-  describe('parseNumericalAbbreviation', () => {
+  describe('parseNumberWithMagnitudeSuffix', () => {
     it('should convert k to thousands', () => {
-      expect(parseNumericalAbbreviation('1k')).toBe(1000)
-      expect(parseNumericalAbbreviation('1K')).toBe(1000)
+      expect(parseNumberWithMagnitudeSuffix('1k')).toBe(1000)
+      expect(parseNumberWithMagnitudeSuffix('1K')).toBe(1000)
     })
 
     it('should convert M to millions', () => {
-      expect(parseNumericalAbbreviation('1M')).toBe(1000000)
-      expect(parseNumericalAbbreviation('1m')).toBe(1000000)
+      expect(parseNumberWithMagnitudeSuffix('1M')).toBe(1000000)
+      expect(parseNumberWithMagnitudeSuffix('1m')).toBe(1000000)
     })
 
     it('should convert B to billions', () => {
-      expect(parseNumericalAbbreviation('1B')).toBe(1000000000)
-      expect(parseNumericalAbbreviation('1b')).toBe(1000000000)
+      expect(parseNumberWithMagnitudeSuffix('1B')).toBe(1000000000)
+      expect(parseNumberWithMagnitudeSuffix('1b')).toBe(1000000000)
+    })
+
+    it('should convert T to trillions', () => {
+      expect(parseNumberWithMagnitudeSuffix('1T')).toBe(1000000000000)
+      expect(parseNumberWithMagnitudeSuffix('1t')).toBe(1000000000000)
     })
 
     it('should handle decimal values correctly', () => {
-      expect(parseNumericalAbbreviation('1.5k')).toBe(1500)
-      expect(parseNumericalAbbreviation('2.5M')).toBe(2500000)
+      expect(parseNumberWithMagnitudeSuffix('1.5k')).toBe(1500)
+      expect(parseNumberWithMagnitudeSuffix('2.5M')).toBe(2500000)
     })
 
     it('should return the original number if no suffix', () => {
-      expect(parseNumericalAbbreviation('500')).toBe(500)
+      expect(parseNumberWithMagnitudeSuffix('500')).toBe(500)
     })
 
     test('returns null for invalid input', () => {
-      expect(parseNumericalAbbreviation('abc')).toBeNull()
+      expect(parseNumberWithMagnitudeSuffix('x1')).toBeNull()
+    })
+
+    test('returns null for invalid suffix', () => {
+      expect(parseNumberWithMagnitudeSuffix('1x')).toBeNull()
     })
   })
 })

--- a/frontend/src/store/quota/helper.js
+++ b/frontend/src/store/quota/helper.js
@@ -4,6 +4,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import { parseNumericalAbbreviation } from '@/utils'
+
 import {
   map,
   replace,
@@ -53,11 +55,11 @@ export function aggregateResourceQuotaStatus (quotas) {
   for (const quota of quotas) {
     for (const [key, value] of Object.entries(quota.hard)) {
       const currentValue = hard[key] ?? Number.MAX_SAFE_INTEGER
-      hard[key] = Math.min(value, currentValue).toString()
+      hard[key] = Math.min(parseNumericalAbbreviation(value), currentValue).toString()
     }
     for (const [key, value] of Object.entries(quota.used)) {
       const currentValue = used[key] ?? Number.MIN_SAFE_INTEGER
-      used[key] = Math.max(value, currentValue).toString()
+      used[key] = Math.max(parseNumericalAbbreviation(value), currentValue).toString()
     }
   }
 

--- a/frontend/src/store/quota/helper.js
+++ b/frontend/src/store/quota/helper.js
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { parseNumericalAbbreviation } from '@/utils'
+import { parseNumberWithMagnitudeSuffix } from '@/utils'
 
 import {
   map,
@@ -55,11 +55,11 @@ export function aggregateResourceQuotaStatus (quotas) {
   for (const quota of quotas) {
     for (const [key, value] of Object.entries(quota.hard)) {
       const currentValue = hard[key] ?? Number.MAX_SAFE_INTEGER
-      hard[key] = Math.min(parseNumericalAbbreviation(value), currentValue).toString()
+      hard[key] = Math.min(parseNumberWithMagnitudeSuffix(value), currentValue).toString()
     }
     for (const [key, value] of Object.entries(quota.used)) {
       const currentValue = used[key] ?? Number.MIN_SAFE_INTEGER
-      used[key] = Math.max(parseNumericalAbbreviation(value), currentValue).toString()
+      used[key] = Math.max(parseNumberWithMagnitudeSuffix(value), currentValue).toString()
     }
   }
 

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -644,25 +644,14 @@ export function omitKeysWithSuffix (obj, suffix) {
   return omit(obj, keys)
 }
 
-export function parseNumericalAbbreviation (abbreviatedNumber) {
-  const regex = /(\d+(?:\.\d+)?)(k|M|B)?/i
-  const match = abbreviatedNumber.match(regex)
-
-  if (!match) {
+export function parseNumberWithMagnitudeSuffix (abbreviatedNumber) {
+  const [, number, suffix] = /^(\d+(?:\.\d*)?)([kmbt]?)$/i.exec(abbreviatedNumber) ?? []
+  if (!number) {
+    logger.error(`Could not parse number with suffix ${abbreviatedNumber} as it does not match regex ^(\\d+(?:\\.\\d*)?)([kmbt]?)$`)
     return null
   }
 
-  const number = parseFloat(match[1])
-  const suffix = match[2]
-
-  switch (suffix?.toLowerCase()) {
-    case 'k':
-      return number * 1e3
-    case 'm':
-      return number * 1e6
-    case 'b':
-      return number * 1e9
-    default:
-      return number
-  }
+  const suffixFactors = { k: 1e3, m: 1e6, b: 1e9, t: 1e12 }
+  const factor = suffixFactors[suffix?.toLowerCase()] ?? 1
+  return Number(number) * factor
 }

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -647,7 +647,7 @@ export function omitKeysWithSuffix (obj, suffix) {
 export function parseNumberWithMagnitudeSuffix (abbreviatedNumber) {
   const [, number, suffix] = /^(\d+(?:\.\d*)?)([kmbt]?)$/i.exec(abbreviatedNumber) ?? []
   if (!number) {
-    logger.error(`Could not parse number with suffix ${abbreviatedNumber} as it does not match regex ^(\\d+(?:\\.\\d*)?)([kmbt]?)$`)
+    logger.error(`Failed to parse ${abbreviatedNumber} because it doesn't follow the required format: a number optionally with a decimal, followed by an optional magnitude suffix ('k', 'm', 'b', 't').`)
     return null
   }
 

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -643,3 +643,26 @@ export function omitKeysWithSuffix (obj, suffix) {
   const keys = Object.keys(obj).filter(key => key.endsWith(suffix))
   return omit(obj, keys)
 }
+
+export function parseNumericalAbbreviation (abbreviatedNumber) {
+  const regex = /(\d+(?:\.\d+)?)(k|M|B)?/i
+  const match = abbreviatedNumber.match(regex)
+
+  if (!match) {
+    return null
+  }
+
+  const number = parseFloat(match[1])
+  const suffix = match[2]
+
+  switch (suffix?.toLowerCase()) {
+    case 'k':
+      return number * 1e3
+    case 'm':
+      return number * 1e6
+    case 'b':
+      return number * 1e9
+    default:
+      return number
+  }
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #1716

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed an issue that caused quotas using numerical abbreviations (e.g., '1k') to not be displayed correctly in the Gardener Dashboard
```
