### PR TITLE
Add PowerDNS support in dashboard

### DIFF
--- a/frontend/__tests__/stores/__snapshots__/credential.spec.js.snap
+++ b/frontend/__tests__/stores/__snapshots__/credential.spec.js.snap
@@ -144,6 +144,7 @@ exports[`stores > credential > should return dnsSecretBindingsList 1`] = `
   "infoblox-dns",
   "netlify-dns",
   "rfc2136",
+  "powerdns",
 ]
 `;
 

--- a/frontend/src/assets/powerdns.svg
+++ b/frontend/src/assets/powerdns.svg
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   version="1.1"
+   id="svg1"
+   xml:space="preserve"
+   width="240"
+   height="240"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" /><inkscape:clipboard
+     style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:#e66e00;fill-opacity:1;stroke-width:0.94342225;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
+     min="869.3442,3.3843836"
+     max="1080.892,144.01854"
+     geom-min="869.3442,3.3843836"
+     geom-max="1080.892,144.01854" />
+  <g
+     id="g1"
+     transform="translate(-869.3442,-3.3843836)">
+    <g
+       id="Ebene_1-2"
+       data-name="Ebene 1"
+       transform="matrix(0.945,0,0,0.95409679,65.462471,50)">
+      <path
+         class="cls-1"
+         d="M 929.76378,34.017 A 34.01575,34.01575 0 1 1 895.748,0.00131 34.01538,34.01538 0 0 1 929.76378,34.017"
+         id="path1"
+         style="fill:#e66e00" />
+      <path
+         class="cls-1"
+         d="M 929.76378,113.38584 A 34.01575,34.01575 0 1 1 895.748,79.37011 a 34.01538,34.01538 0 0 1 34.01579,34.01573"
+         id="path2"
+         style="fill:#e66e00" />
+      <path
+         class="cls-1"
+         d="M 1009.1339,34.017 A 34.01575,34.01575 0 1 1 975.11807,0.00131 34.01538,34.01538 0 0 1 1009.1339,34.017"
+         id="path3"
+         style="fill:#e66e00" />
+      <path
+         class="cls-1"
+         d="m 1009.1339,113.38584 a 34.01575,34.01575 0 1 1 -34.01583,-34.01573 34.01538,34.01538 0 0 1 34.01583,34.01573"
+         id="path4"
+         style="fill:#e66e00" />
+      <path
+         class="cls-1"
+         d="m 1088.5039,34.017 a 34.01575,34.01575 0 1 1 -34.0158,-34.01569 34.01539,34.01539 0 0 1 34.0158,34.01573"
+         id="path5"
+         style="fill:#e66e00" />
+      <path
+         class="cls-1"
+         d="m 1088.5039,113.38584 a 34.01575,34.01575 0 1 1 -34.0158,-34.01573 34.01539,34.01539 0 0 1 34.0158,34.01573"
+         id="path6"
+         style="fill:#e66e00" />
+    </g>
+</g>
+</svg>

--- a/frontend/src/components/GVendorIcon.vue
+++ b/frontend/src/components/GVendorIcon.vue
@@ -93,6 +93,8 @@ const iconSrc = computed(() => {
       return new URL('/src/assets/netlify-dns.svg', import.meta.url)
     case 'rfc2136':
       return new URL('/src/assets/rfc2136.svg', import.meta.url)
+    case 'powerdns':
+      return new URL('/src/assets/powerdns.svg', import.meta.url)
 
     // os
     case 'coreos':

--- a/frontend/src/components/Secrets/GSecretDetailsItemContent.vue
+++ b/frontend/src/components/Secrets/GSecretDetailsItemContent.vue
@@ -239,6 +239,17 @@ export default {
                 value: decodeBase64(secretData.Zone),
               },
             ]
+          case 'powerdns':
+            return [
+              {
+                label: 'Server',
+                value: decodeBase64(secretData.server),
+              },
+              {
+                label: 'API Key',
+                value: 'hidden',
+              },
+            ]
           default:
             return [
               {

--- a/frontend/src/components/Secrets/GSecretDialogPowerdns.vue
+++ b/frontend/src/components/Secrets/GSecretDialogPowerdns.vue
@@ -1,0 +1,136 @@
+<!--
+SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+ -->
+
+<template>
+  <g-secret-dialog
+    v-model="visible"
+    :secret-validations="v$"
+    :secret-binding="secretBinding"
+    create-title="Add new PowerDNS Secret"
+    replace-title="Replace PowerDNS Secret"
+  >
+    <template #secret-slot>
+      <div>
+        <v-text-field
+          v-model="server"
+          color="primary"
+          label="Server"
+          :error-messages="getErrorMessages(v$.server)"
+          variant="underlined"
+          @update:model-value="v$.server.$touch()"
+          @blur="v$.server.$touch()"
+        />
+      </div>
+      <div>
+        <v-text-field
+          v-model="apiKey"
+          color="primary"
+          label="API Key"
+          :append-icon="hideSecret ? 'mdi-eye' : 'mdi-eye-off'"
+          :type="hideSecret ? 'password' : 'text'"
+          :error-messages="getErrorMessages(v$.apiKey)"
+          variant="underlined"
+          @click:append="() => (hideSecret = !hideSecret)"
+          @update:model-value="v$.apiKey.$touch()"
+          @blur="v$.apiKey.$touch()"
+        />
+      </div>
+    </template>
+    <template #help-slot>
+      <div>
+        <p>
+          To use this provider you need to configure the PowerDNS API with an API key. A detailed documentation to generate an API key is available at
+          <g-external-link url="https://doc.powerdns.com/authoritative/http-api/index.html#enabling-the-api" />
+        </p>
+      </div>
+    </template>
+  </g-secret-dialog>
+</template>
+
+<script>
+import { useVuelidate } from '@vuelidate/core'
+import {
+  required,
+  url,
+} from '@vuelidate/validators'
+
+import GSecretDialog from '@/components/Secrets/GSecretDialog'
+
+import { useProvideCredentialContext } from '@/composables/useCredentialContext'
+
+import { getErrorMessages } from '@/utils'
+import { withFieldName } from '@/utils/validators'
+
+export default {
+  components: {
+    GSecretDialog,
+  },
+  props: {
+    modelValue: {
+      type: Boolean,
+      required: true,
+    },
+    secretBinding: {
+      type: Object,
+    },
+  },
+  emits: [
+    'update:modelValue',
+  ],
+  setup () {
+    const { secretStringDataRefs } = useProvideCredentialContext()
+
+    const {
+      server,
+      apiKey,
+    } = secretStringDataRefs({
+      server: 'server',
+      apiKey: 'apiKey',
+    })
+
+    return {
+      server,
+      apiKey,
+      v$: useVuelidate(),
+    }
+  },
+  data () {
+    return {
+      hideSecret: true,
+    }
+  },
+  validations () {
+    return {
+      apiKey: withFieldName('API Key', {
+        required,
+      }),
+      server: withFieldName('Server', {
+        required,
+        url,
+      }),
+    }
+  },
+  computed: {
+    visible: {
+      get () {
+        return this.modelValue
+      },
+      set (modelValue) {
+        this.$emit('update:modelValue', modelValue)
+      },
+    },
+    valid () {
+      return !this.v$.$invalid
+    },
+    isCreateMode () {
+      return !this.secret
+    },
+  },
+  methods: {
+    getErrorMessages,
+  },
+}
+</script>

--- a/frontend/src/components/Secrets/GSecretDialogWrapper.vue
+++ b/frontend/src/components/Secrets/GSecretDialogWrapper.vue
@@ -28,6 +28,7 @@ import NetlifyDialog from '@/components/Secrets/GSecretDialogNetlify'
 import DDnsDialog from '@/components/Secrets/GSecretDialogDDns'
 import DeleteDialog from '@/components/Secrets/GSecretDialogDelete'
 import HcloudDialog from '@/components/Secrets/GSecretDialogHCloud'
+import PowerdnsDialog from '@/components/Secrets/GSecretDialogPowerdns'
 import GenericDialog from '@/components/Secrets/GSecretDialogGeneric'
 
 import head from 'lodash/head'
@@ -47,6 +48,7 @@ const components = {
   NetlifyDialog,
   DDnsDialog,
   HcloudDialog,
+  PowerdnsDialog,
   GenericDialog,
   DeleteDialog,
 }

--- a/frontend/src/store/gardenerExtension.js
+++ b/frontend/src/store/gardenerExtension.js
@@ -46,7 +46,7 @@ export const useGardenerExtensionStore = defineStore('gardenerExtension', () => 
   })
 
   const sortedDnsProviderList = computed(() => {
-    const supportedProviderTypes = ['aws-route53', 'azure-dns', 'azure-private-dns', 'google-clouddns', 'openstack-designate', 'alicloud-dns', 'infoblox-dns', 'netlify-dns', 'rfc2136']
+    const supportedProviderTypes = ['aws-route53', 'azure-dns', 'azure-private-dns', 'google-clouddns', 'openstack-designate', 'alicloud-dns', 'infoblox-dns', 'netlify-dns', 'rfc2136', 'powerdns']
     const resources = flatMap(list.value, 'resources')
     const dnsProvidersFromDnsRecords = filter(resources, ['kind', 'DNSRecord'])
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Since PowerDNS is part of the supported DNSProviders the dashboard should also support it.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```bugfix user
adds powerdns support in dashboard
```
