### PR TITLE
feat: add configurable avatarSource to disable Gravatar

### DIFF
--- a/backend/__tests__/acceptance/__snapshots__/config.spec.cjs.snap
+++ b/backend/__tests__/acceptance/__snapshots__/config.spec.cjs.snap
@@ -17,6 +17,7 @@ exports[`config should return the frontend configuration 1`] = `
 exports[`config should return the frontend configuration 2`] = `
 {
   "apiServerUrl": "https://kubernetes.external.foo.bar",
+  "avatarSource": "gravatar",
   "clusterIdentity": "test-id",
   "features": {
     "terminalEnabled": true,

--- a/backend/__tests__/config.spec.cjs
+++ b/backend/__tests__/config.spec.cjs
@@ -207,6 +207,117 @@ describe('config', function () {
         expect(() => gardener.loadConfig(undefined, { env }))
           .toThrow("Configuration value 'oidc.issuer' is required")
       })
+
+      it('should default avatarSource to gravatar if not defined', function () {
+        const env = Object.assign({
+          NODE_ENV: 'test',
+        }, environmentVariables)
+
+        const config = gardener.loadConfig(undefined, { env })
+        expect(config.frontend.avatarSource).toBe('gravatar')
+      })
+
+      it('should accept valid avatarSource values', function () {
+        const filename = '/etc/gardener/config-with-avatarsource.yaml'
+
+        gardener.readConfig.mockReturnValueOnce({
+          apiServerUrl: 'https://api.example.com',
+          sessionSecret: 'secret',
+          websocketAllowedOrigins: ['*'],
+          frontend: {
+            avatarSource: 'none',
+          },
+        })
+
+        const env = { NODE_ENV: 'test' }
+        const config = gardener.loadConfig(filename, { env })
+        expect(config.frontend.avatarSource).toBe('none')
+      })
+
+      it('should throw on invalid avatarSource value', function () {
+        const filename = '/etc/gardener/config-invalid-avatarsource.yaml'
+
+        gardener.readConfig.mockReturnValueOnce({
+          apiServerUrl: 'https://api.example.com',
+          sessionSecret: 'secret',
+          websocketAllowedOrigins: ['*'],
+          frontend: {
+            avatarSource: 'invalid',
+          },
+        })
+
+        const env = { NODE_ENV: 'test' }
+        expect(() => gardener.loadConfig(filename, { env }))
+          .toThrow("Configuration value 'frontend.avatarSource' must be one of: gravatar, none")
+      })
+
+      it('should default ticket avatarSource to github if ticket config exists but avatarSource not defined', function () {
+        const filename = '/etc/gardener/config-ticket-no-avatarsource.yaml'
+
+        gardener.readConfig.mockReturnValueOnce({
+          apiServerUrl: 'https://api.example.com',
+          sessionSecret: 'secret',
+          websocketAllowedOrigins: ['*'],
+          gitHub: {
+            apiUrl: 'https://github.com',
+          },
+          frontend: {
+            ticket: {
+              gitHubRepoUrl: 'https://github.com/gardener/tickets',
+            },
+          },
+        })
+
+        const env = { NODE_ENV: 'test' }
+        const config = gardener.loadConfig(filename, { env })
+        expect(config.frontend.ticket.avatarSource).toBe('github')
+      })
+
+      it('should accept valid ticket avatarSource values including github', function () {
+        const filename = '/etc/gardener/config-ticket-github.yaml'
+
+        gardener.readConfig.mockReturnValueOnce({
+          apiServerUrl: 'https://api.example.com',
+          sessionSecret: 'secret',
+          websocketAllowedOrigins: ['*'],
+          gitHub: {
+            apiUrl: 'https://github.com',
+          },
+          frontend: {
+            ticket: {
+              avatarSource: 'github',
+              gitHubRepoUrl: 'https://github.com/gardener/tickets',
+            },
+          },
+        })
+
+        const env = { NODE_ENV: 'test' }
+        const config = gardener.loadConfig(filename, { env })
+        expect(config.frontend.ticket.avatarSource).toBe('github')
+      })
+
+      it('should throw on invalid ticket avatarSource value', function () {
+        const filename = '/etc/gardener/config-ticket-invalid.yaml'
+
+        gardener.readConfig.mockReturnValueOnce({
+          apiServerUrl: 'https://api.example.com',
+          sessionSecret: 'secret',
+          websocketAllowedOrigins: ['*'],
+          gitHub: {
+            apiUrl: 'https://github.com',
+          },
+          frontend: {
+            ticket: {
+              avatarSource: 'invalid',
+              gitHubRepoUrl: 'https://github.com/gardener/tickets',
+            },
+          },
+        })
+
+        const env = { NODE_ENV: 'test' }
+        expect(() => gardener.loadConfig(filename, { env }))
+          .toThrow("Configuration value 'frontend.ticket.avatarSource' must be one of: gravatar, none, github")
+      })
     })
   })
 })

--- a/backend/lib/app.js
+++ b/backend/lib/app.js
@@ -52,7 +52,12 @@ const STATIC_ASSETS_OVERRIDE_FS_PATH = join(PUBLIC_FS_PATH, 'static', 'custom-as
 
 // csp sources
 const connectSrc = _.get(config, ['contentSecurityPolicy', 'connectSrc'], ['\'self\''])
-const imgSrc = ['\'self\'', 'data:', 'https://www.gravatar.com']
+const imgSrc = ['\'self\'', 'data:']
+const frontendAvatarSource = _.get(config, ['frontend', 'avatarSource'])
+const ticketAvatarSource = _.get(config, ['frontend', 'ticket', 'avatarSource'])
+if (frontendAvatarSource === 'gravatar' || ticketAvatarSource === 'gravatar') {
+  imgSrc.push('https://www.gravatar.com')
+}
 const gitHubRepoUrl = _.get(config, ['frontend', 'ticket', 'gitHubRepoUrl'])
 if (gitHubRepoUrl) {
   const url = new URL(gitHubRepoUrl)

--- a/backend/lib/config/gardener.js
+++ b/backend/lib/config/gardener.js
@@ -230,6 +230,26 @@ export default {
       _.unset(config, ['frontend', 'ticket'])
     }
 
+    const avatarSource = _.get(config, ['frontend', 'avatarSource'])
+    if (avatarSource) {
+      const validAvatarSources = ['gravatar', 'none']
+      if (!validAvatarSources.includes(avatarSource)) {
+        assert.fail(`Configuration value 'frontend.avatarSource' must be one of: ${validAvatarSources.join(', ')}. Got: ${avatarSource}`)
+      }
+    } else {
+      _.set(config, ['frontend', 'avatarSource'], 'gravatar')
+    }
+
+    const ticketAvatarSource = _.get(config, ['frontend', 'ticket', 'avatarSource'])
+    if (ticketAvatarSource) {
+      const validTicketAvatarSources = ['gravatar', 'none', 'github']
+      if (!validTicketAvatarSources.includes(ticketAvatarSource)) {
+        assert.fail(`Configuration value 'frontend.ticket.avatarSource' must be one of: ${validTicketAvatarSources.join(', ')}. Got: ${ticketAvatarSource}`)
+      }
+    } else if (_.has(config, ['frontend', 'ticket'])) {
+      _.set(config, ['frontend', 'ticket', 'avatarSource'], 'github')
+    }
+
     return config
   },
   readConfig (path) {

--- a/charts/__tests__/gardener-dashboard/runtime/dashboard/__snapshots__/configmap.spec.js.snap
+++ b/charts/__tests__/gardener-dashboard/runtime/dashboard/__snapshots__/configmap.spec.js.snap
@@ -88,6 +88,14 @@ exports[`gardener-dashboard configmap alert should render the template w/o \`ale
 }
 `;
 
+exports[`gardener-dashboard configmap avatarSource should render the template with avatarSource 1`] = `
+{
+  "frontend": {
+    "avatarSource": "none",
+  },
+}
+`;
+
 exports[`gardener-dashboard configmap branding should render the template 1`] = `
 {
   "frontend": {

--- a/charts/__tests__/gardener-dashboard/runtime/dashboard/configmap.spec.js
+++ b/charts/__tests__/gardener-dashboard/runtime/dashboard/configmap.spec.js
@@ -890,6 +890,40 @@ describe('gardener-dashboard', function () {
       })
     })
 
+    describe('avatarSource', function () {
+      it('should render the template with avatarSource', async function () {
+        const values = {
+          global: {
+            dashboard: {
+              frontendConfig: {
+                avatarSource: 'none',
+              },
+            },
+          },
+        }
+        const documents = await renderTemplates(templates, values)
+        expect(documents).toHaveLength(1)
+        const [configMap] = documents
+        const config = yaml.load(configMap.data['config.yaml'])
+        expect(pick(config, ['frontend.avatarSource'])).toMatchSnapshot()
+      })
+
+      it('should not render avatarSource when not specified', async function () {
+        const values = {
+          global: {
+            dashboard: {
+              frontendConfig: {},
+            },
+          },
+        }
+        const documents = await renderTemplates(templates, values)
+        expect(documents).toHaveLength(1)
+        const [configMap] = documents
+        const config = yaml.load(configMap.data['config.yaml'])
+        expect(config.frontend).not.toHaveProperty('avatarSource')
+      })
+    })
+
     describe('socket io', function () {
       it('should render the template with multiple allowed origins', async function () {
         const values = {

--- a/charts/gardener-dashboard/charts/runtime/templates/dashboard/configmap.yaml
+++ b/charts/gardener-dashboard/charts/runtime/templates/dashboard/configmap.yaml
@@ -163,6 +163,9 @@ data:
         {{- end }}
     {{- end }}
     frontend:
+      {{- if .Values.global.dashboard.frontendConfig.avatarSource }}
+      avatarSource: {{ .Values.global.dashboard.frontendConfig.avatarSource }}
+      {{- end }}
       {{- if .Values.global.dashboard.frontendConfig.helpMenuItems }}
       helpMenuItems:
       {{- range .Values.global.dashboard.frontendConfig.helpMenuItems }}

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -150,6 +150,11 @@ global:
 
     frontendConfig:
       landingPageUrl: https://github.com/gardener
+      # # Avatar source configuration for members, accounts, and general dashboard avatars
+      # # Note: The ticket feature has its own separate avatarSource configuration (see frontendConfig.ticket.avatarSource)
+      # # Possible values: gravatar, none
+      # # Default: gravatar
+      # avatarSource: gravatar
       # # asset configuration (see https://github.com/gardener/dashboard/blob/master/docs/customization.md#logos-and-icons for the format and generation of the default values).
       # assets:
       #   favicon-16x16.png: |
@@ -170,7 +175,12 @@ global:
       # - authcode
       # - device-code
       # ticket:
-      #   avatarSource: github # Define from which source the avatar is fetched. For enterprise github instances it is recommended to use gravatar or none. Possible values: github, gravatar, none
+      #   # Avatar source configuration specifically for ticket comments/authors
+      #   # This setting is independent from the global avatarSource configuration above
+      #   # For enterprise GitHub instances it is recommended to use gravatar or none
+      #   # Possible values: github, gravatar, none
+      #   # Default: github
+      #   avatarSource: github
       #   gitHubRepoUrl: https://foo-github.com/dummyorg/dummyrepo
       #   hideClustersWithLabels: # hides clusters with labels on the 'ALL PROJECTS' page if the respective table option is enabled
       #   - ignore

--- a/frontend/src/components/GAccountAvatar.vue
+++ b/frontend/src/components/GAccountAvatar.vue
@@ -6,15 +6,12 @@ SPDX-License-Identifier: Apache-2.0
 
 <template>
   <div class="d-flex flex-nowrap align-center">
-    <v-avatar
+    <g-avatar
+      :account-name="accountName"
       :size="size"
-      class="mr-2"
-    >
-      <v-img
-        :src="avatarUrl"
-        :alt="`avatar of ${accountName}`"
-      />
-    </v-avatar>
+      :alt="`avatar of ${accountName}`"
+      class="mr-1"
+    />
     <a
       v-if="mailTo && isAccountNameEmail"
       :href="`mailto:${accountName}`"
@@ -34,10 +31,9 @@ import {
   toRefs,
 } from 'vue'
 
-import {
-  gravatarUrlGeneric,
-  isEmail,
-} from '@/utils'
+import GAvatar from '@/components/GAvatar.vue'
+
+import { isEmail } from '@/utils'
 
 const props = defineProps({
   accountName: {
@@ -54,11 +50,7 @@ const props = defineProps({
   },
 })
 
-const { accountName, mailTo, size } = toRefs(props)
-
-const avatarUrl = computed(() => {
-  return gravatarUrlGeneric(accountName.value, size.value * 2)
-})
+const { accountName } = toRefs(props)
 
 const isAccountNameEmail = computed(() => {
   return isEmail(accountName.value)

--- a/frontend/src/components/GAvatar.vue
+++ b/frontend/src/components/GAvatar.vue
@@ -1,0 +1,58 @@
+<!--
+SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+<template>
+  <v-avatar
+    :size="size"
+  >
+    <v-img
+      v-if="avatarUrl"
+      :src="avatarUrl"
+      :alt="alt"
+    />
+    <v-icon
+      v-else
+      :size="iconSize"
+      :icon="placeholderIcon"
+      :color="iconColor"
+    />
+  </v-avatar>
+</template>
+
+<script setup>
+import {
+  computed,
+  toRefs,
+} from 'vue'
+
+import { useAvatarUrl } from '@/composables/useAvatarUrl'
+
+const props = defineProps({
+  accountName: {
+    type: String,
+    default: '',
+  },
+  size: {
+    type: Number,
+    default: 40,
+  },
+  iconColor: {
+    type: String,
+    default: 'grey-lighten-1',
+  },
+  alt: {
+    type: String,
+    default: '',
+  },
+})
+
+const { accountName, size } = toRefs(props)
+
+const avatarSize = computed(() => size.value * 2)
+const iconSize = computed(() => size.value)
+
+const { avatarUrl, placeholderIcon } = useAvatarUrl(accountName, avatarSize)
+</script>

--- a/frontend/src/components/GAvatar.vue
+++ b/frontend/src/components/GAvatar.vue
@@ -28,7 +28,7 @@ import {
   toRefs,
 } from 'vue'
 
-import { useAvatarUrl } from '@/composables/useAvatarUrl'
+import { useAvatar } from '@/composables/useAvatar'
 
 const props = defineProps({
   accountName: {
@@ -54,5 +54,5 @@ const { accountName, size } = toRefs(props)
 const avatarSize = computed(() => size.value * 2)
 const iconSize = computed(() => size.value)
 
-const { avatarUrl, placeholderIcon } = useAvatarUrl(accountName, avatarSize)
+const { avatarUrl, placeholderIcon } = useAvatar(accountName, avatarSize)
 </script>

--- a/frontend/src/components/GMainToolbar.vue
+++ b/frontend/src/components/GMainToolbar.vue
@@ -119,28 +119,18 @@ SPDX-License-Identifier: Apache-2.0
             location="bottom right"
             icon="mdi-account-supervisor"
           >
-            <v-avatar
+            <g-avatar
               v-bind="props"
-              size="40"
-              class="cursor-pointer"
-            >
-              <v-img
-                :src="avatarUrl"
-                :alt="`avatar of ${avatarTitle}`"
-              />
-            </v-avatar>
-          </v-badge>
-          <v-avatar
-            v-else
-            v-bind="props"
-            size="40"
-            class="cursor-pointer"
-          >
-            <v-img
-              :src="avatarUrl"
+              :account-name="username"
               :alt="`avatar of ${avatarTitle}`"
             />
-          </v-avatar>
+          </v-badge>
+          <g-avatar
+            v-else
+            v-bind="props"
+            :account-name="username"
+            :alt="`avatar of ${avatarTitle}`"
+          />
         </template>
         <span v-if="isAdmin">
           {{ avatarTitle }}
@@ -317,6 +307,7 @@ import { useAuthnStore } from '@/store/authn'
 import { useConfigStore } from '@/store/config'
 import { useLocalStorageStore } from '@/store/localStorage'
 
+import GAvatar from '@/components/GAvatar.vue'
 import GBreadcrumb from '@/components/GBreadcrumb.vue'
 import GInfoDialog from '@/components/dialogs/GInfoDialog.vue'
 
@@ -345,7 +336,11 @@ const branding = toRef(configStore, 'branding')
 const autoLogin = toRef(localStorageStore, 'autoLogin')
 const colorMode = toRef(localStorageStore, 'colorScheme')
 
-const { isAdmin, username, displayName, avatarUrl, avatarTitle } = storeToRefs(authnStore)
+const { isAdmin, username, displayName } = storeToRefs(authnStore)
+
+const avatarTitle = computed(() => {
+  return `${displayName.value} (${username.value})`
+})
 
 const tabs = computed(() => {
   const meta = route.meta ?? {}

--- a/frontend/src/components/GTicketAvatar.vue
+++ b/frontend/src/components/GTicketAvatar.vue
@@ -1,0 +1,58 @@
+<!--
+SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+<template>
+  <v-avatar
+    :size="size"
+  >
+    <v-img
+      v-if="avatarUrl"
+      :src="avatarUrl"
+      :alt="alt"
+    />
+    <v-icon
+      v-else
+      :size="iconSize"
+      :icon="placeholderIcon"
+      :color="iconColor"
+    />
+  </v-avatar>
+</template>
+
+<script setup>
+import {
+  toRefs,
+  ref,
+} from 'vue'
+
+import { useTicketAvatar } from '@/composables/useTicketAvatar'
+
+const props = defineProps({
+  login: {
+    type: String,
+    required: true,
+  },
+  iconColor: {
+    type: String,
+    default: 'primary',
+  },
+  alt: {
+    type: String,
+    default: '',
+  },
+  githubAvatarUrl: {
+    type: String,
+    default: undefined,
+  },
+})
+
+const { login, githubAvatarUrl, size } = toRefs(props)
+
+const avatarSize = ref(80)
+const iconSize = ref(32)
+
+const { avatarUrl, placeholderIcon } = useTicketAvatar(login, githubAvatarUrl, avatarSize)
+</script>

--- a/frontend/src/components/Members/GServiceAccountRow.vue
+++ b/frontend/src/components/Members/GServiceAccountRow.vue
@@ -14,9 +14,13 @@ SPDX-License-Identifier: Apache-2.0
         class="pa-0"
         density="compact"
       >
-        <v-list-item
-          :prepend-avatar="item.avatarUrl"
-        >
+        <v-list-item>
+          <template #prepend>
+            <g-avatar
+              :account-name="item.username"
+              :size="40"
+            />
+          </template>
           <v-list-item-title>
             {{ item.displayName }}
             <v-icon
@@ -164,6 +168,7 @@ import GAccountRoles from '@/components/Members/GAccountRoles.vue'
 import GTimeString from '@/components/GTimeString.vue'
 import GActionButton from '@/components/GActionButton.vue'
 import GScrollContainer from '@/components/GScrollContainer'
+import GAvatar from '@/components/GAvatar.vue'
 
 import {
   isForeignServiceAccount,

--- a/frontend/src/components/Members/GUserRow.vue
+++ b/frontend/src/components/Members/GUserRow.vue
@@ -14,9 +14,12 @@ SPDX-License-Identifier: Apache-2.0
         class="pa-0"
         density="compact"
       >
-        <v-list-item
-          :prepend-avatar="item.avatarUrl"
-        >
+        <v-list-item>
+          <template #prepend>
+            <g-avatar
+              :account-name="item.username"
+            />
+          </template>
           <v-list-item-title>
             {{ item.displayName }}
           </v-list-item-title>
@@ -82,6 +85,7 @@ import { useAuthzStore } from '@/store/authz'
 
 import GAccountRoles from '@/components/Members/GAccountRoles.vue'
 import GActionButton from '@/components/GActionButton.vue'
+import GAvatar from '@/components/GAvatar.vue'
 
 import { mapTableHeader } from '@/utils'
 

--- a/frontend/src/components/ShootTickets/GTicketComment.vue
+++ b/frontend/src/components/ShootTickets/GTicketComment.vue
@@ -7,20 +7,10 @@ SPDX-License-Identifier: Apache-2.0
 <template>
   <div class="d-flex my-2 mx-4">
     <div class="mr-2">
-      <v-avatar
-        v-if="displayAvatarUrl"
-        size="40px"
-      >
-        <v-img
-          :src="displayAvatarUrl"
-          :title="login"
-          :alt="`avatar of github user ${login}`"
-        />
-      </v-avatar>
-      <v-icon
-        v-else
-        icon="mdi-comment-outline"
-        color="primary"
+      <g-ticket-avatar
+        :login="login"
+        :github-avatar-url="githubAvatarUrl"
+        :alt="`avatar of github user ${login}`"
       />
     </div>
     <div class="comment d-flex flex-column flex-grow-1">
@@ -55,27 +45,19 @@ import {
 } from 'vue'
 import { useTheme } from 'vuetify'
 
-import { useConfigStore } from '@/store/config'
-
 import GTimeString from '@/components/GTimeString.vue'
 import GExternalLink from '@/components/GExternalLink.vue'
-
-import { useAvatarUrl } from '@/composables/useAvatarUrl'
+import GTicketAvatar from '@/components/GTicketAvatar.vue'
 
 import { transformHtml } from '@/utils'
 
 import get from 'lodash/get'
 
-const AvatarEnum = {
-  GITHUB: 'github', // default
-  GRAVATAR: 'gravatar',
-  NONE: 'none',
-}
-
 export default {
   components: {
     GTimeString,
     GExternalLink,
+    GTicketAvatar,
   },
   props: {
     comment: {
@@ -86,9 +68,6 @@ export default {
   setup (props) {
     const { comment } = toRefs(props)
     const theme = useTheme()
-    const configStore = useConfigStore()
-
-    const ticketConfig = computed(() => configStore.ticket)
 
     const commentHtml = computed(() => {
       return transformHtml(get(comment.value, ['data', 'body'], ''))
@@ -102,25 +81,8 @@ export default {
       return get(comment.value, ['metadata', 'created_at'])
     })
 
-    const avatarSource = computed(() => {
-      return get(ticketConfig.value, ['avatarSource'], AvatarEnum.GITHUB)
-    })
-
     const githubAvatarUrl = computed(() => {
       return get(comment.value, ['data', 'user', 'avatar_url'])
-    })
-
-    const { avatarUrl: gravatarUrl } = useAvatarUrl(login, 128, avatarSource)
-
-    const displayAvatarUrl = computed(() => {
-      switch (avatarSource.value) {
-        case AvatarEnum.GITHUB:
-          return githubAvatarUrl.value
-        case AvatarEnum.GRAVATAR:
-          return gravatarUrl.value
-        default:
-          return undefined
-      }
     })
 
     const htmlUrl = computed(() => {
@@ -135,7 +97,7 @@ export default {
       commentHtml,
       login,
       createdAt,
-      displayAvatarUrl,
+      githubAvatarUrl,
       htmlUrl,
       gThemeClass,
     }

--- a/frontend/src/components/editable/GEditableAccount.vue
+++ b/frontend/src/components/editable/GEditableAccount.vue
@@ -31,8 +31,8 @@ SPDX-License-Identifier: Apache-2.0
         >
           <g-account-avatar
             :account-name="modelValue"
-            mail-to
             :color="color"
+            mail-to
           />
         </div>
         <div>
@@ -73,17 +73,14 @@ SPDX-License-Identifier: Apache-2.0
         @update:model-value="v$.internalValue.$touch"
         @blur="v$.internalValue.$touch"
       >
-        <template #item="{ item, props }">
+        <template #item="{ item, props: itemProps }">
           <v-list-item
-            v-bind="props"
-            :title="item.title"
+            v-bind="{ ...itemProps, title: undefined }"
           >
-            <template #prepend>
-              <v-avatar
-                :image="getAvatarUrl(item)"
-                size="x-small"
-              />
-            </template>
+            <g-account-avatar
+              :account-name="item.value"
+              :size="24"
+            />
           </v-list-item>
         </template>
         <template #append>
@@ -114,7 +111,6 @@ import { useVuelidate } from '@vuelidate/core'
 import GAccountAvatar from '@/components/GAccountAvatar.vue'
 
 import {
-  gravatarUrlGeneric,
   setDelayedInputFocus,
   getErrorMessages,
 } from '@/utils'
@@ -244,9 +240,6 @@ export default {
   methods: {
     clearMessages () {
       this.messages = []
-    },
-    getAvatarUrl (item) {
-      return gravatarUrlGeneric(item.value)
     },
     onCancel () {
       this.internalValue = this.modelValue

--- a/frontend/src/composables/useAvatar.js
+++ b/frontend/src/composables/useAvatar.js
@@ -20,7 +20,7 @@ import {
 
 import get from 'lodash/get'
 
-export function useAvatarUrl (username, size = 128, avatarSource = null) {
+export function useAvatar (username, size = 128, avatarSource = null) {
   const configStore = useConfigStore()
   const avatarUrl = ref(undefined)
 

--- a/frontend/src/composables/useAvatarUrl.js
+++ b/frontend/src/composables/useAvatarUrl.js
@@ -1,0 +1,45 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import {
+  ref,
+  computed,
+  unref,
+  watchEffect,
+} from 'vue'
+
+import { useConfigStore } from '@/store/config'
+
+import {
+  gravatarUrlGeneric,
+  isServiceAccountUsername,
+} from '@/utils'
+
+import get from 'lodash/get'
+
+export function useAvatarUrl (username, size = 128, avatarSource = null) {
+  const configStore = useConfigStore()
+  const avatarUrl = ref(undefined)
+
+  const effectiveAvatarSource = computed(() => {
+    return avatarSource ?? get(configStore, ['avatarSource'], 'gravatar')
+  })
+
+  const placeholderIcon = computed(() => isServiceAccountUsername(username.value) ? 'mdi-robot-happy' : 'mdi-account-circle')
+
+  watchEffect(async () => {
+    avatarUrl.value = await gravatarUrlGeneric(
+      username.value,
+      unref(size),
+      effectiveAvatarSource.value,
+    )
+  })
+
+  return {
+    avatarUrl,
+    placeholderIcon,
+  }
+}

--- a/frontend/src/composables/useTicketAvatar.js
+++ b/frontend/src/composables/useTicketAvatar.js
@@ -1,0 +1,62 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import {
+  ref,
+  computed,
+  unref,
+  watchEffect,
+} from 'vue'
+
+import { useConfigStore } from '@/store/config'
+
+import { gravatarUrlGeneric } from '@/utils'
+
+import get from 'lodash/get'
+
+const AvatarSourceEnum = {
+  GITHUB: 'github',
+  GRAVATAR: 'gravatar',
+  NONE: 'none',
+}
+
+export function useTicketAvatar (username, githubAvatarUrl, size = 128) {
+  const configStore = useConfigStore()
+  const avatarUrl = ref(undefined)
+
+  const ticketConfig = computed(() => configStore.ticket)
+
+  const avatarSource = computed(() => {
+    return get(ticketConfig.value, ['avatarSource'], AvatarSourceEnum.GITHUB)
+  })
+
+  const placeholderIcon = computed(() => 'mdi-comment-outline')
+
+  watchEffect(async () => {
+    const source = avatarSource.value
+    const usernameValue = unref(username)
+    const githubUrlValue = unref(githubAvatarUrl)
+
+    switch (source) {
+      case AvatarSourceEnum.GITHUB:
+        avatarUrl.value = githubUrlValue
+        break
+      case AvatarSourceEnum.GRAVATAR:
+        avatarUrl.value = await gravatarUrlGeneric(usernameValue, unref(size), 'gravatar')
+        break
+      case AvatarSourceEnum.NONE:
+        avatarUrl.value = undefined
+        break
+      default:
+        avatarUrl.value = undefined
+    }
+  })
+
+  return {
+    avatarUrl,
+    placeholderIcon,
+  }
+}

--- a/frontend/src/store/authn/index.js
+++ b/frontend/src/store/authn/index.js
@@ -18,7 +18,6 @@ import { useLogger } from '@/composables/useLogger'
 import { useInterceptors } from '@/composables/useApi'
 
 import {
-  gravatarUrlGeneric,
   displayName as getDisplayName,
   fullDisplayName as getFullDisplayName,
 } from '@/utils'
@@ -82,14 +81,6 @@ export const useAuthnStore = defineStore('authn', () => {
     return (user.value?.exp ?? 0) * 1000
   })
 
-  const avatarUrl = computed(() => {
-    return gravatarUrlGeneric(username.value)
-  })
-
-  const avatarTitle = computed(() => {
-    return `${displayName.value} (${username.value})`
-  })
-
   function $reset () {
     user.value = decodeCookie()
   }
@@ -101,8 +92,6 @@ export const useAuthnStore = defineStore('authn', () => {
     displayName,
     fullDisplayName,
     sessionExpiresAt,
-    avatarUrl,
-    avatarTitle,
     isExpired,
     signout,
     signin,

--- a/frontend/src/store/config.js
+++ b/frontend/src/store/config.js
@@ -161,6 +161,10 @@ export const useConfigStore = defineStore('config', () => {
     return state.value?.alert
   })
 
+  const avatarSource = computed(() => {
+    return state.value?.avatarSource
+  })
+
   const accessRestriction = computed(() => {
     return state.value?.accessRestriction
   })
@@ -710,6 +714,7 @@ export const useConfigStore = defineStore('config', () => {
     isInitial,
     appVersion,
     alert,
+    avatarSource,
     accessRestriction,
     sla,
     costObject,

--- a/frontend/src/utils/crypto.js
+++ b/frontend/src/utils/crypto.js
@@ -13,6 +13,14 @@ import set from 'lodash/set'
 
 export { md5 }
 
+export async function sha256 (value) {
+  const encoder = new TextEncoder()
+  const data = encoder.encode(value)
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data)
+  const hashArray = Array.from(new Uint8Array(hashBuffer))
+  return hashArray.map(byte => byte.toString(16).padStart(2, '0')).join('')
+}
+
 export function normalizeObject (obj) {
   if (!obj) {
     return null

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -15,7 +15,7 @@ import { useLogger } from '@/composables/useLogger'
 
 import moment from './moment'
 import {
-  md5,
+  sha256,
   hash,
 } from './crypto'
 import TimeWithOffset from './TimeWithOffset'
@@ -256,17 +256,22 @@ export function isEmail (value) {
   return true
 }
 
-export function gravatarUrlGeneric (username, size = 128) {
+export async function gravatarUrlGeneric (username, size = 128, avatarSource = 'gravatar') {
+  // Support 'none' option - return undefined to hide avatar
+  if (avatarSource === 'none') {
+    return undefined
+  }
+
   if (!username) {
-    return gravatarUrlMp('undefined', size)
+    return await gravatarUrlMp('undefined', size)
   }
   if (isEmail(username)) {
-    return gravatarUrlIdenticon(username, size)
+    return await gravatarUrlIdenticon(username, size)
   }
   if (isServiceAccountUsername(username)) {
-    return gravatarUrlRobohash(username, size)
+    return await gravatarUrlRobohash(username, size)
   }
-  return gravatarUrlRetro(username, size)
+  return await gravatarUrlRetro(username, size)
 }
 
 export function gravatarUrlMp (username, size = 128) {
@@ -285,8 +290,12 @@ export function gravatarUrlRobohash (username, size = 128) {
   return gravatarUrl(username, 'robohash', size)
 }
 
-export function gravatarUrl (value, image, size) {
-  return `https://www.gravatar.com/avatar/${md5(toLower(value))}?d=${image}&s=${size}`
+export async function gravatarUrl (value, image, size) {
+  let hash = await sha256(toLower(value))
+  hash = encodeURIComponent(hash)
+  image = encodeURIComponent(image)
+  size = encodeURIComponent(size)
+  return `https://www.gravatar.com/avatar/${hash}?d=${image}&s=${size}`
 }
 
 export function routes (router, includeRoutesWithProjectScope) {

--- a/frontend/src/views/GMembers.vue
+++ b/frontend/src/views/GMembers.vue
@@ -293,7 +293,6 @@ import { useTwoTableLayout } from '@/composables/useTwoTableLayout'
 
 import {
   displayName,
-  gravatarUrlGeneric,
   isEmail,
   parseServiceAccountUsername,
   isForeignServiceAccount,
@@ -381,7 +380,6 @@ const userList = computed(() => {
     const { username } = user
     return {
       ...user,
-      avatarUrl: gravatarUrlGeneric(username),
       displayName: displayName(username),
       isEmail: isEmail(username),
       isOwner: isOwner(username),
@@ -447,7 +445,6 @@ const serviceAccountList = computed(() => {
     const { username } = serviceAccount
     return {
       ...serviceAccount,
-      avatarUrl: gravatarUrlGeneric(username),
       displayName: displayName(username),
       roleDescriptors: sortedRoleDescriptors(serviceAccount.roles),
       isCurrentUser: isCurrentUser(username),


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
Introduces `avatarSource` configuration to control avatar display. Operators can now disable Gravatar integration by setting `frontend.avatarSource: none`, which displays placeholder icons instead. This addresses privacy requirements for deployments that need to prevent external requests to third-party services.

- `frontend.avatarSource`: `gravatar` (default) | `none`
- `frontend.ticket.avatarSource`: `gravatar` | `none` | `github (default)`
- New `GAvatar` component for centralized avatar rendering
- SHA-256 replaces MD5 for Gravatar hashes

When deploying the dashboard using the Gardener operator, configure via the ConfigMap (`Garden.spec.virtualCluster.gardener.gardenerDashboard.frontendConfigMapRef`):

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: gardener-dashboard-frontend
  namespace: garden
data:
  frontend-config.yaml: |
    frontend:
      avatarSource: none  # gravatar (default) | none
```

**Which issue(s) this PR fixes**:
Fixes #2685 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Add `avatarSource` frontend config to control avatar display (values: `gravatar`, `none`). Setting `none` displays placeholder icons instead of Gravatar images.
```
