### PR TITLE
Bugfix: operation type `Create` and state `Succeeded` does to show succeeded icon

### DIFF
--- a/frontend/src/components/GShootStatus.vue
+++ b/frontend/src/components/GShootStatus.vue
@@ -31,7 +31,7 @@ SPDX-License-Identifier: Apache-2.0
                 v-bind="mergeProps(activatorProps, tooltipProps)"
                 density="comfortable"
                 variant="text"
-                :icon="true"
+                icon
               >
                 <v-progress-circular
                   v-if="showProgress"
@@ -41,7 +41,7 @@ SPDX-License-Identifier: Apache-2.0
                   :color="color"
                 >
                   <v-icon
-                    v-if="!!statusIcon"
+                    v-if="hasStatusIcon"
                     size="small"
                     :color="color"
                     :icon="statusIcon"
@@ -55,7 +55,7 @@ SPDX-License-Identifier: Apache-2.0
                 </v-progress-circular>
                 <template v-else>
                   <v-icon
-                    v-if="!!statusIcon"
+                    v-if="hasStatusIcon"
                     size="small"
                     :color="color"
                     :icon="statusIcon"
@@ -236,6 +236,9 @@ export default {
     isPending () {
       return this.operationState === 'Pending'
     },
+    isSucceeded () {
+      return this.operationState === 'Succeeded'
+    },
     isTypeCreate () {
       return this.operationType === 'Create'
     },
@@ -270,7 +273,7 @@ export default {
       if (this.isShootMarkedForDeletion) {
         return 'mdi-delete-clock'
       }
-      if (this.isTypeCreate) {
+      if (this.isTypeCreate && !this.isSucceeded) {
         return 'mdi-plus'
       }
       if (this.isError) {
@@ -280,6 +283,9 @@ export default {
         return 'mdi-alert-outline'
       }
       return undefined
+    },
+    hasStatusIcon () {
+      return !!this.statusIcon
     },
     statusTitle () {
       const statusTitle = []


### PR DESCRIPTION
recently introduced bug that caused clusters with last operation type `Create` and state `Succeeded` not to show the succeeded icon

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
NONE
```
