### PR TITLE
Comply with DISA STIG V-242415 by mounting secrets as files

### DIFF
--- a/backend/lib/config/gardener.js
+++ b/backend/lib/config/gardener.js
@@ -14,107 +14,107 @@ const { homedir } = require('os')
 const { join } = require('path')
 
 /*
-configMappings defines mappings between config values, their sources (env vars or files),
+configMappings defines mappings between config values, their sources (environment variables or files),
 and destinations in the config object. Properties:
-- envVar: The env var to read the value from.
-- fsPath: (Optional) File path to read the value from if env var is not set.
-- destinationPath: The path in the config object to set the value.
+- environmentVariableName: The environment variable to read the value from.
+- filePath: (Optional) File path to read the value from if environment variable is not set.
+- configPath: The path in the config object to set the value.
 - type: (Optional) 'Boolean', 'Integer', or 'String' (default). Value is converted to this type.
 
 Allows flexible config management from different sources. Values are converted to the desired type.
-If both envVar and fsPath are missing/empty, the config path remains unchanged.
+If both environmentVariableName and filePath are missing/empty, the config path remains unchanged.
 */
 const configMappings = [
   {
-    envVar: 'VUE_APP_VERSION',
-    destinationPath: 'frontend.appVersion'
+    environmentVariableName: 'VUE_APP_VERSION',
+    configPath: 'frontend.appVersion'
   },
   {
-    envVar: 'SESSION_SECRET',
-    fsPath: '/etc/gardener-dashboard/secrets/session/sessionSecret',
-    destinationPath: 'sessionSecret'
+    environmentVariableName: 'SESSION_SECRET',
+    filePath: '/etc/gardener-dashboard/secrets/session/sessionSecret',
+    configPath: 'sessionSecret'
   },
   {
-    envVar: 'API_SERVER_URL',
-    destinationPath: 'apiServerUrl'
+    environmentVariableName: 'API_SERVER_URL',
+    configPath: 'apiServerUrl'
   },
   {
-    envVar: 'OIDC_ISSUER',
-    destinationPath: 'oidc.issuer'
+    environmentVariableName: 'OIDC_ISSUER',
+    configPath: 'oidc.issuer'
   },
   {
-    envVar: 'OIDC_CA',
-    destinationPath: 'oidc.ca'
+    environmentVariableName: 'OIDC_CA',
+    configPath: 'oidc.ca'
   },
   {
-    envVar: 'OIDC_CLIENT_ID',
-    fsPath: '/etc/gardener-dashboard/secrets/oidc/client_id',
-    destinationPath: 'oidc.client_id'
+    environmentVariableName: 'OIDC_CLIENT_ID',
+    filePath: '/etc/gardener-dashboard/secrets/oidc/client_id',
+    configPath: 'oidc.client_id'
   },
   {
-    envVar: 'OIDC_CLIENT_SECRET',
-    fsPath: '/etc/gardener-dashboard/secrets/oidc/client_secret',
-    destinationPath: 'oidc.client_secret'
+    environmentVariableName: 'OIDC_CLIENT_SECRET',
+    filePath: '/etc/gardener-dashboard/secrets/oidc/client_secret',
+    configPath: 'oidc.client_secret'
   },
   {
-    envVar: 'GITHUB_AUTHENTICATION_APP_ID',
-    fsPath: '/etc/gardener-dashboard/secrets/github/authentication.appId',
-    destinationPath: 'gitHub.authentication.appId',
+    environmentVariableName: 'GITHUB_AUTHENTICATION_APP_ID',
+    filePath: '/etc/gardener-dashboard/secrets/github/authentication.appId',
+    configPath: 'gitHub.authentication.appId',
     type: 'Integer'
   },
   {
-    envVar: 'GITHUB_AUTHENTICATION_CLIENT_ID',
-    fsPath: '/etc/gardener-dashboard/secrets/github/authentication.clientId',
-    destinationPath: 'gitHub.authentication.clientId'
+    environmentVariableName: 'GITHUB_AUTHENTICATION_CLIENT_ID',
+    filePath: '/etc/gardener-dashboard/secrets/github/authentication.clientId',
+    configPath: 'gitHub.authentication.clientId'
   },
   {
-    envVar: 'GITHUB_AUTHENTICATION_CLIENT_SECRET',
-    fsPath: '/etc/gardener-dashboard/secrets/github/authentication.clientSecret',
-    destinationPath: 'gitHub.authentication.clientSecret'
+    environmentVariableName: 'GITHUB_AUTHENTICATION_CLIENT_SECRET',
+    filePath: '/etc/gardener-dashboard/secrets/github/authentication.clientSecret',
+    configPath: 'gitHub.authentication.clientSecret'
   },
   {
-    envVar: 'GITHUB_AUTHENTICATION_INSTALLATION_ID',
-    fsPath: '/etc/gardener-dashboard/secrets/github/authentication.installationId',
-    destinationPath: 'gitHub.authentication.installationId',
+    environmentVariableName: 'GITHUB_AUTHENTICATION_INSTALLATION_ID',
+    filePath: '/etc/gardener-dashboard/secrets/github/authentication.installationId',
+    configPath: 'gitHub.authentication.installationId',
     type: 'Integer'
   },
   {
-    envVar: 'GITHUB_AUTHENTICATION_PRIVATE_KEY',
-    fsPath: '/etc/gardener-dashboard/secrets/github/authentication.privateKey',
-    destinationPath: 'gitHub.authentication.privateKey'
+    environmentVariableName: 'GITHUB_AUTHENTICATION_PRIVATE_KEY',
+    filePath: '/etc/gardener-dashboard/secrets/github/authentication.privateKey',
+    configPath: 'gitHub.authentication.privateKey'
   },
   {
-    envVar: 'GITHUB_AUTHENTICATION_TOKEN',
-    fsPath: '/etc/gardener-dashboard/secrets/github/authentication.token',
-    destinationPath: 'gitHub.authentication.token'
+    environmentVariableName: 'GITHUB_AUTHENTICATION_TOKEN',
+    filePath: '/etc/gardener-dashboard/secrets/github/authentication.token',
+    configPath: 'gitHub.authentication.token'
   },
   {
-    envVar: 'GITHUB_WEBHOOK_SECRET',
-    fsPath: '/etc/gardener-dashboard/secrets/github/webhookSecret',
-    destinationPath: 'gitHub.webhookSecret'
+    environmentVariableName: 'GITHUB_WEBHOOK_SECRET',
+    filePath: '/etc/gardener-dashboard/secrets/github/webhookSecret',
+    configPath: 'gitHub.webhookSecret'
   },
   {
-    envVar: 'LOG_LEVEL',
-    destinationPath: 'logLevel'
+    environmentVariableName: 'LOG_LEVEL',
+    configPath: 'logLevel'
   },
   {
-    envVar: 'LOG_HTTP_REQUEST_BODY',
-    destinationPath: 'logHttpRequestBody',
+    environmentVariableName: 'LOG_HTTP_REQUEST_BODY',
+    configPath: 'logHttpRequestBody',
     type: 'Boolean'
   },
   {
-    envVar: 'PORT',
-    destinationPath: 'port',
+    environmentVariableName: 'PORT',
+    configPath: 'port',
     type: 'Integer'
   },
   {
-    envVar: 'METRICS_PORT',
-    destinationPath: 'metricsPort',
+    environmentVariableName: 'METRICS_PORT',
+    configPath: 'metricsPort',
     type: 'Integer'
   }
 ]
 
-function convertValue (value, type) {
+function parseConfigValue (value, type) {
   switch (type) {
     case 'Integer':
       value = parseInt(value, 10)
@@ -125,25 +125,18 @@ function convertValue (value, type) {
       return value
   }
 }
-function getValueFromEnvironment (env, envVar, type) {
-  const value = env[envVar]
-  return convertValue(value, type)
-}
 
 function getValueFromFile (filePath, type) {
   try {
-    if (!fs.existsSync(filePath)) {
-      return undefined
-    }
-    const fileContent = fs.readFileSync(filePath, 'utf8')
-    return convertValue(fileContent, type)
+    const value = fs.readFileSync(filePath, 'utf8')
+    return parseConfigValue(value, type)
   } catch (error) {
-    /* ignore */
+    return undefined
   }
 }
 
-function getValueFromEnvironmentOrFile (env, envVar, filePath, type) {
-  const value = getValueFromEnvironment(env, envVar, type)
+function getValueFromEnvironmentOrFile (env, environmentVariableName, filePath, type) {
+  const value = parseConfigValue(env[environmentVariableName], type)
   if (value !== undefined) {
     return value
   }
@@ -154,12 +147,12 @@ function getValueFromEnvironmentOrFile (env, envVar, filePath, type) {
 }
 
 module.exports = {
-  setConfigFromEnvOrFiles (config, env) {
-    for (const { envVar, destinationPath, fsPath, type = 'String' } of configMappings) {
-      const value = getValueFromEnvironmentOrFile(env, envVar, fsPath, type)
+  assignConfigFromEnvironmentAndFileSystem (config, env) {
+    for (const { environmentVariableName, configPath, filePath, type = 'String' } of configMappings) {
+      const value = getValueFromEnvironmentOrFile(env, environmentVariableName, filePath, type)
 
       if (value !== undefined) {
-        _.set(config, destinationPath, value)
+        _.set(config, configPath, value)
       }
     }
   },
@@ -188,7 +181,7 @@ module.exports = {
         _.merge(config, this.readConfig(filename))
       } catch (err) { /* ignore */ }
     }
-    this.setConfigFromEnvOrFiles(config, env)
+    this.assignConfigFromEnvironmentAndFileSystem(config, env)
     const requiredConfigurationProperties = [
       'sessionSecret',
       'apiServerUrl'

--- a/backend/test/config.spec.js
+++ b/backend/test/config.spec.js
@@ -74,17 +74,14 @@ describe('config', function () {
         SESSION_SECRET: 'secret'
       }
 
-      let existsSyncSpy
       let readFileSyncSpy
 
       beforeEach(() => {
-        existsSyncSpy = jest.spyOn(fs, 'existsSync')
         readFileSyncSpy = jest.spyOn(fs, 'readFileSync')
       })
 
       afterEach(() => {
         gardener.readConfig.mockClear()
-        existsSyncSpy.mockRestore()
         readFileSyncSpy.mockRestore()
       })
 
@@ -163,7 +160,6 @@ describe('config', function () {
           '/etc/gardener-dashboard/secrets/github/authentication.installationId': '67890'
         }
 
-        existsSyncSpy.mockImplementation(filePath => filePath in fileMap)
         readFileSyncSpy.mockImplementation(filePath => {
           if (filePath in fileMap) {
             return fileMap[filePath]

--- a/backend/test/config.spec.js
+++ b/backend/test/config.spec.js
@@ -74,8 +74,18 @@ describe('config', function () {
         SESSION_SECRET: 'secret'
       }
 
+      let existsSyncSpy
+      let readFileSyncSpy
+
       beforeEach(() => {
+        existsSyncSpy = jest.spyOn(fs, 'existsSync')
+        readFileSyncSpy = jest.spyOn(fs, 'readFileSync')
+      })
+
+      afterEach(() => {
         gardener.readConfig.mockClear()
+        existsSyncSpy.mockRestore()
+        readFileSyncSpy.mockRestore()
       })
 
       it('should return the config in test environment', function () {
@@ -141,6 +151,34 @@ describe('config', function () {
         expect(config.oidc.client_id).toBe('client_id')
         expect(config.oidc.client_secret).toBe('client_secret')
         expect(config.oidc.ca).toBe('ca')
+      })
+
+      it('should return the config with values read from the filesystem', function () {
+        const env = Object.assign({}, environmentVariables)
+
+        const fileMap = {
+          '/etc/gardener-dashboard/secrets/oidc/client_id': 'client_id_from_file',
+          '/etc/gardener-dashboard/secrets/oidc/client_secret': 'client_secret_from_file',
+          '/etc/gardener-dashboard/secrets/github/authentication.appId': '12345',
+          '/etc/gardener-dashboard/secrets/github/authentication.installationId': '67890'
+        }
+
+        existsSyncSpy.mockImplementation(filePath => filePath in fileMap)
+        readFileSyncSpy.mockImplementation(filePath => {
+          if (filePath in fileMap) {
+            return fileMap[filePath]
+          }
+          throw new Error(filePath + ': not found')
+        })
+
+        const filename = '/etc/gardener/4/config.yaml'
+        const config = gardener.loadConfig(filename, { env })
+
+        expect(config.oidc.issuer).toBe('https://kubernetes:32001')
+        expect(config.oidc.client_id).toBe('client_id_from_file')
+        expect(config.oidc.client_secret).toBe('client_secret_from_file')
+        expect(config.gitHub.authentication.appId).toBe(12345)
+        expect(config.gitHub.authentication.installationId).toBe(67890)
       })
     })
   })

--- a/charts/__tests__/gardener-dashboard/runtime/dashboard/__snapshots__/deployment.spec.js.snap
+++ b/charts/__tests__/gardener-dashboard/runtime/dashboard/__snapshots__/deployment.spec.js.snap
@@ -1,106 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`gardener-dashboard deployment github app authentication should render GITHUB environment variables 1`] = `
-Array [
-  Object {
-    "name": "SESSION_SECRET",
-    "valueFrom": Object {
-      "secretKeyRef": Object {
-        "key": "keyValue",
-        "name": "gardener-dashboard-sessionsecret",
-      },
-    },
-  },
-  Object {
-    "name": "OIDC_CLIENT_ID",
-    "valueFrom": Object {
-      "secretKeyRef": Object {
-        "key": "client_id",
-        "name": "gardener-dashboard-oidc",
-      },
-    },
-  },
-  Object {
-    "name": "GITHUB_AUTHENTICATION_APP_ID",
-    "valueFrom": Object {
-      "secretKeyRef": Object {
-        "key": "authentication.appId",
-        "name": "gardener-dashboard-github",
-      },
-    },
-  },
-  Object {
-    "name": "GITHUB_AUTHENTICATION_CLIENT_ID",
-    "valueFrom": Object {
-      "secretKeyRef": Object {
-        "key": "authentication.clientId",
-        "name": "gardener-dashboard-github",
-      },
-    },
-  },
-  Object {
-    "name": "GITHUB_AUTHENTICATION_CLIENT_SECRET",
-    "valueFrom": Object {
-      "secretKeyRef": Object {
-        "key": "authentication.clientSecret",
-        "name": "gardener-dashboard-github",
-      },
-    },
-  },
-  Object {
-    "name": "GITHUB_AUTHENTICATION_INSTALLATION_ID",
-    "valueFrom": Object {
-      "secretKeyRef": Object {
-        "key": "authentication.installationId",
-        "name": "gardener-dashboard-github",
-      },
-    },
-  },
-  Object {
-    "name": "GITHUB_AUTHENTICATION_PRIVATE_KEY",
-    "valueFrom": Object {
-      "secretKeyRef": Object {
-        "key": "authentication.privateKey",
-        "name": "gardener-dashboard-github",
-      },
-    },
-  },
-  Object {
-    "name": "GITHUB_WEBHOOK_SECRET",
-    "valueFrom": Object {
-      "secretKeyRef": Object {
-        "key": "webhookSecret",
-        "name": "gardener-dashboard-github",
-      },
-    },
-  },
-  Object {
-    "name": "GARDENER_CONFIG",
-    "value": "/etc/gardener-dashboard/config.yaml",
-  },
-  Object {
-    "name": "METRICS_PORT",
-    "value": "9050",
-  },
-  Object {
-    "name": "POD_NAME",
-    "valueFrom": Object {
-      "fieldRef": Object {
-        "fieldPath": "metadata.name",
-      },
-    },
-  },
-  Object {
-    "name": "POD_NAMESPACE",
-    "valueFrom": Object {
-      "fieldRef": Object {
-        "fieldPath": "metadata.namespace",
-      },
-    },
-  },
-]
-`;
-
 exports[`gardener-dashboard deployment kubeconfig should render the template 1`] = `
 Object {
   "name": "gardener-dashboard-secret-kubeconfig",
@@ -153,6 +52,18 @@ Array [
     },
     "name": "gardener-dashboard-login-config",
   },
+  Object {
+    "name": "gardener-dashboard-sessionsecret",
+    "secret": Object {
+      "secretName": "gardener-dashboard-sessionsecret",
+    },
+  },
+  Object {
+    "name": "gardener-dashboard-oidc",
+    "secret": Object {
+      "secretName": "gardener-dashboard-oidc",
+    },
+  },
 ]
 `;
 
@@ -167,38 +78,21 @@ Array [
     "name": "gardener-dashboard-login-config",
     "subPath": "login-config.json",
   },
+  Object {
+    "mountPath": "/etc/gardener-dashboard/secrets/session",
+    "name": "gardener-dashboard-sessionsecret",
+    "readOnly": true,
+  },
+  Object {
+    "mountPath": "/etc/gardener-dashboard/secrets/oidc",
+    "name": "gardener-dashboard-oidc",
+    "readOnly": true,
+  },
 ]
 `;
 
 exports[`gardener-dashboard deployment should render the template w/ \`client_secret\` 1`] = `
 Array [
-  Object {
-    "name": "SESSION_SECRET",
-    "valueFrom": Object {
-      "secretKeyRef": Object {
-        "key": "keyValue",
-        "name": "gardener-dashboard-sessionsecret",
-      },
-    },
-  },
-  Object {
-    "name": "OIDC_CLIENT_ID",
-    "valueFrom": Object {
-      "secretKeyRef": Object {
-        "key": "client_id",
-        "name": "gardener-dashboard-oidc",
-      },
-    },
-  },
-  Object {
-    "name": "OIDC_CLIENT_SECRET",
-    "valueFrom": Object {
-      "secretKeyRef": Object {
-        "key": "client_secret",
-        "name": "gardener-dashboard-oidc",
-      },
-    },
-  },
   Object {
     "name": "GARDENER_CONFIG",
     "value": "/etc/gardener-dashboard/config.yaml",
@@ -228,24 +122,6 @@ Array [
 
 exports[`gardener-dashboard deployment should render the template w/o \`client_secret\` 1`] = `
 Array [
-  Object {
-    "name": "SESSION_SECRET",
-    "valueFrom": Object {
-      "secretKeyRef": Object {
-        "key": "keyValue",
-        "name": "gardener-dashboard-sessionsecret",
-      },
-    },
-  },
-  Object {
-    "name": "OIDC_CLIENT_ID",
-    "valueFrom": Object {
-      "secretKeyRef": Object {
-        "key": "client_id",
-        "name": "gardener-dashboard-oidc",
-      },
-    },
-  },
   Object {
     "name": "GARDENER_CONFIG",
     "value": "/etc/gardener-dashboard/config.yaml",
@@ -324,24 +200,6 @@ Object {
             ],
             "env": Array [
               Object {
-                "name": "SESSION_SECRET",
-                "valueFrom": Object {
-                  "secretKeyRef": Object {
-                    "key": "keyValue",
-                    "name": "gardener-dashboard-sessionsecret",
-                  },
-                },
-              },
-              Object {
-                "name": "OIDC_CLIENT_ID",
-                "valueFrom": Object {
-                  "secretKeyRef": Object {
-                    "key": "client_id",
-                    "name": "gardener-dashboard-oidc",
-                  },
-                },
-              },
-              Object {
                 "name": "GARDENER_CONFIG",
                 "value": "/etc/gardener-dashboard/config.yaml",
               },
@@ -419,8 +277,18 @@ Object {
                 "subPath": "login-config.json",
               },
               Object {
+                "mountPath": "/etc/gardener-dashboard/secrets/session",
+                "name": "gardener-dashboard-sessionsecret",
+                "readOnly": true,
+              },
+              Object {
                 "mountPath": "/var/run/secrets/projected/serviceaccount",
                 "name": "service-account-token",
+                "readOnly": true,
+              },
+              Object {
+                "mountPath": "/etc/gardener-dashboard/secrets/oidc",
+                "name": "gardener-dashboard-oidc",
                 "readOnly": true,
               },
             ],
@@ -456,6 +324,18 @@ Object {
             "name": "gardener-dashboard-login-config",
           },
           Object {
+            "name": "gardener-dashboard-sessionsecret",
+            "secret": Object {
+              "secretName": "gardener-dashboard-sessionsecret",
+            },
+          },
+          Object {
+            "name": "gardener-dashboard-oidc",
+            "secret": Object {
+              "secretName": "gardener-dashboard-oidc",
+            },
+          },
+          Object {
             "name": "service-account-token",
             "projected": Object {
               "sources": Array [
@@ -485,69 +365,21 @@ Array [
 ]
 `;
 
-exports[`gardener-dashboard deployment when github is configured token authentication should render GITHUB environment variable 1`] = `
-Array [
-  Object {
-    "name": "SESSION_SECRET",
-    "valueFrom": Object {
-      "secretKeyRef": Object {
-        "key": "keyValue",
-        "name": "gardener-dashboard-sessionsecret",
-      },
-    },
+exports[`gardener-dashboard deployment when github is configured should render github secret volume and volumeMount 1`] = `
+Object {
+  "name": "gardener-dashboard-github",
+  "secret": Object {
+    "secretName": "gardener-dashboard-github",
   },
-  Object {
-    "name": "OIDC_CLIENT_ID",
-    "valueFrom": Object {
-      "secretKeyRef": Object {
-        "key": "client_id",
-        "name": "gardener-dashboard-oidc",
-      },
-    },
-  },
-  Object {
-    "name": "GITHUB_AUTHENTICATION_TOKEN",
-    "valueFrom": Object {
-      "secretKeyRef": Object {
-        "key": "authentication.token",
-        "name": "gardener-dashboard-github",
-      },
-    },
-  },
-  Object {
-    "name": "GITHUB_WEBHOOK_SECRET",
-    "valueFrom": Object {
-      "secretKeyRef": Object {
-        "key": "webhookSecret",
-        "name": "gardener-dashboard-github",
-      },
-    },
-  },
-  Object {
-    "name": "GARDENER_CONFIG",
-    "value": "/etc/gardener-dashboard/config.yaml",
-  },
-  Object {
-    "name": "METRICS_PORT",
-    "value": "9050",
-  },
-  Object {
-    "name": "POD_NAME",
-    "valueFrom": Object {
-      "fieldRef": Object {
-        "fieldPath": "metadata.name",
-      },
-    },
-  },
-  Object {
-    "name": "POD_NAMESPACE",
-    "valueFrom": Object {
-      "fieldRef": Object {
-        "fieldPath": "metadata.namespace",
-      },
-    },
-  },
-]
+}
+`;
+
+exports[`gardener-dashboard deployment when github is configured should render github secret volume and volumeMount 2`] = `
+Object {
+  "mountPath": "/etc/gardener-dashboard/secrets/github",
+  "name": "gardener-dashboard-github",
+  "readOnly": true,
+}
 `;
 
 exports[`gardener-dashboard deployment when virtual garden is enabled should render the template 1`] = `

--- a/charts/__tests__/gardener-dashboard/runtime/dashboard/__snapshots__/secrets.spec.js.snap
+++ b/charts/__tests__/gardener-dashboard/runtime/dashboard/__snapshots__/secrets.spec.js.snap
@@ -89,7 +89,7 @@ exports[`gardener-dashboard secret-sessionSecret should render the template with
 Object {
   "apiVersion": "v1",
   "data": Object {
-    "keyValue": "c2Vzc2lvblNlY3JldA==",
+    "sessionSecret": "c2Vzc2lvblNlY3JldA==",
   },
   "kind": "Secret",
   "metadata": Object {

--- a/charts/__tests__/gardener-dashboard/runtime/dashboard/deployment.spec.js
+++ b/charts/__tests__/gardener-dashboard/runtime/dashboard/deployment.spec.js
@@ -203,17 +203,17 @@ describe('gardener-dashboard', function () {
         const [deployment] = documents
         expect(deployment.spec.template.spec.automountServiceAccountToken).toBe(false)
         const volumes = deployment.spec.template.spec.volumes
-        expect(volumes).toHaveLength(4)
-        const [, , , kubeconfigVolume] = volumes
+        expect(volumes).toHaveLength(6)
+        const [, , , , , kubeconfigVolume] = volumes
         expect(kubeconfigVolume).toMatchSnapshot()
         const containers = deployment.spec.template.spec.containers
         expect(containers).toHaveLength(1)
         const [container] = containers
-        expect(container.volumeMounts).toHaveLength(4)
-        const [, , , kubeconfigVolumeMount] = container.volumeMounts
+        expect(container.volumeMounts).toHaveLength(6)
+        const [, , , , kubeconfigVolumeMount] = container.volumeMounts
         expect(kubeconfigVolumeMount).toMatchSnapshot()
-        expect(container.env).toHaveLength(7)
-        const [, , , kubeconfigEnv] = container.env
+        expect(container.env).toHaveLength(5)
+        const [, kubeconfigEnv] = container.env
         expect(kubeconfigEnv).toMatchSnapshot()
       })
     })
@@ -232,12 +232,12 @@ describe('gardener-dashboard', function () {
       expect(documents).toHaveLength(1)
       const [deployment] = documents
       const volumes = deployment.spec.template.spec.volumes
-      expect(volumes).toHaveLength(2)
+      expect(volumes).toHaveLength(4)
       expect(volumes).toMatchSnapshot()
       const containers = deployment.spec.template.spec.containers
       expect(containers).toHaveLength(1)
       const [container] = containers
-      expect(container.volumeMounts).toHaveLength(2)
+      expect(container.volumeMounts).toHaveLength(4)
       expect(container.volumeMounts).toMatchSnapshot()
     })
 
@@ -262,14 +262,14 @@ describe('gardener-dashboard', function () {
         const [deployment] = documents
         expect(deployment.spec.template.spec.serviceAccountName).toEqual('gardener-dashboard')
         const volumes = deployment.spec.template.spec.volumes
-        expect(volumes).toHaveLength(3)
-        const [, , serviceAccountTokenVolume] = volumes
+        expect(volumes).toHaveLength(5)
+        const [, , , , serviceAccountTokenVolume] = volumes
         expect(serviceAccountTokenVolume).toMatchSnapshot()
         const containers = deployment.spec.template.spec.containers
         expect(containers).toHaveLength(1)
         const [container] = containers
-        expect(container.volumeMounts).toHaveLength(3)
-        const [, , serviceAccountTokenVolumeMount] = container.volumeMounts
+        expect(container.volumeMounts).toHaveLength(5)
+        const [, , , serviceAccountTokenVolumeMount] = container.volumeMounts
         expect(serviceAccountTokenVolumeMount).toMatchSnapshot()
       })
 
@@ -311,57 +311,29 @@ describe('gardener-dashboard', function () {
         expect(documents).toHaveLength(1)
         const [deployment] = documents
         const volumes = deployment.spec.template.spec.volumes
-        expect(volumes).toHaveLength(4)
-        const [, , , kubeconfigVolume] = volumes
+        expect(volumes).toHaveLength(6)
+        const [, , , , , kubeconfigVolume] = volumes
         expect(kubeconfigVolume).toMatchSnapshot()
         const containers = deployment.spec.template.spec.containers
         expect(containers).toHaveLength(1)
         const [container] = containers
-        expect(container.volumeMounts).toHaveLength(4)
-        const [, , , kubeconfigVolumeMount] = container.volumeMounts
+        expect(container.volumeMounts).toHaveLength(6)
+        const [, , , , kubeconfigVolumeMount] = container.volumeMounts
         expect(kubeconfigVolumeMount).toMatchSnapshot()
-        expect(container.env).toHaveLength(7)
-        const [, , , kubeconfigEnv] = container.env
+        expect(container.env).toHaveLength(5)
+        const [, kubeconfigEnv] = container.env
         expect(kubeconfigEnv).toMatchSnapshot()
       })
     })
 
     describe('when github is configured', function () {
-      describe('token authentication', function () {
-        it('should render GITHUB environment variable', async function () {
-          const values = {
-            global: {
-              dashboard: {
-                gitHub: {
-                  authentication: {
-                    token: 'token'
-                  }
-                }
-              }
-            }
-          }
-          const documents = await renderTemplates(templates, values)
-          expect(documents).toHaveLength(1)
-          const [deployment] = documents
-          const dashboardContainer = deployment.spec.template.spec.containers[0]
-          expect(dashboardContainer.name).toEqual('gardener-dashboard')
-          expect(dashboardContainer.env).toMatchSnapshot()
-        })
-      })
-    })
-
-    describe('github app authentication', function () {
-      it('should render GITHUB environment variables', async function () {
+      it('should render github secret volume and volumeMount', async function () {
         const values = {
           global: {
             dashboard: {
               gitHub: {
                 authentication: {
-                  appId: 1,
-                  clientId: 'lv1.12ab',
-                  clientSecret: '12abcd',
-                  installationId: 123,
-                  privateKey: 'key'
+                  token: 'foo'
                 }
               }
             }
@@ -372,7 +344,16 @@ describe('gardener-dashboard', function () {
         const [deployment] = documents
         const dashboardContainer = deployment.spec.template.spec.containers[0]
         expect(dashboardContainer.name).toEqual('gardener-dashboard')
-        expect(dashboardContainer.env).toMatchSnapshot()
+        const volumes = deployment.spec.template.spec.volumes
+        expect(volumes).toHaveLength(6)
+        const [, , , , githubVolume] = volumes
+        expect(githubVolume).toMatchSnapshot()
+        const containers = deployment.spec.template.spec.containers
+        expect(containers).toHaveLength(1)
+        const [container] = containers
+        expect(container.volumeMounts).toHaveLength(6)
+        const [, , , , , githubVolumeMount] = container.volumeMounts
+        expect(githubVolumeMount).toMatchSnapshot()
       })
     })
   })

--- a/charts/gardener-dashboard/charts/runtime/templates/dashboard/deployment.yaml
+++ b/charts/gardener-dashboard/charts/runtime/templates/dashboard/deployment.yaml
@@ -72,11 +72,24 @@ spec:
           - key: login-config.json
             path: login-config.json
           defaultMode: 0444
+      - name: gardener-dashboard-sessionsecret
+        secret:
+          secretName: gardener-dashboard-sessionsecret
       {{- if .Values.global.dashboard.frontendConfig.assets }}
       - name: assets
         configMap:
           name: dashboard-assets
           defaultMode: 0444
+      {{- end }}
+      {{- if .Values.global.dashboard.oidc }}
+      - name: gardener-dashboard-oidc
+        secret:
+          secretName: gardener-dashboard-oidc
+      {{- end }}
+      {{- if .Values.global.dashboard.gitHub }}
+      - name: gardener-dashboard-github
+        secret:
+          secretName: gardener-dashboard-github
       {{- end }}
       {{- if .Values.global.dashboard.serviceAccountTokenVolumeProjection.enabled }}
       - name: service-account-token
@@ -159,72 +172,6 @@ spec:
             failureThreshold: {{ .Values.global.dashboard.readinessProbe.failureThreshold }}
           {{- end }}
           env:
-          - name: SESSION_SECRET
-            valueFrom:
-              secretKeyRef:
-                name: gardener-dashboard-sessionsecret
-                key: keyValue
-          {{- if .Values.global.dashboard.oidc }}
-          - name: OIDC_CLIENT_ID
-            valueFrom:
-              secretKeyRef:
-                name: gardener-dashboard-oidc
-                key: client_id
-          {{- if .Values.global.dashboard.oidc.clientSecret }}
-          - name: OIDC_CLIENT_SECRET
-            valueFrom:
-              secretKeyRef:
-                name: gardener-dashboard-oidc
-                key: client_secret
-          {{- end }}
-          {{- if .Values.global.dashboard.oidc.caSecretKeyRef }}
-          - name: OIDC_CA
-            valueFrom:
-              secretKeyRef:
-                name: {{  required ".Values.global.dashboard.oidc.caSecretKeyRef.name is required" .Values.global.dashboard.oidc.caSecretKeyRef.name }}
-                key: {{ .Values.global.dashboard.oidc.caSecretKeyRef.key | default "ca.crt" }}
-          {{- end }}
-          {{- end }}
-          {{- if .Values.global.dashboard.gitHub }}
-          {{- if .Values.global.dashboard.gitHub.authentication.token }}
-          - name: GITHUB_AUTHENTICATION_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: gardener-dashboard-github
-                key: authentication.token
-          {{ else }}
-          - name: GITHUB_AUTHENTICATION_APP_ID
-            valueFrom:
-              secretKeyRef:
-                name: gardener-dashboard-github
-                key: authentication.appId
-          - name: GITHUB_AUTHENTICATION_CLIENT_ID
-            valueFrom:
-              secretKeyRef:
-                name: gardener-dashboard-github
-                key: authentication.clientId
-          - name: GITHUB_AUTHENTICATION_CLIENT_SECRET
-            valueFrom:
-              secretKeyRef:
-                name: gardener-dashboard-github
-                key: authentication.clientSecret
-          - name: GITHUB_AUTHENTICATION_INSTALLATION_ID
-            valueFrom:
-              secretKeyRef:
-                name: gardener-dashboard-github
-                key: authentication.installationId
-          - name: GITHUB_AUTHENTICATION_PRIVATE_KEY
-            valueFrom:
-              secretKeyRef:
-                name: gardener-dashboard-github
-                key: authentication.privateKey
-          {{ end }}
-          - name: GITHUB_WEBHOOK_SECRET
-            valueFrom:
-              secretKeyRef:
-                name: gardener-dashboard-github
-                key: webhookSecret
-          {{- end }}
           - name: GARDENER_CONFIG
             value: /etc/gardener-dashboard/config.yaml
           {{- if .Values.global.dashboard.kubeconfig }}
@@ -252,6 +199,9 @@ spec:
           - name: gardener-dashboard-login-config
             mountPath: /app/public/login-config.json
             subPath: login-config.json
+          - name: gardener-dashboard-sessionsecret
+            mountPath: /etc/gardener-dashboard/secrets/session
+            readOnly: true
           {{- if .Values.global.dashboard.frontendConfig.assets }}
           - name: assets
             mountPath: /app/public/static/assets
@@ -269,6 +219,16 @@ spec:
           {{- if .Values.global.dashboard.kubeconfig }}
           - name: gardener-dashboard-secret-kubeconfig
             mountPath: /etc/gardener-dashboard/secrets/kubeconfig
+            readOnly: true
+          {{- end }}
+          {{- if .Values.global.dashboard.oidc }}
+          - name: gardener-dashboard-oidc
+            mountPath: /etc/gardener-dashboard/secrets/oidc
+            readOnly: true
+          {{- end }}
+          {{- if .Values.global.dashboard.gitHub }}
+          - name: gardener-dashboard-github
+            mountPath: /etc/gardener-dashboard/secrets/github
             readOnly: true
           {{- end }}
       restartPolicy: Always

--- a/charts/gardener-dashboard/charts/runtime/templates/dashboard/secret-sessionSecret.yaml
+++ b/charts/gardener-dashboard/charts/runtime/templates/dashboard/secret-sessionSecret.yaml
@@ -12,5 +12,5 @@ metadata:
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 type: Opaque
 data:
-  keyValue: {{ required ".Values.global.dashboard.sessionSecret is required" (b64enc .Values.global.dashboard.sessionSecret) }}
+  sessionSecret: {{ required ".Values.global.dashboard.sessionSecret is required" (b64enc .Values.global.dashboard.sessionSecret) }}
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR refactors how Kubernetes secrets are provided to pods in order to comply with DISA STIG rule V-242415 which states "Secrets in Kubernetes must not be stored as environment variables".  

Key changes:
- Update pod specs to mount secrets as volumes instead of using `secretKeyRef` and `valueFrom` to expose as environment variables
- Modify application code to read secrets from mounted files instead of env vars

If you are not using the provided Helm chart to deploy the Gardener Dashboard (e.g. gardener operator), ensure secrets are mounted to the filesystem at the appropriate paths:
- OIDC client ID: `/etc/gardener-dashboard/secrets/oidc/client_id`
- OIDC client secret: `/etc/gardener-dashboard/secrets/oidc/client_secret`
- GitHub authentication app ID: `/etc/gardener-dashboard/secrets/github/authentication.appId`
- GitHub authentication client ID: `/etc/gardener-dashboard/secrets/github/authentication.clientId`
- GitHub authentication client secret: `/etc/gardener-dashboard/secrets/github/authentication.clientSecret`
- GitHub authentication installation ID: `/etc/gardener-dashboard/secrets/github/authentication.installationId`
- GitHub authentication private key: `/etc/gardener-dashboard/secrets/github/authentication.privateKey`
- GitHub authentication token: `/etc/gardener-dashboard/secrets/github/authentication.token`
- GitHub webhook secret: `/etc/gardener-dashboard/secrets/github/webhookSecret`

**Which issue(s) this PR fixes**:
Fixes #1816 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The Helm chart was adapted to mount Kubernetes secrets as read-only files instead of storing them as environment variables, in order to comply with DISA STIG V-242415.
```
