### PR TITLE
fix(frontend): cloudprofilelist filtering by providertype

### DIFF
--- a/frontend/src/components/GSelectCloudProfile.vue
+++ b/frontend/src/components/GSelectCloudProfile.vue
@@ -59,8 +59,8 @@ const props = defineProps({
 })
 
 const cloudProfileRef = toRef(props, 'modelValue')
-const cloudProfilesRef = toRef(props, 'cloudProfiles')
-const namespacedCloudProfilesRef = toRef(props, 'namespacedCloudProfiles')
+const cloudProfiles = toRef(props, 'cloudProfiles')
+const namespacedCloudProfiles = toRef(props, 'namespacedCloudProfiles')
 
 const cloudProfileStore = useCloudProfileStore()
 const { seedsByCloudProfileRef } = cloudProfileStore
@@ -78,9 +78,9 @@ const emit = defineEmits([
 const selectItems = computed(() => {
   const items = []
 
-  if (namespacedCloudProfilesRef.value.length > 0) {
+  if (namespacedCloudProfiles.value.length > 0) {
     items.push(
-      ...namespacedCloudProfilesRef.value.map(profile => {
+      ...namespacedCloudProfiles.value.map(profile => {
         const namespacedCloudProfileRef = {
           name: profile.metadata.name,
           kind: 'NamespacedCloudProfile',
@@ -93,15 +93,15 @@ const selectItems = computed(() => {
     )
   }
 
-  if (cloudProfilesRef.value.length > 0) {
+  if (cloudProfiles.value.length > 0) {
     items.push(
-      ...cloudProfilesRef.value.map(profile => {
-        const cloudProfileRefListEntry = {
+      ...cloudProfiles.value.map(profile => {
+        const cloudProfileRef = {
           name: profile.metadata.name,
           kind: 'CloudProfile',
         }
         return {
-          value: cloudProfileRefListEntry,
+          value: cloudProfileRef,
           title: cloudProfileDisplayName(profile),
         }
       }),
@@ -137,10 +137,10 @@ const rules = {
 
 const selectedCloudProfile = computed(() => {
   if (cloudProfileRef.value?.kind === 'CloudProfile') {
-    return find(cloudProfilesRef.value, { metadata: { name: cloudProfileRef.value?.name } })
+    return find(cloudProfiles.value, { metadata: { name: cloudProfileRef.value?.name } })
   }
   if (cloudProfileRef.value?.kind === 'NamespacedCloudProfile') {
-    return find(namespacedCloudProfilesRef.value, { metadata: { name: cloudProfileRef.value?.name } })
+    return find(namespacedCloudProfiles.value, { metadata: { name: cloudProfileRef.value?.name } })
   }
   return undefined
 })

--- a/frontend/src/components/GSelectCloudProfile.vue
+++ b/frontend/src/components/GSelectCloudProfile.vue
@@ -43,25 +43,33 @@ import { withFieldName } from '@/utils/validators'
 import find from 'lodash/find'
 
 const props = defineProps({
-  modelValue: { // cloudProfileRef
+  modelValue: {
     type: Object,
     default: null,
   },
+  cloudProfiles: {
+    type: Array,
+    required: true,
+  },
+  namespacedCloudProfiles: {
+    type: Array,
+    required: false,
+    default: () => [],
+  },
 })
 
-const cloudProfileRef = toRef(props.modelValue)
+const cloudProfileRef = toRef(props, 'modelValue')
+const cloudProfilesRef = toRef(props, 'cloudProfiles')
+const namespacedCloudProfilesRef = toRef(props, 'namespacedCloudProfiles')
 
 const cloudProfileStore = useCloudProfileStore()
 const { seedsByCloudProfileRef } = cloudProfileStore
-const { cloudProfileList } = storeToRefs(cloudProfileStore)
 const projectStore = useProjectStore()
 const { project } = storeToRefs(projectStore)
 
 const seeds = computed(() => {
   return seedsByCloudProfileRef(cloudProfileRef.value, project.value)
 })
-
-const namespacedCloudProfiles = [] // ToDo: To be implemented: useNamespacedCloudProfileStore()
 
 const emit = defineEmits([
   'update:modelValue',
@@ -70,9 +78,9 @@ const emit = defineEmits([
 const selectItems = computed(() => {
   const items = []
 
-  if (namespacedCloudProfiles.length > 0) {
+  if (namespacedCloudProfilesRef.value.length > 0) {
     items.push(
-      ...namespacedCloudProfiles.map(profile => {
+      ...namespacedCloudProfilesRef.value.map(profile => {
         const namespacedCloudProfileRef = {
           name: profile.metadata.name,
           kind: 'NamespacedCloudProfile',
@@ -85,15 +93,15 @@ const selectItems = computed(() => {
     )
   }
 
-  if (cloudProfileList.value.length > 0) {
+  if (cloudProfilesRef.value.length > 0) {
     items.push(
-      ...cloudProfileList.value.map(profile => {
-        const cloudProfileRef = {
+      ...cloudProfilesRef.value.map(profile => {
+        const cloudProfileRefListEntry = {
           name: profile.metadata.name,
           kind: 'CloudProfile',
         }
         return {
-          value: cloudProfileRef,
+          value: cloudProfileRefListEntry,
           title: cloudProfileDisplayName(profile),
         }
       }),
@@ -129,10 +137,10 @@ const rules = {
 
 const selectedCloudProfile = computed(() => {
   if (cloudProfileRef.value?.kind === 'CloudProfile') {
-    return find(cloudProfileList.value, { metadata: { name: cloudProfileRef.value?.name } })
+    return find(cloudProfilesRef.value, { metadata: { name: cloudProfileRef.value?.name } })
   }
   if (cloudProfileRef.value?.kind === 'NamespacedCloudProfile') {
-    return find(namespacedCloudProfiles, { metadata: { name: cloudProfileRef.value?.name } })
+    return find(namespacedCloudProfilesRef.value, { metadata: { name: cloudProfileRef.value?.name } })
   }
   return undefined
 })

--- a/frontend/src/components/NewShoot/GNewShootInfrastructureDetails.vue
+++ b/frontend/src/components/NewShoot/GNewShootInfrastructureDetails.vue
@@ -11,6 +11,7 @@ SPDX-License-Identifier: Apache-2.0
         <g-select-cloud-profile
           ref="cloudProfile"
           v-model="cloudProfileRef"
+          :cloud-profiles="cloudProfiles"
           color="primary"
         />
       </v-col>
@@ -220,6 +221,7 @@ export default {
       providerInfrastructureConfigFirewallImage,
       providerInfrastructureConfigFirewallSize,
       providerInfrastructureConfigFirewallNetworks,
+      cloudProfiles,
       infrastructureBindings,
       regionsWithSeed,
       regionsWithoutSeed,
@@ -250,6 +252,7 @@ export default {
       firewallImage: providerInfrastructureConfigFirewallImage,
       firewallSize: providerInfrastructureConfigFirewallSize,
       firewallNetworks: providerInfrastructureConfigFirewallNetworks,
+      cloudProfiles,
       infrastructureBindings,
       regionsWithSeed,
       regionsWithoutSeed,


### PR DESCRIPTION
**What this PR does / why we need it**:
Cloudprofile list was not filtered by provider type anymore

**Which issue(s) this PR fixes**:
Fixes # #2637

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fix filtering of cloudprofiles by provider type in the create cluster dialog
```
