### PR TITLE
Add merge_group trigger to non-release workflow

### DIFF
--- a/.github/workflows/non-release.yaml
+++ b/.github/workflows/non-release.yaml
@@ -2,6 +2,7 @@ name: Build
 on:
   push:
   pull_request_target:
+  merge_group:
 
 jobs:
   build:


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the `merge_group` event to the on triggers in `.github/workflows/non-release.yaml`. This ensures that required checks (such as `sast-lint`, `verify`, and `OCI Images Summary`) run and report their status when a PR is added to the merge queue, allowing the merge queue to proceed without hanging on unreported checks.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
