### PR TITLE
Update the component name from `dashboard` to `gardener-dashboard`

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -21,7 +21,7 @@ dashboard:
         - linux/amd64
         - linux/arm64
         dockerimages:
-          dashboard:
+          gardener-dashboard:
             inputs:
               repos:
                 source: ~ # default
@@ -66,7 +66,7 @@ dashboard:
               slack_cfg_name: 'scp_workspace'
         publish:
           dockerimages:
-            dashboard:
+            gardener-dashboard:
               image: europe-docker.pkg.dev/gardener-project/releases/gardener/dashboard
               tag_as_latest: true
               extra_push_targets: # may be dropped after all users updated to new registry


### PR DESCRIPTION
**What this PR does / why we need it**:
Similar to https://github.com/gardener/terminal-controller-manager/pull/294. See https://github.com/gardener/gardener/blob/a5714298df3366548b9cb82e26d28622e6cb7c76/imagevector/images.yaml#L43-L46

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The component name is changed from `dashboard` to `gardener-dashboard`.
```
