### PR TITLE
adapt server.mjs to server.js in dashboard deployment

### DIFF
--- a/charts/__tests__/gardener-dashboard/runtime/dashboard/__snapshots__/deployment.spec.js.snap
+++ b/charts/__tests__/gardener-dashboard/runtime/dashboard/__snapshots__/deployment.spec.js.snap
@@ -196,7 +196,7 @@ exports[`gardener-dashboard deployment should render the template with default v
           {
             "args": [
               "--max-old-space-size=920",
-              "server.mjs",
+              "server.js",
             ],
             "env": [
               {
@@ -361,7 +361,7 @@ exports[`gardener-dashboard deployment should render the template with node opti
   "--expose-gc",
   "--trace-gc",
   "--gc-interval=100",
-  "server.mjs",
+  "server.js",
 ]
 `;
 

--- a/charts/gardener-dashboard/charts/runtime/templates/dashboard/deployment.yaml
+++ b/charts/gardener-dashboard/charts/runtime/templates/dashboard/deployment.yaml
@@ -139,7 +139,7 @@ spec:
           {{- range .Values.global.dashboard.nodeOptions }}
           - {{ . }}
           {{- end }}
-          - server.mjs
+          - server.js
           {{- end }}
           image: "{{ include "utils-templates.image" .Values.global.dashboard.image }}"
           imagePullPolicy: {{ .Values.global.dashboard.image.pullPolicy }}


### PR DESCRIPTION
This PR updates the server entry point from `server.mjs` to `server.js` in the Kubernetes deployment template for the gardener dashboard. This change aligns the deployment configuration with the expected server file extension.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This is a simple file extension change in the deployment template. The change is made in `charts/gardener-dashboard/charts/runtime/templates/dashboard/deployment.yaml` on line 142.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:     other
- target_group:   developer
-->
```other developer
adapt server entry point from server.mjs to server.js in dashboard deployment template
```
