### PR TITLE
fix setError caller

### DIFF
--- a/frontend/__tests__/components/GLogin.spec.js
+++ b/frontend/__tests__/components/GLogin.spec.js
@@ -132,10 +132,10 @@ describe('components', () => {
         expect(mockNext.mock.calls[0]).toEqual([expect.any(Function)])
         expect(appStore.setError).toBeCalledTimes(1)
         expect(appStore.setError.mock.calls[0]).toEqual([
-          {
-            text: 'error',
+          expect.objectContaining({
+            message: 'error',
             title: 'title',
-          },
+          }),
         ])
         expect(mockRouter.replace).toBeCalledTimes(1)
         expect(mockRouter.replace.mock.calls[0]).toEqual(['/login'])

--- a/frontend/__tests__/components/GLogin.spec.js
+++ b/frontend/__tests__/components/GLogin.spec.js
@@ -131,7 +131,12 @@ describe('components', () => {
         expect(mockNext).toBeCalledTimes(1)
         expect(mockNext.mock.calls[0]).toEqual([expect.any(Function)])
         expect(appStore.setError).toBeCalledTimes(1)
-        expect(appStore.setError.mock.calls[0]).toEqual([error])
+        expect(appStore.setError.mock.calls[0]).toEqual([
+          {
+            text: 'error',
+            title: 'title',
+          },
+        ])
         expect(mockRouter.replace).toBeCalledTimes(1)
         expect(mockRouter.replace.mock.calls[0]).toEqual(['/login'])
       })

--- a/frontend/src/components/GNotify.vue
+++ b/frontend/src/components/GNotify.vue
@@ -8,6 +8,7 @@ SPDX-License-Identifier: Apache-2.0
     position="bottom right"
     class="ma-2"
     width="360px"
+    pause-on-hover
   >
     <template #body="{ item, close }">
       <v-alert

--- a/frontend/src/components/GRetryOperation.vue
+++ b/frontend/src/components/GRetryOperation.vue
@@ -72,10 +72,7 @@ async function onRetryOperation () {
       },
     })
   } catch (err) {
-    appStore.setError({
-      text: err,
-      duration: -1,
-    })
+    appStore.setError(err)
     logger.error('failed to retry operation', err)
   } finally {
     retryingOperation.value = false

--- a/frontend/src/components/ShootDetails/GShootAdminKubeconfig.vue
+++ b/frontend/src/components/ShootDetails/GShootAdminKubeconfig.vue
@@ -181,10 +181,7 @@ export default {
         const errorDetails = errorDetailsFromError(err)
         this.logger.error(errorMessage, errorDetails.errorCode, errorDetails.detailedMessage, err)
 
-        this.setError({
-          text: err,
-          duration: -1,
-        })
+        this.setError(err)
 
         return false
       }

--- a/frontend/src/layouts/GLogin.vue
+++ b/frontend/src/layouts/GLogin.vue
@@ -184,10 +184,7 @@ export default {
     if (this.error) {
       const err = this.error
       this.error = null
-      this.setError({
-        title: err.title,
-        text: err.message,
-      })
+      this.setError(err)
     }
     next()
   },

--- a/frontend/src/layouts/GLogin.vue
+++ b/frontend/src/layouts/GLogin.vue
@@ -184,7 +184,10 @@ export default {
     if (this.error) {
       const err = this.error
       this.error = null
-      this.setError(err)
+      this.setError({
+        title: err.title,
+        text: err.message,
+      })
     }
     next()
   },

--- a/frontend/src/router/routes.js
+++ b/frontend/src/router/routes.js
@@ -356,7 +356,9 @@ export function createRoutes () {
       },
       beforeEnter (to, from) {
         if (!authzStore.hasShootTerminalAccess) {
-          appStore.setError(new Error('Access to cluster terminal is not allowed'))
+          appStore.setError({
+            text: 'Access to cluster terminal is not allowed',
+          })
           return from
         }
       },
@@ -429,7 +431,9 @@ export function createRoutes () {
       },
       beforeEnter (to, from) {
         if (!authzStore.hasGardenTerminalAccess) {
-          appStore.setError(new Error('Access to garden terminal is not allowed'))
+          appStore.setError({
+            text: 'Access to garden terminal is not allowed.',
+          })
           return from
         }
         to.params.target = 'garden'

--- a/frontend/src/store/app.js
+++ b/frontend/src/store/app.js
@@ -16,6 +16,7 @@ import { errorDetailsFromError } from '@/utils/error'
 import moment from '@/utils/moment'
 
 import assign from 'lodash/assign'
+import pick from 'lodash/pick'
 
 export const useAppStore = defineStore('app', () => {
   const ready = ref(false)
@@ -39,13 +40,28 @@ export const useAppStore = defineStore('app', () => {
 
     if (typeof value === 'string') {
       alert.text = value
-    } else if (value && typeof value === 'object') {
-      const { response, text = '', ...props } = value
-      assign(alert, props)
-      alert.text = response
-        ? errorDetailsFromError(value).detailedMessage
-        : text
+      return notify(alert)
     }
+
+    const alertDetails = pick(value, [
+      'title',
+      'text',
+      'name',
+      'message',
+      'response',
+    ])
+
+    alert.title = alertDetails.title ?? alertDetails.name ?? 'Error'
+    alert.text = alertDetails.response
+      ? errorDetailsFromError(value).detailedMessage
+      : alertDetails.text ?? alertDetails.message ?? 'An unknown error occurred'
+
+    const extraProps = pick(value, [
+      'duration',
+      'ignoreDuplicates',
+      'closeOnClick',
+    ])
+    assign(alert, extraProps)
 
     notify(alert)
   }

--- a/frontend/src/views/GShootItemPlaceholder.vue
+++ b/frontend/src/views/GShootItemPlaceholder.vue
@@ -182,6 +182,7 @@ export default {
     onBeforeRouteUpdate(async to => {
       if (isLoadRequired(route, to)) {
         await load(to)
+        readyState.value = 'loaded'
       }
     })
 


### PR DESCRIPTION
**What this PR does / why we need it**:
`setError` is not called properly and thus (detail) information is missing when a error notification is shown.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed missing details on error notification
```
```feature user
Notifications will remain visible as long as the mouse hovers over them, rather than disappearing after 5 seconds.
```
