### PR TITLE
fix: redact authorization headers in Octokit debug logs

### DIFF
--- a/backend/lib/github/octokit.js
+++ b/backend/lib/github/octokit.js
@@ -19,6 +19,17 @@ const Octokit = Core.plugin(requestLog, legacyRestEndpointMethods, paginateRest,
 
 class OctokitLog {
   static debug (...args) {
+    if (args.length > 1 && typeof args[1] === 'object' && args[1] !== null) {
+      const msg = args[0]
+      const obj = args[1]
+      const hasAuthHeader = obj.headers && obj.headers.authorization
+      if (hasAuthHeader) {
+        const sanitized = _.cloneDeep(obj)
+        sanitized.headers.authorization = '[REDACTED]'
+        logger.debug(msg, sanitized, ...args.slice(2))
+        return
+      }
+    }
     logger.debug(...args)
   }
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
Adds sanitization to the Octokit debug logger to redact authorization headers when logging request options, preventing exposure of sensitive tokens in logs.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
```
