### PR TITLE
Potential fix for code scanning alert no. 24: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/reuse-tool-lint.yaml
+++ b/.github/workflows/reuse-tool-lint.yaml
@@ -2,6 +2,9 @@ name: REUSE Compliance Check
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/gardener/dashboard/security/code-scanning/24](https://github.com/gardener/dashboard/security/code-scanning/24)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will explicitly set `contents: read`, which is the minimal permission required for the `actions/checkout` and `fsfe/reuse-action` steps to function correctly. This ensures that the workflow adheres to the principle of least privilege and avoids granting unnecessary permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
