### PR TITLE
Fix incorrect warning message for forced machine image updates

### DIFF
--- a/frontend/__tests__/composables/useCloudProfile/useKubernetesVersions.spec.js
+++ b/frontend/__tests__/composables/useCloudProfile/useKubernetesVersions.spec.js
@@ -193,7 +193,7 @@ describe('composables', () => {
     })
 
     describe('#useKubernetesVersionExpiration', () => {
-      it('should be info level (patch available, auto update enabled))', () => {
+      it('should be info level (patch available, auto update enabled)', () => {
         const { useKubernetesVersionExpiration } = useKubernetesVersions(cloudProfile)
         const k8sVersion = ref(unclassified164VersionWithExpiration.version)
         const k8sAutoPatch = ref(true)
@@ -204,10 +204,13 @@ describe('composables', () => {
           isValidTerminationDate: true,
           severity: 'info',
           version: unclassified164VersionWithExpiration.version,
+          regularUpdate: true,
+          forcedUpdate: false,
+          noUpdate: false,
         })
       })
 
-      it('should be warning level (patch available, auto update enabled, expiration warning))', () => {
+      it('should be warning level (patch available, auto update enabled, expiration warning)', () => {
         const { useKubernetesVersionExpiration } = useKubernetesVersions(cloudProfile)
         const k8sVersion = ref(supported162VersionWithExpirationWarning.version)
         const k8sAutoPatch = ref(true)
@@ -218,10 +221,13 @@ describe('composables', () => {
           isValidTerminationDate: true,
           severity: 'warning',
           version: supported162VersionWithExpirationWarning.version,
+          regularUpdate: false,
+          forcedUpdate: true,
+          noUpdate: false,
         })
       })
 
-      it('should be warning level (patch available, auto update disabled))', () => {
+      it('should be warning level (patch available, auto update disabled)', () => {
         const { useKubernetesVersionExpiration } = useKubernetesVersions(cloudProfile)
         const k8sVersion = ref(supported162VersionWithExpirationWarning.version)
         const k8sAutoPatch = ref(false)
@@ -232,10 +238,13 @@ describe('composables', () => {
           isValidTerminationDate: true,
           severity: 'warning',
           version: supported162VersionWithExpirationWarning.version,
+          regularUpdate: false,
+          forcedUpdate: true,
+          noUpdate: false,
         })
       })
 
-      it('should be warning level (update available, auto update enabled / disabled))', () => {
+      it('should be warning level (update available, auto update enabled / disabled)', () => {
         const { useKubernetesVersionExpiration } = useKubernetesVersions(cloudProfile)
         const k8sVersion = ref(supported17VersionWithExpirationWarning.version)
         let k8sAutoPatch = ref(true)
@@ -246,6 +255,9 @@ describe('composables', () => {
           isValidTerminationDate: true,
           severity: 'warning',
           version: supported17VersionWithExpirationWarning.version,
+          regularUpdate: false,
+          forcedUpdate: true,
+          noUpdate: false,
         })
 
         k8sAutoPatch = ref(false)
@@ -256,10 +268,13 @@ describe('composables', () => {
           isValidTerminationDate: true,
           severity: 'warning',
           version: supported17VersionWithExpirationWarning.version,
+          regularUpdate: false,
+          forcedUpdate: true,
+          noUpdate: false,
         })
       })
 
-      it('should be error level (only deprecated newer version available))', () => {
+      it('should be error level (only deprecated newer version available)', () => {
         const { useKubernetesVersionExpiration } = useKubernetesVersions(cloudProfile)
         const k8sVersion = ref(supported18VersionWithExpirationWarning.version)
         const k8sAutoPatch = ref(false)
@@ -270,10 +285,13 @@ describe('composables', () => {
           isValidTerminationDate: true,
           severity: 'error',
           version: supported18VersionWithExpirationWarning.version,
+          regularUpdate: false,
+          forcedUpdate: false,
+          noUpdate: true,
         })
       })
 
-      it('should not have warning (version not expired))', () => {
+      it('should not have warning (version not expired)', () => {
         const { useKubernetesVersionExpiration } = useKubernetesVersions(cloudProfile)
         const k8sVersion = ref(unclassified164VersionWithExpiration.version)
         const k8sAutoPatch = ref(false)
@@ -292,10 +310,13 @@ describe('composables', () => {
           isValidTerminationDate: true,
           severity: 'info',
           version: unclassified164VersionWithExpiration.version,
+          regularUpdate: true,
+          forcedUpdate: false,
+          noUpdate: false,
         })
       })
 
-      it('should not have warning (deprecated version has no expiration))', () => {
+      it('should not have warning (deprecated version has no expiration)', () => {
         const { useKubernetesVersionExpiration } = useKubernetesVersions(cloudProfile)
         const k8sVersion = ref(deprecatedOldest16Version.version)
         const k8sAutoPatch = ref(false)
@@ -314,6 +335,9 @@ describe('composables', () => {
           isValidTerminationDate: true,
           severity: 'warning',
           version: deprecated14Version.version,
+          regularUpdate: false,
+          forcedUpdate: true,
+          noUpdate: false,
         })
       })
 
@@ -328,6 +352,9 @@ describe('composables', () => {
           isValidTerminationDate: false,
           severity: 'warning',
           version: expiredVersion.version,
+          regularUpdate: false,
+          forcedUpdate: true,
+          noUpdate: false,
         })
       })
     })

--- a/frontend/__tests__/composables/useCloudProfile/useKubernetesVersions.spec.js
+++ b/frontend/__tests__/composables/useCloudProfile/useKubernetesVersions.spec.js
@@ -203,6 +203,7 @@ describe('composables', () => {
           isExpired: false,
           isValidTerminationDate: true,
           severity: 'info',
+          version: unclassified164VersionWithExpiration.version,
         })
       })
 
@@ -216,6 +217,7 @@ describe('composables', () => {
           isExpired: false,
           isValidTerminationDate: true,
           severity: 'warning',
+          version: supported162VersionWithExpirationWarning.version,
         })
       })
 
@@ -229,6 +231,7 @@ describe('composables', () => {
           isExpired: false,
           isValidTerminationDate: true,
           severity: 'warning',
+          version: supported162VersionWithExpirationWarning.version,
         })
       })
 
@@ -242,6 +245,7 @@ describe('composables', () => {
           isExpired: false,
           isValidTerminationDate: true,
           severity: 'warning',
+          version: supported17VersionWithExpirationWarning.version,
         })
 
         k8sAutoPatch = ref(false)
@@ -251,6 +255,7 @@ describe('composables', () => {
           isExpired: false,
           isValidTerminationDate: true,
           severity: 'warning',
+          version: supported17VersionWithExpirationWarning.version,
         })
       })
 
@@ -264,6 +269,7 @@ describe('composables', () => {
           isExpired: false,
           isValidTerminationDate: true,
           severity: 'error',
+          version: supported18VersionWithExpirationWarning.version,
         })
       })
 
@@ -285,6 +291,7 @@ describe('composables', () => {
           isExpired: false,
           isValidTerminationDate: true,
           severity: 'info',
+          version: unclassified164VersionWithExpiration.version,
         })
       })
 
@@ -306,6 +313,7 @@ describe('composables', () => {
           isExpired: false,
           isValidTerminationDate: true,
           severity: 'warning',
+          version: deprecated14Version.version,
         })
       })
 
@@ -319,6 +327,7 @@ describe('composables', () => {
           isExpired: true,
           isValidTerminationDate: false,
           severity: 'warning',
+          version: expiredVersion.version,
         })
       })
     })

--- a/frontend/__tests__/utils/index.spec.js
+++ b/frontend/__tests__/utils/index.spec.js
@@ -6,6 +6,7 @@
 
 import {
   canI,
+  machineImageHasUpdateForAutoUpdateStrategy,
   machineImageHasUpdate,
   isHtmlColorCode,
   defaultCriNameByKubernetesVersion,
@@ -186,7 +187,7 @@ describe('utils', () => {
     })
   })
 
-  describe('#machineImageHasUpdate', () => {
+  describe('#machineImageHasUpdateForAutoUpdateStrategy', () => {
     const sampleMachineImages = [
       {
         vendorName: 'Foo',
@@ -229,61 +230,65 @@ describe('utils', () => {
 
     it('image should have update (updateStrategy major | patch, minor, major exist)', () => {
       const maschineImage = createMachineImage('1.1.1', 'major')
-      const result = machineImageHasUpdate(maschineImage, sampleMachineImages)
+      const result = machineImageHasUpdateForAutoUpdateStrategy(maschineImage, sampleMachineImages)
       expect(result).toBe(true)
     })
 
     it('image should have update (updateStrategy minor | patch, minor, major exist)', () => {
       const maschineImage = createMachineImage('1.1.1', 'minor')
-      const result = machineImageHasUpdate(maschineImage, sampleMachineImages)
+      const result = machineImageHasUpdateForAutoUpdateStrategy(maschineImage, sampleMachineImages)
       expect(result).toBe(true)
     })
 
     it('image should have update (updateStrategy patch | patch, minor, major exist)', () => {
       const maschineImage = createMachineImage('1.1.1', 'patch')
-      const result = machineImageHasUpdate(maschineImage, sampleMachineImages)
+      const result = machineImageHasUpdateForAutoUpdateStrategy(maschineImage, sampleMachineImages)
       expect(result).toBe(true)
     })
 
     it('image should have update (updateStrategy major | minor, major exist)', () => {
       const maschineImage = createMachineImage('1.1.2', 'major')
-      const result = machineImageHasUpdate(maschineImage, sampleMachineImages)
+      const result = machineImageHasUpdateForAutoUpdateStrategy(maschineImage, sampleMachineImages)
       expect(result).toBe(true)
     })
 
     it('image should have update (updateStrategy minor | minor, major exist)', () => {
       const maschineImage = createMachineImage('1.1.2', 'minor')
-      const result = machineImageHasUpdate(maschineImage, sampleMachineImages)
+      const result = machineImageHasUpdateForAutoUpdateStrategy(maschineImage, sampleMachineImages)
       expect(result).toBe(true)
     })
 
     it('image should not have update (updateStrategy patch | minor, major exist)', () => {
       const maschineImage = createMachineImage('1.1.2', 'patch')
-      const result = machineImageHasUpdate(maschineImage, sampleMachineImages)
+      const result = machineImageHasUpdateForAutoUpdateStrategy(maschineImage, sampleMachineImages)
       expect(result).toBe(false)
     })
 
     it('image should have update (updateStrategy major | major exists)', () => {
       const maschineImage = createMachineImage('1.2.0', 'major')
-      const result = machineImageHasUpdate(maschineImage, sampleMachineImages)
+      const result = machineImageHasUpdateForAutoUpdateStrategy(maschineImage, sampleMachineImages)
       expect(result).toBe(true)
     })
 
     it('image should not have update (updateStrategy minor | major exists)', () => {
       const maschineImage = createMachineImage('1.2.0', 'minor')
-      const result = machineImageHasUpdate(maschineImage, sampleMachineImages)
+      let result = machineImageHasUpdateForAutoUpdateStrategy(maschineImage, sampleMachineImages)
       expect(result).toBe(false)
+      result = machineImageHasUpdate(maschineImage, sampleMachineImages)
+      expect(result).toBe(true)
     })
 
     it('image should not have update (updateStrategy major | none exists)', () => {
       const maschineImage = createMachineImage('2.0.0', 'major')
-      const result = machineImageHasUpdate(maschineImage, sampleMachineImages)
+      let result = machineImageHasUpdateForAutoUpdateStrategy(maschineImage, sampleMachineImages)
+      expect(result).toBe(false)
+      result = machineImageHasUpdate(maschineImage, sampleMachineImages)
       expect(result).toBe(false)
     })
 
     it('image should have update (updateStrategy unknown defaults to major | major exists)', () => {
       const maschineImage = createMachineImage('1.2.0', 'foo')
-      const result = machineImageHasUpdate(maschineImage, sampleMachineImages)
+      const result = machineImageHasUpdateForAutoUpdateStrategy(maschineImage, sampleMachineImages)
       expect(result).toBe(true)
     })
   })

--- a/frontend/src/components/ShootMessages/GK8sExpirationMessage.vue
+++ b/frontend/src/components/ShootMessages/GK8sExpirationMessage.vue
@@ -18,12 +18,13 @@ SPDX-License-Identifier: Apache-2.0
       <span>. </span>
     </span>
     <span v-else-if="isExpired">is expired. </span>
+    <span v-else>will expire soon. </span>
     <span v-if="regularUpdate">Version will be updated in the next maintenance window</span>
     <template v-else-if="forcedUpdate">
       <span v-if="isValidTerminationDate">Version update will be enforced after that date</span>
       <span v-else>Version update will be enforced soon</span>
     </template>
-    <span v-else-if="noUpdate">Version of this cluster will expire soon and there is no supported version available. Please contact your landscape administrator</span>
+    <span v-else-if="noUpdate">There is no supported version available that you can update to. Please contact your landscape administrator</span>
   </div>
 </template>
 

--- a/frontend/src/components/ShootMessages/GK8sExpirationMessage.vue
+++ b/frontend/src/components/ShootMessages/GK8sExpirationMessage.vue
@@ -6,7 +6,9 @@ SPDX-License-Identifier: Apache-2.0
 
 <template>
   <div>
-    <span v-if="isValidTerminationDate">Kubernetes version of this cluster expires
+    Kubernetes <span class="font-weight-bold">version {{ version }}</span> of this cluster
+    <span v-if="isValidTerminationDate">
+      expires
       <g-time-string
         :date-time="expirationDate"
         mode="future"
@@ -15,13 +17,13 @@ SPDX-License-Identifier: Apache-2.0
       />
       <span>. </span>
     </span>
-    <span v-else-if="isExpired">Kubernetes version of this cluster is expired.</span>
-    <span v-if="severity === 'info'">Version will be updated in the next maintenance window</span>
-    <template v-else-if="severity === 'warning'">
+    <span v-else-if="isExpired">is expired. </span>
+    <span v-if="regularUpdate">Version will be updated in the next maintenance window</span>
+    <template v-else-if="forcedUpdate">
       <span v-if="isValidTerminationDate">Version update will be enforced after that date</span>
       <span v-else>Version update will be enforced soon</span>
     </template>
-    <span v-else-if="severity === 'error'">Kubernetes version of this cluster will expire soon and there is no newer supported version available. Please contact your landscape administrator</span>
+    <span v-else-if="noUpdate">Version of this cluster will expire soon and there is no supported version available. Please contact your landscape administrator</span>
   </div>
 </template>
 
@@ -40,13 +42,25 @@ export default {
       type: Boolean,
       required: true,
     },
-    severity: {
+    version: {
       type: String,
+      required: true,
+    },
+    regularUpdate: {
+      type: Boolean,
+      required: true,
+    },
+    forcedUpdate: {
+      type: Boolean,
+      required: true,
+    },
+    noUpdate: {
+      type: Boolean,
       required: true,
     },
     isExpired: {
       type: Boolean,
-      default: false,
+      required: true,
     },
   },
 }

--- a/frontend/src/components/ShootMessages/GShootMessages.vue
+++ b/frontend/src/components/ShootMessages/GShootMessages.vue
@@ -208,6 +208,7 @@ const k8sMessage = computed(() => {
     isValidTerminationDate,
     severity,
     isExpired,
+    version,
   } = k8sExpiration.value
   return [{
     key: 'k8sWarning',
@@ -218,8 +219,11 @@ const k8sMessage = computed(() => {
       props: {
         expirationDate,
         isValidTerminationDate,
-        severity,
         isExpired,
+        version,
+        regularUpdate: severity === 'info',
+        forcedUpdate: severity === 'warning',
+        noUpdate: severity === 'error',
       },
     },
   }]
@@ -253,7 +257,9 @@ const machineImageMessages = computed(() => {
           expirationDate,
           isValidTerminationDate,
           isExpired,
-          severity,
+          regularUpdate: severity === 'info',
+          forcedUpdate: severity === 'warning',
+          noUpdate: severity === 'error',
           name,
           workerName,
           version,

--- a/frontend/src/components/ShootMessages/GShootMessages.vue
+++ b/frontend/src/components/ShootMessages/GShootMessages.vue
@@ -209,6 +209,9 @@ const k8sMessage = computed(() => {
     severity,
     isExpired,
     version,
+    regularUpdate,
+    forcedUpdate,
+    noUpdate,
   } = k8sExpiration.value
   return [{
     key: 'k8sWarning',
@@ -221,9 +224,9 @@ const k8sMessage = computed(() => {
         isValidTerminationDate,
         isExpired,
         version,
-        regularUpdate: severity === 'info',
-        forcedUpdate: severity === 'warning',
-        noUpdate: severity === 'error',
+        regularUpdate,
+        forcedUpdate,
+        noUpdate,
       },
     },
   }]
@@ -246,6 +249,9 @@ const machineImageMessages = computed(() => {
       workerName,
       severity,
       supportedVersionAvailable,
+      regularUpdate,
+      forcedUpdate,
+      noUpdate,
     } = workerGroup
     return {
       key: `image_${workerName}_${name}`,
@@ -257,9 +263,9 @@ const machineImageMessages = computed(() => {
           expirationDate,
           isValidTerminationDate,
           isExpired,
-          regularUpdate: severity === 'info',
-          forcedUpdate: severity === 'warning',
-          noUpdate: severity === 'error',
+          regularUpdate,
+          forcedUpdate,
+          noUpdate,
           name,
           workerName,
           version,

--- a/frontend/src/components/ShootMessages/GWorkerGroupExpirationMessage.vue
+++ b/frontend/src/components/ShootMessages/GWorkerGroupExpirationMessage.vue
@@ -6,9 +6,9 @@ SPDX-License-Identifier: Apache-2.0
 
 <template>
   <div>
-    Machine image <span class="font-weight-bold">{{ name }} | Version: {{ version }}</span> of worker group <span class="font-weight-bold">{{ workerName }}: </span>
+    Machine image <span class="font-weight-bold">{{ name }} | version {{ version }}</span> of worker group <span class="font-weight-bold">{{ workerName }}</span>
     <span v-if="isValidTerminationDate">
-      Image expires
+      expires
       <g-time-string
         :date-time="expirationDate"
         mode="future"
@@ -17,13 +17,13 @@ SPDX-License-Identifier: Apache-2.0
       />
       <span>. </span>
     </span>
-    <span v-else-if="isExpired">Image is expired. </span>
-    <span v-if="severity === 'info'">Version will be updated in the next maintenance window</span>
-    <template v-else-if="severity === 'warning'">
+    <span v-else-if="isExpired"> is expired. </span>
+    <span v-if="regularUpdate">Version will be updated in the next maintenance window</span>
+    <template v-else-if="forcedUpdate">
       <span v-if="isValidTerminationDate">Machine Image update will be enforced after that date</span>
       <span v-else>Machine Image update will be enforced soon</span>
     </template>
-    <template v-else-if="severity === 'error'">
+    <template v-else-if="noUpdate">
       <div>
         Machine image version
         <span v-if="isExpired">is expired</span>
@@ -70,8 +70,16 @@ export default {
       type: String,
       required: true,
     },
-    severity: {
-      type: String,
+    regularUpdate: {
+      type: Boolean,
+      required: true,
+    },
+    forcedUpdate: {
+      type: Boolean,
+      required: true,
+    },
+    noUpdate: {
+      type: Boolean,
       required: true,
     },
     supportedVersionAvailable: {

--- a/frontend/src/components/ShootMessages/GWorkerGroupExpirationMessage.vue
+++ b/frontend/src/components/ShootMessages/GWorkerGroupExpirationMessage.vue
@@ -18,6 +18,7 @@ SPDX-License-Identifier: Apache-2.0
       <span>. </span>
     </span>
     <span v-else-if="isExpired"> is expired. </span>
+    <span v-else>will expire soon. </span>
     <span v-if="regularUpdate">Version will be updated in the next maintenance window</span>
     <template v-else-if="forcedUpdate">
       <span v-if="isValidTerminationDate">Machine Image update will be enforced after that date</span>
@@ -25,10 +26,7 @@ SPDX-License-Identifier: Apache-2.0
     </template>
     <template v-else-if="noUpdate">
       <div>
-        Machine image version
-        <span v-if="isExpired">is expired</span>
-        <span v-else>will expire soon</span>
-        and there is no newer supported version available.
+        There is no supported version available that you can update to.
       </div>
       <div v-if="supportedVersionAvailable">
         However, an older <code>supported</code> version for this image vendor is available. You may want to consider downgrading to that version.

--- a/frontend/src/components/ShootWorkers/GMachineImage.vue
+++ b/frontend/src/components/ShootWorkers/GMachineImage.vue
@@ -55,7 +55,7 @@ import GMultiMessage from '@/components/GMultiMessage'
 
 import {
   getErrorMessages,
-  machineImageHasUpdate,
+  machineImageHasUpdateForAutoUpdateStrategy,
   transformHtml,
 } from '@/utils'
 import { withFieldName } from '@/utils/validators'
@@ -151,7 +151,7 @@ export default {
           severity: 'warning',
         })
       }
-      if (this.autoUpdate && this.machineImageHasUpdate) {
+      if (this.autoUpdate && this.machineImageHasUpdateForAutoUpdateStrategy) {
         hints.push({
           type: 'text',
           hint: 'You selected a version that is eligible for an automatic update. You should disable automatic operating system updates if you want to maintain this specific version',
@@ -167,8 +167,8 @@ export default {
       }
       return JSON.stringify(hints)
     },
-    machineImageHasUpdate () {
-      return machineImageHasUpdate(this.machineImage, this.machineImages)
+    machineImageHasUpdateForAutoUpdateStrategy () {
+      return machineImageHasUpdateForAutoUpdateStrategy(this.machineImage, this.machineImages)
     },
   },
   validations () {

--- a/frontend/src/composables/useCloudProfile/useKubernetesVersions.js
+++ b/frontend/src/composables/useCloudProfile/useKubernetesVersions.js
@@ -194,6 +194,7 @@ export function useKubernetesVersions (cloudProfile) {
           version: k8sVersion.value,
           expirationDate: UNKNOWN_EXPIRED_TIMESTAMP,
           isValidTerminationDate: false,
+          isExpired: true,
           severity: 'warning',
         }
       }
@@ -212,9 +213,10 @@ export function useKubernetesVersions (cloudProfile) {
       }
 
       return {
+        version: version.version,
         expirationDate: version.expirationDate,
-        isExpired: version.isExpired,
         isValidTerminationDate: isValidTerminationDate(version.expirationDate),
+        isExpired: version.isExpired,
         severity,
       }
     })

--- a/frontend/src/composables/useCloudProfile/useKubernetesVersions.js
+++ b/frontend/src/composables/useCloudProfile/useKubernetesVersions.js
@@ -18,6 +18,7 @@ import {
 
 import {
   isValidTerminationDate,
+  getVersionExpirationWarning,
   UNKNOWN_EXPIRED_TIMESTAMP,
 } from '@/utils/index.js'
 
@@ -141,24 +142,6 @@ export function useKubernetesVersions (cloudProfile) {
 
     const patchAvailable = useKubernetesVersionIsNotLatestPatch(k8sVersion)
 
-    function getVersionExpirationWarningSeverity (options) {
-      const {
-        isExpirationWarning,
-        autoPatchEnabled,
-        updateAvailable,
-        autoUpdatePossible,
-      } = options
-      const autoPatchEnabledAndPossible = autoPatchEnabled && autoUpdatePossible
-      if (!isExpirationWarning) {
-        return autoPatchEnabledAndPossible
-          ? 'info'
-          : undefined
-      }
-      if (!updateAvailable) {
-        return 'error'
-      }
-      return 'warning'
-    }
     function kubernetesVersionUpdatePathAvailable () {
       if (patchAvailable.value) {
         return true
@@ -195,20 +178,23 @@ export function useKubernetesVersions (cloudProfile) {
           expirationDate: UNKNOWN_EXPIRED_TIMESTAMP,
           isValidTerminationDate: false,
           isExpired: true,
-          severity: 'warning',
+          severity: 'warning', // we treat unknown versions as expiring soon to trigger attention and investigation
+          regularUpdate: false,
+          forcedUpdate: true, // we treat it as expired so update will be enforced
+          noUpdate: false,
         }
       }
 
       const updatePathAvailable = kubernetesVersionUpdatePathAvailable()
 
-      const severity = getVersionExpirationWarningSeverity({
+      const expirationWarning = getVersionExpirationWarning({
         isExpirationWarning: version.isExpirationWarning,
         autoPatchEnabled: k8sAutoPatch.value,
         updateAvailable: updatePathAvailable,
         autoUpdatePossible: patchAvailable.value,
       })
 
-      if (!severity) {
+      if (!expirationWarning) {
         return undefined
       }
 
@@ -217,7 +203,7 @@ export function useKubernetesVersions (cloudProfile) {
         expirationDate: version.expirationDate,
         isValidTerminationDate: isValidTerminationDate(version.expirationDate),
         isExpired: version.isExpired,
-        severity,
+        ...expirationWarning,
       }
     })
   }

--- a/frontend/src/composables/useCloudProfile/useKubernetesVersions.js
+++ b/frontend/src/composables/useCloudProfile/useKubernetesVersions.js
@@ -136,7 +136,7 @@ export function useKubernetesVersions (cloudProfile) {
    * @throws {Error} If k8sVersion or k8sAutoPatch are not refs
    */
   function useKubernetesVersionExpiration (k8sVersion, k8sAutoPatch) {
-    if (!isRef(k8sVersion) && !isRef(k8sAutoPatch)) {
+    if (!isRef(k8sVersion) || !isRef(k8sAutoPatch)) {
       throw Error('k8sVersion and k8sAutoPatch must be a ref!')
     }
 

--- a/frontend/src/composables/useShootMessages.js
+++ b/frontend/src/composables/useShootMessages.js
@@ -13,6 +13,7 @@ import { useMachineImages } from '@/composables/useCloudProfile/useMachineImages
 
 import {
   isValidTerminationDate,
+  machineImageHasUpdateForAutoUpdateStrategy,
   machineImageHasUpdate,
   machineVendorHasSupportedVersion,
   UNKNOWN_EXPIRED_TIMESTAMP,
@@ -85,16 +86,18 @@ export function useShootMessages (cloudProfile) {
             isValidTerminationDate: false,
             severity: 'warning',
             supportedVersionAvailable: false,
+            isExpired: true,
           }
         }
 
+        const updateAvailableForUpdateStrategy = machineImageHasUpdateForAutoUpdateStrategy(workerImageDetails, allMachineImages)
         const updateAvailable = machineImageHasUpdate(workerImageDetails, allMachineImages)
         const supportedVersionAvailable = machineVendorHasSupportedVersion(workerImageDetails, allMachineImages)
         const severity = getVersionExpirationWarningSeverity({
           isExpirationWarning: workerImageDetails.isExpirationWarning,
           autoPatchEnabled: imageAutoPatch.value,
           updateAvailable,
-          autoUpdatePossible: updateAvailable,
+          autoUpdatePossible: updateAvailableForUpdateStrategy,
         })
 
         return {

--- a/frontend/src/composables/useShootMessages.js
+++ b/frontend/src/composables/useShootMessages.js
@@ -16,34 +16,14 @@ import {
   machineImageHasUpdateForAutoUpdateStrategy,
   machineImageHasUpdate,
   machineVendorHasSupportedVersion,
+  getVersionExpirationWarning,
   UNKNOWN_EXPIRED_TIMESTAMP,
 } from '@/utils'
 
 import map from 'lodash/map'
-import filter from 'lodash/filter'
+import compact from 'lodash/compact'
 import find from 'lodash/find'
 import get from 'lodash/get'
-
-/**
- * Get version expiration warning severity
- */
-function getVersionExpirationWarningSeverity (options) {
-  const {
-    isExpirationWarning,
-    autoPatchEnabled,
-    updateAvailable,
-    autoUpdatePossible,
-  } = options
-
-  const autoPatchEnabledAndPossible = autoPatchEnabled && autoUpdatePossible
-  if (!isExpirationWarning) {
-    return autoPatchEnabledAndPossible ? 'info' : undefined
-  }
-  if (!updateAvailable) {
-    return 'error'
-  }
-  return 'warning'
-}
 
 /**
  * Composable for shoot message validation and warnings
@@ -86,30 +66,37 @@ export function useShootMessages (cloudProfile) {
             isValidTerminationDate: false,
             severity: 'warning',
             supportedVersionAvailable: false,
-            isExpired: true,
+            isExpired: true, // we treat it as expired
+            regularUpdate: false,
+            forcedUpdate: true, // probably expired so update will be enforced
+            noUpdate: false,
           }
         }
 
         const updateAvailableForUpdateStrategy = machineImageHasUpdateForAutoUpdateStrategy(workerImageDetails, allMachineImages)
         const updateAvailable = machineImageHasUpdate(workerImageDetails, allMachineImages)
         const supportedVersionAvailable = machineVendorHasSupportedVersion(workerImageDetails, allMachineImages)
-        const severity = getVersionExpirationWarningSeverity({
+        const expirationWarning = getVersionExpirationWarning({
           isExpirationWarning: workerImageDetails.isExpirationWarning,
           autoPatchEnabled: imageAutoPatch.value,
           updateAvailable,
           autoUpdatePossible: updateAvailableForUpdateStrategy,
         })
 
+        if (!expirationWarning) {
+          return undefined
+        }
+
         return {
           ...workerImageDetails,
           isValidTerminationDate: isValidTerminationDate(workerImageDetails.expirationDate),
           workerName: worker.name,
-          severity,
           supportedVersionAvailable,
+          ...expirationWarning,
         }
       })
 
-      return filter(workerGroups, 'severity')
+      return compact(workerGroups)
     })
   }
 

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -641,6 +641,14 @@ const allowedSemverDiffs = {
 }
 
 export function machineImageHasUpdate (machineImage, machineImages) {
+  return some(machineImages, ({ version, vendorName, isSupported }) => {
+    return isSupported &&
+      machineImage.vendorName === vendorName &&
+      semver.gt(version, machineImage.version)
+  })
+}
+
+export function machineImageHasUpdateForAutoUpdateStrategy (machineImage, machineImages) {
   let { updateStrategy } = machineImage
   if (!Object.keys(allowedSemverDiffs).includes(updateStrategy)) {
     updateStrategy = 'major'

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -666,6 +666,37 @@ export function machineVendorHasSupportedVersion (machineImage, machineImages) {
   return some(machineImages, { vendorName, isSupported })
 }
 
+export function getVersionExpirationWarning ({
+  isExpirationWarning,
+  autoPatchEnabled,
+  updateAvailable,
+  autoUpdatePossible,
+}) {
+  const autoPatchEnabledAndPossible =
+    autoPatchEnabled && autoUpdatePossible
+
+  if (!isExpirationWarning && !autoPatchEnabledAndPossible) {
+    return undefined
+  }
+
+  const noUpdate = isExpirationWarning && !updateAvailable
+  const forcedUpdate = isExpirationWarning && updateAvailable
+  const regularUpdate = !isExpirationWarning
+
+  const severity = noUpdate
+    ? 'error'
+    : forcedUpdate
+      ? 'warning'
+      : 'info'
+
+  return {
+    severity,
+    regularUpdate,
+    forcedUpdate,
+    noUpdate,
+  }
+}
+
 export const UNKNOWN_EXPIRED_TIMESTAMP = '1970-01-01T00:00:00Z'
 
 export function sortedRoleDescriptors (roleNames) {


### PR DESCRIPTION
Improve code readability by explicitly passing regularUpdate, forcedUpdate, and noUpdate parameters instead of using severity, which had implicit semantics Align Kubernetes machine image expiration message

<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
Clusters that had no update for the `updateStrategy` (e.g. *minor*) defined in cloud profile are incorrectly flagged as `error` even if there is a higher supported version available (e.g. *major*)
<img width="796" height="239" alt="Screenshot 2026-02-12 at 13 20 13" src="https://github.com/user-attachments/assets/8f970f90-4435-4a30-874b-ac30ceb77096" />

This PR ensures correct handling for this case
<img width="803" height="134" alt="Screenshot 2026-02-12 at 13 19 41" src="https://github.com/user-attachments/assets/db2a441d-1cc9-4ade-908d-7c942f8e0887" />


**Which issue(s) this PR fixes**:
Fixes #2772

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed an incorrect warning message for forced machine image update
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Clearer expiration messaging with explicit version labels and distinct regular/forced/no-update states.
  - Improved machine image auto-update eligibility that respects update strategy and informs hint severity.

* **Tests**
  - Updated test suites to validate the new expiration messages, update-availability flags, and updated utility behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->