### PR TITLE
Fix issue when no costObject is defined

### DIFF
--- a/frontend/src/components/dialogs/GProjectDialog.vue
+++ b/frontend/src/components/dialogs/GProjectDialog.vue
@@ -207,7 +207,7 @@ const costObjectDescriptionHtml = computed(() => {
   return transformHtml(description)
 })
 const costObjectRegex = computed(() => get(costObjectSettings.value, 'regex'))
-const costObjectErrorMessage = computed(() => get(costObjectSettings.value, 'errorMessage'))
+const costObjectErrorMessage = computed(() => get(costObjectSettings.value, 'errorMessage', ''))
 
 const isUniqueProjectName = withMessage(
   'A project with this name already exists',

--- a/frontend/src/views/GAdministration.vue
+++ b/frontend/src/views/GAdministration.vue
@@ -608,7 +608,7 @@ const costObjectRules = computed(() => {
 
   return {
     projectCostObject: withMessage(
-      () => get(configStore.costObjectSettings, 'errorMessage'),
+      () => get(configStore.costObjectSettings, 'errorMessage', ''),
       helpers.regex(new RegExp(pattern)),
     ),
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixed issue introduced with #1926 and #1934 where the following error is displayed in the console logs when no cost object is defined
```
Error: [@vuelidate/validators]: First parameter to "withMessage" should be string or a function returning a string, provided undefined
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
