### PR TITLE
Use `scss` api `modern-compiler`

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -165,6 +165,9 @@ export default defineConfig(({ command, mode }) => {
         sass: {
           api: 'modern-compiler',
         },
+        scss: {
+          api: 'modern-compiler',
+        },
       },
     },
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the following warning when running `yarn build`:

Deprecation Warning: The legacy JS API is deprecated and will be removed in Dart Sass 2.0.0.

More info: https://sass-lang.com/d/legacy-js-api

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
