### PR TITLE
ci: prevent duplicate CI runs by limiting non-release workflow push trigger to master and hotfix-*

### DIFF
--- a/.github/workflows/non-release.yaml
+++ b/.github/workflows/non-release.yaml
@@ -1,6 +1,9 @@
 name: Build
 on:
   push:
+    branches:
+    - master
+    - hotfix-*
   pull_request:
     types:
     - opened


### PR DESCRIPTION
**What this PR does / why we need it**:
- Restricts the push trigger in .github/workflows/non-release.yaml to master and hotfix-* only.
- Prevents duplicate CI executions when a PR is opened from a feature branch (previously both push and pull_request could fire).
- Conserves CI resources and keeps checks clearer on PRs.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
