### PR TITLE
Use GitHub app token

### DIFF
--- a/.github/workflows/cherry-pick.yaml
+++ b/.github/workflows/cherry-pick.yaml
@@ -141,12 +141,18 @@ jobs:
         with:
           ref: master
 
+      - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        id: token
+        with:
+          app-id: ${{ vars.GARDENER_GITHUB_ACTIONS_APP_ID }}
+          private-key: ${{ secrets.GARDENER_GITHUB_ACTIONS_PRIVATE_KEY }}
+
       - name: Perform Cherry Pick
         uses: ./.github/actions/cherry-pick
         with:
           pr-number: ${{ github.event.issue.number }}
           target-branch: ${{ matrix.target-branch }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.token.outputs.token }}
 
   summary:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**What this PR does / why we need it**:
Use GitHub app token for cherry-pick action to be able to create PRs. Otherwise it will fail with the error
```
Creating cherry-pick PR
pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve pull requests (createPullRequest)
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
