### PR TITLE
fix(frontend) Region Selection - wrong property access

### DIFF
--- a/frontend/src/store/cloudProfile/index.js
+++ b/frontend/src/store/cloudProfile/index.js
@@ -215,6 +215,7 @@ export const useCloudProfileStore = defineStore('cloudProfile', () => {
     }
     const seeds = seedStore.seedsForCloudProfileByProject(cloudProfile, project)
 
+    // need to use get as map does not support array paths
     const uniqueSeedRegions = uniq(map(seeds, seed => get(seed, ['spec', 'provider', 'region'])))
     const uniqueSeedRegionsWithZones = filter(uniqueSeedRegions, isValidRegion(cloudProfile))
     return uniqueSeedRegionsWithZones

--- a/frontend/src/store/cloudProfile/index.js
+++ b/frontend/src/store/cloudProfile/index.js
@@ -215,7 +215,7 @@ export const useCloudProfileStore = defineStore('cloudProfile', () => {
     }
     const seeds = seedStore.seedsForCloudProfileByProject(cloudProfile, project)
 
-    const uniqueSeedRegions = uniq(map(seeds, 'spec.region'))
+    const uniqueSeedRegions = uniq(map(seeds, seed => get(seed, ['spec', 'provider', 'region'])))
     const uniqueSeedRegionsWithZones = filter(uniqueSeedRegions, isValidRegion(cloudProfile))
     return uniqueSeedRegionsWithZones
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes: Region list empty in “Create Cluster” — wrong seed path used

**Which issue(s) this PR fixes**:
Fixes #2643

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed an issue where supported regions were not correctly identified as *recommended regions*. This caused invalid defaulting of regions, and in cases where `seedCandidateDeterminationStrategy` was set to `SameRegion`, the region list could incorrectly be empty
```
