### PR TITLE
ci: Configure OCI registry routing for `openmfp` branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,8 +37,10 @@ jobs:
         args:
           - name: gardener-dashboard
             target: dashboard
-            # special-handling: push to different repository for `openmpf`-branch
-            oci-repository: gardener/dashboard${{ github.ref_name == 'openmfp' && '-openmpf' || '' }}
+            # special-handling: push to different repository for `openmfp`-branch
+            # head_ref = source branch (PRs), ref_name = push target (direct pushes)
+            oci-repository: gardener/dashboard${{ (github.head_ref || github.ref_name) == 'openmfp' && '-openmfp' || '' }}
+            oci-registry: ${{ (github.head_ref || github.ref_name) == 'openmfp' && 'europe-docker.pkg.dev/gardener-project/releases' || '' }}
             ocm-labels:
               name: gardener.cloud/cve-categorisation
               value:
@@ -52,7 +54,7 @@ jobs:
       name: ${{ matrix.args.name }}
       version: ${{ needs.prepare.outputs.version }}
       target: ${{ matrix.args.target }}
-      oci-registry: ${{ needs.prepare.outputs.oci-registry }}
+      oci-registry: ${{ matrix.args.oci-registry || needs.prepare.outputs.oci-registry }}
       oci-repository: ${{ matrix.args.oci-repository }}
       oci-platforms: linux/amd64,linux/arm64
       ocm-labels: ${{ toJSON(matrix.args.ocm-labels) }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Configures the build workflow to push OCI images from the `openmfp` branch to the releases registry (`europe-docker.pkg.dev/gardener-project/releases`) while keeping all other branches on the default registry.
- Sets `oci-registry` to releases registry when branch exactly matches `openmfp`
- Sets `oci-repository` to `gardener/dashboard-openmfp` for openmfp branch
- Other branches fall back to default registry from prepare job outputs

**Changes**

- Modified [.github/workflows/build.yaml](cci:7://file:///Users/d050337/SAPDevelop/git/gardener/dashboard/.github/workflows/build.yaml:0:0-0:0) to detect `openmfp` branch using branch name detection
- Sets `oci-registry` to releases registry when branch exactly matches `openmfp`
- Sets `oci-repository` to `gardener/dashboard-openmfp` for openmfp branch
- Other branches fall back to default registry from prepare job outputs

**How branch detection works**

The expression `(github.head_ref || github.ref_name)` handles two scenarios:

**For Pull Requests:**
- `github.head_ref`: Contains the source branch (branch being merged FROM, e.g., `openmfp`)
- `github.ref_name`: Contains the target branch (branch being merged INTO, e.g., `master`)
- Logic uses `github.head_ref` because it's present in PR contexts

**For Direct Pushes (head-update trigger):**
- `github.head_ref`: Not present (empty)
- `github.ref_name`: Contains the branch being pushed to
- Logic falls back to `github.ref_name` since `head_ref` is empty

## Behavior

| Scenario | Branch Checked | Registry Used |
|----------|----------------|---------------|
| PR from `openmfp` → `master` | `openmfp` (from `head_ref`) | `europe-docker.pkg.dev/gardener-project/releases` |
| PR from `enh/feature` → `master` | `enh/feature` (from `head_ref`) | Default registry |
| PR from `enh/openmfp-feature` → `openmfp` | `enh/openmfp-feature` (from `head_ref`) | Default registry |
| Direct push to `openmfp` | `openmfp` (from `ref_name`) | `europe-docker.pkg.dev/gardener-project/releases` |
| Direct push to any other branch | Branch name (from `ref_name`) | Default registry |

**Note:** The logic checks the **source branch name** in PRs, not the target. Only exact matches to `openmfp` trigger the releases registry.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
