### PR TITLE
Fix merge-check of cherry-pick action

### DIFF
--- a/.github/workflows/cherry-pick.yaml
+++ b/.github/workflows/cherry-pick.yaml
@@ -23,7 +23,13 @@ jobs:
       - name: Check if PR is merged
         id: check_merged
         run: |
-          MERGED=$(gh pr view ${{ github.event.issue.number }} --json merged --jq '.merged')
+          STATE=$(gh pr view ${{ github.event.issue.number }} --json state --jq '.state')
+          if [ "$STATE" = "MERGED" ]; then
+            MERGED="true"
+          else
+            MERGED="false"
+            echo "PR is not merged; current state: $STATE"
+          fi
           echo "merged=$MERGED" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the error:

```
Run MERGED=$(gh pr view 2549 --json merged --jq '.merged')
Unknown JSON field: "merged"
Available fields:
  additions
  assignees
  author
  autoMergeRequest
  baseRefName
  baseRefOid
  body
  changedFiles
  closed
  closedAt
  closingIssuesReferences
  comments
  commits
  createdAt
  deletions
  files
  fullDatabaseId
  headRefName
  headRefOid
  headRepository
  headRepositoryOwner
  id
  isCrossRepository
  isDraft
  labels
  latestReviews
  maintainerCanModify
  mergeCommit
  mergeStateStatus
  mergeable
  mergedAt
  mergedBy
  milestone
  number
  potentialMergeCommit
  projectCards
  projectItems
  reactionGroups
  reviewDecision
  reviewRequests
  reviews
  state
  statusCheckRollup
  title
  updatedAt
  url
Error: Process completed with exit code 1.
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
