### PR TITLE
Fix: `ul` must not be a child of `p`

### DIFF
--- a/frontend/src/components/Secrets/GSecretDialogGcp.vue
+++ b/frontend/src/components/Secrets/GSecretDialogGcp.vue
@@ -44,13 +44,14 @@ SPDX-License-Identifier: Apache-2.0
 
         <p>
           Ensure that the service account has at least the roles below.
-          <ul>
-            <li>Service Account Admin</li>
-            <li>Service Account Token Creator</li>
-            <li>Service Account User</li>
-            <li>Compute Admin</li>
-          </ul>
         </p>
+
+        <ul>
+          <li>Service Account Admin</li>
+          <li>Service Account Token Creator</li>
+          <li>Service Account User</li>
+          <li>Compute Admin</li>
+        </ul>
 
         <p>
           The Service Account has to be enabled for the Google Identity and Access Management API.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the warning, that `ul` must not be a child of `p`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
