### PR TITLE
Do not show header warnings permanently

### DIFF
--- a/frontend/src/store/app.js
+++ b/frontend/src/store/app.js
@@ -77,7 +77,6 @@ export const useAppStore = defineStore('app', () => {
       setAlertWithType('warning', {
         title: code === '299' ? 'Kubernetes Warning' : undefined,
         text,
-        duration: -1,
       })
     })
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR, header warnings are dismissed automatically after 5 seconds. This should already slightly improve the UX regarding the following issue https://github.com/gardener/dashboard/issues/2256

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Kubernetes warning notifications are dismissed after 5 seconds
```
