### PR TITLE
Terminal: Drop usage of deprecated `credential.secretRef` field

### DIFF
--- a/backend/__fixtures__/config.js
+++ b/backend/__fixtures__/config.js
@@ -65,7 +65,7 @@ const defaultConfig = {
       },
     ],
     gardenTerminalHost: {
-      seedRef: 'infra1-seed2',
+      seedRef: 'infra1-seed',
     },
     garden: {
       operatorCredentials: {

--- a/backend/__fixtures__/secrets.js
+++ b/backend/__fixtures__/secrets.js
@@ -11,7 +11,6 @@ const { cloneDeep, merge, find, filter, has, get, set, mapValues, split, startsW
 const createError = require('http-errors')
 const pathToRegexp = require('path-to-regexp')
 const { toBase64, createUrl } = require('./helper')
-const seeds = require('./seeds')
 
 const certificateAuthorityData = toBase64('certificate-authority-data')
 const clientCertificateData = toBase64('client-certificate-data')
@@ -161,21 +160,6 @@ const secrets = {
       },
     })
   },
-  getSeedSecret (namespace, name) {
-    const seedName = name.substring(11)
-    const seed = seeds.get(seedName)
-    const { type, region } = seed.spec.provider
-    return getSecret({
-      name,
-      namespace,
-      data: {
-        kubeconfig: getKubeconfig({
-          server: `https://api.${region}.${type}.seed.cluster`,
-          name: `shoot--garden--${seedName}`,
-        }),
-      },
-    })
-  },
   getMonitoringSecret (namespace, name, creationTimestamp) {
     return getSecret({
       name,
@@ -243,10 +227,6 @@ const mocks = {
       const { params: { namespace, name } = {} } = matchResult
       const [hostname] = split(headers[':authority'], ':')
       if (hostname === 'kubernetes') {
-        if (namespace === 'garden' && startsWith(name, 'seedsecret-')) {
-          const item = secrets.getSeedSecret(namespace, name)
-          return Promise.resolve(item)
-        }
         if (endsWith(name, '.kubeconfig')) {
           const item = secrets.getShootSecret(namespace, name)
           return Promise.resolve(item)

--- a/backend/__fixtures__/seeds.js
+++ b/backend/__fixtures__/seeds.js
@@ -16,7 +16,6 @@ function getSeed ({
   seedProtected = false,
   seedVisible = true,
   labels = {},
-  withSecretRef = true,
 }) {
   uid = uid || `seed--${name}`
   const seed = {
@@ -47,12 +46,6 @@ function getSeed ({
       key: 'seed.gardener.cloud/protected',
     })
   }
-  if (withSecretRef) {
-    seed.spec.secretRef = {
-      name: `seedsecret-${name}`,
-      namespace: 'garden',
-    }
-  }
 
   return seed
 }
@@ -62,7 +55,7 @@ const seedList = [
   getSeed({ name: 'infra1-seed', region: 'foo-east', kind: 'infra1' }),
   getSeed({ name: 'infra1-seed2', region: 'foo-west', kind: 'infra1' }),
   getSeed({ name: 'infra3-seed', region: 'foo-europe', kind: 'infra3', labels: { 'test-unreachable': 'true', biz: 'baz' } }),
-  getSeed({ name: 'infra4-seed-without-secretRef', region: 'foo-south', kind: 'infra1', withSecretRef: false }),
+  getSeed({ name: 'infra4-seed-managed', region: 'foo-south', kind: 'infra1' }),
   getSeed({ name: 'infra3-seed-with-selector', region: 'foo-europe', kind: 'infra3', seedProtected: false, seedVisible: true, labels: { foo: 'bar', fooz: 'baz' } }),
   getSeed({ name: 'infra3-seed-without-selector', region: 'foo-europe', kind: 'infra3', seedProtected: false, seedVisible: true }),
   getSeed({ name: 'infra3-seed-protected', region: 'foo-europe', kind: 'infra3', seedProtected: true }),

--- a/backend/__fixtures__/shoots.js
+++ b/backend/__fixtures__/shoots.js
@@ -42,7 +42,7 @@ const shootList = [
     createdBy: 'foo@example.org',
     purpose: 'fooPurpose',
     secretBindingName: 'barSecretName',
-    seed: 'infra4-seed-without-secretRef',
+    seed: 'infra1-seed',
     advertisedAddresses: null,
   }),
   getShoot({

--- a/backend/__fixtures__/terminals.js
+++ b/backend/__fixtures__/terminals.js
@@ -65,9 +65,9 @@ function getTerminal (options = {}) {
         temporaryNamespace: true,
         namespace: 'term-host-' + identifier,
         credentials: {
-          secretRef: {
+          shootRef: {
             namespace: 'garden',
-            name: 'host.kubeconfig',
+            name: 'host',
           },
         },
         pod: {

--- a/backend/test/acceptance/__snapshots__/api.cloudprofiles.spec.js.snap
+++ b/backend/test/acceptance/__snapshots__/api.cloudprofiles.spec.js.snap
@@ -43,7 +43,7 @@ exports[`api cloudprofiles should return all cloudprofiles 2`] = `
       "seedNames": [
         "infra1-seed",
         "infra1-seed2",
-        "infra4-seed-without-secretRef",
+        "infra4-seed-managed",
       ],
       "seedSelector": {},
       "type": "infra1",
@@ -155,7 +155,7 @@ exports[`api cloudprofiles should return all cloudprofiles 2`] = `
         "infra1-seed",
         "infra1-seed2",
         "infra3-seed",
-        "infra4-seed-without-secretRef",
+        "infra4-seed-managed",
         "infra3-seed-with-selector",
         "infra3-seed-without-selector",
       ],

--- a/backend/test/acceptance/__snapshots__/api.seeds.spec.js.snap
+++ b/backend/test/acceptance/__snapshots__/api.seeds.spec.js.snap
@@ -89,7 +89,7 @@ exports[`api seeds should return all seeds 2`] = `
       "visible": true,
     },
     "metadata": {
-      "name": "infra4-seed-without-secretRef",
+      "name": "infra4-seed-managed",
       "unreachable": false,
     },
   },

--- a/backend/test/acceptance/__snapshots__/api.shoots.spec.js.snap
+++ b/backend/test/acceptance/__snapshots__/api.shoots.spec.js.snap
@@ -1244,7 +1244,7 @@ exports[`api shoots should return all shoots for a non-admin user 2`] = `
         "purpose": "fooPurpose",
         "region": "foo-west",
         "secretBindingName": "barSecretName",
-        "seedName": "infra4-seed-without-secretRef",
+        "seedName": "infra1-seed",
       },
       "status": {
         "technicalID": "shoot--foo--dummyShoot",
@@ -1388,7 +1388,7 @@ exports[`api shoots should return all shoots for an admin user 2`] = `
         "purpose": "fooPurpose",
         "region": "foo-west",
         "secretBindingName": "barSecretName",
-        "seedName": "infra4-seed-without-secretRef",
+        "seedName": "infra1-seed",
       },
       "status": {
         "technicalID": "shoot--foo--dummyShoot",
@@ -1494,7 +1494,7 @@ exports[`api shoots should return all unhealthy shoots 2`] = `
         "purpose": "fooPurpose",
         "region": "foo-west",
         "secretBindingName": "barSecretName",
-        "seedName": "infra4-seed-without-secretRef",
+        "seedName": "infra1-seed",
       },
       "status": {
         "technicalID": "shoot--foo--dummyShoot",
@@ -1611,7 +1611,7 @@ exports[`api shoots should return shoot info without gardenlogin kubeconfig 1`] 
     {
       ":authority": "kubernetes:6443",
       ":method": "get",
-      ":path": "/apis/core.gardener.cloud/v1beta1/namespaces/garden/shoots/infra4-seed-without-secretRef",
+      ":path": "/apis/core.gardener.cloud/v1beta1/namespaces/garden/shoots/infra1-seed",
       ":scheme": "https",
       "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImZvb0BleGFtcGxlLm9yZyIsImlhdCI6MTU3NzgzNjgwMCwiYXVkIjpbImdhcmRlbmVyIl0sImV4cCI6MzE1NTcxNjgwMCwianRpIjoianRpIn0.k3kGjF6AgugJLdwERXEWZPaibFAPFPOnmpT3YM9H0xU",
     },
@@ -1947,7 +1947,7 @@ exports[`api shoots should return shoots for a single namespace 2`] = `
         "purpose": "fooPurpose",
         "region": "foo-west",
         "secretBindingName": "barSecretName",
-        "seedName": "infra4-seed-without-secretRef",
+        "seedName": "infra1-seed",
       },
       "status": {
         "technicalID": "shoot--foo--dummyShoot",

--- a/backend/test/acceptance/__snapshots__/api.terminals.spec.js.snap
+++ b/backend/test/acceptance/__snapshots__/api.terminals.spec.js.snap
@@ -550,7 +550,7 @@ exports[`api terminals garden should create a terminal resource 1`] = `
     {
       ":authority": "kubernetes:6443",
       ":method": "get",
-      ":path": "/apis/seedmanagement.gardener.cloud/v1alpha1/namespaces/garden/managedseeds/infra1-seed2",
+      ":path": "/apis/seedmanagement.gardener.cloud/v1alpha1/namespaces/garden/managedseeds/infra1-seed",
       ":scheme": "https",
       "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFkbWluQGV4YW1wbGUub3JnIiwiaWF0IjoxNTc3ODM2ODAwLCJhdWQiOlsiZ2FyZGVuZXIiXSwiZXhwIjozMTU1NzE2ODAwLCJqdGkiOiJqdGkifQ.PwFHRt9M8dJf8YcCVlbyH4xu2QpL3jBI1oEC_Zdmtzk",
     },
@@ -559,7 +559,7 @@ exports[`api terminals garden should create a terminal resource 1`] = `
     {
       ":authority": "kubernetes:6443",
       ":method": "get",
-      ":path": "/apis/seedmanagement.gardener.cloud/v1alpha1/namespaces/garden/managedseeds/infra1-seed2",
+      ":path": "/apis/seedmanagement.gardener.cloud/v1alpha1/namespaces/garden/managedseeds/infra1-seed",
       ":scheme": "https",
       "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFkbWluQGV4YW1wbGUub3JnIiwiaWF0IjoxNTc3ODM2ODAwLCJhdWQiOlsiZ2FyZGVuZXIiXSwiZXhwIjozMTU1NzE2ODAwLCJqdGkiOiJqdGkifQ.PwFHRt9M8dJf8YcCVlbyH4xu2QpL3jBI1oEC_Zdmtzk",
     },
@@ -568,7 +568,7 @@ exports[`api terminals garden should create a terminal resource 1`] = `
     {
       ":authority": "kubernetes:6443",
       ":method": "get",
-      ":path": "/api/v1/namespaces/garden/secrets/seedsecret-infra1-seed2",
+      ":path": "/apis/core.gardener.cloud/v1beta1/namespaces/garden/shoots/infra1-seed",
       ":scheme": "https",
       "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFkbWluQGV4YW1wbGUub3JnIiwiaWF0IjoxNTc3ODM2ODAwLCJhdWQiOlsiZ2FyZGVuZXIiXSwiZXhwIjozMTU1NzE2ODAwLCJqdGkiOiJqdGkifQ.PwFHRt9M8dJf8YcCVlbyH4xu2QpL3jBI1oEC_Zdmtzk",
     },
@@ -601,8 +601,8 @@ exports[`api terminals garden should create a terminal resource 1`] = `
       "spec": {
         "host": {
           "credentials": {
-            "secretRef": {
-              "name": "seedsecret-infra1-seed2",
+            "shootRef": {
+              "name": "infra1-seed",
               "namespace": "garden",
             },
           },
@@ -658,7 +658,7 @@ exports[`api terminals garden should create a terminal resource 1`] = `
 exports[`api terminals garden should create a terminal resource 2`] = `
 {
   "hostCluster": {
-    "kubeApiServer": "api-seed.ingress.foo-west.infra1.example.org",
+    "kubeApiServer": "api-garden--infra1-seed.ingress.foo-east.infra1.example.org",
     "namespace": "term-host-21",
   },
   "imageHelpText": "Dummy Image Description",
@@ -756,15 +756,22 @@ exports[`api terminals garden should fetch a terminal resource 1`] = `
   [
     {
       ":authority": "kubernetes:6443",
-      ":method": "get",
-      ":path": "/api/v1/namespaces/garden/secrets/host.kubeconfig",
+      ":method": "post",
+      ":path": "/apis/core.gardener.cloud/v1beta1/namespaces/garden/shoots/host/adminkubeconfig",
       ":scheme": "https",
       "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFkbWluQGV4YW1wbGUub3JnIiwiaWF0IjoxNTc3ODM2ODAwLCJhdWQiOlsiZ2FyZGVuZXIiXSwiZXhwIjozMTU1NzE2ODAwLCJqdGkiOiJqdGkifQ.PwFHRt9M8dJf8YcCVlbyH4xu2QpL3jBI1oEC_Zdmtzk",
+    },
+    {
+      "apiVersion": "authentication.gardener.cloud/v1alpha1",
+      "kind": "AdminKubeconfigRequest",
+      "spec": {
+        "expirationSeconds": 600,
+      },
     },
   ],
   [
     {
-      ":authority": "api.host.garden.shoot.cluster",
+      ":authority": "shootapiserverhostname:6443",
       ":method": "post",
       ":path": "/api/v1/namespaces/term-host-1/serviceaccounts/term-attach-1/token",
       ":scheme": "https",
@@ -925,7 +932,7 @@ exports[`api terminals garden should reuse a terminal session 1`] = `
     {
       ":authority": "kubernetes:6443",
       ":method": "get",
-      ":path": "/apis/seedmanagement.gardener.cloud/v1alpha1/namespaces/garden/managedseeds/infra1-seed2",
+      ":path": "/apis/seedmanagement.gardener.cloud/v1alpha1/namespaces/garden/managedseeds/infra1-seed",
       ":scheme": "https",
       "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFkbWluQGV4YW1wbGUub3JnIiwiaWF0IjoxNTc3ODM2ODAwLCJhdWQiOlsiZ2FyZGVuZXIiXSwiZXhwIjozMTU1NzE2ODAwLCJqdGkiOiJqdGkifQ.PwFHRt9M8dJf8YcCVlbyH4xu2QpL3jBI1oEC_Zdmtzk",
     },
@@ -934,7 +941,7 @@ exports[`api terminals garden should reuse a terminal session 1`] = `
     {
       ":authority": "kubernetes:6443",
       ":method": "get",
-      ":path": "/apis/seedmanagement.gardener.cloud/v1alpha1/namespaces/garden/managedseeds/infra1-seed2",
+      ":path": "/apis/seedmanagement.gardener.cloud/v1alpha1/namespaces/garden/managedseeds/infra1-seed",
       ":scheme": "https",
       "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFkbWluQGV4YW1wbGUub3JnIiwiaWF0IjoxNTc3ODM2ODAwLCJhdWQiOlsiZ2FyZGVuZXIiXSwiZXhwIjozMTU1NzE2ODAwLCJqdGkiOiJqdGkifQ.PwFHRt9M8dJf8YcCVlbyH4xu2QpL3jBI1oEC_Zdmtzk",
     },
@@ -943,7 +950,7 @@ exports[`api terminals garden should reuse a terminal session 1`] = `
     {
       ":authority": "kubernetes:6443",
       ":method": "get",
-      ":path": "/api/v1/namespaces/garden/secrets/seedsecret-infra1-seed2",
+      ":path": "/apis/core.gardener.cloud/v1beta1/namespaces/garden/shoots/infra1-seed",
       ":scheme": "https",
       "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImFkbWluQGV4YW1wbGUub3JnIiwiaWF0IjoxNTc3ODM2ODAwLCJhdWQiOlsiZ2FyZGVuZXIiXSwiZXhwIjozMTU1NzE2ODAwLCJqdGkiOiJqdGkifQ.PwFHRt9M8dJf8YcCVlbyH4xu2QpL3jBI1oEC_Zdmtzk",
     },
@@ -971,7 +978,7 @@ exports[`api terminals garden should reuse a terminal session 1`] = `
 exports[`api terminals garden should reuse a terminal session 2`] = `
 {
   "hostCluster": {
-    "kubeApiServer": "api-seed.ingress.foo-west.infra1.example.org",
+    "kubeApiServer": "api-garden--infra1-seed.ingress.foo-east.infra1.example.org",
     "namespace": "term-host-1",
   },
   "imageHelpText": "Foo Image Description",

--- a/backend/test/acceptance/api.terminals.spec.js
+++ b/backend/test/acceptance/api.terminals.spec.js
@@ -139,7 +139,7 @@ describe('api', function () {
         mockRequest.mockImplementationOnce(fixtures.terminals.mocks.list())
         mockRequest.mockImplementationOnce(fixtures.managedseeds.mocks.get())
         mockRequest.mockImplementationOnce(fixtures.managedseeds.mocks.get())
-        mockRequest.mockImplementationOnce(fixtures.secrets.mocks.get())
+        mockRequest.mockImplementationOnce(fixtures.shoots.mocks.get())
         mockRequest.mockImplementationOnce(fixtures.terminals.mocks.create())
 
         const res = await agent
@@ -213,7 +213,7 @@ describe('api', function () {
         mockRequest.mockImplementationOnce(fixtures.terminals.mocks.list())
         mockRequest.mockImplementationOnce(fixtures.managedseeds.mocks.get())
         mockRequest.mockImplementationOnce(fixtures.managedseeds.mocks.get())
-        mockRequest.mockImplementationOnce(fixtures.secrets.mocks.get())
+        mockRequest.mockImplementationOnce(fixtures.shoots.mocks.get())
         mockRequest.mockImplementationOnce(fixtures.terminals.mocks.patch())
 
         const res = await agent
@@ -244,7 +244,7 @@ describe('api', function () {
       it('should fetch a terminal resource', async function () {
         mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
         mockRequest.mockImplementationOnce(fixtures.terminals.mocks.watch())
-        mockRequest.mockImplementationOnce(fixtures.secrets.mocks.get())
+        mockRequest.mockImplementationOnce(fixtures.shoots.mocks.createAdminKubeconfigRequest())
         mockRequest.mockImplementationOnce(fixtures.serviceaccounts.mocks.createTokenRequest())
 
         const res = await agent

--- a/charts/gardener-dashboard/charts/runtime/templates/dashboard/configmap.yaml
+++ b/charts/gardener-dashboard/charts/runtime/templates/dashboard/configmap.yaml
@@ -135,15 +135,6 @@ data:
       serviceAccountTokenExpiration: {{ .Values.global.terminal.serviceAccountTokenExpiration }}
       {{- end }}
       gardenTerminalHost:
-        {{- if .Values.global.terminal.gardenTerminalHost.secretRef }}
-        apiServerIngressHost: {{ .Values.global.terminal.gardenTerminalHost.apiServerIngressHost }}
-        secretRef:
-          namespace: {{ .Values.global.terminal.gardenTerminalHost.secretRef.namespace }}
-          {{- with .Values.global.terminal.gardenTerminalHost.secretRef.labelSelector }}
-          labelSelector:
-{{ toYaml . | trim | nindent 12 }}
-          {{- end }}
-        {{- end }}
         {{- if .Values.global.terminal.gardenTerminalHost.seedRef }}
         seedRef: {{ .Values.global.terminal.gardenTerminalHost.seedRef }}
         {{- end }}

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -437,18 +437,13 @@ global:
   #   allowedHostSourceList:
   #   - "*.seed.example.com"
   #   gardenTerminalHost: # cluster that hosts the terminal pods for the (virtual) garden cluster
-  #     apiServerIngressHost: api.example.org # is host in browser-trusted certificate. Optional, but required if using secretRef
-  #     secretRef:
-  #       namespace: garden # namespace, in which the secret for the gardenTerminalHost resides on the (virtual) garden cluster
-  #       labelSelector:
-  #       - runtime=gardenTerminalHost
-  #       # seedRef: my-soil
-  #       # shootRef:
-  #       #   name: myshoot
-  #       #   namespace: garden
+  #     seedRef: seed1 # must be a managed seed
+  #     # shootRef:
+  #     #   name: shoot1
+  #     #   namespace: garden
   #   garden: # (virtual) garden
   #     operatorCredentials: # this is the credential used for operators for the (virtual) garden cluster, to create terminal session specific service accounts
-  #       serviceAccountRef: # serviceAccountRef or secretRef
+  #       serviceAccountRef:
   #         name: dashboard-terminal-admin
   #         namespace: garden
   #     # role bindings that the access service account within the terminal pod should receive

--- a/docs/operations/webterminals.md
+++ b/docs/operations/webterminals.md
@@ -45,7 +45,7 @@ According to the privileges of the user (operator / enduser) and the selected ta
 The frontend makes another POST request to the dashboard backend to fetch the terminal session. The Backend waits until the `terminal` resource is in a "ready" state (timeout 10s) before sending a response to the frontend. More to that later.
 
 ### 4. Terminal Resource
-The `terminal` resource, among other things, holds the information of the desired host and target cluster. The credentials to these clusters are declared as references (secretRef / serviceAccountRef). The `terminal` resource itself doesn’t contain sensitive information.
+The `terminal` resource, among other things, holds the information of the desired host and target cluster. The credentials to these clusters are declared as references (`shootRef`, `serviceAccountRef`). The `terminal` resource itself doesn’t contain sensitive information.
 
 ### 5. Admission
 A validating webhook is in place to ensure that the user, that created the `terminal` resource, has the **permission to read the referenced credentials**. There is also a mutating webhook in place. Both admission configurations have **`failurePolicy: Fail`**.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes the usage of the `credential.secretRef` property from both the terminal `host` and `target` properties. This property was originally used for:

- Referencing the `Seed`'s kubeconfig. However, the `spec.secretRef` field has been [removed](https://github.com/gardener/gardener/pull/8896) from the `Seed` API in Gardener without replacement.
- Referencing the `Shoot`'s static token kubeconfig, which was stored as a `<shootname>.kubeconfig` `Secret` (for Kubernetes versions below 1.27). With the availability of the `shoot/adminkubeconfig` API to request admin kubeconfigs for `Shoot` clusters, referencing the static token kubeconfig `Secret` is no longer necessary.

Additionally, with [gardener/terminal-controller-manager#320](https://github.com/gardener/terminal-controller-manager/pull/320), the `credential.secretRef` field was dropped from the `Terminal` API.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the block below.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The `credential.secretRef` property has been removed from the terminal `host` and `target` properties. As a result, the dashboard no longer uses this field:
- For `Seed` resources, `spec.secretRef` was removed from the API without replacement, eliminating the need for `credential.secretRef`.
- For `Shoot` resources, `credential.shootRef` now replaces the previously used `credential.secretRef` for static token kubeconfigs.