### PR TITLE
[hotfix-1.81] CI: switch actions/checkout fetch-depth from 10 to 0 to unblock Yarn version (merge-base) resolution

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
     with:
       mode: ${{ inputs.mode }}
       version-commit-callback-action-path: .github/actions/prepare-release
-      checkout-fetch-depth: 10
+      checkout-fetch-depth: 0
     permissions:
       contents: read
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- Changes `actions/checkout` configuration from `fetch-depth: 10` to `fetch-depth: 0` (full history) in the workflow(s) that run the version bump logic.
- Yarn 4’s version command consults Git merge-base against configured changesetBaseRefs (e.g., master, origin/master, hotfix-…); shallow clones can lack a common ancestor, leading to:
  - Usage Error: `No ancestor could be found between any of HEAD and master, origin/master, hotfix-…`
- Fetching full history ensures the merge-base is available and restores stability for the bump_version step and related release/hotfix workflows.
- Official Yarn documentation recommends overriding fetch-depth to 0:
  - https://yarnpkg.com/features/release-workflow#commit-history

  > ### Commit history
  > The [version plugin](https://github.com/yarnpkg/berry/tree/master/packages/plugin-version) requires access to the commit history in order to be able to correctly infer which packages require release specifications. In particular, when using GitHub Actions with actions/checkout@v2 or greater the default behavior is for Git to fetch just the version being checked, which would cause problems. To correct this, you will need to override the fetch-depth configuration value to fetch the whole commit history:
  > 
  > - uses: actions/checkout@v2
  >   with:
  >     fetch-depth: 0


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
- This change slightly increases checkout time/storage due to a full fetch, but is required so Yarn can resolve the merge-base reliably in CI.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
