### PR TITLE
Add OCI Images Summary job to aggregate matrix results for required status checks

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -65,7 +65,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Check matrix status
+      - name: Fail if OCI matrix failed
         if: ${{ needs.oci-images.result != 'success' }}
         run: exit 1
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,6 +57,18 @@ jobs:
       ocm-labels: ${{ toJSON(matrix.args.ocm-labels) }}
       extra-tags: latest
 
+  oci-images-summary:
+    name: OCI Images Summary
+    runs-on: ubuntu-latest
+    needs: oci-images
+    if: ${{ always() }}  # Ensures this job runs even if the matrix partially fails
+    permissions:
+      contents: read
+    steps:
+      - name: Check matrix status
+        if: ${{ needs.oci-images.result != 'success' }}
+        run: exit 1
+
   verify:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces a lightweight aggregator job (`oci-images-summary`) that depends on the `oci-images` matrix. It runs unconditionally and fails if any matrix variant fails, allowing the entire matrix to be required as a single status check in branch protection rules.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
