### PR TITLE
[master] Ticket title should contain project name

### DIFF
--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -198,7 +198,7 @@ global:
       #   #       accessRestrictions[].options[].description: option description
       #   #       accessRestrictions[].options[].key: unique identifier
       #   newIssue:
-      #     title: "[${shootNamespace}/${shootName}] <problem>"
+      #     title: "[${shootProjectName}/${shootName}] <problem>"
       #     labels: # these are the labels that are automatically preselected when creating a new ticket
       #     - default-label
       #     # GitHub issue forms

--- a/frontend/src/components/GTicketsCard.vue
+++ b/frontend/src/components/GTicketsCard.vue
@@ -104,7 +104,7 @@ export default {
     ticketLink () {
       const newIssue = this.newIssue
       if (!newIssue.title) {
-        newIssue.title = `[${this.shootNamespace}/${this.shootName}]`
+        newIssue.title = `[${this.shootProjectName}/${this.shootName}]`
       }
 
       const options = {


### PR DESCRIPTION
**What this PR does / why we need it**:
Ticket titles should start with `[<projectName>/<shootName>]`.
This bug was introduced in #1775 and caused tickets to not show up in the dashboard.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Ticket titles start with `[<projectName>/<shootName>]`, unless overridden by a Gardener administrator's configuration.
```
