### PR TITLE
Dockerfile: fix LegacyKeyValueFormat warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN yarn workspace @gardener-dashboard/monitor run test --coverage
 ############# node-scratch #############
 FROM scratch as node-scratch
 
-ENV NODE_ENV "production"
+ENV NODE_ENV="production"
 
 COPY --from=builder /volume /
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the following warning

```bash
LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 59)
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
