### PR TITLE
Enhance Migration Process: Consider All Seeds and Warn for Provider Mismatch

### DIFF
--- a/frontend/src/components/GSeedConfiguration.vue
+++ b/frontend/src/components/GSeedConfiguration.vue
@@ -48,7 +48,10 @@ import { useShootItem } from '@/composables/useShootItem'
 
 import { errorDetailsFromError } from '@/utils/error'
 
-import { map } from '@/lodash'
+import {
+  find,
+  map,
+} from '@/lodash'
 
 export default {
   components: {
@@ -70,8 +73,8 @@ export default {
     })
 
     const providerMismatch = computed(() => {
-      const selectedSeed = seedStore.seedList.find(seed => seed.metadata.name === seedName.value)
-      const sourceSeed = seedStore.seedList.find(seed => seed.metadata.name === shootSeedName.value)
+      const selectedSeed = find(seedStore.seedList, ['metadata.name', seedName.value])
+      const sourceSeed = find(seedStore.seedList, ['metadata.name', shootSeedName.value])
       if (!selectedSeed || !sourceSeed) {
         return false
       }

--- a/frontend/src/components/GSeedConfiguration.vue
+++ b/frontend/src/components/GSeedConfiguration.vue
@@ -48,10 +48,7 @@ import { useShootItem } from '@/composables/useShootItem'
 
 import { errorDetailsFromError } from '@/utils/error'
 
-import {
-  map,
-  filter,
-} from '@/lodash'
+import { map } from '@/lodash'
 
 export default {
   components: {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the seed selection process to consider all available seeds during Shoot migration, rather than filtering by provider type. It also adds a warning to inform users about potential provider mismatches and related network connectivity issues that could affect the migration.

**Which issue(s) this PR fixes**:
Fixes #2032

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Consider all seeds for Shoot migration and add warning for provider mismatch
```
