### PR TITLE
Potential fix for code scanning alert no. 1: Loop bound injection

### DIFF
--- a/backend/lib/services/members/MemberManager.js
+++ b/backend/lib/services/members/MemberManager.js
@@ -179,6 +179,13 @@ class MemberManager {
   }
 
   setItemRoles (item, roles) {
+    if (!Array.isArray(roles)) {
+      throw new UnprocessableEntity('Roles must be an array')
+    }
+    const MAX_ROLES = 100; // Define a reasonable limit for roles
+    if (roles.length > MAX_ROLES) {
+      throw new UnprocessableEntity(`Roles array exceeds the maximum allowed size of ${MAX_ROLES}`)
+    }
     roles = _.compact(roles)
     if (!roles.length && item.kind !== 'ServiceAccount') {
       throw new UnprocessableEntity('At least one role is required')

--- a/backend/lib/services/members/MemberManager.js
+++ b/backend/lib/services/members/MemberManager.js
@@ -182,7 +182,7 @@ class MemberManager {
     if (!Array.isArray(roles)) {
       throw new UnprocessableEntity('Roles must be an array')
     }
-    const MAX_ROLES = 100; // Define a reasonable limit for roles
+    const MAX_ROLES = 10 // Define a reasonable limit for roles
     if (roles.length > MAX_ROLES) {
       throw new UnprocessableEntity(`Roles array exceeds the maximum allowed size of ${MAX_ROLES}`)
     }


### PR DESCRIPTION
Potential fix for [https://github.com/gardener/dashboard/security/code-scanning/1](https://github.com/gardener/dashboard/security/code-scanning/1)

To fix the issue, we need to validate the `roles` array to ensure it is both an array and has a reasonable size limit before it is used in the loop. This can be achieved by:
1. Checking if `roles` is an array using `Array.isArray`.
2. Limiting the maximum allowed size of the `roles` array to a predefined constant (e.g., `MAX_ROLES`).
3. Throwing an error if the validation fails.

The validation should be added in the `setItemRoles` method in `MemberManager.js`, as this is where the `roles` parameter is directly used.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
