### PR TITLE
Fixes bug with project create and pins sass to 1.74.1

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -1367,7 +1367,7 @@ const RAW_RUNTIME_STATE =
           ["netmask", "npm:2.0.2"],\
           ["pinia", "virtual:8d919ffb8fd728f827df3f6a566e8e923223ffcec68f7450d83bbbc2dc25d6b8c987e111cbab484b209f253bdf2f2e00663b01a986262c44511128466462a76f#npm:2.1.7"],\
           ["rollup-plugin-visualizer", "virtual:8d919ffb8fd728f827df3f6a566e8e923223ffcec68f7450d83bbbc2dc25d6b8c987e111cbab484b209f253bdf2f2e00663b01a986262c44511128466462a76f#npm:5.12.0"],\
-          ["sass", "npm:1.77.8"],\
+          ["sass", "npm:1.74.1"],\
           ["semver", "npm:7.6.3"],\
           ["socket.io-client", "npm:4.7.5"],\
           ["splitpanes", "npm:3.1.5"],\
@@ -10323,10 +10323,10 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["sass", [\
-      ["npm:1.77.8", {\
-        "packageLocation": "./.yarn/cache/sass-npm-1.77.8-d0ad322666-2bfd627940.zip/node_modules/sass/",\
+      ["npm:1.74.1", {\
+        "packageLocation": "./.yarn/cache/sass-npm-1.74.1-8ef77a6612-4610257ee2.zip/node_modules/sass/",\
         "packageDependencies": [\
-          ["sass", "npm:1.77.8"],\
+          ["sass", "npm:1.74.1"],\
           ["chokidar", "npm:3.6.0"],\
           ["immutable", "npm:4.3.4"],\
           ["source-map-js", "npm:1.2.0"]\
@@ -11555,7 +11555,7 @@ const RAW_RUNTIME_STATE =
           ["lightningcss", null],\
           ["postcss", "npm:8.4.39"],\
           ["rollup", "npm:4.13.0"],\
-          ["sass", "npm:1.77.8"],\
+          ["sass", "npm:1.74.1"],\
           ["stylus", null],\
           ["sugarss", null],\
           ["terser", null]\

--- a/backend/lib/services/projects.js
+++ b/backend/lib/services/projects.js
@@ -40,7 +40,7 @@ exports.create = async function ({ user, body }) {
   const client = user.client
 
   const name = _.get(body, 'metadata.name')
-  _.set(body, 'metadata.namespace', `garden-${name}`)
+  _.set(body, 'spec.namespace', `garden-${name}`)
   let project = await client['core.gardener.cloud'].projects.create(body)
 
   const isProjectReady = ({ type, object: project }) => {

--- a/backend/test/__snapshots__/services.projects.spec.js.snap
+++ b/backend/test/__snapshots__/services.projects.spec.js.snap
@@ -4,6 +4,8 @@ exports[`services/projects #create should create a project and return it when re
 {
   "metadata": {
     "name": "foo",
+  },
+  "spec": {
     "namespace": "garden-foo",
   },
   "status": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -91,7 +91,7 @@
     "eslint-plugin-vue": "^9.23.0",
     "jsdom": "^24.0.0",
     "rollup-plugin-visualizer": "^5.12.0",
-    "sass": "^1.72.0",
+    "sass": "~1.74.1",
     "unplugin-fonts": "^1.1.1",
     "vite": "^5.1.6",
     "vite-plugin-compression": "^0.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -823,7 +823,7 @@ __metadata:
     netmask: "npm:^2.0.2"
     pinia: "npm:^2.1.7"
     rollup-plugin-visualizer: "npm:^5.12.0"
-    sass: "npm:^1.72.0"
+    sass: "npm:~1.74.1"
     semver: "npm:^7.6.0"
     socket.io-client: "npm:^4.7.5"
     splitpanes: "npm:^3.1.5"
@@ -8317,16 +8317,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sass@npm:^1.72.0":
-  version: 1.77.8
-  resolution: "sass@npm:1.77.8"
+"sass@npm:~1.74.1":
+  version: 1.74.1
+  resolution: "sass@npm:1.74.1"
   dependencies:
     chokidar: "npm:>=3.0.0 <4.0.0"
     immutable: "npm:^4.0.0"
     source-map-js: "npm:>=0.6.2 <2.0.0"
   bin:
     sass: sass.js
-  checksum: 10c0/2bfd62794070352c804f949e69bd8bb5b4ec846deeb924251b2c3f7b503170fb1ae186f513f0166907749eb34e0277dee747edcb78c886fb471aac01be1e864c
+  checksum: 10c0/4610257ee27823276ce4998a534b4ee9f313e5a0b3d3899e70e0f87096feeae4cd8dd3c2f765b52f57dd87f5dab22370ef63f95a837a189fbb9401396d5ce717
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**What this PR does / why we need it**:
* Namespace must be in project spec not metadata
* Do not Update sass until vuetify fixes https://github.com/vuetifyjs/vuetify/issues/20139 
**Which issue(s) this PR fixes**:
Fixes #2008 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
