### PR TITLE
Prepare Hotfix GithubAction: request workflows write permission

### DIFF
--- a/.github/workflows/prepare-hotfix-branch.yaml
+++ b/.github/workflows/prepare-hotfix-branch.yaml
@@ -43,6 +43,7 @@ jobs:
           private-key: ${{ secrets.GARDENER_GITHUB_ACTIONS_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
+          permission-workflows: write
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:


### PR DESCRIPTION
**What this PR does / why we need it**:
The `gardenlogin` workflow run failed as the workflow did not request the workflow write permission ([ref](https://github.com/gardener/gardenlogin/actions/runs/16969030104/job/48100654446))
```bash
set -euo pipefail
  git fetch --tags origin
  
  if ! git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
    echo "Tag not found: $TAG"
    exit 1
  fi
  
  if git ls-remote --exit-code origin "$HOTFIX_BRANCH" >/dev/null 2>&1; then
    echo "Hotfix branch $HOTFIX_BRANCH already exists"
    exit 1
  fi
  if git ls-remote --exit-code origin "$PREPARE_BRANCH" >/dev/null 2>&1; then
    echo "Prepare branch $PREPARE_BRANCH already exists"
    exit 1
  fi
  
  # Create the hotfix branch from the tag, push it, then create the prepare branch from hotfix
  git checkout -b "$HOTFIX_BRANCH" "$TAG"
  git push origin "$HOTFIX_BRANCH"
  git checkout -b "$PREPARE_BRANCH" "$HOTFIX_BRANCH"
  echo "Created branches: $HOTFIX_BRANCH and $PREPARE_BRANCH"
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    TAG: v0.7.0
    HOTFIX_BRANCH: hotfix-v0.7
    PREPARE_BRANCH: hotfix-prepare-v0.7
From https://github.com/gardener/gardenlogin
 * [new branch]      8R0WNI3-release-assets -> origin/8R0WNI3-release-assets
 * [new branch]      fix-windows-exe-suffix -> origin/fix-windows-exe-suffix
 * [new branch]      hotfix-v0.5            -> origin/hotfix-v0.5
 * [new branch]      import-release-commit  -> origin/import-release-commit
 * [new branch]      prepare-hotfix-branch  -> origin/prepare-hotfix-branch
 * [new branch]      renovate/dependencies  -> origin/renovate/dependencies
 * [new branch]      renovate/go-1.x        -> origin/renovate/go-1.x
 * [new tag]         v0.1.0                 -> v0.1.0
 * [new tag]         v0.1.1                 -> v0.1.1
 * [new tag]         v0.1.2                 -> v0.1.2
 * [new tag]         v0.1.3                 -> v0.1.3
 * [new tag]         v0.1.4                 -> v0.1.4
 * [new tag]         v0.1.5                 -> v0.1.5
 * [new tag]         v0.2.0                 -> v0.2.0
 * [new tag]         v0.3.0                 -> v0.3.0
 * [new tag]         v0.4.0                 -> v0.4.0
 * [new tag]         v0.5.0                 -> v0.5.0
 * [new tag]         v0.5.1                 -> v0.5.1
 * [new tag]         v0.6.0                 -> v0.6.0
 * [new tag]         v0.7.0                 -> v0.7.0
Switched to a new branch 'hotfix-v0.7'
To https://github.com/gardener/gardenlogin
 ! [remote rejected] hotfix-v0.7 -> hotfix-v0.7 (refusing to allow a GitHub App to create or update workflow `.github/workflows/build.yaml` without `workflows` permission)
error: failed to push some refs to 'https://github.com/gardener/gardenlogin'
Error: Process completed with exit code 1.
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
