### PR TITLE
ci: Fix release.yaml permission

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,7 @@ jobs:
       contents: write
       id-token: write
       packages: write
+      pull-requests: write
     with:
       mode: release
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the error 
```
The workflow is not valid. .github/workflows/release.yaml (Line: 13, Col: 3): Error calling workflow 'gardener/dashboard/.github/workflows/build.yaml@708123fd7d563a072c3130223dea91e3f77da042'. The nested job 'prepare' is requesting 'pull-requests: write', but is only allowed 'pull-requests: none'.
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
