### PR TITLE
Move GShootListRowActions from GShootListRow to GShootList component

### DIFF
--- a/frontend/src/components/GShootListRow.vue
+++ b/frontend/src/components/GShootListRow.vue
@@ -202,10 +202,13 @@ SPDX-License-Identifier: Apache-2.0
             icon="mdi-key"
             :disabled="isClusterAccessDialogDisabled"
             :tooltip="showClusterAccessActionTitle"
-            @click="showDialog('access')"
+            @click="triggerAction('access')"
           />
-          <g-shoot-list-row-actions
+          <g-action-button
             v-if="canPatchShoots"
+            icon="mdi-dots-vertical"
+            tooltip="Cluster Actions"
+            @click="triggerAction('menu', $event)"
           />
         </v-row>
       </template>
@@ -255,7 +258,6 @@ import GShootVersionChip from '@/components/ShootVersion/GShootVersionChip.vue'
 import GTicketLabel from '@/components/ShootTickets/GTicketLabel.vue'
 import GShootSeedName from '@/components/GShootSeedName.vue'
 import GShootMessages from '@/components/ShootMessages/GShootMessages.vue'
-import GShootListRowActions from '@/components/GShootListRowActions.vue'
 import GAutoHide from '@/components/GAutoHide.vue'
 import GExternalLink from '@/components/GExternalLink.vue'
 import GControlPlaneHighAvailabilityTag from '@/components/ControlPlaneHighAvailability/GControlPlaneHighAvailabilityTag.vue'
@@ -290,7 +292,7 @@ const props = defineProps({
 const shootItem = toRef(props, 'modelValue')
 
 const emit = defineEmits([
-  'showDialog',
+  'triggerAction',
 ])
 
 const shootStore = useShootStore()
@@ -426,10 +428,11 @@ const cells = computed(() => {
   })
 })
 
-function showDialog (action) {
-  emit('showDialog', {
+function triggerAction (action, e) {
+  emit('triggerAction', {
     action,
-    shootItem: shootItem.value,
+    item: shootItem.value,
+    target: e.target,
   })
 }
 

--- a/frontend/src/components/GShootListRowActions.vue
+++ b/frontend/src/components/GShootListRowActions.vue
@@ -6,21 +6,15 @@ SPDX-License-Identifier: Apache-2.0
 
 <template>
   <v-menu
-    v-model="menu"
+    v-model="visible"
     location="left"
     :close-on-content-click="false"
     eager
+    :activator="activator"
   >
-    <template #activator="{ props }">
-      <g-action-button
-        v-bind="props"
-        icon="mdi-dots-vertical"
-        tooltip="Cluster Actions"
-      />
-    </template>
     <v-list
       dense
-      @click.capture="menu = false"
+      @click.capture="visible = false"
     >
       <v-list-item>
         <g-shoot-action-change-hibernation
@@ -64,9 +58,12 @@ SPDX-License-Identifier: Apache-2.0
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import {
+  toRefs,
+  ref,
+  computed,
+} from 'vue'
 
-import GActionButton from '@/components/GActionButton.vue'
 import GShootActionChangeHibernation from '@/components/ShootHibernation/GShootActionChangeHibernation.vue'
 import GShootActionMaintenanceStart from '@/components/ShootMaintenance/GShootActionMaintenanceStart.vue'
 import GShootActionReconcileStart from '@/components/GShootActionReconcileStart.vue'
@@ -75,13 +72,39 @@ import GShootActionDeleteCluster from '@/components/GShootActionDeleteCluster.vu
 import GShootActionForceDelete from '@/components/GShootActionForceDelete.vue'
 import GShootVersionConfiguration from '@/components/ShootVersion/GShootVersionConfiguration.vue'
 
-import { useShootItem } from '@/composables/useShootItem'
+import { useProvideShootItem } from '@/composables/useShootItem'
+
+const props = defineProps({
+  modelValue: {
+    type: Boolean,
+    required: true,
+  },
+  selectedShoot: {
+    type: Object,
+  },
+  activator: {
+    type: Element,
+  },
+})
+
+const { modelValue, selectedShoot, activator } = toRefs(props)
+
+const emit = defineEmits([
+  'update:modelValue',
+])
+
+const visible = computed({
+  get () {
+    return modelValue.value
+  },
+  set (value) {
+    emit('update:modelValue', value)
+  },
+})
 
 const {
   canForceDeleteShoot,
-} = useShootItem()
-
-const menu = ref(false)
+} = useProvideShootItem(selectedShoot)
 
 const rotationType = ref('ALL_CREDENTIALS')
 </script>

--- a/frontend/src/views/GShootList.vue
+++ b/frontend/src/views/GShootList.vue
@@ -180,7 +180,7 @@ SPDX-License-Identifier: Apache-2.0
           <g-shoot-list-row
             :model-value="item"
             :visible-headers="visibleHeaders"
-            @show-dialog="showDialog"
+            @trigger-action="triggerAction"
           />
         </template>
         <template #bottom="{ pageCount }">
@@ -223,6 +223,11 @@ SPDX-License-Identifier: Apache-2.0
         </v-card>
       </v-dialog>
     </v-card>
+    <g-shoot-list-row-actions
+      v-model="showRowActions"
+      :activator="rowActionsActivator"
+      :selected-shoot="shootItem"
+    />
   </v-container>
 </template>
 
@@ -257,6 +262,7 @@ import GIconBase from '@/components/icons/GIconBase.vue'
 import GCertifiedKubernetes from '@/components/icons/GCertifiedKubernetes.vue'
 import GDataTableFooter from '@/components/GDataTableFooter.vue'
 import GShootAccessCard from '@/components/ShootDetails/GShootAccessCard.vue'
+import GShootListRowActions from '@/components/GShootListRowActions.vue'
 
 import { useProjectShootCustomFields } from '@/composables/useProjectShootCustomFields'
 import { isCustomField } from '@/composables/useProjectShootCustomFields/helper'
@@ -285,6 +291,7 @@ export default {
     GCertifiedKubernetes,
     GTableColumnSelection,
     GDataTableFooter,
+    GShootListRowActions,
   },
   inject: ['logger'],
   beforeRouteEnter (to, from, next) {
@@ -379,6 +386,8 @@ export default {
         { value: 10, title: '10' },
         { value: 20, title: '20' },
       ],
+      showRowActions: false,
+      rowActionsActivator: undefined,
     }
   },
   computed: {
@@ -826,15 +835,20 @@ export default {
       'setFocusMode',
       'setSortBy',
     ]),
-    async showDialog (args) {
+    async triggerAction (args) {
       switch (args.action) {
         case 'access':
           try {
-            await this.setSelection(args.shootItem.metadata)
+            await this.setSelection(args.item.metadata)
             this.dialog = args.action
           } catch (err) {
-            this.logger('Failed to select shoot: %s', err.message)
+            this.logger.error('Failed to select shoot: %s', err.message)
           }
+          break
+        case 'menu':
+          await this.setSelection(args.item.metadata)
+          this.rowActionsActivator = args.target
+          this.showRowActions = true
       }
     },
     hideDialog () {


### PR DESCRIPTION
**What this PR does / why we need it**:
Move GShootListRowActions from GShootListRow to GShootList component
This ensures the action components are only rendered once. This greatly improves performance

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
