### PR TITLE
Cleanup legacy EU access-only sync mechanism and config mapping

### DIFF
--- a/frontend/src/composables/useShootAccessRestrictions/index.js
+++ b/frontend/src/composables/useShootAccessRestrictions/index.js
@@ -4,17 +4,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import {
-  computed,
-  ref,
-} from 'vue'
+import { computed } from 'vue'
 
 import { useCloudProfileStore } from '@/store/cloudProfile'
 
 import { NAND } from './helper'
 
 import get from 'lodash/get'
-import isEmpty from 'lodash/isEmpty'
 import set from 'lodash/set'
 import unset from 'lodash/unset'
 import keyBy from 'lodash/keyBy'
@@ -36,8 +32,6 @@ export const useShootAccessRestrictions = (shootItem, options = {}) => {
   } = mapValues(shootPropertyMappings, path => {
     return computed(() => get(shootItem.value, path))
   })
-
-  const unsetLegacyAccessRestriction = ref(false)
 
   const accessRestrictionDefinitionList = computed(() => {
     return cloudProfileStore.accessRestrictionDefinitionsByCloudProfileRefAndRegion({
@@ -106,20 +100,9 @@ export const useShootAccessRestrictions = (shootItem, options = {}) => {
       if (index === -1) {
         accessRestrictions.push({ name: key })
       }
-
-      // TODO(petersutter): remove this block after gardener has dropped the access restriction sync logic for spec.seedSelector.matchLabels
-      if (key === 'eu-access-only') {
-        unsetLegacyAccessRestriction.value = false
-      }
     } else {
       if (index !== -1) {
         accessRestrictions.splice(index, 1)
-      }
-
-      // TODO(petersutter): remove this block after gardener has dropped the access restriction sync logic for spec.seedSelector.matchLabels
-      if (key === 'eu-access-only') {
-        // Due to the migration/sync logic in g/g, to deactivate the `eu-access-only` access restriction, both `spec.AccessRestriction[@name="eu-access-only"]` and `spec.seedSelector.matchLabels["seed.gardener.cloud/eu-access"]` must be removed at the same time.
-        unsetLegacyAccessRestriction.value = true
       }
     }
     setAccessRestrictions(accessRestrictions)
@@ -162,29 +145,6 @@ export const useShootAccessRestrictions = (shootItem, options = {}) => {
       spec: {
         accessRestrictions,
       },
-    }
-
-    // TODO(petersutter): remove this block after gardener has dropped the access restriction sync logic for spec.seedSelector.matchLabels
-    if (unsetLegacyAccessRestriction.value) {
-      let seedSelector = get(shootItem.value, ['spec', 'seedSelector'])
-
-      unset(seedSelector, ['matchLabels', 'seed.gardener.cloud/eu-access'])
-
-      if (isEmpty(get(seedSelector, ['matchLabels']))) {
-        unset(seedSelector, ['matchLabels'])
-      }
-
-      if (isEmpty(seedSelector)) {
-        seedSelector = null
-      }
-
-      data.spec.seedSelector = seedSelector
-      data.metadata = {
-        annotations: {
-          'support.gardener.cloud/eu-access-for-cluster-addons': null,
-          'support.gardener.cloud/eu-access-for-cluster-nodes': null,
-        },
-      }
     }
     return data
   }

--- a/frontend/src/store/config.js
+++ b/frontend/src/store/config.js
@@ -149,26 +149,7 @@ export const useConfigStore = defineStore('config', () => {
   })
 
   const accessRestriction = computed(() => {
-    // TODO(petersutter): remove mapping from seed.gardener.cloud/eu-access to eu-access-only in dashboard version >=1.80.0. Add breaking change release note.
-    const accessRestriction = state.value?.accessRestriction
-    if (!accessRestriction) {
-      return
-    }
-
-    const items = map(accessRestriction.items, item => {
-      if (item.key === 'seed.gardener.cloud/eu-access') {
-        return {
-          ...item,
-          key: 'eu-access-only',
-        }
-      }
-      return item
-    })
-
-    return {
-      ...accessRestriction,
-      items,
-    }
+    return state.value?.accessRestriction
   })
 
   const sla = computed(() => {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes the temporary mapping that was introduced in a previous PR ([ref](https://github.com/gardener/dashboard/pull/2196)) where `accessRestriction.items[@key="seed.gardener.cloud/eu-access"]` was mapped to `accessRestriction.items[@key="eu-access-only"]`. As announced in the original PR, this mapping was meant to be temporary to give operators time to update their configurations. The grace period has now passed, and we are proceeding with the removal as planned.

The removal of this mapping completes the transition that was started with the previous changes, and operators should now be using the `eu-access-only` key directly in their access restriction configurations as previously advised.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This change follows through on the previously communicated plan to remove the temporary mapping. Operators were given advance notice in the previous PR that this change would be coming.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The temporary mapping from `accessRestriction.items[@key="seed.gardener.cloud/eu-access"]` to `accessRestriction.items[@key="eu-access-only"]` has been removed as previously announced ([ref](https://github.com/gardener/dashboard/pull/2196)).
```
