### PR TITLE
[master] Make storage size configuration more explicit

### DIFF
--- a/frontend/src/components/ShootWorkers/GMachineType.vue
+++ b/frontend/src/components/ShootWorkers/GMachineType.vue
@@ -30,7 +30,7 @@ SPDX-License-Identifier: Apache-2.0
           <span v-if="item.raw.cpu">CPU: {{ item.raw.cpu }} | </span>
           <span v-if="item.raw.gpu">GPU: {{ item.raw.gpu }} | </span>
           <span v-if="item.raw.memory">Memory: {{ item.raw.memory }}</span>
-          <span v-if="item.raw.storage"> | Storage Class: {{ item.raw.storage.class }}</span>
+          <span v-if="item.raw.storage"> | Volume Type: {{ item.raw.storage.type }} | Class: {{ item.raw.storage.class }} | Default Size: {{ item.raw.storage.size }}</span>
         </v-list-item-subtitle>
       </v-list-item>
     </template>

--- a/frontend/src/components/ShootWorkers/GVolumeSizeInput.vue
+++ b/frontend/src/components/ShootWorkers/GVolumeSizeInput.vue
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
       @update:model-value="onInputStorageKind"
     />
     <v-text-field
-      v-if="hasVolumeTypes || customStorageSize"
+      v-if="hasVolumeTypes || hasCustomStorageSize"
       ref="volumeSize"
       v-model="innerValue"
       :min="min"
@@ -42,7 +42,7 @@ export default {
     modelValue: {
       type: [String, Number],
     },
-    customStorageSize: {
+    hasCustomStorageSize: {
       type: Boolean,
       default: false,
     },
@@ -68,7 +68,7 @@ export default {
   },
   emits: [
     'update:modelValue',
-    'update:customStorageSize',
+    'update:hasCustomStorageSize',
     'blur',
   ],
   computed: {
@@ -89,14 +89,10 @@ export default {
     },
     storageKind: {
       get () {
-        return this.customStorageSize ? 'custom' : 'default'
+        return this.hasCustomStorageSize ? 'custom' : 'default'
       },
       set (value) {
-        if (value === 'custom') {
-          this.$emit('update:customStorageSize', true)
-        } else {
-          this.$emit('update:customStorageSize', false)
-        }
+        this.$emit('update:hasCustomStorageSize', value === 'custom')
       },
     },
     storageKindItems () {

--- a/frontend/src/components/ShootWorkers/GVolumeSizeInput.vue
+++ b/frontend/src/components/ShootWorkers/GVolumeSizeInput.vue
@@ -119,20 +119,9 @@ export default {
     emitBlur (e) {
       this.$emit('blur', e)
     },
-    customFilter (title, query, item) {
-      if (item.raw.key === 'default') {
-        if (!query.length) {
-          return true
-        }
-      }
-      if (item.raw.key === 'custom') {
-        return /^(\d+)$/.test(query)
-      }
-      return false
-    },
     onInputStorageKind () {
       this.innerValue = undefined
-      this.$nextTick(() => this.$refs.volumeSize.focus())
+      this.$nextTick(() => this.$refs.volumeSize?.focus())
     },
   },
 }

--- a/frontend/src/components/ShootWorkers/GVolumeSizeInput.vue
+++ b/frontend/src/components/ShootWorkers/GVolumeSizeInput.vue
@@ -5,17 +5,33 @@ SPDX-License-Identifier: Apache-2.0
 -->
 
 <template>
-  <v-text-field
-    v-model="innerValue"
-    :min="min"
-    :color="color"
-    suffix="Gi"
-    :label="label"
-    type="number"
-    :error-messages="errorMessages"
-    variant="underlined"
-    @blur="emitBlur"
-  />
+  <div class="d-flex">
+    <v-select
+      v-if="!hasVolumeTypes"
+      v-model="storageKind"
+      :color="color"
+      label="Volume"
+      variant="underlined"
+      :items="storageKindItems"
+      class="mr-1"
+      @blur="emitBlur"
+      @update:model-value="onInputStorageKind"
+    />
+    <v-text-field
+      v-if="hasVolumeTypes || customStorageSize"
+      ref="volumeSize"
+      v-model="innerValue"
+      :min="min"
+      :color="color"
+      suffix="Gi"
+      label="Volume Size"
+      type="number"
+      :error-messages="errorMessages"
+      variant="underlined"
+      style="maxWidth: 80px"
+      @blur="emitBlur"
+    />
+  </div>
 </template>
 
 <script>
@@ -25,6 +41,10 @@ export default {
   props: {
     modelValue: {
       type: [String, Number],
+    },
+    customStorageSize: {
+      type: Boolean,
+      default: false,
     },
     label: {
       type: String,
@@ -38,9 +58,17 @@ export default {
     min: {
       type: [String, Number],
     },
+    defaultStorageSize: {
+      type: [String, Number],
+    },
+    hasVolumeTypes: {
+      type: Boolean,
+      default: false,
+    },
   },
   emits: [
     'update:modelValue',
+    'update:customStorageSize',
     'blur',
   ],
   computed: {
@@ -59,6 +87,30 @@ export default {
         }
       },
     },
+    storageKind: {
+      get () {
+        return this.customStorageSize ? 'custom' : 'default'
+      },
+      set (value) {
+        if (value === 'custom') {
+          this.$emit('update:customStorageSize', true)
+        } else {
+          this.$emit('update:customStorageSize', false)
+        }
+      },
+    },
+    storageKindItems () {
+      return [
+        {
+          title: this.defaultStorageSize ? `default (${this.defaultStorageSize})` : 'default',
+          value: 'default',
+        },
+        {
+          title: 'custom',
+          key: 'custom',
+        },
+      ]
+    },
   },
   methods: {
     format (modelValue) {
@@ -66,6 +118,21 @@ export default {
     },
     emitBlur (e) {
       this.$emit('blur', e)
+    },
+    customFilter (title, query, item) {
+      if (item.raw.key === 'default') {
+        if (!query.length) {
+          return true
+        }
+      }
+      if (item.raw.key === 'custom') {
+        return /^(\d+)$/.test(query)
+      }
+      return false
+    },
+    onInputStorageKind () {
+      this.innerValue = undefined
+      this.$nextTick(() => this.$refs.volumeSize.focus())
     },
   },
 }

--- a/frontend/src/components/ShootWorkers/GWorkerInputGeneric.vue
+++ b/frontend/src/components/ShootWorkers/GWorkerInputGeneric.vue
@@ -299,7 +299,7 @@ export default {
 
     const volumeSizeRules = {
       minVolumeSize: withMessage(`Minimum size is ${this.minimumVolumeSize}`, value => {
-        if (this.noVolumeSize) {
+        if (!this.hasVolumeSize) {
           return true
         }
         if (!value) {
@@ -477,8 +477,8 @@ export default {
     workerGroupName () {
       return this.worker.name ? `[Worker Group ${this.worker.name}]` : '[Worker Group]'
     },
-    noVolumeSize () {
-      return !this.volumeInCloudProfile && !this.customStorageSize
+    hasVolumeSize () {
+      return this.volumeInCloudProfile || this.customStorageSize
     },
   },
   mounted () {
@@ -504,11 +504,11 @@ export default {
       this.v$.worker.name.$touch()
     },
     onInputVolumeSize () {
-      if (this.noVolumeSize) {
+      if (this.hasVolumeSize) {
+        set(this.worker, 'volume.size', this.volumeSize)
+      } else {
         // default size, must not write to shoot spec
         delete this.worker.volume
-      } else {
-        set(this.worker, 'volume.size', this.volumeSize)
       }
       this.v$.volumeSize.$touch()
     },

--- a/frontend/src/components/ShootWorkers/GWorkerInputGeneric.vue
+++ b/frontend/src/components/ShootWorkers/GWorkerInputGeneric.vue
@@ -69,7 +69,7 @@ SPDX-License-Identifier: Apache-2.0
       <div :class="volumeInCloudProfile ? 'small-input' : 'regular-input'">
         <g-volume-size-input
           v-model="volumeSize"
-          v-model:custom-storage-size="customStorageSize"
+          v-model:has-custom-storage-size="hasCustomStorageSize"
           :min="minimumVolumeSize"
           :default-storage-size="selectedMachineType.storage?.size"
           :has-volume-types="volumeInCloudProfile"
@@ -256,7 +256,7 @@ export default {
     return {
       immutableZones: undefined,
       volumeSize: undefined,
-      customStorageSize: false,
+      hasCustomStorageSize: false,
     }
   },
   validations () {
@@ -478,7 +478,7 @@ export default {
       return this.worker.name ? `[Worker Group ${this.worker.name}]` : '[Worker Group]'
     },
     hasVolumeSize () {
-      return this.volumeInCloudProfile || this.customStorageSize
+      return this.volumeInCloudProfile || this.hasCustomStorageSize
     },
   },
   mounted () {
@@ -486,7 +486,7 @@ export default {
     if (volumeSize) {
       this.volumeSize = volumeSize
       if (!this.volumeInCloudProfile) {
-        this.customStorageSize = true
+        this.hasCustomStorageSize = true
       }
     }
     this.onInputVolumeSize()

--- a/frontend/src/store/cloudProfile/index.js
+++ b/frontend/src/store/cloudProfile/index.js
@@ -611,14 +611,6 @@ export const useCloudProfileStore = defineStore('cloudProfile', () => {
         type: volumeType.name,
         size: defaultVolumeSize,
       }
-    } else if (!machineType.storage) {
-      worker.volume = {
-        size: defaultVolumeSize,
-      }
-    } else if (machineType.storage.type !== 'fixed') {
-      worker.volume = {
-        size: machineType.storage.size,
-      }
     }
     return worker
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
Enhanced Volume Management for OpenStack Workers
This Fix addresses and resolves a critical issue our users have experienced. Previously, updating OpenStack workers via the dashboard inadvertently led to the loss of custom volume sizes. This release brings a fix to this bug, ensuring that your custom volume configurations are retained post-update.
Additionally, we've improved the storage size configuration interface. Now, it's easier to distinguish between default and custom volumes, allowing for a more intuitive setup process. This enhancement aims to streamline your experience, making volume management more straightforward and error-free.

<img width="1247" alt="Screenshot 2024-02-21 at 17 37 05" src="https://github.com/gardener/dashboard/assets/35373687/daab48d9-058d-45b9-b357-0655732b7e76">

<img width="308" alt="Screenshot 2024-02-21 at 15 44 00" src="https://github.com/gardener/dashboard/assets/35373687/bcc388e4-d7d6-4863-becd-afa91a129eab">


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
NONE
```
