### PR TITLE
fix(frontend/seed-helper): read `unreachableSeeds` directly instead of `.value`

### DIFF
--- a/frontend/src/composables/useSeedHelper.js
+++ b/frontend/src/composables/useSeedHelper.js
@@ -25,7 +25,7 @@ export function createSeedHelperComposable (seedItem, options = {}) {
   } = options
 
   const isSeedUnreachable = computed(() => {
-    const matchLabels = configStore.unreachableSeeds.value?.matchLabels
+    const matchLabels = configStore.unreachableSeeds?.matchLabels
     if (!matchLabels) {
       return false
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
`configStore.unreachableSeeds` is not a ref; accessing `.value` yield `undefined`.

This PR fixes an issue, where the terminal tile is visible even though it should be hidden because the seed is not reachable by the dashboard and terminal-controller-manager

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
