### PR TITLE
Fix alertmanager URL

### DIFF
--- a/frontend/src/components/GClusterMetrics.vue
+++ b/frontend/src/components/GClusterMetrics.vue
@@ -105,7 +105,7 @@ export default {
     },
     alertmanagerUrl () {
       if (this.isOidcObservabilityUrlsEnabled) {
-        return this.getOidcDeploymentUrl('alertmanager')
+        return this.getOidcStatefulsetUrl('alertmanager')
       }
 
       return `https://au-${this.prefix}.${this.seedIngressDomain}`


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the alertmanager URL. The alertmanager is a statefulset and follows the same convention as the Prometheus statefulset, listing the index of the statefulset pod.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed alertmanager URL.
```
