### PR TITLE
Group Dev Dependencies for Monthly Updates and enable patch auto updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,7 +12,7 @@
   ],
   ignorePaths: [
     "**/node_modules/**",
-    "**/.yarn/**",
+    "**/.yarn/**"
   ],
   customManagers: [
     {
@@ -21,9 +21,18 @@
       fileMatch: ["^\.ci\/pipeline_definitions$"],
       matchStrings: ["image: ['\"]?(?<depName>.*?):(?<currentValue>.*?)['\"]?\\s"],
       datasourceTemplate: "docker"
-    },
+    }
   ],
   packageRules: [
+    {
+      matchDepTypes: ["devDependencies"],
+      groupName: "Monthly Dev Dependencies",
+      schedule: ["on the first day of the month"]
+    },
+    {
+      matchUpdateTypes: ["patch"],
+      automerge: true
+    },
     {
       // Ignore major updates for these dependencies until we support ES modules
       matchDatasources: ["npm"],


### PR DESCRIPTION
**What this PR does / why we need it**:

- This PR configures Renovate to group all JavaScript development dependencies into a single pull request that is scheduled to update on the first day of each month. 
- It also enables automerging for all patch updates to streamline the update process.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
