### PR TITLE
Switch to `pull_request` for builds/tests, `pull_request_target` for trusted writes on label

### DIFF
--- a/.github/workflows/non-release.yaml
+++ b/.github/workflows/non-release.yaml
@@ -1,11 +1,20 @@
 name: Build
 on:
   push:
+  pull_request:
+    types:
+    - opened
+    - edited
+    - reopened
+    - synchronize
   pull_request_target:
+    types:
+    - labeled
   merge_group:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request_target' || (github.event_name == 'pull_request_target' && github.event.label.name == 'reviewed/ok-to-test') }}
     uses: ./.github/workflows/build.yaml
     with:
       mode: snapshot
@@ -16,6 +25,7 @@ jobs:
       id-token: write
 
   component-descriptor:
+    if: ${{ github.event_name != 'pull_request_target' || (github.event_name == 'pull_request_target' && github.event.label.name == 'reviewed/ok-to-test') }}
     uses: gardener/cc-utils/.github/workflows/post-build.yaml@master
     needs:
       - build


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the Build workflow to primarily use the pull_request event for triggering builds and tests on PR actions (opened, edited, reopened, synchronize), enforcing read-only permissions on the `GITHUB_TOKEN` for pull requests from forked repositories of outside contributors.

> With the exception of GITHUB_TOKEN, secrets are not passed to the runner when a workflow is triggered from a forked repository. The GITHUB_TOKEN has read-only permissions in pull requests from forked repositories. For more information, see [Use GITHUB_TOKEN for authentication in workflows](https://docs.github.com/en/actions/security-guides/automatic-token-authentication).

https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflows-in-forked-repositories

For cases requiring writes (e.g., image pushes), the workflow adds a `pull_request_target` trigger on the `labeled` event type, conditioned to run only when the `reviewed/ok-to-test` label is added. This allows trusted execution for PRs from external contributors, via the trusted-checkout action in `build.yaml`, but should only be added after review.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
