### PR TITLE
[renovate] Add yarnDedupeHighest postUpdateOptions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,6 +14,9 @@
     '**/node_modules/**',
     '**/.yarn/**',
   ],
+  postUpdateOptions: [
+    'yarnDedupeHighest',
+  ],
   customManagers: [
     {
       customType: 'regex',


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the `yarnDedupeHighest` option to `postUpdateOptions`, which aims to address the issue of versions being reverted back and forth during each Renovate run (see force pushes by renovate in PR https://github.com/gardener/dashboard/pull/2246)
https://docs.renovatebot.com/configuration-options/

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
