### PR TITLE
Fix alertmanager url

### DIFF
--- a/frontend/src/components/GClusterMetrics.vue
+++ b/frontend/src/components/GClusterMetrics.vue
@@ -105,7 +105,7 @@ export default {
     },
     alertmanagerUrl () {
       if (this.isOidcObservabilityUrlsEnabled) {
-        return this.getOidcStatefulsetUrl('alertmanager')
+        return this.getOidcStatefulsetUrl('alertmanager-shoot')
       }
 
       return `https://au-${this.prefix}.${this.seedIngressDomain}`


### PR DESCRIPTION
**What this PR does / why we need it**:
Similar to the prometheus-shoot url, the target alertmanager has to be suffixed with -shoot

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed Alertmanager URL
```
