### PR TITLE
fix(frontend): preserve new shoot draft when switching between create and YAML editor views

### DIFF
--- a/frontend/__tests__/composables/useItemPlaceholder.spec.js
+++ b/frontend/__tests__/composables/useItemPlaceholder.spec.js
@@ -1,0 +1,107 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import {
+  defineComponent,
+  nextTick,
+  reactive,
+  ref,
+} from 'vue'
+import {
+  flushPromises,
+  mount,
+} from '@vue/test-utils'
+
+import { useItemPlaceholder } from '@/composables/useItemPlaceholder'
+
+let beforeRouteUpdateHandler
+
+vi.mock('vue-router', () => ({
+  onBeforeRouteLeave: vi.fn(),
+  onBeforeRouteUpdate: handler => {
+    beforeRouteUpdateHandler = handler
+  },
+}))
+
+function createDeferred () {
+  let resolve
+  const promise = new Promise(_resolve => {
+    resolve = _resolve
+  })
+  return {
+    promise,
+    resolve,
+  }
+}
+
+describe('composables', () => {
+  describe('useItemPlaceholder', () => {
+    beforeEach(() => {
+      beforeRouteUpdateHandler = undefined
+    })
+
+    it('should keep rendering the router-view when switching between sibling routes with identical params', async () => {
+      const item = ref(true)
+      const route = reactive({
+        name: 'NewShoot',
+        params: {
+          namespace: 'garden-test',
+        },
+        path: '/namespace/garden-test/shoots/+',
+      })
+      const deferredLoad = createDeferred()
+      const load = vi.fn()
+        .mockResolvedValueOnce(undefined)
+        .mockImplementationOnce(() => deferredLoad.promise)
+
+      let state
+      const TestComponent = defineComponent({
+        setup () {
+          state = useItemPlaceholder({
+            route,
+            item,
+            load,
+            errorComponent: 'error-view',
+            loadingComponent: 'loading-view',
+          })
+
+          return () => null
+        },
+      })
+
+      const wrapper = mount(TestComponent)
+      await flushPromises()
+
+      expect(beforeRouteUpdateHandler).toEqual(expect.any(Function))
+      expect(load).toHaveBeenCalledTimes(1)
+      expect(state.component.value).toBe('router-view')
+
+      const to = {
+        name: 'NewShootEditor',
+        params: {
+          namespace: 'garden-test',
+        },
+        path: '/namespace/garden-test/shoots/+/yaml',
+      }
+
+      const navigation = beforeRouteUpdateHandler(to)
+      await nextTick()
+
+      expect(state.component.value).toBe('router-view')
+
+      route.name = to.name
+      route.path = to.path
+      deferredLoad.resolve()
+
+      await navigation
+      await flushPromises()
+
+      expect(state.component.value).toBe('router-view')
+
+      wrapper.unmount()
+    })
+  })
+})

--- a/frontend/eslint.config.cjs
+++ b/frontend/eslint.config.cjs
@@ -218,6 +218,7 @@ module.exports = [
       'vite.config.js',
     ],
     rules: {
+      'vue/one-component-per-file': 'off',
       'security/detect-object-injection': 'off',
       'security/detect-non-literal-fs-filename': 'off',
       'security/detect-unsafe-regex': 'off',

--- a/frontend/src/composables/useItemPlaceholder.js
+++ b/frontend/src/composables/useItemPlaceholder.js
@@ -19,7 +19,7 @@ import {
 
 import isEqual from 'lodash/isEqual'
 
-function isLoadRequired (route, to) {
+function shouldReloadForRouteChange (route, to) {
   return route.name !== to.name || !isEqual(route.params, to.params)
 }
 
@@ -70,9 +70,11 @@ export function useItemPlaceholder ({
     }
   })
 
-  async function loadRoute (to) {
+  async function loadRoute (to, { showLoading = true } = {}) {
     error.value = null
-    readyState.value = 'loading'
+    if (showLoading) {
+      readyState.value = 'loading'
+    }
     await load(to, {
       setError: value => {
         error.value = value
@@ -94,8 +96,10 @@ export function useItemPlaceholder ({
   })
 
   onBeforeRouteUpdate(async to => {
-    if (isLoadRequired(route, to)) {
-      await loadRoute(to)
+    if (shouldReloadForRouteChange(route, to)) {
+      await loadRoute(to, {
+        showLoading: !isEqual(route.params, to.params),
+      })
     }
   })
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
Prevents the new shoot draft from being reset when switching between the create form and the YAML editor for the same route params.

The root cause was that `useItemPlaceholder` treated sibling route changes as requiring a full loading transition, which temporarily replaced the `router-view` and unmounted `GNewShootPlaceholder`. That remount recreated the shoot manifest and discarded the current draft state.

This PR updates the behavior so sibling navigation with unchanged params keeps the child subtree mounted. It also adds a regression test covering the `NewShoot` <-> `NewShootEditor` navigation case.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
bugfix for issue introduced with https://github.com/gardener/dashboard/pull/2820

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced loading state behavior during route navigation—loading indicators now display only when route parameters change, reducing unnecessary loading indicators when navigating between similar routes.

* **Tests**
  * Added test suite for route navigation scenarios with placeholder rendering.

* **Chores**
  * Updated linting configuration for test files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->