### PR TITLE
update autoscaler values on blur instead of input

### DIFF
--- a/frontend/src/components/ShootWorkers/GWorkerInputGeneric.vue
+++ b/frontend/src/components/ShootWorkers/GWorkerInputGeneric.vue
@@ -90,7 +90,7 @@ SPDX-License-Identifier: Apache-2.0
           label="Autoscaler Min."
           variant="underlined"
           @input="v$.worker.minimum.$touch()"
-          @blur="v$.worker.minimum.$touch()"
+          @blur="v$.worker.minimum.$touch(); overrideMax()"
         />
       </div>
       <div class="small-input">
@@ -103,7 +103,7 @@ SPDX-License-Identifier: Apache-2.0
           variant="underlined"
           :error-messages="getErrorMessages(v$.worker.maximum)"
           @input="v$.worker.maximum.$touch()"
-          @blur="v$.worker.maximum.$touch()"
+          @blur="v$.worker.maximum.$touch(); overrideMin()"
         />
       </div>
       <div class="small-input">
@@ -361,9 +361,6 @@ export default {
       },
       set (value) {
         this.worker.minimum = Math.max(0, parseInt(value))
-        if (this.innerMax < this.worker.minimum) {
-          this.worker.maximum = this.worker.minimum
-        }
       },
     },
     innerMax: {
@@ -372,9 +369,6 @@ export default {
       },
       set: function (value) {
         this.worker.maximum = Math.max(0, parseInt(value))
-        if (this.innerMin > this.worker.maximum) {
-          this.worker.minimum = this.worker.maximum
-        }
       },
     },
     maxSurge: {
@@ -513,6 +507,16 @@ export default {
       this.worker.machine.type = get(defaultMachineType, ['name'])
       const defaultMachineImage = this.defaultMachineImageForCloudProfileRefAndMachineType(this.cloudProfileRef, defaultMachineType)
       this.worker.machine.image = pick(defaultMachineImage, ['name', 'version'])
+    },
+    overrideMax () {
+      if (this.innerMax < this.worker.minimum) {
+        this.worker.maximum = this.worker.minimum
+      }
+    },
+    overrideMin () {
+      if (this.innerMin > this.worker.maximum) {
+        this.worker.minimum = this.worker.maximum
+      }
     },
     getErrorMessages,
   },

--- a/frontend/src/components/ShootWorkers/GWorkerInputGeneric.vue
+++ b/frontend/src/components/ShootWorkers/GWorkerInputGeneric.vue
@@ -90,7 +90,7 @@ SPDX-License-Identifier: Apache-2.0
           label="Autoscaler Min."
           variant="underlined"
           @input="v$.worker.minimum.$touch()"
-          @blur="v$.worker.minimum.$touch(); overrideMax()"
+          @blur="ensureValidAutoscalerMin()"
         />
       </div>
       <div class="small-input">
@@ -103,7 +103,7 @@ SPDX-License-Identifier: Apache-2.0
           variant="underlined"
           :error-messages="getErrorMessages(v$.worker.maximum)"
           @input="v$.worker.maximum.$touch()"
-          @blur="v$.worker.maximum.$touch(); overrideMin()"
+          @blur="ensureValidAutoscalerMax()"
         />
       </div>
       <div class="small-input">
@@ -508,12 +508,16 @@ export default {
       const defaultMachineImage = this.defaultMachineImageForCloudProfileRefAndMachineType(this.cloudProfileRef, defaultMachineType)
       this.worker.machine.image = pick(defaultMachineImage, ['name', 'version'])
     },
-    overrideMax () {
+    ensureValidAutoscalerMin () {
+      this.v$.worker.minimum.$touch()
+      // Ensure maximum is not less than minimum
       if (this.innerMax < this.worker.minimum) {
         this.worker.maximum = this.worker.minimum
       }
     },
-    overrideMin () {
+    ensureValidAutoscalerMax () {
+      this.v$.worker.maximum.$touch()
+      // Ensure minimum is not greater than maximum
       if (this.innerMin > this.worker.maximum) {
         this.worker.minimum = this.worker.maximum
       }


### PR DESCRIPTION
**What this PR does / why we need it**:
Triggers the update of the min and max autoscaler only on blur. 
**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/dashboard/issues/2468

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
update of dependent autoscaler value will only be triggered after the ui element is not focused anymore
```
