### PR TITLE
Implemented Fallback for non semver compatible machine image versions

### DIFF
--- a/frontend/__tests__/stores/cloudProfile.spec.js
+++ b/frontend/__tests__/stores/cloudProfile.spec.js
@@ -119,14 +119,14 @@ describe('stores', () => {
 
       it('should transform machine images from cloud profile', () => {
         const dashboardMachineImages = cloudProfileStore.machineImagesByCloudProfileName('foo')
-        expect(dashboardMachineImages).toHaveLength(5)
+        expect(dashboardMachineImages).toHaveLength(6)
 
         const expiredImage = find(dashboardMachineImages, { name: 'suse-chost', version: '15.1.20191127' })
         expect(expiredImage.isExpired).toBe(true)
         expect(expiredImage.isSupported).toBe(false)
 
         const invalidImage = find(dashboardMachineImages, { name: 'foo', version: '1.02.3' })
-        expect(invalidImage).toBeUndefined()
+        expect(invalidImage.isInvalidSemverVersion).toBe(true)
 
         const suseImage = find(dashboardMachineImages, { name: 'suse-chost', version: '15.1.20191027' })
         expect(suseImage.expirationDate).toBe('2119-04-05T01:02:03Z')

--- a/frontend/src/components/ShootWorkers/GMachineImage.vue
+++ b/frontend/src/components/ShootWorkers/GMachineImage.vue
@@ -121,6 +121,13 @@ export default {
     },
     hint () {
       const hints = []
+      if (this.machineImage.isInvalidSemverVersion) {
+        hints.push({
+          type: 'text',
+          hint: 'Invalid Image Version: This image might not be sorted correctly or lead to wrong update alerts',
+          severity: 'warning',
+        })
+      }
       if (this.machineImage.vendorHint) {
         hints.push({
           type: 'html',


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #1467

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Added Fallback Solution for Non-SemVer Compatible Machine Image Versions : In previous versions, machine images from some vendors that did not adhere to Semantic Versioning (SemVer) standards were omitted from user view in the dashboard. This was due to the system's strict adherence to SemVer for sorting and presenting image versions, which resulted in non-compliant versions being filtered out. To address this, we have introduced a fallback solution that allows for the comparison and inclusion of non-SemVer compliant machine image versions. This ensures that all vendor images, regardless of their versioning format, are now visible to users on the dashboard.
```
```other operator
Added Fallback Solution for Non-SemVer Compatible Machine Image Versions: While this update improves the visibility of non-compliant versions, landscape operators are still encouraged to maintain machine image versions in a SemVer-compatible manner whenever possible. This is crucial because the fallback solution may not guarantee the correct sorting and update information for non-SemVer compliant versions.
```
