### PR TITLE
Fix vite warning

### DIFF
--- a/frontend/src/components/Secrets/GSecretDialogNetlify.vue
+++ b/frontend/src/components/Secrets/GSecretDialogNetlify.vue
@@ -38,9 +38,7 @@ SPDX-License-Identifier: Apache-2.0
         <p>
           Then base64 encode the token. For eg. if the generated token in 1234567890123456, use
         </p>
-        <p>
-          <pre>$ echo -n '1234567890123456789' | base64</pre>
-        </p>
+        <pre>$ echo -n '1234567890123456789' | base64</pre>
         <p>
           For details see
           <g-external-link url="https://docs.netlify.com/cli/get-started/#obtain-a-token-in-the-netlify-ui" />

--- a/frontend/src/components/Secrets/GSecretDialogNetlify.vue
+++ b/frontend/src/components/Secrets/GSecretDialogNetlify.vue
@@ -33,14 +33,14 @@ SPDX-License-Identifier: Apache-2.0
     <template #help-slot>
       <div>
         <p>
-          You need to provide an access token for Netlify to allow the dns-controller-manager to authenticate to Netlify DNS API.
+          You need to provide an access token for Netlify to allow the dns-controller-manager to authenticate with the Netlify DNS API.
         </p>
         <p>
-          Then base64 encode the token. For eg. if the generated token in 1234567890123456, use
+          Then, base64 encode the token. For example, if the generated token in 1234567890123456, use
         </p>
         <pre>$ echo -n '1234567890123456789' | base64</pre>
         <p>
-          For details see
+          For details, see
           <g-external-link url="https://docs.netlify.com/cli/get-started/#obtain-a-token-in-the-netlify-ui" />
         </p>
       </div>


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the following vite warning and also improves a help text

```bash
10:11:55 AM [vite] warning: <pre> cannot be child of <p>, according to HTML specifications. This can cause hydration errors or potentially disrupt future functionality.
40 |          </p>
41 |          <p>
42 |            <pre>$ echo -n '1234567890123456789' | base64</pre>
   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
43 |          </p>
44 |          <p>
  Plugin: vite:vue
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
