### PR TITLE
fix(backend): Info endpoint error when retrieving dashboard version information

### DIFF
--- a/backend/eslint.config.cjs
+++ b/backend/eslint.config.cjs
@@ -29,6 +29,11 @@ const importNewlinesConfig = {
 module.exports = [
   ...neostandard({}),
   {
+    languageOptions: {
+      ecmaVersion: 2025,
+    },
+  },
+  {
     rules: {
       '@stylistic/comma-dangle': ['error', 'always-multiline'],
       'no-console': 'error',

--- a/backend/lib/routes/info.js
+++ b/backend/lib/routes/info.js
@@ -16,7 +16,7 @@ const { dashboardClient } = kubeClientModule
 
 async function getVersionFromPackageJson () {
   const { default: packageJson } = await import('../../package.json', {
-    with: { type: 'json' }
+    with: { type: 'json' },
   })
 
   const { version } = packageJson

--- a/backend/lib/routes/info.js
+++ b/backend/lib/routes/info.js
@@ -15,7 +15,9 @@ const { extend } = requestModule
 const { dashboardClient } = kubeClientModule
 
 async function getVersionFromPackageJson () {
-  const { default: packageJson } = await import('../../package.json')
+  const { default: packageJson } = await import('../../package.json', {
+    with: { type: 'json' }
+  })
 
   const { version } = packageJson
   return version


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix error when retrieving dashboard version information in info endpoint

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Resolved a server error that occurred when retrieving information in the About dialog
```
