### PR TITLE
fix: disable eager loading for tooltips globally

### DIFF
--- a/frontend/src/plugins/vuetify.js
+++ b/frontend/src/plugins/vuetify.js
@@ -89,4 +89,9 @@ export default createVuetify({
     themes: { light, dark },
     variations,
   },
+  defaults: {
+    VTooltip: {
+      eager: false,
+    },
+  },
 })


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
Disables eager loading for VTooltip components by setting `eager: false` in Vuetify defaults configuration.

This improves performance by ensuring tooltips are only mounted when actually needed (on hover/focus), rather than being pre-rendered in the DOM. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
```
