### PR TITLE
[hotfix-1.74] Automated cherry pick of #1824: [master] Ticket title should contain project name

### DIFF
--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -198,7 +198,7 @@ global:
       #   #       accessRestrictions[].options[].description: option description
       #   #       accessRestrictions[].options[].key: unique identifier
       #   newIssue:
-      #     title: "[${shootNamespace}/${shootName}] <problem>"
+      #     title: "[${shootProjectName}/${shootName}] <problem>"
       #     labels: # these are the labels that are automatically preselected when creating a new ticket
       #     - default-label
       #     # GitHub issue forms

--- a/frontend/src/components/GTicketsCard.vue
+++ b/frontend/src/components/GTicketsCard.vue
@@ -104,7 +104,7 @@ export default {
     ticketLink () {
       const newIssue = this.newIssue
       if (!newIssue.title) {
-        newIssue.title = `[${this.shootNamespace}/${this.shootName}]`
+        newIssue.title = `[${this.shootProjectName}/${this.shootName}]`
       }
 
       const options = {


### PR DESCRIPTION
/kind bug

Cherry pick of #1824 on hotfix-1.74.

#1824: [master] Ticket title should contain project name

**Release Notes:**
```bugfix user
Ticket titles start with `[<projectName>/<shootName>]`, unless overridden by a Gardener administrator's configuration.
```