### PR TITLE
Filter Non-Kube-Apiserver `AdvertisedAddresses`

### DIFF
--- a/backend/lib/services/shoots.js
+++ b/backend/lib/services/shoots.js
@@ -493,6 +493,11 @@ Note that the kubeconfig refers to the path of the garden cluster kubeconfig whi
   }
 
   for (const [i, address] of shoot.status.advertisedAddresses.entries()) {
+    const isKubeApiserverAddress = _.includes(['external', 'internal', 'unmanaged'], address.name)
+    if (!isKubeApiserverAddress) {
+      continue
+    }
+
     const name = `${userName}-${address.name}`
     if (i === 0) {
       cfg['current-context'] = name

--- a/backend/lib/services/shoots.js
+++ b/backend/lib/services/shoots.js
@@ -493,7 +493,7 @@ Note that the kubeconfig refers to the path of the garden cluster kubeconfig whi
   }
 
   for (const [i, address] of shoot.status.advertisedAddresses.entries()) {
-    const isKubeApiserverAddress = _.includes(['external', 'internal', 'unmanaged'], address.name)
+    const isKubeApiserverAddress = ['external', 'internal', 'unmanaged'].includes(address.name)
     if (!isKubeApiserverAddress) {
       continue
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the generation process of the `gardenlogin` kubeconfig to filter the `Shoot.status.advertisedAddresses` and only include the kube-apiserver addresses. This change is necessary because, as of `gardener/gardener` `v1.91.0`, the `advertisedAddresses` might also include the `service-account-issuer` url.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
The `gardenlogin` kubeconfig now only includes kube-apiserver addresses from `Shoot.status.advertisedAddresses`. This ensures compatibility with `gardener/gardener` version `v1.91.0` and later.
```
