### PR TITLE
Remove check-docforge from pipeline_definitions

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -47,8 +47,6 @@ dashboard:
       steps:
         check:
           image: 'node:20-alpine3.18'
-        check-docforge:
-          image: 'golang:1.22.3'
     release:
       traits:
         version:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes check-docforge from pipeline_definitions so that docforge could be removed from repo

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
NONE
```
