### PR TITLE
[renovate] Ignore major updates for ES modules

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -38,8 +38,7 @@
         "p-event",
         "p-limit",
         "p-retry",
-        "p-timeout",
-        "vite",
+        "p-timeout"
       ],
       matchUpdateTypes: ["major"],
       enabled: false

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,11 +22,27 @@
   ],
   packageRules: [
     {
-      // Group npm major, minor and patch in separate PRs.
+      // Ignore major updates for these dependencies until we support ES modules
       matchDatasources: ["npm"],
-      groupName: "packages",
-      separateMajorMinor: true,
-      separateMinorPatch: true
+      matchPackageNames: [
+        "@octokit/core",
+        "@octokit/plugin-paginate-graphql",
+        "@octokit/plugin-paginate-rest",
+        "@octokit/plugin-request-log",
+        "@octokit/plugin-rest-endpoint-methods",
+        "chalk",
+        "codemirror",
+        "eslint-plugin-jest",
+        "eslint-plugin-n",
+        "jest",
+        "p-event",
+        "p-limit",
+        "p-retry",
+        "p-timeout",
+        "vite",
+      ],
+      matchUpdateTypes: ["major"],
+      enabled: false
     },
     {
       // Group github-actions in one PR.


### PR DESCRIPTION
**What this PR does / why we need it**:
- Ignore major updates for these dependencies until we support ES modules
- Do not group PRs. This seems to cause issues with renovate bot reverting changes back and forth in a PR

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
