### PR TITLE
fix(security): drop obsolete unsafe-eval from CSP

### DIFF
--- a/backend/lib/app.js
+++ b/backend/lib/app.js
@@ -93,7 +93,7 @@ app.use(helmet.contentSecurityPolicy({
     styleSrc: ['\'self\'', '\'unsafe-inline\''],
     fontSrc: ['\'self\'', 'data:'],
     imgSrc,
-    scriptSrc: ['\'self\'', '\'unsafe-eval\''],
+    scriptSrc: ['\'self\''],
     frameAncestors: ['\'self\''],
   },
 }))


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
Removes obsolete 'unsafe-eval' from the Content Security Policy `script-src` directive.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
```
