### PR TITLE
ci(cherry-pick): Adapt to breaking change from cc-utils

### DIFF
--- a/.github/actions/cherry-pick/extract_pr_info.py
+++ b/.github/actions/cherry-pick/extract_pr_info.py
@@ -88,6 +88,11 @@ def extract_pr_info(pr_number: int, repo_owner: str, repo_name: str, github_toke
                     content=pr.body
                 )
 
+                if malformed_blocks:
+                    logger.info(f"Found {len(malformed_blocks)} malformed release note block(s)")
+                    for block in malformed_blocks:
+                        logger.warning(f"Malformed release note block: {block}")
+
                 if valid_blocks:
                     logger.info(f"Found {len(valid_blocks)} release note block(s)")
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adapts to a breaking change introduced with https://github.com/gardener/cc-utils/pull/1388

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
