### PR TITLE
[OpenMFP] use namespace instead of project for fga checks

### DIFF
--- a/backend/lib/openfga/index.js
+++ b/backend/lib/openfga/index.js
@@ -112,13 +112,13 @@ async function getDerivedResourceRules (username, namespace, accountId) {
     return []
   }
 
-  const checks = permissionMappings.map(({ relation, object }) => ({
+  const checks = permissionMappings.map(({ correlationId, relation, object }) => ({
     tuple_key: {
       user: `user:${username}`,
       relation,
       object,
     },
-    correlation_id: relation,
+    correlation_id: correlationId,
   }))
 
   let fgaResult
@@ -131,7 +131,7 @@ async function getDerivedResourceRules (username, namespace, accountId) {
     throw new Error('Error performing batch permission checks')
   }
 
-  const isAllowed = ({ relation: correlationId }) => {
+  const isAllowed = ({ correlationId }) => {
     return _.get(fgaResult, [correlationId, 'allowed'], false)
   }
 

--- a/backend/lib/openfga/index.js
+++ b/backend/lib/openfga/index.js
@@ -107,6 +107,11 @@ function batchCheck (checks) {
 
 async function getDerivedResourceRules (username, namespace, accountId) {
   const permissionMappings = getPermissionMappings(accountId, namespace)
+  if (_.isEmpty(permissionMappings)) {
+    logger.debug('No permission mappings for user "%s", account "%s", namespace "%s"', username, accountId, namespace)
+    return []
+  }
+
   const checks = permissionMappings.map(({ relation, object }) => ({
     tuple_key: {
       user: `user:${username}`,

--- a/backend/lib/openfga/index.js
+++ b/backend/lib/openfga/index.js
@@ -105,18 +105,8 @@ function batchCheck (checks) {
   })
 }
 
-function getProjectName (namespace) {
-  try {
-    return cache.findProjectByNamespace(namespace).metadata.name
-  } catch (err) {
-    // ignore error when project is not found
-    return null
-  }
-}
-
 async function getDerivedResourceRules (username, namespace, accountId) {
-  const projectName = getProjectName(namespace)
-  const permissionMappings = getPermissionMappings(accountId, projectName)
+  const permissionMappings = getPermissionMappings(accountId, namespace)
   const checks = permissionMappings.map(({ relation, object }) => ({
     tuple_key: {
       user: `user:${username}`,

--- a/backend/lib/openfga/permissionMappings.js
+++ b/backend/lib/openfga/permissionMappings.js
@@ -21,6 +21,9 @@ function getAccountPermissions (accountId) {
       apiGroups: ['core.gardener.cloud'],
       resources: ['projects'],
       relation: 'gardener_project_create',
+      // A correlation_id can be composed of any string of alphanumeric characters or dashes between 1-36 characters in length.
+      // https://openfga.dev/docs/getting-started/perform-check#03-calling-batch-check-api
+      correlationId: 'gardener-project-create',
       object: `account:${accountId}`,
     },
   ]
@@ -38,6 +41,7 @@ function getProjectPermissions (namespace) {
       apiGroups: ['core.gardener.cloud'],
       resources: ['shoots'],
       relation: 'gardener_shoot_create',
+      correlationId: 'gardener-shoot-create',
       object: `gardener_project:${namespace}`,
     },
     {
@@ -45,6 +49,7 @@ function getProjectPermissions (namespace) {
       apiGroups: ['core.gardener.cloud'],
       resources: ['shoots'],
       relation: 'gardener_shoot_patch',
+      correlationId: 'gardener-shoot-patch',
       object: `gardener_project:${namespace}`,
     },
     {
@@ -52,6 +57,7 @@ function getProjectPermissions (namespace) {
       apiGroups: ['core.gardener.cloud'],
       resources: ['shoots'],
       relation: 'gardener_shoot_delete',
+      correlationId: 'gardener-shoot-delete',
       object: `gardener_project:${namespace}`,
     },
     {
@@ -59,6 +65,23 @@ function getProjectPermissions (namespace) {
       apiGroups: ['core.gardener.cloud'],
       resources: ['shoots/binding'],
       relation: 'gardener_shoot_binding_patch',
+      correlationId: 'gardener-shoot-binding-patch',
+      object: `gardener_project:${namespace}`,
+    },
+    {
+      verbs: ['create'],
+      apiGroups: ['core.gardener.cloud'],
+      resources: ['shoots/adminkubeconfig'],
+      relation: 'gardener_shoots_adminkubeconfig_create',
+      correlationId: 'gardener-shoots-adminkc-create',
+      object: `gardener_project:${namespace}`,
+    },
+    {
+      verbs: ['create'],
+      apiGroups: ['core.gardener.cloud'],
+      resources: ['shoots/viewerkubeconfig'],
+      relation: 'gardener_shoots_viewerkubeconfig_create',
+      correlationId: 'gardener-shoots-viewerkc-create',
       object: `gardener_project:${namespace}`,
     },
     // Terminals
@@ -67,6 +90,7 @@ function getProjectPermissions (namespace) {
       apiGroups: ['dashboard.gardener.cloud'],
       resources: ['terminals'],
       relation: 'gardener_terminal_create',
+      correlationId: 'gardener-terminal-create',
       object: `gardener_project:${namespace}`,
     },
     // Secrets
@@ -75,6 +99,7 @@ function getProjectPermissions (namespace) {
       apiGroups: [''],
       resources: ['secrets'],
       relation: 'gardener_secrets_get',
+      correlationId: 'gardener-secrets-get',
       object: `gardener_project:${namespace}`,
     },
     {
@@ -82,6 +107,7 @@ function getProjectPermissions (namespace) {
       apiGroups: [''],
       resources: ['secrets'],
       relation: 'gardener_secrets_create',
+      correlationId: 'gardener-secrets-create',
       object: `gardener_project:${namespace}`,
     },
     {
@@ -89,6 +115,7 @@ function getProjectPermissions (namespace) {
       apiGroups: [''],
       resources: ['secrets'],
       relation: 'gardener_secrets_patch',
+      correlationId: 'gardener-secrets-patch',
       object: `gardener_project:${namespace}`,
     },
     {
@@ -96,6 +123,7 @@ function getProjectPermissions (namespace) {
       apiGroups: [''],
       resources: ['secrets'],
       relation: 'gardener_secrets_delete',
+      correlationId: 'gardener-secrets-delete',
       object: `gardener_project:${namespace}`,
     },
     // Service Accounts
@@ -104,6 +132,7 @@ function getProjectPermissions (namespace) {
       apiGroups: [''],
       resources: ['serviceaccounts/token'],
       relation: 'gardener_token_request_create',
+      correlationId: 'gardener-token-request-create',
       object: `gardener_project:${namespace}`,
     },
     {
@@ -111,6 +140,7 @@ function getProjectPermissions (namespace) {
       apiGroups: [''],
       resources: ['serviceaccounts'],
       relation: 'gardener_service_account_create',
+      correlationId: 'gardener-service-account-create',
       object: `gardener_project:${namespace}`,
     },
     {
@@ -118,6 +148,7 @@ function getProjectPermissions (namespace) {
       apiGroups: [''],
       resources: ['serviceaccounts'],
       relation: 'gardener_service_account_patch',
+      correlationId: 'gardener-service-account-patch',
       object: `gardener_project:${namespace}`,
     },
     {
@@ -125,6 +156,7 @@ function getProjectPermissions (namespace) {
       apiGroups: [''],
       resources: ['serviceaccounts'],
       relation: 'gardener_service_account_delete',
+      correlationId: 'gardener-service-account-delete',
       object: `gardener_project:${namespace}`,
     },
     // Projects
@@ -133,6 +165,7 @@ function getProjectPermissions (namespace) {
       apiGroups: ['core.gardener.cloud'],
       resources: ['projects'],
       relation: 'gardener_project_patch',
+      correlationId: 'gardener-project-patch',
       object: `gardener_project:${namespace}`,
     },
     {
@@ -140,6 +173,7 @@ function getProjectPermissions (namespace) {
       apiGroups: ['core.gardener.cloud'],
       resources: ['projects'],
       relation: 'gardener_project_delete',
+      correlationId: 'gardener-project-delete',
       object: `gardener_project:${namespace}`,
     },
     {
@@ -147,6 +181,7 @@ function getProjectPermissions (namespace) {
       apiGroups: ['core.gardener.cloud'],
       resources: ['projects'],
       relation: 'gardener_project_members_manage',
+      correlationId: 'gardener-project-members-manage',
       object: `gardener_project:${namespace}`,
     },
   ]

--- a/backend/lib/openfga/permissionMappings.js
+++ b/backend/lib/openfga/permissionMappings.js
@@ -3,9 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-module.exports = function getPermissionMappings (accountId, projectName) {
+module.exports = function getPermissionMappings (accountId, namespace) {
   const accountPermissions = getAccountPermissions(accountId)
-  const projectPermissions = getProjectPermissions(projectName)
+  const projectPermissions = getProjectPermissions(namespace)
 
   return [...accountPermissions, ...projectPermissions]
 }
@@ -26,8 +26,8 @@ function getAccountPermissions (accountId) {
   ]
 }
 
-function getProjectPermissions (projectName) {
-  if (!projectName) {
+function getProjectPermissions (namespace) {
+  if (!namespace) {
     return []
   }
 
@@ -38,28 +38,28 @@ function getProjectPermissions (projectName) {
       apiGroups: ['core.gardener.cloud'],
       resources: ['shoots'],
       relation: 'gardener_shoot_create',
-      object: `gardener_project:${projectName}`,
+      object: `gardener_project:${namespace}`,
     },
     {
       verbs: ['patch'],
       apiGroups: ['core.gardener.cloud'],
       resources: ['shoots'],
       relation: 'gardener_shoot_patch',
-      object: `gardener_project:${projectName}`,
+      object: `gardener_project:${namespace}`,
     },
     {
       verbs: ['delete'],
       apiGroups: ['core.gardener.cloud'],
       resources: ['shoots'],
       relation: 'gardener_shoot_delete',
-      object: `gardener_project:${projectName}`,
+      object: `gardener_project:${namespace}`,
     },
     {
       verbs: ['patch'],
       apiGroups: ['core.gardener.cloud'],
       resources: ['shoots/binding'],
       relation: 'gardener_shoot_binding_patch',
-      object: `gardener_project:${projectName}`,
+      object: `gardener_project:${namespace}`,
     },
     // Terminals
     {
@@ -67,7 +67,7 @@ function getProjectPermissions (projectName) {
       apiGroups: ['dashboard.gardener.cloud'],
       resources: ['terminals'],
       relation: 'gardener_terminal_create',
-      object: `gardener_project:${projectName}`,
+      object: `gardener_project:${namespace}`,
     },
     // Secrets
     {
@@ -75,28 +75,28 @@ function getProjectPermissions (projectName) {
       apiGroups: [''],
       resources: ['secrets'],
       relation: 'gardener_secrets_get',
-      object: `gardener_project:${projectName}`,
+      object: `gardener_project:${namespace}`,
     },
     {
       verbs: ['create'],
       apiGroups: [''],
       resources: ['secrets'],
       relation: 'gardener_secrets_create',
-      object: `gardener_project:${projectName}`,
+      object: `gardener_project:${namespace}`,
     },
     {
       verbs: ['patch'],
       apiGroups: [''],
       resources: ['secrets'],
       relation: 'gardener_secrets_patch',
-      object: `gardener_project:${projectName}`,
+      object: `gardener_project:${namespace}`,
     },
     {
       verbs: ['delete'],
       apiGroups: [''],
       resources: ['secrets'],
       relation: 'gardener_secrets_delete',
-      object: `gardener_project:${projectName}`,
+      object: `gardener_project:${namespace}`,
     },
     // Service Accounts
     {
@@ -104,28 +104,28 @@ function getProjectPermissions (projectName) {
       apiGroups: [''],
       resources: ['serviceaccounts/token'],
       relation: 'gardener_token_request_create',
-      object: `gardener_project:${projectName}`,
+      object: `gardener_project:${namespace}`,
     },
     {
       verbs: ['create'],
       apiGroups: [''],
       resources: ['serviceaccounts'],
       relation: 'gardener_service_account_create',
-      object: `gardener_project:${projectName}`,
+      object: `gardener_project:${namespace}`,
     },
     {
       verbs: ['patch'],
       apiGroups: [''],
       resources: ['serviceaccounts'],
       relation: 'gardener_service_account_patch',
-      object: `gardener_project:${projectName}`,
+      object: `gardener_project:${namespace}`,
     },
     {
       verbs: ['delete'],
       apiGroups: [''],
       resources: ['serviceaccounts'],
       relation: 'gardener_service_account_delete',
-      object: `gardener_project:${projectName}`,
+      object: `gardener_project:${namespace}`,
     },
     // Projects
     {
@@ -133,21 +133,21 @@ function getProjectPermissions (projectName) {
       apiGroups: ['core.gardener.cloud'],
       resources: ['projects'],
       relation: 'gardener_project_patch',
-      object: `gardener_project:${projectName}`,
+      object: `gardener_project:${namespace}`,
     },
     {
       verbs: ['delete'],
       apiGroups: ['core.gardener.cloud'],
       resources: ['projects'],
       relation: 'gardener_project_delete',
-      object: `gardener_project:${projectName}`,
+      object: `gardener_project:${namespace}`,
     },
     {
       verbs: ['manage-members'],
       apiGroups: ['core.gardener.cloud'],
       resources: ['projects'],
       relation: 'gardener_project_members_manage',
-      object: `gardener_project:${projectName}`,
+      object: `gardener_project:${namespace}`,
     },
   ]
 }

--- a/backend/lib/services/authorization.js
+++ b/backend/lib/services/authorization.js
@@ -195,7 +195,7 @@ exports.selfSubjectRulesReview = async function (user, namespace, accountId) {
 }
 
 async function fgaSelfSubjectRulesReview (user, namespace, accountId) {
-  if (!openfga.client || !accountId) {
+  if (!openfga.client) {
     return
   }
   const username = user.id

--- a/frontend/src/components/ShootDetails/GShootKubeconfig.vue
+++ b/frontend/src/components/ShootDetails/GShootKubeconfig.vue
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 -->
 
 <template>
-  <g-list-item v-if="canGetSecrets">
+  <g-list-item>
     <template #prepend>
       <v-icon
         :icon="icon"


### PR DESCRIPTION
**What this PR does / why we need it**:
Adapt batch check requests to use namespace instead of project name

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
