### PR TITLE
feat: display link to seed plutono

### DIFF
--- a/frontend/src/components/GClusterMetrics.vue
+++ b/frontend/src/components/GClusterMetrics.vue
@@ -6,42 +6,76 @@ SPDX-License-Identifier: Apache-2.0
 
 <template>
   <g-list>
-    <g-link-list-tile
-      icon="mdi-developer-board"
-      app-title="Plutono"
-      :url="plutonoUrl"
-      :url-text="plutonoUrl"
-      :is-shoot-status-hibernated="isShootStatusHibernated"
-    />
-    <g-link-list-tile
-      app-title="Prometheus"
-      :url="prometheusUrl"
-      :url-text="prometheusUrl"
-      :is-shoot-status-hibernated="isShootStatusHibernated"
-      content-class="pt-0"
-    />
-    <g-link-list-tile
-      v-if="hasAlertmanager"
-      app-title="Alertmanager"
-      :url="alertmanagerUrl"
-      :url-text="alertmanagerUrl"
-      :is-shoot-status-hibernated="isShootStatusHibernated"
-      content-class="pt-0"
-    />
-    <v-divider
-      v-show="!!username && !!password"
-      inset
-    />
-    <g-username-password
-      :username="username"
-      :password="password"
-    />
+    <g-list-item v-if="!seedIngressDomain">
+      <template #prepend>
+        <v-icon color="primary">
+          mdi-alert-circle-outline
+        </v-icon>
+      </template>
+      <g-list-item-content>
+        Cluster Metrics not available
+      </g-list-item-content>
+    </g-list-item>
+    <template v-else>
+      <g-link-list-tile
+        v-if="isAdmin"
+        icon="mdi-developer-board"
+        app-title="Seed Plutono"
+        :url="seedPlutonoUrl"
+        :url-text="seedPlutonoUrl"
+      />
+      <template v-if="!isTestingCluster">
+        <g-link-list-tile
+          :icon="plutonoIcon"
+          app-title="Plutono"
+          :url="plutonoUrl"
+          :url-text="plutonoUrl"
+          :is-shoot-status-hibernated="isShootStatusHibernated"
+        />
+        <g-link-list-tile
+          app-title="Prometheus"
+          :url="prometheusUrl"
+          :url-text="prometheusUrl"
+          :is-shoot-status-hibernated="isShootStatusHibernated"
+          content-class="pt-0"
+        />
+        <g-link-list-tile
+          v-if="hasAlertmanager"
+          app-title="Alertmanager"
+          :url="alertmanagerUrl"
+          :url-text="alertmanagerUrl"
+          :is-shoot-status-hibernated="isShootStatusHibernated"
+          content-class="pt-0"
+        />
+        <v-divider
+          v-show="!!username && !!password"
+          inset
+        />
+        <g-username-password
+          :username="username"
+          :password="password"
+        />
+      </template>
+      <g-list-item v-else>
+        <template #prepend>
+          <v-icon color="primary">
+            mdi-alert-circle-outline
+          </v-icon>
+        </template>
+        <g-list-item-content>
+          Cluster Metrics not available for clusters with purpose testing
+        </g-list-item-content>
+      </g-list-item>
+    </template>
   </g-list>
 </template>
 
 <script>
 
+import { storeToRefs } from 'pinia'
+
 import { useConfigStore } from '@/store/config'
+import { useAuthnStore } from '@/store/authn'
 
 import GUsernamePassword from '@/components/GUsernamePasswordListTile'
 import GLinkListTile from '@/components/GLinkListTile'
@@ -61,6 +95,11 @@ export default {
     GLinkListTile,
   },
   setup () {
+    const authnStore = useAuthnStore()
+    const {
+      isAdmin,
+    } = storeToRefs(authnStore)
+
     const {
       isOidcObservabilityUrlsEnabled,
     } = useConfigStore()
@@ -69,6 +108,7 @@ export default {
       shootItem,
       shootInfo,
       isShootStatusHibernated,
+      isTestingCluster,
     } = useShootItem()
 
     const {
@@ -86,9 +126,16 @@ export default {
       seedIngressDomain,
       shootTechnicalId,
       isOidcObservabilityUrlsEnabled,
+      isAdmin,
+      isTestingCluster,
     }
   },
   computed: {
+    plutonoIcon () {
+      return this.isAdmin
+        ? undefined
+        : 'mdi-developer-board'
+    },
     plutonoUrl () {
       if (this.isOidcObservabilityUrlsEnabled) {
         return this.getOidcDeploymentUrl('plutono')
@@ -109,6 +156,9 @@ export default {
       }
 
       return `https://au-${this.prefix}.${this.seedIngressDomain}`
+    },
+    seedPlutonoUrl () {
+      return `https://plutono-garden.${this.seedIngressDomain}`
     },
     username () {
       return get(this.shootInfo, ['monitoringUsername'], '')

--- a/frontend/src/components/GClusterMetrics.vue
+++ b/frontend/src/components/GClusterMetrics.vue
@@ -132,6 +132,7 @@ export default {
   },
   computed: {
     plutonoIcon () {
+      // Avoid duplicate icon when Seed Plutono tile is also shown for admins
       return this.isAdmin
         ? undefined
         : 'mdi-developer-board'

--- a/frontend/src/components/ShootDetails/GShootMonitoringCard.vue
+++ b/frontend/src/components/ShootDetails/GShootMonitoringCard.vue
@@ -52,22 +52,10 @@ SPDX-License-Identifier: Apache-2.0
       </g-list-item-content>
     </g-list-item>
     <template
-      v-if="isOidcObservabilityUrlsEnabled || canGetCloudProviderCredentials"
+      v-if="showMetricsSection"
     >
       <v-divider inset />
-      <g-cluster-metrics
-        v-if="!metricsNotAvailableText"
-      />
-      <g-list-item v-else>
-        <template #prepend>
-          <v-icon color="primary">
-            mdi-alert-circle-outline
-          </v-icon>
-        </template>
-        <g-list-item-content>
-          {{ metricsNotAvailableText }}
-        </g-list-item-content>
-      </g-list-item>
+      <g-cluster-metrics />
     </template>
   </v-card>
 </template>
@@ -86,7 +74,6 @@ import GSeedStatusTags from '@/components/GSeedStatusTags'
 import GClusterMetrics from '@/components/GClusterMetrics'
 
 import { useShootItem } from '@/composables/useShootItem'
-import { useShootHelper } from '@/composables/useShootHelper'
 const authnStore = useAuthnStore()
 const {
   isAdmin,
@@ -106,20 +93,11 @@ const {
   shootNamespace,
   shootName,
   shootConditions,
-  isTestingCluster,
 } = shootItem
 
-const {
-  seedIngressDomain,
-} = useShootHelper()
-
-const metricsNotAvailableText = computed(() => {
-  if (isTestingCluster.value) {
-    return 'Cluster Metrics not available for clusters with purpose testing'
-  }
-  if (!seedIngressDomain.value) {
-    return 'Cluster Metrics not available'
-  }
-  return undefined
+const showMetricsSection = computed(() => {
+  return isAdmin.value ||
+    isOidcObservabilityUrlsEnabled ||
+    canGetCloudProviderCredentials.value
 })
 </script>


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
A link to the seed plutono is displayed on the shoot details page (admin/operator only)

**Which issue(s) this PR fixes**:
Fixes #2751 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
A link to the seed plutono is displayed on the shoot details page
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cluster metrics now display conditionally based on cluster configuration and user role.
  * Admin users can access Seed Plutono metrics in addition to standard monitoring tools.
  * Testing cluster users receive an alert indicating metrics are unavailable in test environments.

* **Refactor**
  * Simplified metrics section visibility logic for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->