### PR TITLE
fix: add dropped sync back from ui to shoot editor

### DIFF
--- a/frontend/src/components/GShootEditor.vue
+++ b/frontend/src/components/GShootEditor.vue
@@ -46,7 +46,7 @@ SPDX-License-Identifier: Apache-2.0
                   size="x-small"
                   icon="mdi-reload"
                   :disabled="!touched"
-                  @click="resetEditor"
+                  @click="refreshEditor"
                 />
               </div>
             </template>

--- a/frontend/src/components/GShootEditor.vue
+++ b/frontend/src/components/GShootEditor.vue
@@ -224,7 +224,7 @@ const {
   helpTooltip,
   loadEditor,
   focusEditor,
-  resetEditor,
+  refreshEditor,
   destroyEditor,
   execUndo,
   execRedo,

--- a/frontend/src/components/ShootWorkers/GWorkerConfiguration.vue
+++ b/frontend/src/components/ShootWorkers/GWorkerConfiguration.vue
@@ -209,7 +209,7 @@ export default {
     const {
       touched,
       getEditorValue,
-      setEditorValue,
+      refreshEditor,
     } = useProvide(injectionKey, useShootEditor(editorData, {
       completionPaths: [
         'spec.properties.provider.properties.workers',
@@ -238,7 +238,7 @@ export default {
       editorData,
       touched,
       getEditorValue,
-      setEditorValue,
+      refreshEditor,
     }
   },
   computed: {
@@ -263,7 +263,8 @@ export default {
             // dialog downsize as editor not yet rendered
             this.overviewTabHeight = this.$refs.overviewTab.$el.getBoundingClientRect().height
             this.disableWorkerAnimation = true
-            this.setEditorValue(this.editorData)
+            //
+            this.refreshEditor()
             break
           }
         }

--- a/frontend/src/components/ShootWorkers/GWorkerConfiguration.vue
+++ b/frontend/src/components/ShootWorkers/GWorkerConfiguration.vue
@@ -263,7 +263,6 @@ export default {
             // dialog downsize as editor not yet rendered
             this.overviewTabHeight = this.$refs.overviewTab.$el.getBoundingClientRect().height
             this.disableWorkerAnimation = true
-            //
             this.refreshEditor()
             break
           }

--- a/frontend/src/components/ShootWorkers/GWorkerConfiguration.vue
+++ b/frontend/src/components/ShootWorkers/GWorkerConfiguration.vue
@@ -209,6 +209,7 @@ export default {
     const {
       touched,
       getEditorValue,
+      setEditorValue,
     } = useProvide(injectionKey, useShootEditor(editorData, {
       completionPaths: [
         'spec.properties.provider.properties.workers',
@@ -237,6 +238,7 @@ export default {
       editorData,
       touched,
       getEditorValue,
+      setEditorValue,
     }
   },
   computed: {
@@ -261,6 +263,7 @@ export default {
             // dialog downsize as editor not yet rendered
             this.overviewTabHeight = this.$refs.overviewTab.$el.getBoundingClientRect().height
             this.disableWorkerAnimation = true
+            this.setEditorValue(this.editorData)
             break
           }
         }

--- a/frontend/src/composables/useShootEditor.js
+++ b/frontend/src/composables/useShootEditor.js
@@ -161,8 +161,8 @@ export function useShootEditor (initialValue, options = {}) {
     }
   }
 
-  function resetEditor () {
-    setEditorValue(shootItem.value, false)
+  function refreshEditor () {
+    setEditorValue(shootItem.value)
   }
 
   function focusEditor () {
@@ -242,7 +242,7 @@ export function useShootEditor (initialValue, options = {}) {
     getDocumentValue,
     getEditorValue,
     setEditorValue,
-    resetEditor,
+    refreshEditor,
     focusEditor,
     execUndo,
     execRedo,


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the sync back of changes from the yml editor to the ui in the worker dialog

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The support for the feature seems to have been accidentally doped in a larger refactoring.  
<img width="2085" height="746" alt="image" src="https://github.com/user-attachments/assets/0cabe90f-ca02-41ad-a7cb-fb8a2f71f308" />

https://github.com/gardener/dashboard/commit/4b4c5107a9adbd328243788f908775c5ae184b49#diff-dfc9408d18447ae4d21cdfd88a66e781b056740502a371f75435ee5a208f265fL179
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
