### PR TITLE
Fix promisify warning

### DIFF
--- a/backend/lib/io.js
+++ b/backend/lib/io.js
@@ -28,7 +28,7 @@ function expiresIn (socket) {
 
 function authenticateFn (options) {
   const cookieParserAsync = promisify(cookieParser())
-  const authenticateAsync = promisify(authenticate(options))
+  const authenticateAsync = authenticate(options)
   const noop = () => {}
   const res = {
     clearCookie: noop,
@@ -37,7 +37,11 @@ function authenticateFn (options) {
 
   return async req => {
     await cookieParserAsync(req, res)
-    await authenticateAsync(req, res)
+    await authenticateAsync(req, res, (err) => {
+      if (err) {
+        throw err
+      }
+    })
     return req.user
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes warning: `(node:45589) [DEP0174] DeprecationWarning: Calling promisify on a function that returns a Promise is likely a mistake.`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
