### PR TITLE
[hotfix] Use static row heigh

### DIFF
--- a/frontend/src/views/GShootList.vue
+++ b/frontend/src/views/GShootList.vue
@@ -152,6 +152,8 @@ SPDX-License-Identifier: Apache-2.0
         :custom-key-sort="customKeySort"
         density="compact"
         hover
+        item-height="37"
+        :item-key="getItemKey"
         must-sort
         fixed-header
         class="g-table"
@@ -166,9 +168,8 @@ SPDX-License-Identifier: Apache-2.0
         <template #no-data>
           No clusters to show
         </template>
-        <template #item="{ item, itemRef }">
+        <template #item="{ item }">
           <g-shoot-list-row
-            :ref="itemRef"
             :model-value="item"
             :visible-headers="visibleHeaders"
           />
@@ -813,6 +814,9 @@ export default {
         unset(reactiveObject, [key])
       }
       Object.assign(reactiveObject, defaultState)
+    },
+    getItemKey (item, fallback) {
+      return get(item, ['raw', 'metadata', 'uid'], fallback)
     },
   },
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Use static row height as a workaround to fix lazy row rendering in shoot table

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Lazy rendering was not functioning correctly in some scenarios, leading to performance issues with large cluster lists
```
