### PR TITLE
fix: do not treat certain infra errors as credential issues

### DIFF
--- a/frontend/src/utils/errorCodes.js
+++ b/frontend/src/utils/errorCodes.js
@@ -56,14 +56,12 @@ const errorCodes = {
     description: 'Cloud provider quota exceeded. Please request limit increases.',
     temporaryError: false,
     userError: true,
-    infraAccountError: true,
   },
   ERR_INFRA_DEPENDENCIES: {
     shortDescription: 'Infrastructure Dependencies',
     description: 'Infrastructure operation failed due to issues with cloud provider resources, configuration, or unmanaged resources. Please check your cloud environment, resolve any unmet requirements or conflicts, and remove any manually created resources related to this Shoot.',
     temporaryError: false,
     userError: true,
-    infraAccountError: true,
   },
   ERR_CLEANUP_CLUSTER_RESOURCES: {
     shortDescription: 'Cleanup Cluster',
@@ -76,7 +74,6 @@ const errorCodes = {
     description: 'The underlying infrastructure provider proclaimed that it does not have enough resources to fulfill your request at this point in time. You might want to wait or change your shoot configuration.',
     temporaryError: false,
     userError: true,
-    infraAccountError: true,
   },
   ERR_CONFIGURATION_PROBLEM: {
     shortDescription: 'Configuration Problem',


### PR DESCRIPTION
**What this PR does / why we need it**:
mark infrastructure quota-exceeded and resource-depleted errors as non-credential issues

**Which issue(s) this PR fixes**:
Fixes #2512

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->

