### PR TITLE
Dynamic height for shoot table rows

### DIFF
--- a/frontend/src/views/GShootList.vue
+++ b/frontend/src/views/GShootList.vue
@@ -145,7 +145,6 @@ SPDX-License-Identifier: Apache-2.0
         :custom-key-sort="customKeySort"
         density="compact"
         hover
-        item-height="37"
         :item-key="getItemKey"
         must-sort
         fixed-header
@@ -161,8 +160,9 @@ SPDX-License-Identifier: Apache-2.0
         <template #no-data>
           No clusters to show
         </template>
-        <template #item="{ item }">
+        <template #item="{ item, itemRef }">
           <g-shoot-list-row
+            :ref="itemRef"
             :model-value="item"
             :visible-headers="visibleHeaders"
           />


### PR DESCRIPTION
**What this PR does / why we need it**:
As vuetify has merged and released fix for dynamic table rows in virtual table (https://github.com/vuetifyjs/vuetify/pull/21442) we can now remove the workaround using fixed height in shoot table.

To ensure that this works I recommend to check number of rendered table rows by executing

```js
console.log(document.querySelector('table')?.rows.length ?? 0)
```

from time to time in browser js console - at least before every release.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
