### PR TITLE
[renovate] Automerge golang docker image updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -46,6 +46,12 @@
       matchManagers: ["github-actions"],
       matchUpdateTypes: ["patch", "digest"],
       automerge: true
+    },
+    {
+      // Automerge golang docker image updates
+      matchDatasources: ["docker"],
+      matchPackageNames: ["golang"],
+      automerge: true
     }
   ]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This renovate config change will automerge PRs like https://github.com/gardener/dashboard/pull/1739

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
