### PR TITLE
Do not double quote string in yaml config example

### DIFF
--- a/frontend/src/components/GGardenctlConfigExample.vue
+++ b/frontend/src/components/GGardenctlConfigExample.vue
@@ -82,7 +82,7 @@ export default {
     gardenctlConfigYaml () {
       return `gardens:
   - identity: ${this.clusterIdentity}
-    kubeconfig: "<path-to-garden-cluster-kubeconfig>"`
+    kubeconfig: <path-to-garden-cluster-kubeconfig>`
     },
     configCmd () {
       return `gardenctl config set-garden ${this.clusterIdentity} --kubeconfig "<path-to-garden-cluster-kubeconfig>"`


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR addresses an issue with the handling of YAML string config values. Previously, these values were double quoted, which caused problems when using Windows paths. The backslash character in the Windows path needed to be escaped due to the double quotes, which was not intuitive for users.

To resolve this, we have updated the example config value for the `kubeconfig` key so that it is no longer double quoted. This change simplifies the use of Windows paths and eliminates the need for users to manually escape the backslash character.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
