### PR TITLE
Add support for `STACKIT` infrastructure

### DIFF
--- a/frontend/src/assets/stackit.svg
+++ b/frontend/src/assets/stackit.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Ebene_1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 536.44 395.08">
+  <defs>
+    <style>
+      .cls-1 {
+        fill: #0a1e2d;
+      }
+    </style>
+  </defs>
+  <polygon class="cls-1" points="137.81 0 89.73 225.29 209.92 225.29 235.79 104.1 514.23 104.1 536.44 0 137.81 0"/>
+  <polygon class="cls-1" points="327.59 169.09 301.57 290.99 22.2 290.99 0 395.08 399.55 395.08 447.78 169.09 327.59 169.09"/>
+</svg>

--- a/frontend/src/components/GVendorIcon.vue
+++ b/frontend/src/components/GVendorIcon.vue
@@ -63,6 +63,8 @@ const iconSrc = computed(() => {
       return new URL('/src/assets/gcp.svg', import.meta.url)
     case 'openstack':
       return new URL('/src/assets/openstack.svg', import.meta.url)
+    case 'stackit':
+      return new URL('/src/assets/stackit.svg', import.meta.url)
     case 'alicloud':
       return new URL('/src/assets/alicloud.svg', import.meta.url)
     case 'vsphere':

--- a/frontend/src/store/cloudProfile/index.js
+++ b/frontend/src/store/cloudProfile/index.js
@@ -162,6 +162,7 @@ export const useCloudProfileStore = defineStore('cloudProfile', () => {
     'hcloud',
     'onmetal',
     'ironcore',
+    'stackit',
     'local',
   ])
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add STACKIT to the list of supported providers. 

STACKIT used to give customers access to the Openstack API, but that will be replaced by its own [infrastructure API](https://docs.stackit.cloud/stackit/en/release-notes-23101442.html#ReleaseNotes-29072025InfrastructureAPIDeprecationNotice) . We are also in the process of writing and later open-sourcing the required `cloud-provider-stackit` and `gardener-extension-provider-stackit`.

Once the providers are ready (and the API stable), we will add full support in the dashboard.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Add support for STACKIT infrastructure
```
