### PR TITLE
fix: hide credential item if not available (viewer)

### DIFF
--- a/frontend/src/components/ShootDetails/GShootInfrastructureCard.vue
+++ b/frontend/src/components/ShootDetails/GShootInfrastructureCard.vue
@@ -34,7 +34,7 @@ SPDX-License-Identifier: Apache-2.0
           </div>
         </g-list-item-content>
       </g-list-item>
-      <g-list-item v-if="hasShootWorkerGroups">
+      <g-list-item v-if="shootCloudProviderBinding && hasShootWorkerGroups">
         <g-list-item-content label="Credential">
           <g-binding-name
             :binding="shootCloudProviderBinding"
@@ -42,7 +42,7 @@ SPDX-License-Identifier: Apache-2.0
           />
         </g-list-item-content>
       </g-list-item>
-      <g-list-item v-if="hasShootWorkerGroups">
+      <g-list-item v-if="shootCloudProviderBinding && hasShootWorkerGroups">
         <g-credential-details-item-content
           :credential="credential"
           :shared="isSharedBinding"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed credential information display so credential sections appear only when both a cloud provider binding and worker groups are present, preventing irrelevant credential details from showing in the infrastructure view.
  * Improves clarity of the infrastructure details page and reduces confusion when provider binding information is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->