### PR TITLE
fix(frontend) sshKeyPairRotation: wrong property access when checking for ssh access enabled

### DIFF
--- a/frontend/__tests__/components/GShootCredentialRotation.spec.js
+++ b/frontend/__tests__/components/GShootCredentialRotation.spec.js
@@ -70,7 +70,7 @@ describe('components', () => {
             workers: [
               {},
             ],
-            workerSettings: {
+            workersSettings: {
               sshAccess: {
                 enabled: true,
               },
@@ -129,7 +129,7 @@ describe('components', () => {
 
     describe('Credential tiles', () => {
       it('should not include SSH key rotation when SSH access is disabled', () => {
-        shootItem.spec.provider.workerSettings.sshAccess.enabled = false
+        shootItem.spec.provider.workersSettings.sshAccess.enabled = false
         const wrapper = mountShootCredentialRotationCard(shootItem)
         const credentialWrappers = wrapper.findAllComponents(GCredentialTile)
 
@@ -139,7 +139,7 @@ describe('components', () => {
       })
 
       it('should include SSH key rotation when SSH access is enabled', () => {
-        shootItem.spec.provider.workerSettings.sshAccess.enabled = true
+        shootItem.spec.provider.workersSettings.sshAccess.enabled = true
         const wrapper = mountShootCredentialRotationCard(shootItem)
         const credentialWrappers = wrapper.findAllComponents(GCredentialTile)
 

--- a/frontend/src/composables/useShootSpec.js
+++ b/frontend/src/composables/useShootSpec.js
@@ -108,7 +108,7 @@ export function useShootSpec (shootItem, options = {}) {
   })
 
   const sshAccessEnabled = computed(() => {
-    return get(shootSpec.value, ['provider', 'workerSettings', 'sshAccess', 'enabled'], false)
+    return get(shootSpec.value, ['provider', 'workersSettings', 'sshAccess', 'enabled'], false)
   })
 
   const shootAddons = computed(() => {


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
```
