### PR TITLE
ci: Remove needs/cherry-pick label on successful cherry-pick

### DIFF
--- a/.github/actions/cherry-pick-summary/action.yaml
+++ b/.github/actions/cherry-pick-summary/action.yaml
@@ -31,3 +31,10 @@ runs:
         gh pr comment "$PR_NUMBER" \
           --body "$SUMMARY" \
           --repo ${{ github.repository }}
+
+        if [ "$CHERRY_PICK_RESULT" = "success" ]; then
+          # Remove the label if present; do not fail if it's missing
+          gh pr edit "$PR_NUMBER" \
+            --remove-label "needs/cherry-pick" \
+            --repo ${{ github.repository }} || true
+        fi


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove needs/cherry-pick label on successful cherry-pick

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
