### PR TITLE
Do not set `spec.addons` in case all addons are disabled

### DIFF
--- a/frontend/__tests__/composables/__snapshots__/useShootContext.spec.js.snap
+++ b/frontend/__tests__/composables/__snapshots__/useShootContext.spec.js.snap
@@ -87,14 +87,6 @@ exports[`composables > useShootContext > should change the infrastructure kind 1
     "namespace": "garden-test",
   },
   "spec": {
-    "addons": {
-      "kubernetesDashboard": {
-        "enabled": false,
-      },
-      "nginxIngress": {
-        "enabled": false,
-      },
-    },
     "cloudProfile": {
       "kind": "CloudProfile",
       "name": "gcp",
@@ -181,14 +173,6 @@ exports[`composables > useShootContext > should change to credentials binding 1`
     "namespace": "garden-test",
   },
   "spec": {
-    "addons": {
-      "kubernetesDashboard": {
-        "enabled": false,
-      },
-      "nginxIngress": {
-        "enabled": false,
-      },
-    },
     "cloudProfile": {
       "kind": "CloudProfile",
       "name": "aws",
@@ -284,14 +268,6 @@ exports[`composables > useShootContext > should create a default "alicloud" shoo
     "namespace": "garden-test",
   },
   "spec": {
-    "addons": {
-      "kubernetesDashboard": {
-        "enabled": false,
-      },
-      "nginxIngress": {
-        "enabled": false,
-      },
-    },
     "cloudProfile": {
       "kind": "CloudProfile",
       "name": "alicloud",
@@ -385,14 +361,6 @@ exports[`composables > useShootContext > should create a default "aws" shoot man
     "namespace": "garden-test",
   },
   "spec": {
-    "addons": {
-      "kubernetesDashboard": {
-        "enabled": false,
-      },
-      "nginxIngress": {
-        "enabled": false,
-      },
-    },
     "cloudProfile": {
       "kind": "CloudProfile",
       "name": "aws",
@@ -488,14 +456,6 @@ exports[`composables > useShootContext > should create a default "azure" shoot m
     "namespace": "garden-test",
   },
   "spec": {
-    "addons": {
-      "kubernetesDashboard": {
-        "enabled": false,
-      },
-      "nginxIngress": {
-        "enabled": false,
-      },
-    },
     "cloudProfile": {
       "kind": "CloudProfile",
       "name": "az",
@@ -585,14 +545,6 @@ exports[`composables > useShootContext > should create a default "gcp" shoot man
     "namespace": "garden-test",
   },
   "spec": {
-    "addons": {
-      "kubernetesDashboard": {
-        "enabled": false,
-      },
-      "nginxIngress": {
-        "enabled": false,
-      },
-    },
     "cloudProfile": {
       "kind": "CloudProfile",
       "name": "gcp",
@@ -679,14 +631,6 @@ exports[`composables > useShootContext > should create a default "ironcore" shoo
     "namespace": "garden-test",
   },
   "spec": {
-    "addons": {
-      "kubernetesDashboard": {
-        "enabled": false,
-      },
-      "nginxIngress": {
-        "enabled": false,
-      },
-    },
     "cloudProfile": {
       "kind": "CloudProfile",
       "name": "ironcore",
@@ -761,14 +705,6 @@ exports[`composables > useShootContext > should create a default "openstack" sho
     "namespace": "garden-test",
   },
   "spec": {
-    "addons": {
-      "kubernetesDashboard": {
-        "enabled": false,
-      },
-      "nginxIngress": {
-        "enabled": false,
-      },
-    },
     "cloudProfile": {
       "kind": "CloudProfile",
       "name": "openstack-1",

--- a/frontend/__tests__/composables/useShootContext.spec.js
+++ b/frontend/__tests__/composables/useShootContext.spec.js
@@ -75,6 +75,56 @@ describe('composables', () => {
       expect(createShootManifest('aws')).toMatchSnapshot()
     })
 
+    it('should omit spec.addons if no addon is enabled', () => {
+      createShootManifest('aws')
+
+      expect(shootContextStore.shootManifest.spec.addons).toBeUndefined()
+    })
+
+    it('should include spec.addons if an addon is enabled', () => {
+      createShootManifest('aws')
+
+      shootContextStore.setAddonEnabled('nginxIngress', true)
+
+      expect(shootContextStore.shootManifest.spec.addons).toEqual({
+        kubernetesDashboard: {
+          enabled: false,
+        },
+        nginxIngress: {
+          enabled: true,
+        },
+      })
+    })
+
+    it('should recreate spec.addons when enabling an addon after loading a manifest without addons', () => {
+      shootContextStore.setShootManifest({
+        metadata: {
+          name: 'test-shoot',
+        },
+        spec: {
+          provider: {
+            workers: [
+              {
+                name: 'worker-test',
+                minimum: 1,
+                maximum: 2,
+              },
+            ],
+          },
+        },
+      })
+
+      expect(shootContextStore.shootManifest.spec.addons).toBeUndefined()
+
+      shootContextStore.setAddonEnabled('nginxIngress', true)
+
+      expect(shootContextStore.shootManifest.spec.addons).toEqual({
+        nginxIngress: {
+          enabled: true,
+        },
+      })
+    })
+
     it('should create a default "azure" shoot manifest', async () => {
       expect(createShootManifest('azure')).toMatchSnapshot()
     })

--- a/frontend/src/composables/useShootContext.js
+++ b/frontend/src/composables/useShootContext.js
@@ -96,15 +96,6 @@ export function createShootContextComposable (options = {}) {
     return some(value, ['enabled', true])
   }
 
-  function ensureAddonsObject () {
-    let value = get(manifest.value, ['spec', 'addons'])
-    if (!value) {
-      value = {}
-      set(manifest.value, ['spec', 'addons'], value)
-    }
-    return value
-  }
-
   function normalizeManifest (value) {
     const object = Object.assign({
       apiVersion: 'core.gardener.cloud/v1beta1',
@@ -725,7 +716,10 @@ export function createShootContextComposable (options = {}) {
   }
 
   function setAddonEnabled (name, value) {
-    set(ensureAddonsObject(), [name, 'enabled'], value)
+    addons.value = {
+      ...addons.value,
+      [name]: { enabled: value },
+    }
   }
 
   /* maintenance */

--- a/frontend/src/composables/useShootContext.js
+++ b/frontend/src/composables/useShootContext.js
@@ -74,6 +74,7 @@ import unset from 'lodash/unset'
 import flatMap from 'lodash/flatMap'
 import keyBy from 'lodash/keyBy'
 import map from 'lodash/map'
+import some from 'lodash/some'
 import has from 'lodash/has'
 import set from 'lodash/set'
 import get from 'lodash/get'
@@ -91,11 +92,27 @@ export function createShootContextComposable (options = {}) {
     seedStore = useSeedStore(),
   } = options
 
+  function hasEnabledAddons (value) {
+    return some(value, ['enabled', true])
+  }
+
+  function ensureAddonsObject () {
+    let value = get(manifest.value, ['spec', 'addons'])
+    if (!value) {
+      value = {}
+      set(manifest.value, ['spec', 'addons'], value)
+    }
+    return value
+  }
+
   function normalizeManifest (value) {
     const object = Object.assign({
       apiVersion: 'core.gardener.cloud/v1beta1',
       kind: 'Shoot',
     }, value)
+    if (!hasEnabledAddons(get(object, ['spec', 'addons']))) {
+      unset(object, ['spec', 'addons'])
+    }
     if (workerless.value) {
       unset(object, ['spec', 'provider', 'infrastructureConfig'])
       unset(object, ['spec', 'provider', 'controlPlaneConfig'])
@@ -708,7 +725,7 @@ export function createShootContextComposable (options = {}) {
   }
 
   function setAddonEnabled (name, value) {
-    set(addons.value, [name, 'enabled'], value)
+    set(ensureAddonsObject(), [name, 'enabled'], value)
   }
 
   /* maintenance */

--- a/frontend/src/composables/useShootContext.js
+++ b/frontend/src/composables/useShootContext.js
@@ -682,21 +682,16 @@ export function createShootContextComposable (options = {}) {
   /* addons */
   const addons = computed({
     get () {
-      return get(manifest.value, ['spec', 'addons'], {})
-    },
-    set (value) {
-      set(manifest.value, ['spec', 'addons'], value)
+      return get(manifest.value, ['spec', 'addons'])
     },
   })
 
   function resetAddons () {
-    const defaultAddons = {}
     if (!providerState.workerless) {
       for (const { name, enabled } of visibleAddonDefinitionList.value) {
-        set(defaultAddons, [name], { enabled })
+        set(manifest.value, ['spec', 'addons', name, 'enabled'], enabled)
       }
     }
-    addons.value = defaultAddons
   }
 
   const visibleAddonDefinitionList = computed(() => {
@@ -716,10 +711,7 @@ export function createShootContextComposable (options = {}) {
   }
 
   function setAddonEnabled (name, value) {
-    addons.value = {
-      ...addons.value,
-      [name]: { enabled: value },
-    }
+    set(manifest.value, ['spec', 'addons', name, 'enabled'], value)
   }
 
   /* maintenance */


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed addon handling: disabled addon sets are removed from manifests; enabling an addon recreates addon entries cleanly without retaining stale entries.

* **Tests**
  * Added tests for addon behavior: omission when none are enabled, correct population when an addon is enabled, and recreation when enabling after a manifest without addons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->