### PR TITLE
Switch VPA's API version to `autoscaling.k8s.io/v1`

### DIFF
--- a/charts/__tests__/gardener-dashboard/runtime/dashboard/__snapshots__/vpa.spec.js.snap
+++ b/charts/__tests__/gardener-dashboard/runtime/dashboard/__snapshots__/vpa.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`gardener-dashboard vpa should render the template with default values 1`] = `
 {
-  "apiVersion": "autoscaling.k8s.io/v1beta2",
+  "apiVersion": "autoscaling.k8s.io/v1",
   "kind": "VerticalPodAutoscaler",
   "metadata": {
     "labels": {
@@ -50,7 +50,7 @@ exports[`gardener-dashboard vpa should render the template with default values 1
 
 exports[`gardener-dashboard vpa should render the template with overwritten values 1`] = `
 {
-  "apiVersion": "autoscaling.k8s.io/v1beta2",
+  "apiVersion": "autoscaling.k8s.io/v1",
   "kind": "VerticalPodAutoscaler",
   "metadata": {
     "labels": {

--- a/charts/gardener-dashboard/charts/runtime/templates/dashboard/vpa.yaml
+++ b/charts/gardener-dashboard/charts/runtime/templates/dashboard/vpa.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.global.dashboard.enabled }}
 {{- if .Values.global.dashboard.vpa }}
-apiVersion: autoscaling.k8s.io/v1beta2
+apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: gardener-dashboard-vpa


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
Similar to https://github.com/gardener/gardener-extension-shoot-cert-service/pull/284

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
chart: An issue causing the `controlledValues: RequestsOnly` field not to be set for the `gardener-dashboard-vpa` VPA is now fixed.
```
