### PR TITLE
Make prepare-hotfix workflow reusable

### DIFF
--- a/.github/actions/prepare-hotfix-branch/action.yaml
+++ b/.github/actions/prepare-hotfix-branch/action.yaml
@@ -1,0 +1,107 @@
+name: Prepare Hotfix Branch
+
+description: Creates hotfix and preparation branches from a tag and optionally runs a repository specific callback.
+
+inputs:
+  tag:
+    description: The tag for which the hotfix should be created
+    required: true
+  github-token:
+    description: Token used for pushing changes and creating pull request
+    required: true
+  callback-action-path:
+    description: Optional path to a callback action executed after bumping the version
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Git Identity
+      uses: gardener/cc-utils/.github/actions/setup-git-identity@master
+
+    - name: Stage callback action outside repo (if provided)
+      id: stage-callback
+      if: ${{ inputs.callback-action-path != '' }}
+      shell: bash
+      env:
+        CALLBACK_ACTION_PATH: ${{ inputs.callback-action-path }}
+      run: |
+        set -eu
+        # copy the callback action OUTSIDE the repository before switching refs;
+        # also, we need a static path, as github-actions do not allow using parameters
+        # for this
+        cp -r "$CALLBACK_ACTION_PATH" ../prepare-hotfix-callback-action
+        echo "Callback action staged at ../prepare-hotfix-callback-action"
+        echo "callback-path=../prepare-hotfix-callback-action" >> $GITHUB_OUTPUT
+
+    - name: Compute and validate branch names
+      shell: bash
+      env:
+        TAG: ${{ inputs.tag }}
+      run: |
+        set -eu
+        if [[ ! "$TAG" =~ \.0$ ]]; then
+          echo "Tag does not end with .0"
+          exit 1
+        fi
+        BASE_VERSION="${TAG%.*}"
+        HOTFIX_BRANCH="hotfix-${BASE_VERSION}"
+        if [[ ! "$HOTFIX_BRANCH" =~ ^hotfix-[a-zA-Z0-9.-]+$ ]]; then
+          echo "Invalid hotfix branch name derived from tag: $HOTFIX_BRANCH"
+          exit 1
+        fi
+        PREPARE_BRANCH="hotfix-prepare-${BASE_VERSION}"
+        echo "HOTFIX_BRANCH=$HOTFIX_BRANCH" >> "$GITHUB_ENV"
+        echo "PREPARE_BRANCH=$PREPARE_BRANCH" >> "$GITHUB_ENV"
+        echo "Computed branches: $HOTFIX_BRANCH and $PREPARE_BRANCH"
+
+    - name: Check and create branches (base on tag)
+      shell: bash
+      env:
+        TAG: ${{ inputs.tag }}
+      run: |
+        set -euo pipefail
+        git fetch --tags origin
+
+        if ! git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+          echo "Tag not found: $TAG"
+          exit 1
+        fi
+
+        if git ls-remote --exit-code origin "$HOTFIX_BRANCH" >/dev/null 2>&1; then
+          echo "Hotfix branch $HOTFIX_BRANCH already exists"
+          exit 1
+        fi
+        if git ls-remote --exit-code origin "$PREPARE_BRANCH" >/dev/null 2>&1; then
+          echo "Prepare branch $PREPARE_BRANCH already exists"
+          exit 1
+        fi
+
+        # Create the hotfix branch from the tag, push it, then create the prepare branch from hotfix
+        git checkout -b "$HOTFIX_BRANCH" "$TAG"
+        git push origin "$HOTFIX_BRANCH"
+        git checkout -b "$PREPARE_BRANCH" "$HOTFIX_BRANCH"
+        echo "Created branches: $HOTFIX_BRANCH and $PREPARE_BRANCH"
+
+    - name: Bump patch version
+      uses: gardener/cc-utils/.github/actions/version@master
+      with:
+        version-operation: bump-patch
+        prerelease: dev
+        repository-operation: commit-to-head
+        commit-message: Bump patch version to ${version} for hotfix
+        callback-action-path: ${{ steps.stage-callback.outputs.callback-path }}
+
+    - name: Push prepare branch and create Pull Request
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+      run: |
+        set -euo pipefail
+        git push origin "$PREPARE_BRANCH"
+        gh pr create \
+          --base "$HOTFIX_BRANCH" \
+          --head "$PREPARE_BRANCH" \
+          --title "[$HOTFIX_BRANCH] Prepare hotfix branch" \
+          --body "Bumps the patch version for release preparation."

--- a/.github/actions/prepare-hotfix/action.yaml
+++ b/.github/actions/prepare-hotfix/action.yaml
@@ -1,0 +1,20 @@
+name: Prepare Hotfix
+
+runs:
+  using: composite
+  steps:
+    - name: Add hotfix branch to .yarnrc.yml
+      shell: bash
+      run: |
+        set -euo pipefail
+        echo "Adding hotfix branch to .yarnrc.yml"
+        cat <<EOT >> .yarnrc.yml
+
+        changesetBaseRefs:
+          - "master"
+          - "origin/master"
+          - "$HOTFIX_BRANCH"
+          - "origin/$HOTFIX_BRANCH"
+        EOT
+        git add .yarnrc.yml
+        git commit -m "Add hotfix branch to changesetBaseRefs in .yarnrc.yml"

--- a/.github/workflows/prepare-hotfix-branch.yaml
+++ b/.github/workflows/prepare-hotfix-branch.yaml
@@ -1,12 +1,30 @@
 name: Prepare Hotfix Branch
 
 on:
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+      callback-action-path:
+        required: false
+        type: string
+        default: ''
+    secrets:
+      GARDENER_GITHUB_ACTIONS_PRIVATE_KEY:
+        description: "Private key for the Gardener GitHub Actions app"
+        required: true
   workflow_dispatch:
     inputs:
       tag:
         description: 'The tag for which the hotfix should be created'
         required: true
         type: string
+      callback-action-path:
+        description: 'Callback action path'
+        required: false
+        type: string
+        default: .github/actions/prepare-hotfix
 
 permissions:
   contents: none  # we rely on the GitHub App token instead
@@ -28,71 +46,13 @@ jobs:
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          ref: ${{ env.TAG }}
+          ref: ${{ github.event.repository.default_branch }}
           token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 1
 
-      - name: Setup Git Identity
-        uses: gardener/cc-utils/.github/actions/setup-git-identity@master
-
-      - name: Compute and validate branch names
-        run: |
-          if [[ ! "$TAG" =~ \.0$ ]]; then
-            echo "Tag does not end with .0"
-            exit 1
-          fi
-          BASE_VERSION="${TAG%.*}"
-          HOTFIX_BRANCH="hotfix-${BASE_VERSION}"
-          if [[ ! "$HOTFIX_BRANCH" =~ ^hotfix-[a-zA-Z0-9.-]+$ ]]; then
-            echo "Invalid hotfix branch name derived from tag: $HOTFIX_BRANCH"
-            exit 1
-          fi
-          PREPARE_BRANCH="hotfix-prepare-${BASE_VERSION}"
-          echo "HOTFIX_BRANCH=$HOTFIX_BRANCH" >> $GITHUB_ENV
-          echo "PREPARE_BRANCH=$PREPARE_BRANCH" >> $GITHUB_ENV
-
-      - name: Check and create branches
-        run: |
-          git fetch origin
-          if git ls-remote --exit-code origin "$HOTFIX_BRANCH" > /dev/null 2>&1; then
-            echo "Hotfix branch $HOTFIX_BRANCH already exists"
-            exit 1
-          fi
-          if git ls-remote --exit-code origin "$PREPARE_BRANCH" > /dev/null 2>&1; then
-            echo "Prepare branch $PREPARE_BRANCH already exists"
-            exit 1
-          fi
-          git checkout -b "$HOTFIX_BRANCH"
-          git push origin "$HOTFIX_BRANCH"
-          git checkout -b "$PREPARE_BRANCH" # do not push yet
-
-      - name: Bump patch version
-        uses: gardener/cc-utils/.github/actions/version@master
+      - name: Prepare hotfix branch
+        uses: gardener/dashboard/.github/actions/prepare-hotfix-branch@master
         with:
-          version-operation: bump-patch
-          prerelease: dev
-          repository-operation: commit-to-head
-          commit-message: Bump patch version to ${version} for hotfix
-
-      - name: Update and commit .yarnrc.yml
-        run: |
-          cat <<EOF >> .yarnrc.yml
-
-          changesetBaseRefs:
-            - "master"
-            - "origin/master"
-            - "$HOTFIX_BRANCH"
-            - "origin/$HOTFIX_BRANCH"
-          EOF
-          git add .yarnrc.yml
-          git commit -m "Add hotfix branch to changesetBaseRefs in .yarnrc.yml"
-
-      - name: Push prepare branch and create Pull Request
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          git push origin "$PREPARE_BRANCH"
-          gh pr create \
-            --base "$HOTFIX_BRANCH" \
-            --head "$PREPARE_BRANCH" \
-            --title "[$HOTFIX_BRANCH] Prepare hotfix branch" \
-            --body "Bumps the patch version and adds the hotfix branch references to .yarnrc.yml for release preparation."
+          tag: ${{ env.TAG }}
+          github-token: ${{ steps.app-token.outputs.token }}
+          callback-action-path: ${{ inputs.callback-action-path }}


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR, the prepare hotfix workflow can now be reused from other repositories, like gardenlogin, gardenctl-v2 etc.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
