### PR TITLE
[master] fix: shrinking input field for oci runtimes

### DIFF
--- a/frontend/src/components/ShootWorkers/GContainerRuntime.vue
+++ b/frontend/src/components/ShootWorkers/GContainerRuntime.vue
@@ -11,7 +11,6 @@ SPDX-License-Identifier: Apache-2.0
     <v-select
       v-model="criName"
       v-messages-color="{ color: 'warning' }"
-      style="flex: 0 0 125px"
       color="primary"
       item-color="primary"
       :items="criItems"

--- a/frontend/src/components/ShootWorkers/GContainerRuntime.vue
+++ b/frontend/src/components/ShootWorkers/GContainerRuntime.vue
@@ -5,10 +5,14 @@ SPDX-License-Identifier: Apache-2.0
 -->
 
 <template>
-  <div class="d-flex flex-row">
+  <div
+    class="d-flex flex-row"
+    style="min-width: 250px;"
+  >
     <v-select
       v-model="criName"
       v-messages-color="{ color: 'warning' }"
+      class="flex-grow-0 flex-shrink-0"
       color="primary"
       item-color="primary"
       :items="criItems"
@@ -23,11 +27,11 @@ SPDX-License-Identifier: Apache-2.0
     <v-select
       v-if="criContainerRuntimeTypes.length"
       v-model="selectedCriContainerRuntimeTypes"
-      class="ml-1"
+      class="ml-1 flex-shrink-0"
       color="primary"
       item-color="primary"
       :items="criContainerRuntimeTypes"
-      label="Additional OCI Runtimes"
+      label="Add. OCI Runtimes"
       multiple
       chips
       closable-chips

--- a/frontend/src/components/ShootWorkers/GContainerRuntime.vue
+++ b/frontend/src/components/ShootWorkers/GContainerRuntime.vue
@@ -7,12 +7,11 @@ SPDX-License-Identifier: Apache-2.0
 <template>
   <div
     class="d-flex flex-row"
-    style="min-width: 250px;"
   >
     <v-select
       v-model="criName"
+      style="flex: 0 0 125px"
       v-messages-color="{ color: 'warning' }"
-      class="flex-grow-0 flex-shrink-0"
       color="primary"
       item-color="primary"
       :items="criItems"
@@ -27,7 +26,8 @@ SPDX-License-Identifier: Apache-2.0
     <v-select
       v-if="criContainerRuntimeTypes.length"
       v-model="selectedCriContainerRuntimeTypes"
-      class="ml-1 flex-shrink-0"
+      class="ml-1"
+      style="flex: 0 0 125px"
       color="primary"
       item-color="primary"
       :items="criContainerRuntimeTypes"

--- a/frontend/src/components/ShootWorkers/GContainerRuntime.vue
+++ b/frontend/src/components/ShootWorkers/GContainerRuntime.vue
@@ -10,8 +10,8 @@ SPDX-License-Identifier: Apache-2.0
   >
     <v-select
       v-model="criName"
-      style="flex: 0 0 125px"
       v-messages-color="{ color: 'warning' }"
+      style="flex: 0 0 125px"
       color="primary"
       item-color="primary"
       :items="criItems"


### PR DESCRIPTION
**What this PR does / why we need it**:
Improves usability of the select dialog in the worker group for `Additional OCI Runtimes`
**Which issue(s) this PR fixes**:
Fixes # https://github.com/gardener/dashboard/issues/2426

**Special notes for your reviewer**:
The issue is reproduced in : 
[Vuetify Playground](https://play.vuetifyjs.com/#eNq9ld9r2zAQx/+Vq1+8QeSkCYUucwclsB8PYzAGfWj6oNgXR0yWhCQnDSH/+052nSWO08Fgw2Ck00e68935q8dd5Gw2vDcmWVcYTaPUY2kk9/hhrgDSNePG1MN6kmnluVBoX0xkzMUaMsmdu5tHOVtKfJ5Hh9XedQgvtrHcnJAd1mJRSW6ZUKbyHZDQK8ZAW1EIxeUUgLE+4KJzqzd0ZM+uVzeA81uJtFIKxTYi96spjG9G5vSL+wOk5DmUmHnYCL/SlW/cnIdwhHYX4BBaHVNBQbFRE59bWaF+stE8Ot+0ZqXOUYa4XXEBQOd4gY4KLLUlcgf1aArxhlslVBHDvm9ryxsrSm63fYigjjqc+wo3DWD4uMeYxwOIF+GVxU99rOSL+oNmbT/C90p5UWIfvBLKE7tAcOTbQx9j0DrhPCrPAt6TI24Fr8+pVI5WktP8/KDhf+6DUrLrPzfAUWZnXIqlporWKZ6FqvBch/FHGoq8Nn9CbYuG+IHP3IXBw1ZT1xf95chWwrhzc1lJL4zEf9o2bSvc57nwQlOW4dvsS9sPrjdcqR1fSGQX4v67WqdDEo9TPetYTufHs3TY1dZgaaQ3HR5JMk1dZoXx4NBXjTKL0mhq6x1YXMIellaXEJOaxwEPuVbOA/36cBeIN/FnlFLDg7Yyv4rfHiHcfA1C8cJ1fkMC02Hjm7xGg/reKCngJHOOLo7kRLBhF84tOel8o5OTEenk+9r4Wzyvb1tj6GGa08Mrr2uT4VRRVZB1XEN78rofRJPkJrm+Jf+T5F0yjgZLLh020bS3WGN7+gWgYezD)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
