### PR TITLE
Remove fallback to read cluster ca Secret

### DIFF
--- a/backend/lib/services/shoots.js
+++ b/backend/lib/services/shoots.js
@@ -386,18 +386,8 @@ async function getGardenClusterIdentity () {
 exports.getGardenClusterIdentity = getGardenClusterIdentity
 
 async function getClusterCaData (client, { namespace, name }) {
-  try {
-    const configmap = await client.core.configmaps.get(namespace, `${name}.ca-cluster`)
-    return encodeBase64(configmap.data?.['ca.crt'])
-  } catch (err) {
-    // TODO(petersutter): Remove this fallback of reading the `<shoot-name>.ca-cluster` Secret when Gardener no longer reconciles it, presumably with Gardener v1.97.
-    if (isHttpError(err, 404)) {
-      const caCluster = await client.core.secrets.get(namespace, `${name}.ca-cluster`)
-      return caCluster.data?.['ca.crt']
-    } else {
-      throw err
-    }
-  }
+  const configmap = await client.core.configmaps.get(namespace, `${name}.ca-cluster`)
+  return encodeBase64(configmap.data?.['ca.crt'])
 }
 exports.getClusterCaData = getClusterCaData
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes the fallback to read the cluster ca from the `Secret`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The dashboard no longer falls back to reading the cluster CA from the deprecated `<shoot-name>.ca-cluster` `Secret`. This change requires Gardener `v1.89.0` or higher.
```
