### PR TITLE
fix: Use correct link for control plane high availability documentation

### DIFF
--- a/frontend/src/components/ControlPlaneHighAvailability/GManageControlPlaneHighAvailability.vue
+++ b/frontend/src/components/ControlPlaneHighAvailability/GManageControlPlaneHighAvailability.vue
@@ -77,7 +77,7 @@ SPDX-License-Identifier: Apache-2.0
     />
     <g-external-link
       v-else
-      url="https://github.com/gardener/gardener/blob/master/docs/usage/shoot_high_availability.md"
+      url="https://github.com/gardener/gardener/blob/master/docs/usage/high-availability/shoot_high_availability.md"
     >
       More information
     </g-external-link>


### PR DESCRIPTION
**What this PR does / why we need it**:

The external link to the control plane high-availability page is broken.

**Actual:**
❌ [`https://github.com/gardener/gardener/blob/master/docs/usage/shoot_high_availability.md`](https://github.com/gardener/gardener/blob/master/docs/usage/shoot_high_availability.md)

**Expected:**
✅ [`https://github.com/gardener/gardener/blob/master/docs/usage/high-availability/shoot_high_availability.md`](https://github.com/gardener/gardener/blob/master/docs/usage/high-availability/shoot_high_availability.md)

![Screenshot 2024-12-09 at 11 28 51](https://github.com/user-attachments/assets/f936841c-61e5-4538-abaf-c898adfd9dcb)

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

Should the link use the Gardener documentation homepage instead?
👉 https://gardener.cloud/docs/gardener/high-availability/shoot_high_availability/

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc operator
Fix the link reference to the control plane high availability page.
```
