### PR TITLE
Disable custom, now obsolete, cherry-pick workflow

### DIFF
--- a/.github/workflows/cherry-pick.yaml
+++ b/.github/workflows/cherry-pick.yaml
@@ -14,7 +14,9 @@ jobs:
       github.event.issue.pull_request &&
       contains(github.event.comment.body, '/cherry-pick ') &&
       (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER') &&
-      github.event.comment.user.type == 'User'
+      github.event.comment.user.type == 'User' &&
+      !startsWith(github.event.comment.user.login, 'gardener-ci-robot') &&
+      !startsWith(github.event.comment.user.login, 'gardener-prow')
     uses: gardener/dashboard/.github/workflows/cherry-pick-reusable.yaml@master
     with:
       pr-number: ${{ github.event.issue.number }}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
This PR disables the custom cherry-pick workflow, as prow will take over this task (using the same known cherry-pick command)

For example:
- custom cherry-pick PR: https://github.com/gardener/dashboard/pull/2721
- prow cherry-pick PR: https://github.com/gardener/dashboard/pull/2720

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
