### PR TITLE
fix: missed yarn dependency

### DIFF
--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -57,7 +57,7 @@ module.exports = {
     enforceFieldsOnAllWorkspaces(ctx, {
       license: 'Apache-2.0',
       'engines.node': '^22.7.0',
-      'packageManager': 'yarn@4.9.1',
+      'packageManager': 'yarn@4.9.2',
       'repository.type': 'git',
       'repository.url': 'git+https://github.com/gardener/dashboard.git',
       'repository.directory': workspace => workspace.cwd,


### PR DESCRIPTION
yarn.config.cjs was not updated by

https://github.com/gardener/dashboard/pull/2473

as done previously by
https://github.com/gardener/dashboard/pull/2395

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes dependency issues caused by https://github.com/gardener/dashboard/pull/2473 since it did not update yarn.config.cjs 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
