### PR TITLE
Use GitHub App token in prepare-hotfix workflow

### DIFF
--- a/.github/workflows/prepare-hotfix-branch.yaml
+++ b/.github/workflows/prepare-hotfix-branch.yaml
@@ -11,15 +11,19 @@ on:
 jobs:
   prepare-hotfix:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     env:
       TAG: ${{ inputs.tag }}
     steps:
+      - name: Create GitHub App token
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e   # v2.0.6
+        id: app-token
+        with:
+          app-id: ${{ vars.GARDENER_GITHUB_ACTIONS_APP_ID }}
+          private-key: ${{ secrets.GARDENER_GITHUB_ACTIONS_PRIVATE_KEY }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ env.TAG }}
+          token: ${{ steps.app-token.outputs.token }}
       - name: Setup Git Identity
         uses: gardener/cc-utils/.github/actions/setup-git-identity@master
       - name: Compute and validate branch names
@@ -74,7 +78,7 @@ jobs:
           git commit -m "Add hotfix branch to changesetBaseRefs in .yarnrc.yml"
       - name: Push prepare branch and create Pull Request
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git push origin "$PREPARE_BRANCH"
           gh pr create \


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the prepare-hotfix workflow to use a token from the Gardener GitHub Actions App instead of the default GITHUB_TOKEN. This is necessary because the workflow needs to push to protected branches, and the app provides the required permissions to bypass rulesets as an exception.

This aligns with the migration to GitHub Actions and the use of rulesets for branch protection, as documented here: https://github.com/gardener/cc-utils/blob/master/doc/github_actions.rst#branch-protection---rulesets.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
