### PR TITLE
[master] CI: switch actions/checkout fetch-depth from 10 to 0 to unblock Yarn version (merge-base) resolution

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
     with:
       mode: ${{ inputs.mode }}
       version-commit-callback-action-path: .github/actions/prepare-release
-      checkout-fetch-depth: 10
+      checkout-fetch-depth: 0
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual cherry-pick because of conflicts of https://github.com/gardener/dashboard/pull/2599

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
