### PR TITLE
Potential fix for code scanning alert no. 25: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dependency-diagrams.yml
+++ b/.github/workflows/dependency-diagrams.yml
@@ -9,6 +9,9 @@ on:
       - 'master'
       - 'hotfix-*'
 
+permissions:
+  contents: write
+
 jobs:
   generate-diagrams:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/gardener/dashboard/security/code-scanning/25](https://github.com/gardener/dashboard/security/code-scanning/25)

To fix the issue, we will add a `permissions` block at the workflow level to define the least privileges required. Based on the workflow's steps:
1. The `actions/checkout` step requires `contents: read` to access the repository.
2. The `EndBug/add-and-commit` step requires `contents: write` to commit changes to the repository.

We will set `contents: write` at the workflow level to cover both read and write operations. This ensures the workflow has the necessary permissions while adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
