### PR TITLE
Add constraint DualStackNodesMigrationReady to wellKnownConditions.

### DIFF
--- a/frontend/src/store/config.js
+++ b/frontend/src/store/config.js
@@ -103,6 +103,12 @@ const wellKnownConditions = {
     description: 'Indicates that there is at least one CA certificate which expires in less than 1 year. A credentials rotation operation should be considered.',
     sortOrder: '12',
   },
+  DualStackNodesMigrationReady: {
+    name: 'Dual Stack Nodes Migration Ready',
+    shortName: 'DSNM',
+    description: 'Indicates that the nodes of a shoot are ready for dual-stack migration of the cluster. If this is in error state, the nodes need to be rolled before the migration can continue. This error is expected at the beginning of the migration process and does not require immediate user action.',
+    sortOrder: '13',
+  },
 }
 
 export function getCondition (type) {


### PR DESCRIPTION
**What this PR does / why we need it**:
The constraint DualStackNodesMigrationReady is set to false during the migration from single-stack IPv4 to dual-stack IPv4/IPv6 clusters. This PR adds a description as a constraint with state false might be confusing for users.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Added description for constraint DualStackNodesMigrationReady
```
