### PR TITLE
oidc-use-pkce deprecation

### DIFF
--- a/frontend/src/views/GAccount.vue
+++ b/frontend/src/views/GAccount.vue
@@ -378,9 +378,6 @@ export default {
           args.push('--oidc-extra-scope=' + scope)
         }
       }
-      if (oidc.usePKCE || !oidc.clientSecret) {
-        args.push('--oidc-use-pkce')
-      }
       if (oidc.certificateAuthorityData) {
         args.push('--certificate-authority-data=' + oidc.certificateAuthorityData)
       } else if (oidc.insecureSkipTlsVerify) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, kubectl works fine, but complains about the following:
```
Flag --oidc-use-pkce has been deprecated, use --oidc-pkce-method instead. For the most providers, you don't need to set the flag.
```

**Which issue(s) this PR fixes**:
None, should I open a separate one?

**Special notes for your reviewer**:
I didn't test this code, my intent is to get rid of the following line in the kubeconfigs, that are generated:
```
          - '--oidc-use-pkce'
```

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Flag --oidc-use-pkce has been deprecated. In case your use-case requires it, use --oidc-pkce-method instead. For the most providers, you don't need to set the flag.
```
