### PR TITLE
ci(yarn): disable lifecycle scripts during dependency installation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -110,8 +110,7 @@ jobs:
       - name: run-eslint
         run: |
           set -eu
-          yarn install --immutable --immutable-cache --check-cache --refresh-lockfile
-          set -eu
+          YARN_ENABLE_SCRIPTS=0 yarn install --immutable --immutable-cache --check-cache --refresh-lockfile
           (
             cd frontend
             yarn lint --format=@microsoft/eslint-formatter-sarif -o ../dashboard-frontend.sarif

--- a/.github/workflows/dependency-diagrams.yml
+++ b/.github/workflows/dependency-diagrams.yml
@@ -35,7 +35,9 @@ jobs:
           node-version: '22.18.0'
 
       - name: Install dependencies
-        run: yarn install
+        run: |
+          set -eu
+          YARN_ENABLE_SCRIPTS=0 yarn install --immutable --immutable-cache --check-cache --refresh-lockfile
 
       - name: Generate dependency diagrams
         run: yarn generate-all-dependency-diagrams

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -7459,7 +7459,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["esbuild", [\
       ["npm:0.25.1", {\
-        "packageLocation": "./.yarn/unplugged/esbuild-npm-0.25.1-d9214fa98d/node_modules/esbuild/",\
+        "packageLocation": "./.yarn/cache/esbuild-npm-0.25.1-d9214fa98d-80fca30dd0.zip/node_modules/esbuild/",\
         "packageDependencies": [\
           ["@esbuild/aix-ppc64", "npm:0.25.1"],\
           ["@esbuild/android-arm", "npm:0.25.1"],\
@@ -14276,7 +14276,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["unrs-resolver", [\
       ["npm:1.11.1", {\
-        "packageLocation": "./.yarn/unplugged/unrs-resolver-npm-1.11.1-9828edd1f1/node_modules/unrs-resolver/",\
+        "packageLocation": "./.yarn/cache/unrs-resolver-npm-1.11.1-9828edd1f1-c91b112c71.zip/node_modules/unrs-resolver/",\
         "packageDependencies": [\
           ["@unrs/resolver-binding-android-arm-eabi", "npm:1.11.1"],\
           ["@unrs/resolver-binding-android-arm64", "npm:1.11.1"],\
@@ -14743,14 +14743,14 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["vue-demi", [\
       ["npm:0.13.11", {\
-        "packageLocation": "./.yarn/unplugged/vue-demi-virtual-9761a07e89/node_modules/vue-demi/",\
+        "packageLocation": "./.yarn/cache/vue-demi-npm-0.13.11-3e74f92dc7-8f1a38e41e.zip/node_modules/vue-demi/",\
         "packageDependencies": [\
           ["vue-demi", "npm:0.13.11"]\
         ],\
         "linkType": "SOFT"\
       }],\
       ["virtual:14a035260190bd051f2358aefb643bcd023ae70253c045851948c31be5d833b297d317f2cdfb9a1eca7e8034e4574c70d045bd8b1f40ac830574c3873a4d7732#npm:0.13.11", {\
-        "packageLocation": "./.yarn/unplugged/vue-demi-virtual-9761a07e89/node_modules/vue-demi/",\
+        "packageLocation": "./.yarn/__virtual__/vue-demi-virtual-9761a07e89/0/cache/vue-demi-npm-0.13.11-3e74f92dc7-8f1a38e41e.zip/node_modules/vue-demi/",\
         "packageDependencies": [\
           ["@types/vue", null],\
           ["@types/vue__composition-api", null],\

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -6,6 +6,8 @@ enableTelemetry: false
 
 enableTransparentWorkspaces: false
 
+enableScripts: false
+
 immutablePatterns:
   - .pnp.*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ COPY . .
 
 # validate zero-installs project and disable network
 RUN yarn config set enableNetwork false
-RUN yarn install --immutable --immutable-cache
+RUN YARN_ENABLE_SCRIPTS=0 yarn install --immutable --immutable-cache
 
 ############# node-scratch #############
 FROM scratch AS node-scratch


### PR DESCRIPTION
**What this PR does / why we need it**:
Adopts a default‑deny posture for install‑time lifecycle scripts in Yarn by disabling third‑party postinstall execution during dependency installation. This aligns with Yarn’s guidance to avoid postinstall scripts and with common CI hardening practices to reduce supply‑chain risk from malicious install hooks.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
- Set `enableScripts: false` in `.yarnrc.yml` (applies to local and CI).
https://yarnpkg.com/configuration/yarnrc#enableScripts
  > If false, Yarn will not execute the postinstall scripts from third-party packages when installing the project (workspaces will still see their postinstall scripts evaluated, as they're assumed to be safe if you're running an install within them).
- Also explicitly set `YARN_ENABLE_SCRIPTS=0` in CI workflows as an additional safeguard and for documentation purposes.
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
