### PR TITLE
Adapt to new shoot access restriction configurations in `CloudProfile`, `Seed`, and `Shoot` APIs

### DIFF
--- a/charts/__tests__/gardener-dashboard/runtime/dashboard/__snapshots__/configmap.spec.js.snap
+++ b/charts/__tests__/gardener-dashboard/runtime/dashboard/__snapshots__/configmap.spec.js.snap
@@ -9,11 +9,9 @@ exports[`gardener-dashboard configmap access restrictions should render the temp
           "display": {
             "description": "display Foo description",
             "title": "display Foo",
-            "visibleIf": true,
           },
           "input": {
             "description": "input Foo description",
-            "inverted": true,
             "title": "input Foo",
           },
           "key": "foo",
@@ -31,9 +29,6 @@ exports[`gardener-dashboard configmap access restrictions should render the temp
               "key": "foo-option-1",
             },
             {
-              "display": {
-                "visibleIf": true,
-              },
               "input": {
                 "description": "input Foo  Option 2 description",
                 "inverted": true,
@@ -56,7 +51,7 @@ exports[`gardener-dashboard configmap access restrictions should render the temp
       "items": [
         {
           "display": {
-            "visibleIf": true,
+            "title": "Foo Only",
           },
           "input": {
             "title": "Foo",

--- a/charts/__tests__/gardener-dashboard/runtime/dashboard/configmap.spec.js
+++ b/charts/__tests__/gardener-dashboard/runtime/dashboard/configmap.spec.js
@@ -250,7 +250,7 @@ describe('gardener-dashboard', function () {
                     {
                       key: 'foo',
                       display: {
-                        visibleIf: true,
+                        title: 'Foo Only',
                       },
                       input: {
                         title: 'Foo',
@@ -279,14 +279,12 @@ describe('gardener-dashboard', function () {
                     {
                       key: 'foo',
                       display: {
-                        visibleIf: true,
                         title: 'display Foo',
                         description: 'display Foo description',
                       },
                       input: {
                         title: 'input Foo',
                         description: 'input Foo description',
-                        inverted: true,
                       },
                       options: [
                         {
@@ -304,9 +302,6 @@ describe('gardener-dashboard', function () {
                         },
                         {
                           key: 'foo-option-2',
-                          display: {
-                            visibleIf: true,
-                          },
                           input: {
                             title: 'input Foo Option 2',
                             description: 'input Foo  Option 2 description',

--- a/charts/gardener-dashboard/charts/runtime/templates/dashboard/configmap.yaml
+++ b/charts/gardener-dashboard/charts/runtime/templates/dashboard/configmap.yaml
@@ -284,26 +284,27 @@ data:
         items:
         {{- range .Values.global.dashboard.frontendConfig.accessRestriction.items }}
         - key: {{ .key }}
+          {{- if .display }}
           display:
-            visibleIf: {{ .display.visibleIf }}{{- if .display.title }}
+            {{- if .display.title }}
             title: {{ .display.title }}{{- end }}{{- if .display.description }}
             description: {{ .display.description }}{{- end }}
+          {{- end }}
           input:
             title: {{ quote .input.title }}
             {{- if .input.description }}
             description: {{ quote .input.description }}
             {{- end }}
-            {{- if .input.inverted }}
-            inverted: {{ .input.inverted }}
-            {{- end }}
           {{- if .options }}
           options:
           {{- range .options }}
           - key: {{ .key }}
+            {{- if .display }}
             display:
               visibleIf: {{ .display.visibleIf }}{{- if .display.title }}
               title: {{ .display.title }}{{- end }}{{- if .display.description }}
               description: {{ .display.description }}{{- end }}
+            {{- end }}
             input:
               title: {{ quote .input.title }}
               {{- if .input.description }}

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -289,16 +289,14 @@ global:
       # accessRestriction:
       #   noItemsText: No access restriction options available for region ${region} and cloud profile ${cloudProfile}
       #   items:
-      #   - key: seed.gardener.cloud/eu-access
+      #   - key: eu-access
       #     display:
-      #       visibleIf: true
       #       # title: foo # optional title, if not defined key will be used
       #       # description: bar # optional description displayed in a tooltip
       #     input:
       #       title: EU Access
       #       description: |
       #         This service is offered to you with our regular SLAs and 24x7 support for the control plane of the cluster. 24x7 support for cluster add-ons and nodes is only available if you meet the following conditions:
-      #       # inverted: false
       #     options:
       #     - key: support.gardener.cloud/eu-access-for-cluster-addons
       #       display:

--- a/docs/operations/access-restrictions.md
+++ b/docs/operations/access-restrictions.md
@@ -1,88 +1,115 @@
 # Access Restrictions
 
-The dashboard can be configured with access restrictions.
+For an overview and usage of access restrictions, refer to the [Access Restrictions Usage Documentation](https://github.com/gardener/gardener/blob/master/docs/usage/shoot/access_restrictions.md).
 
-<img src="../images/access-restrictions-1.png">
+## Configuring the Dashboard
 
-Access restrictions are shown for regions that have a matching label in the `CloudProfile`
-```yaml
-  regions:
-  - name: pangaea-north-1
-    zones:
-    - name: pangaea-north-1a
-    - name: pangaea-north-1b
-    - name: pangaea-north-1c
-    labels:
-      seed.gardener.cloud/eu-access: "true"
-```
+Operators can configure the Gardener Dashboard to define available access restrictions and their options. This configuration determines what is displayed to end-users in the Dashboard UI.
 
-- If the user selects the access restriction, `spec.seedSelector.matchLabels[key]` will be set.
-- When selecting an option, `metadata.annotations[optionKey]` will be set.
+### Configuration Methods
 
-The value that is set depends on the configuration. See _2._ under _Configuration_ section below.
+The Dashboard can be installed and configured in two ways:
 
-```yaml
-apiVersion: core.gardener.cloud/v1beta1
-kind: Shoot
-metadata:
-  annotations:
-    support.gardener.cloud/eu-access-for-cluster-addons: "true"
-    support.gardener.cloud/eu-access-for-cluster-nodes: "true"
-  ...
-spec:
-  seedSelector:
-    matchLabels:
-      seed.gardener.cloud/eu-access: "true"
-```
+1. **Via Helm Chart**: Configuration is provided through the `values.yaml` file.
+2. **Via Gardener Operator**: Configuration is provided through a ConfigMap referenced by the Gardener Operator.
 
-In order for the shoot (with enabled access restriction) to be scheduled on a seed, the seed needs to have the label set. E.g.
-```yaml
-apiVersion: core.gardener.cloud/v1beta1
-kind: Seed
-metadata:
-  labels:
-    seed.gardener.cloud/eu-access: "true"
-...
-```
+#### 1. Installing via Helm Chart
 
-<img src="../images/access-restrictions-2.png">
+When installing the Dashboard via Helm chart, access restrictions are configured in the `values.yaml` file.
 
-**Configuration**
-As gardener administrator:
-1. you can control the visibility of the chips with the `accessRestriction.items[].display.visibleIf` and `accessRestriction.items[].options[].display.visibleIf` property. E.g. in this example the access restriction chip is shown if the value is true and the option is shown if the value is false.
-2. you can control the value of the input field (switch / checkbox) with the `accessRestriction.items[].input.inverted` and `accessRestriction.items[].options[].input.inverted` property. Setting the `inverted` property to `true` will invert the value. That means that when selecting the input field the value will be`'false'` instead of `'true'`.
-3. you can configure the text that is displayed when no access restriction options are available by setting `accessRestriction.noItemsText`
-example `values.yaml`:
+**Example `values.yaml`:**
+
 ```yaml
 accessRestriction:
   noItemsText: No access restriction options available for region {region} and cloud profile {cloudProfile}
   items:
-  - key: seed.gardener.cloud/eu-access
+  - key: eu-access-only
     display:
-      visibleIf: true
-      # title: foo # optional title, if not defined key will be used
-      # description: bar # optional description displayed in a tooltip
+      title: EU Access Only # Optional title; if not specified, `key` is used
+      description: Restricts access to EU regions only # Optional description displayed in a tooltip
     input:
       title: EU Access
       description: |
-        This service is offered to you with our regular SLAs and 24x7 support for the control plane of the cluster. 24x7 support for cluster add-ons and nodes is only available if you meet the following conditions:
+        This service is offered with our regular SLAs and 24x7 support for the control plane of the cluster. 24x7 support for cluster add-ons and nodes is only available if you meet the following conditions:
     options:
     - key: support.gardener.cloud/eu-access-for-cluster-addons
       display:
-        visibleIf: false
-        # title: bar # optional title, if not defined key will be used
-        # description: baz # optional description displayed in a tooltip
+        visibleIf: true # Controls visibility based on a condition
       input:
-        title: No personal data is used as name or in the content of Gardener or Kubernetes resources (e.g. Gardener project name or Kubernetes namespace, configMap or secret in Gardener or Kubernetes)
+        title: No personal data is used in resource names or contents
         description: |
-          If you can't comply, only third-level/dev support at usual 8x5 working hours in EEA will be available to you for all cluster add-ons such as DNS and certificates, Calico overlay network and network policies, kube-proxy and services, and everything else that would require direct inspection of your cluster through its API server
-        inverted: true
+          If you can't comply, only third-level support during usual 8x5 working hours in the EEA will be available for cluster add-ons.
+        inverted: false # Determines if the input value is inverted
     - key: support.gardener.cloud/eu-access-for-cluster-nodes
       display:
-        visibleIf: false
+        visibleIf: false # Controls visibility based on a condition
       input:
-        title: No personal data is stored in any Kubernetes volume except for container file system, emptyDirs, and persistentVolumes (in particular, not on hostPath volumes)
+        title: No personal data is stored in Kubernetes volumes except certain types
         description: |
-          If you can't comply, only third-level/dev support at usual 8x5 working hours in EEA will be available to you for all node-related components such as Docker and Kubelet, the operating system, and everything else that would require direct inspection of your nodes through a privileged pod or SSH
-        inverted: true
+          If you can't comply, only third-level support during usual 8x5 working hours in the EEA will be available for node-related components.
+        inverted: true # Determines if the input value is inverted
 ```
+
+#### 2. Installing via Gardener Operator
+
+When the Dashboard is installed via the Gardener Operator, access restrictions are configured in a separate `ConfigMap` referenced by the Operator using `.spec.virtualCluster.gardener.gardenerDashboard.frontendConfigMapRef` within the `Garden` resource.
+
+**Example ConfigMap:**
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gardener-dashboard-frontend
+  namespace: garden
+data:
+  frontend-config.yaml: |
+    accessRestriction:
+      noItemsText: No access restriction options available for region {region} and cloud profile {cloudProfile}
+      items:
+      - key: eu-access-only
+        display:
+          title: EU Access Only
+          description: Restricts access to EU regions only
+        input:
+          title: EU Access
+          description: |
+            This service is offered with our regular SLAs and 24x7 support for the control plane of the cluster. 24x7 support for cluster add-ons and nodes is only available if you meet the following conditions:
+        options:
+        - key: support.gardener.cloud/eu-access-for-cluster-addons
+          display:
+            visibleIf: true
+          input:
+            title: No personal data is used in resource names or contents
+            description: |
+              If you can't comply, only third-level support during usual 8x5 working hours in the EEA will be available for cluster add-ons.
+            inverted: false
+        - key: support.gardener.cloud/eu-access-for-cluster-nodes
+          display:
+            visibleIf: false
+          input:
+            title: No personal data is stored in Kubernetes volumes except certain types
+            description: |
+              If you can't comply, only third-level support during usual 8x5 working hours in the EEA will be available for node-related components.
+            inverted: true
+```
+
+### Understanding `input` and `display`
+
+- **`display`**:
+  - **Purpose**: Defines how the access restriction and its options are presented in the Dashboard UI using **chips**.
+  - **Properties**:
+    - `title`: Label shown on the chip. If not specified, `key` is used.
+    - `description`: Tooltip content when hovering over the chip.
+    - `visibleIf` (for options): Determines if the option's chip is displayed based on its value.
+
+- **`input`**:
+  - **Purpose**: Configures the interactive elements (switches, checkboxes) that users interact with to enable or disable access restrictions and options.
+  - **Properties**:
+    - `title`: Label for the input control.
+    - `description`: Detailed information or instructions for the input control.
+    - `inverted` (for options): Determines if the input value is inverted (`true` or `false`). When `inverted` is `true`, the control behaves inversely (e.g., checked means `false`).
+
+### No Access Restrictions Available
+
+If no access restrictions are available for the selected region and cloud profile, the text specified in `accessRestriction.noItemsText` is displayed. Placeholders `{region}` and `{cloudProfile}` can be used in the text.

--- a/frontend/__fixtures__/config.js
+++ b/frontend/__fixtures__/config.js
@@ -59,7 +59,6 @@ export default {
       {
         key: 'seed.gardener.cloud/eu-access',
         display: {
-          visibleIf: true,
           title: 'Limited Access',
           description: 'Clusters will not be migrated ...',
         },

--- a/frontend/__tests__/composables/useShootAccessRestrictions.spec.js
+++ b/frontend/__tests__/composables/useShootAccessRestrictions.spec.js
@@ -31,7 +31,7 @@ describe('composables', () => {
       accessRestrictionDefinition = {
         key: 'foo',
         input: {
-          inverted: false,
+          title: 'Foo',
         },
         options: [
           {
@@ -62,20 +62,20 @@ describe('composables', () => {
       }
       shootResource = shallowRef({
         metadata: {
-          annotations: {
-            'foo-option-1': 'false',
-            'foo-option-2': 'false',
-            'foo-option-3': 'true',
-          },
         },
         spec: {
           cloudProfileName: 'cloud-profile-name',
           region: 'region',
-          seedSelector: {
-            matchLabels: {
-              foo: 'true',
+          accessRestrictions: [
+            {
+              name: 'foo',
+              options: {
+                'foo-option-1': 'false',
+                'foo-option-2': 'false',
+                'foo-option-3': 'true',
+              },
             },
-          },
+          ],
         },
       })
 
@@ -93,7 +93,7 @@ describe('composables', () => {
       })
       const { key, options } = accessRestrictionDefinition
       expect(getAccessRestrictionValue(key)).toBe(true)
-      expect(options.map(({ key }) => getAccessRestrictionOptionValue(key))).toEqual([
+      expect(options.map(({ key: optionKey }) => getAccessRestrictionOptionValue(key, optionKey))).toEqual([
         false,
         true,
         false,
@@ -101,15 +101,14 @@ describe('composables', () => {
       ])
     })
 
-    it('should invert access restriction', () => {
-      accessRestrictionDefinition.input.inverted = true
+    it('should get access restriction value', () => {
       const {
         getAccessRestrictionValue,
       } = useShootAccessRestrictions(shootResource, {
         cloudProfileStore,
       })
       const { key } = accessRestrictionDefinition
-      expect(getAccessRestrictionValue(key)).toBe(false)
+      expect(getAccessRestrictionValue(key)).toBe(true)
     })
 
     it('should not invert option', () => {
@@ -120,7 +119,7 @@ describe('composables', () => {
       } = useShootAccessRestrictions(shootResource, {
         cloudProfileStore,
       })
-      expect(getAccessRestrictionOptionValue(option.key)).toBe(false)
+      expect(getAccessRestrictionOptionValue(accessRestrictionDefinition.key, option.key)).toBe(false)
     })
 
     it('should invert option', () => {
@@ -131,7 +130,7 @@ describe('composables', () => {
       } = useShootAccessRestrictions(shootResource, {
         cloudProfileStore,
       })
-      expect(getAccessRestrictionOptionValue(option.key)).toBe(true)
+      expect(getAccessRestrictionOptionValue(accessRestrictionDefinition.key, option.key)).toBe(true)
     })
   })
 })

--- a/frontend/src/components/ShootAccessRestrictions/GAccessRestrictions.vue
+++ b/frontend/src/components/ShootAccessRestrictions/GAccessRestrictions.vue
@@ -43,11 +43,11 @@ SPDX-License-Identifier: Apache-2.0
       >
         <div class="action-select">
           <v-checkbox
-            :model-value="getAccessRestrictionOptionValue(optionKey) "
+            :model-value="getAccessRestrictionOptionValue(key, optionKey) "
             :disabled="getDisabled(key)"
             color="primary"
             density="compact"
-            @update:model-value="value => setAccessRestrictionOptionValue(optionKey, value)"
+            @update:model-value="value => setAccessRestrictionOptionValue(key, optionKey, value)"
           />
         </div>
         <div
@@ -80,7 +80,6 @@ SPDX-License-Identifier: Apache-2.0
 
 <script setup>
 import { useShootContext } from '@/composables/useShootContext'
-import { NAND } from '@/composables/useShootAccessRestrictions/helper'
 
 import { transformHtml } from '@/utils'
 
@@ -96,10 +95,7 @@ const {
 } = useShootContext()
 
 function getDisabled (key) {
-  const value = getAccessRestrictionValue(key)
-  const { input } = accessRestrictionDefinitions.value[key] // eslint-disable-line security/detect-object-injection
-  const inverted = !!input?.inverted
-  return !NAND(value, inverted)
+  return !getAccessRestrictionValue(key)
 }
 
 function getTextClass (key) {

--- a/frontend/src/composables/useShootAccessRestrictions/index.js
+++ b/frontend/src/composables/useShootAccessRestrictions/index.js
@@ -8,8 +8,6 @@ import { computed } from 'vue'
 
 import { useCloudProfileStore } from '@/store/cloudProfile'
 
-import { useAnnotations } from '../useObjectMetadata'
-
 import { NAND } from './helper'
 
 import {
@@ -31,29 +29,11 @@ export const useShootAccessRestrictions = (shootItem, options = {}) => {
   } = options
 
   const {
-    getAnnotation: getShootAnnotation,
-    setAnnotation: setShootAnnotation,
-    unsetAnnotation: unsetShootAnnotation,
-  } = useAnnotations(shootItem)
-
-  const {
     cloudProfileName,
     region,
   } = mapValues(shootPropertyMappings, path => {
     return computed(() => get(shootItem.value, path))
   })
-
-  function getSeedSelectorMatchLabel (key, defaultValue) {
-    return get(shootItem.value, `spec.seedSelector.matchLabels["${key}"]`, `${defaultValue}`)
-  }
-
-  function setSeedSelectorMatchLabel (key, value) {
-    set(shootItem.value, `spec.seedSelector.matchLabels["${key}"]`, `${value}`)
-  }
-
-  function unsetSeedSelectorMatchLabel (key) {
-    unset(shootItem.value, `spec.seedSelector.matchLabels["${key}"]`)
-  }
 
   const accessRestrictionDefinitionList = computed(() => {
     return cloudProfileStore.accessRestrictionDefinitionsByCloudProfileNameAndRegion({
@@ -94,58 +74,80 @@ export const useShootAccessRestrictions = (shootItem, options = {}) => {
     return accessRestrictionOptionDefinitions
   })
 
+  function getAccessRestrictions () {
+    return get(shootItem.value, ['spec', 'accessRestrictions'], [])
+  }
+
+  function setAccessRestrictions (accessRestrictions) {
+    if (accessRestrictions.length > 0) {
+      set(shootItem.value, ['spec', 'accessRestrictions'], accessRestrictions)
+    } else {
+      unset(shootItem.value, ['spec', 'accessRestrictions'])
+    }
+  }
+
+  function getAccessRestrictionItem (key) {
+    return getAccessRestrictions().find(ar => ar.name === key)
+  }
+
   function getAccessRestrictionValue (key) {
-    const { input } = get(accessRestrictionDefinitions.value, [key])
-    const inverted = !!input?.inverted
-    const defaultValue = inverted
-    const value = getSeedSelectorMatchLabel(key, defaultValue) === 'true'
-    return NAND(value, inverted)
+    const accessRestrictionItem = getAccessRestrictionItem(key)
+    return !!accessRestrictionItem
   }
 
   function setAccessRestrictionValue (key, value) {
-    const { input, options } = get(accessRestrictionDefinitions.value, [key])
-    const enabled = NAND(value, !!input?.inverted)
-    if (enabled) {
-      setSeedSelectorMatchLabel(key, 'true')
+    const accessRestrictions = getAccessRestrictions()
+    const index = accessRestrictions.findIndex(ar => ar.name === key)
+    if (value) {
+      if (index === -1) {
+        accessRestrictions.push({ name: key })
+      }
     } else {
-      unsetSeedSelectorMatchLabel(key)
-    }
-    for (const key of Object.keys(options)) {
-      if (enabled) {
-        setAccessRestrictionOptionValue(key, false)
-      } else {
-        unsetShootAnnotation(key)
+      if (index !== -1) {
+        accessRestrictions.splice(index, 1)
       }
     }
+    setAccessRestrictions(accessRestrictions)
   }
 
-  function getAccessRestrictionOptionValue (key) {
-    const { accessRestrictionKey } = get(accessRestrictionOptionDefinitions.value, [key])
-    const { input } = get(accessRestrictionDefinitions.value, [accessRestrictionKey, 'options', key])
+  function getAccessRestrictionOptionValue (accessRestrictionKey, optionKey) {
+    const { input } = get(accessRestrictionDefinitions.value, [accessRestrictionKey, 'options', optionKey])
     const inverted = !!input?.inverted
     const defaultValue = inverted
-    const value = getShootAnnotation(key, `${defaultValue}`) === 'true'
+
+    const accessRestrictionItem = getAccessRestrictionItem(accessRestrictionKey)
+    if (!accessRestrictionItem || !accessRestrictionItem.options) {
+      return NAND(defaultValue, inverted)
+    }
+    const value = get(accessRestrictionItem.options, [optionKey], `${defaultValue}`) === 'true'
     return NAND(value, inverted)
   }
 
-  function setAccessRestrictionOptionValue (key, value) {
-    const { accessRestrictionKey } = get(accessRestrictionOptionDefinitions.value, [key])
-    const { input } = get(accessRestrictionDefinitions.value, [accessRestrictionKey, 'options', key])
+  function setAccessRestrictionOptionValue (accessRestrictionKey, optionKey, value) {
+    const { input } = get(accessRestrictionDefinitions.value, [accessRestrictionKey, 'options', optionKey])
     const inverted = !!input?.inverted
-    setShootAnnotation(key, `${NAND(value, inverted)}`)
+    const optionValue = NAND(value, inverted) ? 'true' : 'false'
+
+    const accessRestrictions = getAccessRestrictions()
+    let accessRestrictionItem = accessRestrictions.find(ar => ar.name === accessRestrictionKey)
+    if (!accessRestrictionItem) {
+      accessRestrictionItem = { name: accessRestrictionKey, options: {} }
+      accessRestrictions.push(accessRestrictionItem)
+    }
+    if (!accessRestrictionItem.options) {
+      accessRestrictionItem.options = {}
+    }
+    set(accessRestrictionItem.options, [optionKey], optionValue)
+    setAccessRestrictions(accessRestrictions)
   }
 
   function getAccessRestrictionPatchData () {
-    const data = {}
-    for (const definition of accessRestrictionDefinitionList.value) {
-      const path = `spec.seedSelector.matchLabels["${definition.key}"]`
-      set(data, path, get(shootItem.value, path, null))
-      for (const optionDefinition of definition.options) {
-        const path = `metadata.annotations["${optionDefinition.key}"]`
-        set(data, path, get(shootItem.value, path, null))
-      }
+    const accessRestrictions = get(shootItem.value, ['spec', 'accessRestrictions'], [])
+    return {
+      spec: {
+        accessRestrictions,
+      },
     }
-    return data
   }
 
   const accessRestrictionList = computed(() => {
@@ -154,7 +156,6 @@ export const useShootAccessRestrictions = (shootItem, options = {}) => {
       const {
         key,
         display: {
-          visibleIf = false,
           title = key,
           description,
         },
@@ -162,30 +163,30 @@ export const useShootAccessRestrictions = (shootItem, options = {}) => {
       } = definition
 
       const value = getAccessRestrictionValue(key)
-      if (visibleIf !== value) {
-        continue // skip
+      if (!value) {
+        continue // Skip if access restriction is not enabled
       }
 
       const accessRestrictionOptionList = []
-      for (const optionDefinition of optionDefinitions) {
+      for (const optionDefinition of Object.values(optionDefinitions)) {
         const {
-          key,
+          key: optionKey,
           display: {
-            visibleIf = false,
-            title = key,
-            description,
+            visibleIf = true,
+            title: optionTitle = optionKey,
+            description: optionDescription,
           },
         } = optionDefinition
 
-        const value = getAccessRestrictionOptionValue(key)
-        if (value !== visibleIf) {
-          continue // skip
+        const optionValue = getAccessRestrictionOptionValue(key, optionKey)
+        if (optionValue !== visibleIf) {
+          continue // Skip
         }
 
         accessRestrictionOptionList.push({
-          key,
-          title,
-          description,
+          key: optionKey,
+          title: optionTitle,
+          description: optionDescription,
         })
       }
 
@@ -209,9 +210,6 @@ export const useShootAccessRestrictions = (shootItem, options = {}) => {
     setAccessRestrictionValue,
     getAccessRestrictionOptionValue,
     setAccessRestrictionOptionValue,
-    getSeedSelectorMatchLabel,
-    setSeedSelectorMatchLabel,
-    unsetSeedSelectorMatchLabel,
     accessRestrictionList,
     getAccessRestrictionPatchData,
   }

--- a/frontend/src/store/cloudProfile/index.js
+++ b/frontend/src/store/cloudProfile/index.js
@@ -495,7 +495,7 @@ export const useCloudProfileStore = defineStore('cloudProfile', () => {
     if (!cloudProfile) {
       return []
     }
-    const regionData = find(cloudProfile.data.regions, ['name', region])
+    const regionData = find(cloudProfile.data.regions, [['name'], region])
     if (!regionData) {
       return []
     }

--- a/frontend/src/store/cloudProfile/index.js
+++ b/frontend/src/store/cloudProfile/index.js
@@ -464,7 +464,7 @@ export const useCloudProfileStore = defineStore('cloudProfile', () => {
 
   function accessRestrictionNoItemsTextForCloudProfileNameAndRegion ({ cloudProfileName, region }) {
     const defaultNoItemsText = 'No access restriction options available for region ${region}' // eslint-disable-line no-template-curly-in-string
-    const noItemsText = get(configStore, 'accessRestriction.noItemsText', defaultNoItemsText)
+    const noItemsText = get(configStore, ['accessRestriction', 'noItemsText'], defaultNoItemsText)
 
     return template(noItemsText)({
       region,
@@ -477,23 +477,29 @@ export const useCloudProfileStore = defineStore('cloudProfile', () => {
       return []
     }
 
-    const labels = labelsByCloudProfileNameAndRegion({ cloudProfileName, region })
-    if (isEmpty(labels)) {
+    const allowedAccessRestrictions = accessRestrictionsByCloudProfileNameAndRegion({ cloudProfileName, region })
+    if (isEmpty(allowedAccessRestrictions)) {
       return []
     }
 
-    const items = get(configStore, 'accessRestriction.items')
+    const allowedAccessRestrictionNames = allowedAccessRestrictions.map(ar => ar.name)
+
+    const items = get(configStore, ['accessRestriction', 'items'])
     return filter(items, ({ key }) => {
-      return key && get(labels, [key]) === 'true'
+      return key && allowedAccessRestrictionNames.includes(key)
     })
   }
 
-  function labelsByCloudProfileNameAndRegion ({ cloudProfileName, region }) {
+  function accessRestrictionsByCloudProfileNameAndRegion ({ cloudProfileName, region }) {
     const cloudProfile = cloudProfileByName(cloudProfileName)
     if (!cloudProfile) {
-      return {}
+      return []
     }
-    return get(find(cloudProfile.data.regions, ['name', region]), 'labels')
+    const regionData = find(cloudProfile.data.regions, ['name', region])
+    if (!regionData) {
+      return []
+    }
+    return get(regionData, ['accessRestrictions'], [])
   }
 
   function defaultMachineImageForCloudProfileNameAndMachineType (cloudProfileName, machineType) {
@@ -692,7 +698,7 @@ export const useCloudProfileStore = defineStore('cloudProfile', () => {
     volumeTypesByCloudProfileName,
     defaultMachineImageForCloudProfileNameAndMachineType,
     minimumVolumeSizeByMachineTypeAndVolumeType,
-    labelsByCloudProfileNameAndRegion,
+    accessRestrictionsByCloudProfileNameAndRegion,
     accessRestrictionDefinitionsByCloudProfileNameAndRegion,
     accessRestrictionNoItemsTextForCloudProfileNameAndRegion,
     kubernetesVersions,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR now uses the new fields in `CloudProfile`, `Seed`, and `Shoot` APIs for the shoot access restriction configuration. The new fields were introduced with https://github.com/gardener/gardener/pull/10654.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Access Restrictions:
- This dashboard version requires Gardener version `v1.107.0` if access restrictions are configured.
- The `accessRestriction.items[].display.visibleIf` and `accessRestriction.items[].display.inverted` configurations are no longer supported and will be ignored. The dashboard will now assume `visibleIf=true` and `inverted=false`. However, this change does not affect the `accessRestriction.items[].input.options[].display.visibleIf` and `accessRestriction.items[].input.options[].display.inverted` settings.
```
