### PR TITLE
Temporary disable flaky test

### DIFF
--- a/backend/__tests__/acceptance/auth.spec.js
+++ b/backend/__tests__/acceptance/auth.spec.js
@@ -199,7 +199,8 @@ describe('auth', function () {
     expect(url.searchParams.get('state')).toEqual('state')
   })
 
-  it('should fail to redirect to authorization url', async function () {
+  // TODO migrate to latest pRetry version and use abort signal in afterEach hook to ensure that the retry is aborted. Then this test can be enabled again.
+  it.skip('should fail to redirect to authorization url', async function () {
     const message = 'Issuer not available'
     discovery.mockRejectedValueOnce(new Error(message))
 


### PR DESCRIPTION
**What this PR does / why we need it**:
One test was temporarily disabled with this PR until we have migrated to the latest `pRetry` version and use an abort signal in the `afterEach` hook to ensure that retries are properly aborted.  
Currently, the test is skipped because the retry mechanism in `getConfiguration` repeatedly calls the `discovery` function on failure. Since retries are not aborted between tests, `discovery` may be called multiple times, which interferes with other tests that expect it to be called only once. This leads to test leakage, where ongoing retries from a failed test can affect subsequent tests and make the test suite unreliable.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
