### PR TITLE
Revert "fix(security): drop obsolete unsafe-eval from CSP (#2710)"

### DIFF
--- a/backend/lib/app.js
+++ b/backend/lib/app.js
@@ -93,7 +93,7 @@ app.use(helmet.contentSecurityPolicy({
     styleSrc: ['\'self\'', '\'unsafe-inline\''],
     fontSrc: ['\'self\'', 'data:'],
     imgSrc,
-    scriptSrc: ['\'self\''],
+    scriptSrc: ['\'self\'', '\'unsafe-eval\''],
     frameAncestors: ['\'self\''],
   },
 }))


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
This reverts commit 6d4687def9558be555b03bbb30b4a983b1c0fb3e / #2710.

We require this excemption when using Lodash Template, which is used in:
1. __GTicketsCard.vue__ - For ticket URL templating
2. __GLoginTeaser.vue__ - For login teaser text
3. __GLoginFooter.vue__ - For footer text
4. __GTeaser.vue__ - For generic teaser text

Additionally, `url-template` is used in: 
5. __GShootExternalToolsCard.vue__ - For external tool URL templating

Otherwise this leads to the following errors (not observable when running vite dev server), when navigating to the above mentioned components:
Firefox: `EvalError: call to Function() blocked by CSP`
Chrome: `EvalError: Evaluating a string as JavaScript violates the following Content Security Policy directive because 'unsafe-eval' is not an allowed source of script: script-src 'self'".`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
