### PR TITLE
Support Multiple Cost Object Types in Configuration

### DIFF
--- a/backend/__fixtures__/projects.js
+++ b/backend/__fixtures__/projects.js
@@ -45,6 +45,7 @@ function getProject ({ name, namespace, uid, resourceVersion = '42', createdBy, 
   }
   if (costObject) {
     set(metadata, 'annotations["billing.gardener.cloud/costObject"]', costObject)
+    set(metadata, 'annotations["billing.gardener.cloud/costObjectType"]', 'CO')
   }
   return {
     metadata,

--- a/backend/lib/routes/config.js
+++ b/backend/lib/routes/config.js
@@ -50,7 +50,7 @@ function sanitizeFrontendConfig (frontendConfig) {
   const sanitizedFrontendConfig = _.cloneDeep(frontendConfig)
   const {
     alert = {},
-    costObject = {},
+    costObjects = [],
     sla = {},
     addonDefinition = {},
     accessRestriction: {
@@ -62,7 +62,9 @@ function sanitizeFrontendConfig (frontendConfig) {
   } = sanitizedFrontendConfig
 
   convertAndSanitize(alert, 'message')
-  convertAndSanitize(costObject, 'description')
+  for (const costObject of costObjects) {
+    convertAndSanitize(costObject, 'description')
+  }
   convertAndSanitize(sla, 'description')
   convertAndSanitize(addonDefinition, 'description')
   convertAndSanitize(resourceQuotaHelp, 'text')

--- a/charts/__tests__/gardener-dashboard/runtime/dashboard/__snapshots__/configmap.spec.js.snap
+++ b/charts/__tests__/gardener-dashboard/runtime/dashboard/__snapshots__/configmap.spec.js.snap
@@ -146,6 +146,22 @@ exports[`gardener-dashboard configmap controlPlaneHighAvailabilityHelp should re
 }
 `;
 
+exports[`gardener-dashboard configmap costObjects should render the template with costObjects configuration 1`] = `
+{
+  "frontend": {
+    "costObjects": [
+      {
+        "description": "Example Description",
+        "errorMessage": "Invalid cost object",
+        "regex": "^example.*$",
+        "title": "Cost Object",
+        "type": "CO",
+      },
+    ],
+  },
+}
+`;
+
 exports[`gardener-dashboard configmap experimental should render the template with experimental features 1`] = `
 {
   "frontend": {

--- a/charts/__tests__/gardener-dashboard/runtime/dashboard/configmap.spec.js
+++ b/charts/__tests__/gardener-dashboard/runtime/dashboard/configmap.spec.js
@@ -163,6 +163,34 @@ describe('gardener-dashboard', function () {
       })
     })
 
+    describe('costObjects', function () {
+      it('should render the template with costObjects configuration', async function () {
+        const values = {
+          global: {
+            dashboard: {
+              frontendConfig: {
+                costObjects: [
+                  {
+                    type: 'CO',
+                    title: 'Cost Object',
+                    description: 'Example Description',
+                    regex: '^example.*$',
+                    errorMessage: 'Invalid cost object'
+                  }
+                ]
+              }
+            }
+          }
+        }
+
+        const documents = await renderTemplates(templates, values)
+        expect(documents).toHaveLength(1)
+        const [configMap] = documents
+        const config = yaml.load(configMap.data['config.yaml'])
+        expect(pick(config, ['frontend.costObjects'])).toMatchSnapshot()
+      })
+    })
+
     describe('oidc', () => {
       let values
 

--- a/charts/gardener-dashboard/charts/runtime/templates/dashboard/configmap.yaml
+++ b/charts/gardener-dashboard/charts/runtime/templates/dashboard/configmap.yaml
@@ -261,12 +261,15 @@ data:
         identifier: {{ .Values.global.dashboard.frontendConfig.alert.identifier }}
         {{- end }}
       {{- end }}
-      {{- if .Values.global.dashboard.frontendConfig.costObject }}
-      costObject:
-        title: {{ .Values.global.dashboard.frontendConfig.costObject.title }}
-        description: {{ .Values.global.dashboard.frontendConfig.costObject.description }}
-        regex: {{ .Values.global.dashboard.frontendConfig.costObject.regex }}
-        errorMessage: {{ .Values.global.dashboard.frontendConfig.costObject.errorMessage }}
+      {{- if .Values.global.dashboard.frontendConfig.costObjects }}
+      costObjects:
+      {{- range .Values.global.dashboard.frontendConfig.costObjects }}
+      - type: {{ required ".Values.global.dashboard.frontendConfig.costObjects.type is required" (quote .type) }}
+        title: {{ required ".Values.global.dashboard.frontendConfig.costObjects.title is required" (quote .title) }}
+        description: {{ quote .description }}
+        regex: {{ quote .regex }}
+        errorMessage: {{ quote .errorMessage }}
+      {{- end }}
       {{- end }}
       {{- if .Values.global.dashboard.frontendConfig.sla }}
       sla:

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -273,8 +273,9 @@ global:
       #       - wide
       #   heartbeatIntervalSeconds: 60
 
-      # # costObject is used for billing purposes and is assigned to the gardener project
-      # costObject:
+      # # costObjects are used for billing purposes and the cost object and type is assigned to the gardener project
+      # costObjects:
+      # - type: CO
       #   title: Cost Object
       #   description: Costs for the control planes of the clusters in this project will be charged to this cost object.
       #   regex: ^([0-9]{10})$

--- a/frontend/__fixtures__/config.js
+++ b/frontend/__fixtures__/config.js
@@ -40,12 +40,15 @@ export default {
     maxExpirationSeconds: 86400,
   },
   seedCandidateDeterminationStrategy: 'MinimalDistance',
-  costObject: {
-    title: 'Cost Center',
-    description: 'Costs for the control planes of the clusters in this project will be charged to this cost center.',
-    regex: '^([0-9]{9,10})?$',
-    errorMessage: 'Must be a valid cost center',
-  },
+  costObjects: [
+    {
+      type: 'CO',
+      title: 'Cost Center',
+      description: 'Costs for the control planes of the clusters in this project will be charged to this cost center.',
+      regex: '^([0-9]{9,10})?$',
+      errorMessage: 'Must be a valid cost center',
+    },
+  ],
   sla: {
     title: 'Terms and Conditions',
     description: '<p><a href="https://gardener.cloud/terms-and-conditions" target="_blank">Terms and Conditions</a></p>',

--- a/frontend/src/components/GProjectCostObject.vue
+++ b/frontend/src/components/GProjectCostObject.vue
@@ -1,0 +1,106 @@
+<!--
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+<template>
+  <v-row v-if="costObjectsSettingEnabled">
+    <v-col cols="6">
+      <v-select
+        v-model="v$.costObjectType.$model"
+        :items="costObjectTypes"
+        label="Cost Object Type"
+        required
+        :error-messages="getErrorMessages(v$.costObjectType)"
+      />
+    </v-col>
+    <v-col cols="6">
+      <v-text-field
+        v-model="v$.costObject.$model"
+        variant="underlined"
+        color="primary"
+        label="Cost Object"
+        :error-messages="getErrorMessages(v$.costObject)"
+      />
+    </v-col>
+    <v-col
+      v-if="!!costObjectDescriptionHtml"
+      cols="12"
+    >
+      <v-alert
+        density="compact"
+        type="info"
+        variant="tonal"
+        color="primary"
+      >
+        <!-- eslint-disable vue/no-v-html -->
+        <div
+          class="alert-banner-message"
+          v-html="costObjectDescriptionHtml"
+        />
+        <!-- eslint-enable vue/no-v-html -->
+      </v-alert>
+    </v-col>
+  </v-row>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { useVuelidate } from '@vuelidate/core'
+import {
+  helpers,
+  requiredIf,
+} from '@vuelidate/validators'
+
+import { useProjectContext } from '@/composables/useProjectContext'
+import { useProjectCostObject } from '@/composables/useProjectCostObject'
+
+import { withMessage } from '@/utils/validators'
+import { getErrorMessages } from '@/utils'
+
+import { head } from '@/lodash'
+
+const {
+  projectManifest,
+  costObject,
+  costObjectType,
+} = useProjectContext()
+
+const {
+  costObjectsSettingEnabled,
+  costObjectTypes,
+  costObjectDescriptionHtml,
+  costObjectRegex,
+  costObjectErrorMessage,
+} = useProjectCostObject(projectManifest)
+
+if (!costObjectType.value) {
+  costObjectType.value = head(costObjectTypes.value)?.value
+}
+
+const isValidCostObject = computed(() => {
+  return withMessage(
+    costObjectErrorMessage.value,
+    helpers.withParams(
+      { type: 'regex', pattern: costObjectRegex.value },
+      helpers.regex(costObjectRegex.value),
+    ),
+  )
+})
+
+const rules = {
+  costObject: {
+    isValidCostObject,
+  },
+  costObjectType: {
+    requiredIf: requiredIf(() => !!costObject.value),
+  },
+}
+
+const v$ = useVuelidate(rules, { costObject, costObjectType })
+
+</script>
+
+<style lang="scss" scoped>
+</style>

--- a/frontend/src/components/GProjectCostObject.vue
+++ b/frontend/src/components/GProjectCostObject.vue
@@ -9,6 +9,7 @@ SPDX-License-Identifier: Apache-2.0
     <v-col cols="6">
       <v-select
         v-model="v$.costObjectType.$model"
+        variant="underlined"
         :items="costObjectTypes"
         label="Cost Object Type"
         required
@@ -101,6 +102,3 @@ const rules = {
 const v$ = useVuelidate(rules, { costObject, costObjectType })
 
 </script>
-
-<style lang="scss" scoped>
-</style>

--- a/frontend/src/components/GProjectCostObjectConfiguration.vue
+++ b/frontend/src/components/GProjectCostObjectConfiguration.vue
@@ -1,0 +1,73 @@
+<!--
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+<template>
+  <g-generic-action-button-dialog
+    ref="actionDialog"
+    width="450"
+    caption="Update Cost Object"
+    :can-perform-action="canPatchProject"
+    @before-dialog-opened="setProjectManifest(projectItem)"
+    @dialog-opened="onConfigurationDialogOpened"
+  >
+    <template #content>
+      <v-card-text>
+        <g-project-cost-object />
+      </v-card-text>
+    </template>
+  </g-generic-action-button-dialog>
+</template>
+
+<script setup>
+import {
+  inject,
+  ref,
+  toRef,
+} from 'vue'
+
+import { useAuthzStore } from '@/store/authz'
+import { useProjectStore } from '@/store/project'
+
+import GGenericActionButtonDialog from '@/components/dialogs/GGenericActionButtonDialog'
+import GProjectCostObject from '@/components/GProjectCostObject'
+
+import { useProjectContext } from '@/composables/useProjectContext'
+import { useProjectItem } from '@/composables/useProjectItem'
+
+import { errorDetailsFromError } from '@/utils/error'
+
+const authzStore = useAuthzStore()
+const projectStore = useProjectStore()
+
+const { projectItem } = useProjectItem()
+const { setProjectManifest, getCostObjectPatchDocument } = useProjectContext()
+
+const canPatchProject = toRef(authzStore, 'canPatchProject')
+const actionDialog = ref(null)
+
+const logger = inject('logger')
+
+async function onConfigurationDialogOpened () {
+  const confirmed = await actionDialog.value.waitForDialogClosed()
+  if (confirmed) {
+    await updateConfiguration()
+  }
+}
+
+async function updateConfiguration () {
+  try {
+    const patchDocument = getCostObjectPatchDocument()
+    await projectStore.patchProject(patchDocument)
+  } catch (err) {
+    const errorMessage = 'Could not update cost object'
+    const errorDetails = errorDetailsFromError(err)
+    const detailedErrorMessage = errorDetails.detailedMessage
+    actionDialog.value.setError({ errorMessage, detailedErrorMessage })
+    logger.error(errorMessage, errorDetails.errorCode, errorDetails.detailedMessage, err)
+  }
+}
+
+</script>

--- a/frontend/src/components/Secrets/GSelectSecret.vue
+++ b/frontend/src/components/Secrets/GSelectSecret.vue
@@ -135,8 +135,7 @@ export default {
 
     const projectItem = toRef(projectStore, 'project')
     const {
-      costObjectSettingEnabled,
-      costObjectTitle,
+      costObjectsSettingEnabled,
       costObjectErrorMessage,
     } = useProjectCostObject(projectItem)
 
@@ -150,8 +149,7 @@ export default {
 
     return {
       projectName,
-      costObjectSettingEnabled,
-      costObjectTitle,
+      costObjectsSettingEnabled,
       costObjectErrorMessage,
       v$,
     }
@@ -164,12 +162,11 @@ export default {
   },
   validations () {
     const projectName = this.projectName
-    const costObjectTitle = this.costObjectTitle
 
     const messageFn = ({ $model }) => {
       return projectName === get($model, 'metadata.projectName')
-        ? `${costObjectTitle} is required. Go to the ADMINISTRATION page to edit the project and set the ${costObjectTitle}.`
-        : `${costObjectTitle} is required and has to be set on the Project ${toUpper(projectName)}`
+        ? 'A Cost Object is required. Go to the ADMINISTRATION page to edit the project and set the Cost Object.'
+        : `A Cost Object is required and has to be set on the Project ${toUpper(projectName)}`
     }
 
     const requiresCostObjectIfEnabled = (enabled = false) => withParams(
@@ -184,7 +181,7 @@ export default {
     return {
       internalValue: withFieldName('Secret', {
         required,
-        requiresCostObjectIfEnabled: withMessage(messageFn, requiresCostObjectIfEnabled(this.costObjectSettingEnabled)),
+        requiresCostObjectIfEnabled: withMessage(messageFn, requiresCostObjectIfEnabled(this.costObjectsSettingEnabled)),
       }),
     }
   },

--- a/frontend/src/components/dialogs/GProjectDialog.vue
+++ b/frontend/src/components/dialogs/GProjectDialog.vue
@@ -31,31 +31,7 @@ SPDX-License-Identifier: Apache-2.0
           </v-col>
         </v-row>
 
-        <v-row v-if="costObjectSettingEnabled">
-          <v-col cols="12">
-            <v-text-field
-              v-model="v$.costObject.$model"
-              variant="underlined"
-              color="primary"
-              :label="costObjectTitle"
-              :error-messages="getErrorMessages(v$.costObject)"
-            />
-            <v-alert
-              v-if="!!costObjectDescriptionHtml"
-              density="compact"
-              type="info"
-              variant="tonal"
-              color="primary"
-            >
-              <!-- eslint-disable vue/no-v-html -->
-              <div
-                class="alert-banner-message"
-                v-html="costObjectDescriptionHtml"
-              />
-              <!-- eslint-enable vue/no-v-html -->
-            </v-alert>
-          </v-col>
-        </v-row>
+        <g-project-cost-object />
 
         <v-row>
           <v-col cols="12">
@@ -126,7 +102,6 @@ import { useVuelidate } from '@vuelidate/core'
 import {
   maxLength,
   required,
-  helpers,
 } from '@vuelidate/validators'
 import { useRouter } from 'vue-router'
 
@@ -134,10 +109,10 @@ import { useProjectStore } from '@/store/project'
 
 import GMessage from '@/components/GMessage.vue'
 import GToolbar from '@/components/GToolbar.vue'
+import GProjectCostObject from '@/components/GProjectCostObject.vue'
 
 import { useLogger } from '@/composables/useLogger'
 import { useProvideProjectContext } from '@/composables/useProjectContext'
-import { useProjectCostObject } from '@/composables/useProjectCostObject'
 
 import {
   messageFromErrors,
@@ -177,7 +152,6 @@ const {
   projectName,
   description,
   purpose,
-  costObject,
 } = useProvideProjectContext()
 
 const projectNames = toRef(projectStore, 'projectNames')
@@ -197,28 +171,12 @@ const loading = ref(false)
 
 const refProjectName = ref(null)
 
-const {
-  costObjectSettingEnabled,
-  costObjectTitle,
-  costObjectDescriptionHtml,
-  costObjectRegex,
-  costObjectErrorMessage,
-} = useProjectCostObject()
-
 const isUniqueProjectName = withMessage(
   'A project with this name already exists',
   value => !value ? true : !projectNames.value.includes(value),
 )
 
-const isValidCostObject = withMessage(
-  costObjectErrorMessage.value,
-  helpers.regex(costObjectRegex.value),
-)
-
 const rules = {
-  costObject: {
-    isValidCostObject,
-  },
   projectName: {
     required,
     maxLength: maxLength(10),
@@ -229,7 +187,7 @@ const rules = {
   },
 }
 
-const v$ = useVuelidate(rules, { projectName, costObject })
+const v$ = useVuelidate(rules, { projectName })
 
 watch(visible, value => {
   if (value) {

--- a/frontend/src/composables/useProjectContext.js
+++ b/frontend/src/composables/useProjectContext.js
@@ -107,7 +107,11 @@ export function createProjectContextComposable () {
   } = useProjectShootCustomFields(manifest)
 
   /* costObject */
-  const { costObject } = useProjectCostObject(manifest, { projectMetadataComposable })
+  const {
+    costObject,
+    costObjectType,
+    getCostObjectPatchDocument,
+  } = useProjectCostObject(manifest, { projectMetadataComposable })
 
   return {
     /* manifest */
@@ -136,6 +140,8 @@ export function createProjectContextComposable () {
     generateKeyFromName,
     /* costObject */
     costObject,
+    costObjectType,
+    getCostObjectPatchDocument,
   }
 }
 

--- a/frontend/src/composables/useProjectCostObject.js
+++ b/frontend/src/composables/useProjectCostObject.js
@@ -16,8 +16,10 @@ import { transformHtml } from '@/utils'
 import { useProjectMetadata } from './useProjectMetadata'
 
 import {
+  find,
   get,
   isEmpty,
+  map,
 } from '@/lodash'
 
 export const useProjectCostObject = (projectItem, options = {}) => {
@@ -27,8 +29,10 @@ export const useProjectCostObject = (projectItem, options = {}) => {
   } = options
 
   const {
+    projectName,
     getProjectAnnotation,
     setProjectAnnotation,
+    unsetProjectAnnotation,
   } = projectMetadataComposable
 
   const costObject = computed({
@@ -36,18 +40,41 @@ export const useProjectCostObject = (projectItem, options = {}) => {
       return getProjectAnnotation('billing.gardener.cloud/costObject')
     },
     set (value) {
-      setProjectAnnotation('billing.gardener.cloud/costObject', value)
+      if (value) {
+        setProjectAnnotation('billing.gardener.cloud/costObject', value)
+      } else {
+        unsetProjectAnnotation('billing.gardener.cloud/costObject')
+      }
     },
   })
 
-  const costObjectSettings = toRef(configStore, 'costObjectSettings')
+  const costObjectType = computed({
+    get () {
+      return getProjectAnnotation('billing.gardener.cloud/costObjectType')
+    },
+    set (value) {
+      setProjectAnnotation('billing.gardener.cloud/costObjectType', value)
+    },
+  })
 
-  const costObjectSettingEnabled = computed(() => !isEmpty(costObjectSettings.value))
+  const costObjectsSettings = toRef(configStore, 'costObjectsSettings')
+
+  const costObjectsSettingEnabled = computed(() => !isEmpty(costObjectsSettings.value))
+
+  const costObjectTypes = computed(() => {
+    return map(costObjectsSettings.value, ({ type, title }) => ({ value: type, title }))
+  })
+
+  const costObjectSettings = computed(() => {
+    return find(costObjectsSettings.value, ['type', costObjectType.value])
+  })
 
   const costObjectDescriptionHtml = computed(() => {
     const description = get(costObjectSettings.value, 'description')
     return transformHtml(description)
   })
+
+  const costObjectSettingsType = computed(() => get(costObjectSettings.value, 'type'))
 
   const costObjectTitle = computed(() => get(costObjectSettings.value, 'title'))
 
@@ -56,14 +83,30 @@ export const useProjectCostObject = (projectItem, options = {}) => {
     return new RegExp(pattern) // eslint-disable-line security/detect-non-literal-regexp
   })
 
-  const costObjectErrorMessage = computed(() => get(costObjectSettings.value, 'errorMessage', ''))
+  const costObjectErrorMessage = computed(() => get(costObjectSettings.value, 'errorMessage', 'Invalid cost object'))
+
+  function getCostObjectPatchDocument () {
+    return {
+      metadata: {
+        name: projectName.value,
+        annotations: {
+          'billing.gardener.cloud/costObject': getProjectAnnotation('billing.gardener.cloud/costObject', null),
+          'billing.gardener.cloud/costObjectType': getProjectAnnotation('billing.gardener.cloud/costObjectType', null),
+        },
+      },
+    }
+  }
 
   return {
     costObject,
-    costObjectSettingEnabled,
+    costObjectsSettingEnabled,
+    costObjectTypes,
+    costObjectType,
     costObjectDescriptionHtml,
+    costObjectSettingsType,
     costObjectTitle,
     costObjectRegex,
     costObjectErrorMessage,
+    getCostObjectPatchDocument,
   }
 }

--- a/frontend/src/composables/useProjectItem.js
+++ b/frontend/src/composables/useProjectItem.js
@@ -48,7 +48,8 @@ export function createProjectItemComposable (projectItem) {
   /* costObject */
   const {
     costObject,
-    costObjectSettingEnabled,
+    costObjectType,
+    costObjectsSettingEnabled,
     costObjectDescriptionHtml,
     costObjectTitle,
     costObjectRegex,
@@ -106,7 +107,8 @@ export function createProjectItemComposable (projectItem) {
     projectPhase,
     /* costObject */
     costObject,
-    costObjectSettingEnabled,
+    costObjectType,
+    costObjectsSettingEnabled,
     costObjectDescriptionHtml,
     costObjectTitle,
     costObjectRegex,

--- a/frontend/src/store/config.js
+++ b/frontend/src/store/config.js
@@ -19,6 +19,7 @@ import { useApi } from '@/composables/useApi'
 import { hash } from '@/utils/crypto'
 
 import {
+  map,
   get,
   isEmpty,
   camelCase,
@@ -304,23 +305,27 @@ export const useConfigStore = defineStore('config', () => {
     return `cfg.${identifier}`
   })
 
-  const costObjectSettings = computed(() => {
-    const costObject = state.value?.costObject
-    if (!costObject) {
+  const costObjectsSettings = computed(() => {
+    const costObjects = state.value?.costObjects
+    if (!costObjects) {
       return undefined
     }
 
-    const title = costObject.title || ''
-    const description = costObject.description || ''
-    const regex = costObject.regex
-    const errorMessage = costObject.errorMessage
+    return map(costObjects, costObject => {
+      const type = costObject.type || ''
+      const title = costObject.title || ''
+      const description = costObject.description || ''
+      const regex = costObject.regex
+      const errorMessage = costObject.errorMessage
 
-    return {
-      regex,
-      title,
-      description,
-      errorMessage,
-    }
+      return {
+        type,
+        regex,
+        title,
+        description,
+        errorMessage,
+      }
+    })
   })
 
   const appVersion = computed(() => {
@@ -414,7 +419,7 @@ export const useConfigStore = defineStore('config', () => {
     alertBannerMessage,
     alertBannerType,
     alertBannerIdentifier,
-    costObjectSettings,
+    costObjectsSettings,
     purposeRequiresHibernationSchedule,
     isShootHasNoHibernationScheduleWarning,
     fetchConfig,

--- a/frontend/src/views/GAdministration.vue
+++ b/frontend/src/views/GAdministration.vue
@@ -305,7 +305,7 @@ SPDX-License-Identifier: Apache-2.0
             </v-card>
           </v-col>
           <v-col
-            v-if="costObjectSettingEnabled"
+            v-if="costObjectsSettingEnabled"
             class="pa-3"
           >
             <v-card>
@@ -319,38 +319,21 @@ SPDX-License-Identifier: Apache-2.0
                     />
                   </template>
                   <div class="text-body-2 text-medium-emphasis">
-                    {{ costObjectTitle }}
+                    {{ costObjectTitle || "Cost Object" }}
                   </div>
-                  <div class="text-body-1 wrap-text">
-                    <g-editable-text
-                      :read-only="!canPatchProject"
-                      color="action-button"
-                      :model-value="costObject"
-                      :rules="costObjectRules"
-                      :save="updateCostObject"
-                    >
-                      <template
-                        v-if="costObjectDescriptionHtml"
-                        #info
-                      >
-                        <v-alert
-                          icon="mdi-information-outline"
-                          density="compact"
-                          variant="tonal"
-                          rounded="0"
-                          :color="color"
-                          class="mb-0"
-                        >
-                          <!-- eslint-disable vue/no-v-html -->
-                          <div
-                            class="alertBannerMessage"
-                            v-html="costObjectDescriptionHtml"
-                          />
-                          <!-- eslint-enable vue/no-v-html -->
-                        </v-alert>
-                      </template>
-                    </g-editable-text>
+                  <div
+                    v-if="costObject"
+                    class="text-body-1 wrap-text"
+                  >
+                    {{ costObject }}
                   </div>
+                  <span
+                    v-else
+                    class="font-weight-light text-disabled"
+                  >Not defined</span>
+                  <template #append>
+                    <g-project-cost-object-configuration />
+                  </template>
                 </g-list-item>
               </g-list>
             </v-card>
@@ -523,6 +506,7 @@ import GAccountAvatar from '@/components/GAccountAvatar.vue'
 import GDialog from '@/components/dialogs/GDialog.vue'
 import GTimeString from '@/components/GTimeString.vue'
 import GShootCustomField from '@/components/GShootCustomField.vue'
+import GProjectCostObjectConfiguration from '@/components/GProjectCostObjectConfiguration.vue'
 import GShootCustomFieldsConfiguration from '@/components/GShootCustomFieldsConfiguration.vue'
 import GResourceQuotaHelp from '@/components/GResourceQuotaHelp.vue'
 import GTextRouterLink from '@/components/GTextRouterLink.vue'
@@ -579,11 +563,8 @@ const {
   projectStaleSinceTimestamp: staleSinceTimestamp,
   projectStaleAutoDeleteTimestamp: staleAutoDeleteTimestamp,
   costObject,
-  costObjectSettingEnabled,
+  costObjectsSettingEnabled,
   costObjectTitle,
-  costObjectDescriptionHtml,
-  costObjectRegex,
-  costObjectErrorMessage,
 } = useProvideProjectItem(project)
 
 const {
@@ -607,11 +588,7 @@ const userList = computed(() => {
   }
   return Array.from(members)
 })
-const isValidCostObject = withMessage(
-  costObjectErrorMessage.value,
-  helpers.regex(costObjectRegex.value),
-)
-const costObjectRules = computed(() => ({ costObject: isValidCostObject }))
+
 const ownerRules = computed(() => {
   const userListIncludesValidator = helpers.withParams(
     { type: 'userListIncludes' },
@@ -663,17 +640,6 @@ function updatePurpose (value) {
   return updateProperty('purpose', value)
 }
 
-function updateCostObject (value) {
-  if (costObjectSettingEnabled.value) {
-    if (!value) {
-      value = null
-    }
-    return updateProperty('costObject', value, {
-      error: 'Failed to update billing information of project',
-    })
-  }
-}
-
 async function updateProperty (key, value, options = {}) {
   const { metadata: { name }, spec: { namespace } } = projectStore.project
   try {
@@ -681,14 +647,7 @@ async function updateProperty (key, value, options = {}) {
       metadata: { name },
       spec: { namespace },
     }
-    switch (key) {
-      case 'costObject':
-        set(mergePatchDocument, ['metadata', 'annotations', 'billing.gardener.cloud/costObject'], value)
-        break
-      default:
-        set(mergePatchDocument, ['spec', key], value)
-        break
-    }
+    set(mergePatchDocument, ['spec', key], value)
     await projectStore.patchProject(mergePatchDocument)
   } catch (err) {
     const { error = `Failed to update project ${key}` } = options


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enhances the existing cost object configuration by allowing administrators to define multiple cost object types. Users can then select from these predefined types in the UI. The update introduces a dropdown menu where users can choose between different cost object types configured by the administrator.

Previously, the cost object value was stored under `annotations["billing.gardener.cloud/costObject"]` on the `Project`. With this update, the newly introduced type is stored under `annotations["billing.gardener.cloud/costObjectType"]`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:


**Release note**:
```breaking operator
Cost Object: You must migrate existing configurations to the new format. Previously, the configuration used `Values.global.dashboard.frontendConfig.costObject`. It should now be updated to `Values.global.dashboard.frontendConfig.costObjects`, which is a list of objects. Each object in this list must include a `type` property, alongside existing properties such as `title`, `description`, and `regex`.
```
```feature operator
Enhanced cost object configuration to support multiple cost object types. The selected type is now stored under `Project.annotations["billing.gardener.cloud/costObjectType"]`.
```