### PR TITLE
feat: link to managed seed shoot and combine readiness

### DIFF
--- a/backend/__tests__/acceptance/__snapshots__/api.managedseeds.spec.cjs.snap
+++ b/backend/__tests__/acceptance/__snapshots__/api.managedseeds.spec.cjs.snap
@@ -1,0 +1,153 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`api managedseed-shoots should forbid listing managed seed shoots without full garden access 1`] = `
+[
+  [
+    {
+      ":authority": "kubernetes:6443",
+      ":method": "post",
+      ":path": "/apis/authorization.k8s.io/v1/selfsubjectaccessreviews",
+      ":scheme": "https",
+      "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImpvaG4uZG9lQGV4YW1wbGUub3JnIiwiaWF0IjoxNTc3ODM2ODAwLCJhdWQiOlsiZ2FyZGVuZXIiXSwiZXhwIjozMTU1NzE2ODAwLCJqdGkiOiJqdGkifQ.LkQ9PEN893UNTsZZn2Ux_CAYNOoQ2ISboWuHiAc5HHU",
+    },
+    {
+      "apiVersion": "authorization.k8s.io/v1",
+      "kind": "SelfSubjectAccessReview",
+      "spec": {
+        "nonResourceAttributes": undefined,
+        "resourceAttributes": {
+          "group": "seedmanagement.gardener.cloud",
+          "namespace": "garden",
+          "resource": "managedseeds",
+          "verb": "list",
+        },
+      },
+    },
+  ],
+  [
+    {
+      ":authority": "kubernetes:6443",
+      ":method": "post",
+      ":path": "/apis/authorization.k8s.io/v1/selfsubjectaccessreviews",
+      ":scheme": "https",
+      "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImpvaG4uZG9lQGV4YW1wbGUub3JnIiwiaWF0IjoxNTc3ODM2ODAwLCJhdWQiOlsiZ2FyZGVuZXIiXSwiZXhwIjozMTU1NzE2ODAwLCJqdGkiOiJqdGkifQ.LkQ9PEN893UNTsZZn2Ux_CAYNOoQ2ISboWuHiAc5HHU",
+    },
+    {
+      "apiVersion": "authorization.k8s.io/v1",
+      "kind": "SelfSubjectAccessReview",
+      "spec": {
+        "nonResourceAttributes": undefined,
+        "resourceAttributes": {
+          "group": "core.gardener.cloud",
+          "namespace": "garden",
+          "resource": "shoots",
+          "verb": "list",
+        },
+      },
+    },
+  ],
+]
+`;
+
+exports[`api managedseed-shoots should return managed seed shoots in the garden namespace 1`] = `
+[
+  [
+    {
+      ":authority": "kubernetes:6443",
+      ":method": "post",
+      ":path": "/apis/authorization.k8s.io/v1/selfsubjectaccessreviews",
+      ":scheme": "https",
+      "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImpvaG4uZG9lQGV4YW1wbGUub3JnIiwiaWF0IjoxNTc3ODM2ODAwLCJhdWQiOlsiZ2FyZGVuZXIiXSwiZXhwIjozMTU1NzE2ODAwLCJqdGkiOiJqdGkifQ.LkQ9PEN893UNTsZZn2Ux_CAYNOoQ2ISboWuHiAc5HHU",
+    },
+    {
+      "apiVersion": "authorization.k8s.io/v1",
+      "kind": "SelfSubjectAccessReview",
+      "spec": {
+        "nonResourceAttributes": undefined,
+        "resourceAttributes": {
+          "group": "seedmanagement.gardener.cloud",
+          "namespace": "garden",
+          "resource": "managedseeds",
+          "verb": "list",
+        },
+      },
+    },
+  ],
+  [
+    {
+      ":authority": "kubernetes:6443",
+      ":method": "post",
+      ":path": "/apis/authorization.k8s.io/v1/selfsubjectaccessreviews",
+      ":scheme": "https",
+      "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImpvaG4uZG9lQGV4YW1wbGUub3JnIiwiaWF0IjoxNTc3ODM2ODAwLCJhdWQiOlsiZ2FyZGVuZXIiXSwiZXhwIjozMTU1NzE2ODAwLCJqdGkiOiJqdGkifQ.LkQ9PEN893UNTsZZn2Ux_CAYNOoQ2ISboWuHiAc5HHU",
+    },
+    {
+      "apiVersion": "authorization.k8s.io/v1",
+      "kind": "SelfSubjectAccessReview",
+      "spec": {
+        "nonResourceAttributes": undefined,
+        "resourceAttributes": {
+          "group": "core.gardener.cloud",
+          "namespace": "garden",
+          "resource": "shoots",
+          "verb": "list",
+        },
+      },
+    },
+  ],
+]
+`;
+
+exports[`api managedseeds should forbid listing managed seeds without garden access 1`] = `
+[
+  [
+    {
+      ":authority": "kubernetes:6443",
+      ":method": "post",
+      ":path": "/apis/authorization.k8s.io/v1/selfsubjectaccessreviews",
+      ":scheme": "https",
+      "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImpvaG4uZG9lQGV4YW1wbGUub3JnIiwiaWF0IjoxNTc3ODM2ODAwLCJhdWQiOlsiZ2FyZGVuZXIiXSwiZXhwIjozMTU1NzE2ODAwLCJqdGkiOiJqdGkifQ.LkQ9PEN893UNTsZZn2Ux_CAYNOoQ2ISboWuHiAc5HHU",
+    },
+    {
+      "apiVersion": "authorization.k8s.io/v1",
+      "kind": "SelfSubjectAccessReview",
+      "spec": {
+        "nonResourceAttributes": undefined,
+        "resourceAttributes": {
+          "group": "seedmanagement.gardener.cloud",
+          "namespace": "garden",
+          "resource": "managedseeds",
+          "verb": "list",
+        },
+      },
+    },
+  ],
+]
+`;
+
+exports[`api managedseeds should return managed seeds in the garden namespace 1`] = `
+[
+  [
+    {
+      ":authority": "kubernetes:6443",
+      ":method": "post",
+      ":path": "/apis/authorization.k8s.io/v1/selfsubjectaccessreviews",
+      ":scheme": "https",
+      "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImpvaG4uZG9lQGV4YW1wbGUub3JnIiwiaWF0IjoxNTc3ODM2ODAwLCJhdWQiOlsiZ2FyZGVuZXIiXSwiZXhwIjozMTU1NzE2ODAwLCJqdGkiOiJqdGkifQ.LkQ9PEN893UNTsZZn2Ux_CAYNOoQ2ISboWuHiAc5HHU",
+    },
+    {
+      "apiVersion": "authorization.k8s.io/v1",
+      "kind": "SelfSubjectAccessReview",
+      "spec": {
+        "nonResourceAttributes": undefined,
+        "resourceAttributes": {
+          "group": "seedmanagement.gardener.cloud",
+          "namespace": "garden",
+          "resource": "managedseeds",
+          "verb": "list",
+        },
+      },
+    },
+  ],
+]
+`;

--- a/backend/__tests__/acceptance/api.managedseeds.spec.cjs
+++ b/backend/__tests__/acceptance/api.managedseeds.spec.cjs
@@ -1,0 +1,179 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+'use strict'
+
+const { mockRequest } = require('@gardener-dashboard/request')
+const { Store } = require('@gardener-dashboard/kube-client')
+const cache = require('../../dist/lib/cache')
+
+function createStore (items) {
+  const store = new Store()
+  store.replace(items)
+  return store
+}
+
+describe('api', function () {
+  let agent
+
+  beforeAll(() => {
+    agent = createAgent()
+
+    cache.initialize({
+      managedseeds: {
+        store: createStore(fixtures.managedseeds.list()),
+      },
+      shoots: {
+        store: createStore(fixtures.shoots.list()),
+      },
+    })
+  })
+
+  afterAll(() => {
+    return agent.close()
+  })
+
+  beforeEach(() => {
+    mockRequest.mockReset()
+  })
+
+  describe('managedseeds', function () {
+    const user = fixtures.auth.createUser({ id: 'john.doe@example.org' })
+
+    it('should return managed seeds in the garden namespace', async function () {
+      mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+
+      const res = await agent
+        .get('/api/namespaces/garden/managedseeds')
+        .set('cookie', await user.cookie)
+        .expect('content-type', /json/)
+        .expect(200)
+
+      expect(mockRequest).toHaveBeenCalledTimes(1)
+      expect(mockRequest.mock.calls).toMatchSnapshot()
+
+      expect(res.body).toEqual([
+        {
+          metadata: {
+            name: 'infra1-seed',
+            namespace: 'garden',
+            uid: 4,
+          },
+          spec: {
+            shoot: {
+              name: 'infra1-seed',
+            },
+          },
+        },
+      ])
+    })
+
+    it('should forbid listing managed seeds without garden access', async function () {
+      mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess({ allowed: false }))
+
+      const res = await agent
+        .get('/api/namespaces/garden/managedseeds')
+        .set('cookie', await user.cookie)
+        .expect('content-type', /json/)
+        .expect(403)
+
+      expect(mockRequest).toHaveBeenCalledTimes(1)
+      expect(mockRequest.mock.calls).toMatchSnapshot()
+      expect(res.body).toEqual(expect.objectContaining({
+        code: 403,
+        reason: 'Forbidden',
+        message: 'You are not allowed to list managed seeds in the garden namespace',
+      }))
+    })
+
+    it('should reject non-garden namespaces', async function () {
+      const res = await agent
+        .get('/api/namespaces/garden-foo/managedseeds')
+        .set('cookie', await user.cookie)
+        .expect('content-type', /json/)
+        .expect(422)
+
+      expect(mockRequest).not.toHaveBeenCalled()
+      expect(res.body).toEqual(expect.objectContaining({
+        code: 422,
+        reason: 'Unprocessable Entity',
+        message: 'Managed seeds are restricted to the garden namespace',
+      }))
+    })
+  })
+
+  describe('managedseed-shoots', function () {
+    const user = fixtures.auth.createUser({ id: 'john.doe@example.org' })
+
+    it('should return managed seed shoots in the garden namespace', async function () {
+      mockRequest
+        .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+        .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+
+      const res = await agent
+        .get('/api/namespaces/garden/managedseed-shoots')
+        .set('cookie', await user.cookie)
+        .expect('content-type', /json/)
+        .expect(200)
+
+      expect(mockRequest).toHaveBeenCalledTimes(2)
+      expect(mockRequest.mock.calls).toMatchSnapshot()
+
+      expect(res.body).toEqual([
+        {
+          metadata: {
+            name: 'infra1-seed',
+            namespace: 'garden',
+            uid: 4,
+          },
+          status: {
+            advertisedAddresses: [
+              {
+                name: 'external',
+                url: 'https://api.infra1-seed.garden.shoot.test',
+              },
+            ],
+          },
+        },
+      ])
+    })
+
+    it('should forbid listing managed seed shoots without full garden access', async function () {
+      mockRequest
+        .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+        .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess({ allowed: false }))
+
+      const res = await agent
+        .get('/api/namespaces/garden/managedseed-shoots')
+        .set('cookie', await user.cookie)
+        .expect('content-type', /json/)
+        .expect(403)
+
+      expect(mockRequest).toHaveBeenCalledTimes(2)
+      expect(mockRequest.mock.calls).toMatchSnapshot()
+      expect(res.body).toEqual(expect.objectContaining({
+        code: 403,
+        reason: 'Forbidden',
+        message: 'You are not allowed to list managed seed shoots in the garden namespace',
+      }))
+    })
+
+    it('should reject non-garden namespaces for managed seed shoots', async function () {
+      const res = await agent
+        .get('/api/namespaces/garden-foo/managedseed-shoots')
+        .set('cookie', await user.cookie)
+        .expect('content-type', /json/)
+        .expect(422)
+
+      expect(mockRequest).not.toHaveBeenCalled()
+      expect(res.body).toEqual(expect.objectContaining({
+        code: 422,
+        reason: 'Unprocessable Entity',
+        message: 'Managed seed shoots are restricted to the garden namespace',
+      }))
+    })
+  })
+})

--- a/backend/__tests__/acceptance/auth.spec.cjs
+++ b/backend/__tests__/acceptance/auth.spec.cjs
@@ -218,6 +218,8 @@ describe('auth', function () {
 
     mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewToken())
     mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+    mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+    mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
 
     authorizationCodeGrant.mockImplementationOnce((config, currentUrl, checks) => {
       assert.strictEqual(currentUrl.searchParams.get('code'), OTAC)
@@ -229,7 +231,7 @@ describe('auth', function () {
       .redirects(0)
       .expect(302)
 
-    expect(mockRequest).toHaveBeenCalledTimes(2)
+    expect(mockRequest).toHaveBeenCalledTimes(4)
     expect(mockRequest.mock.calls[0]).toEqual([
       {
         ...pick(fixtures.kube, [':scheme', ':authority', 'authorization']),
@@ -251,7 +253,7 @@ describe('auth', function () {
 
     expect(discovery).toHaveBeenCalledTimes(1)
     expect(res.headers).toHaveProperty('location', '/')
-    expect(mockRequest).toHaveBeenCalledTimes(2)
+    expect(mockRequest).toHaveBeenCalledTimes(4)
     expect(authorizationCodeGrant).toHaveBeenCalledTimes(1)
   })
 
@@ -287,6 +289,8 @@ describe('auth', function () {
 
     mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewToken())
     mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+    mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+    mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
 
     const res = await agent
       .post('/auth')
@@ -294,7 +298,7 @@ describe('auth', function () {
       .expect('content-type', /json/)
       .expect(200)
 
-    expect(mockRequest).toHaveBeenCalledTimes(2)
+    expect(mockRequest).toHaveBeenCalledTimes(4)
     expect(mockRequest.mock.calls[0]).toEqual([
       {
         ...pick(fixtures.kube, [':scheme', ':authority', 'authorization']),
@@ -390,6 +394,8 @@ describe('auth', function () {
 
     mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewToken())
     mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+    mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+    mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
     discovery.mockResolvedValue({
       code_challenge_methods_supported: ['S256'],
       issuer: 'https://issuer.example.org',
@@ -403,7 +409,7 @@ describe('auth', function () {
       .expect('content-type', /json/)
       .expect(200)
 
-    expect(mockRequest).toHaveBeenCalledTimes(2)
+    expect(mockRequest).toHaveBeenCalledTimes(4)
     expect(mockRequest.mock.calls).toEqual([[
       {
         ...pick(fixtures.kube, [':scheme', ':authority', 'authorization']),
@@ -439,6 +445,46 @@ describe('auth', function () {
           },
         },
       },
+    ], [
+      {
+        ...pick(fixtures.kube, [':scheme', ':authority']),
+        authorization: `Bearer ${tokenSet.refresh_token}`,
+        ':method': 'post',
+        ':path': '/apis/authorization.k8s.io/v1/selfsubjectaccessreviews',
+      },
+      {
+        apiVersion: 'authorization.k8s.io/v1',
+        kind: 'SelfSubjectAccessReview',
+        spec: {
+          nonResourceAttributes: undefined,
+          resourceAttributes: {
+            group: 'seedmanagement.gardener.cloud',
+            resource: 'managedseeds',
+            verb: 'list',
+            namespace: 'garden',
+          },
+        },
+      },
+    ], [
+      {
+        ...pick(fixtures.kube, [':scheme', ':authority']),
+        authorization: `Bearer ${tokenSet.refresh_token}`,
+        ':method': 'post',
+        ':path': '/apis/authorization.k8s.io/v1/selfsubjectaccessreviews',
+      },
+      {
+        apiVersion: 'authorization.k8s.io/v1',
+        kind: 'SelfSubjectAccessReview',
+        spec: {
+          nonResourceAttributes: undefined,
+          resourceAttributes: {
+            group: 'core.gardener.cloud',
+            resource: 'shoots',
+            verb: 'list',
+            namespace: 'garden',
+          },
+        },
+      },
     ]])
 
     expect(refreshTokenGrant).toHaveBeenCalledTimes(1)
@@ -463,6 +509,7 @@ describe('auth', function () {
       exp: accessTokenPayload.exp,
       aud: accessTokenPayload.aud,
       isAdmin: false,
+      canGetManagedSeedAndShootInGardenNs: true,
       refresh_at: refreshTokenPayload.exp,
       rti: expect.stringMatching(/^[a-z0-9]{7}$/),
     })

--- a/backend/__tests__/acceptance/io.cors.spec.cjs
+++ b/backend/__tests__/acceptance/io.cors.spec.cjs
@@ -35,6 +35,8 @@ describe('cors', () => {
     mockRequest
       .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
       .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+      .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+      .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
     expect(() => createAgent('io', cache))
       .toThrow('WebSocket allowed origins configuration is required')
   })
@@ -42,6 +44,8 @@ describe('cors', () => {
   it('should reject connections from disallowed origins', async () => {
     Object.defineProperty(config, 'websocketAllowedOrigins', { value: ['https://allowed.example.org'] })
     mockRequest
+      .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+      .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
       .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
       .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
     agent = createAgent('io', cache)
@@ -56,6 +60,8 @@ describe('cors', () => {
     mockRequest
       .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
       .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+      .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+      .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
     agent = createAgent('io', cache)
     const cookie = await user.cookie
     await expect(
@@ -68,6 +74,8 @@ describe('cors', () => {
     mockRequest
       .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
       .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+      .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+      .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
     agent = createAgent('io', cache)
     const cookie = await user.cookie
     socket = await agent.connect({ cookie, originHeader: 'https://allowed.example.org' })
@@ -77,6 +85,8 @@ describe('cors', () => {
   it('should allow connections when "*" is configured', async () => {
     Object.defineProperty(config, 'websocketAllowedOrigins', { value: ['*'] })
     mockRequest
+      .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+      .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
       .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
       .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
     agent = createAgent('io', cache)

--- a/backend/__tests__/acceptance/io.spec.cjs
+++ b/backend/__tests__/acceptance/io.spec.cjs
@@ -76,6 +76,22 @@ function createStore (items) {
   return store
 }
 
+function notFoundStatus ({ group, kind, uid }) {
+  return {
+    kind: 'Status',
+    apiVersion: 'v1',
+    status: 'Failure',
+    message: `${kind} with uid ${uid} does not exist`,
+    reason: 'NotFound',
+    details: {
+      uid,
+      group,
+      kind,
+    },
+    code: 404,
+  }
+}
+
 describe('api', function () {
   let agent
   let socket
@@ -88,7 +104,36 @@ describe('api', function () {
         store: createStore(fixtures.projects.list()),
       },
       shoots: {
-        store: createStore(fixtures.shoots.list()),
+        store: createStore([
+          ...fixtures.shoots.list(),
+          fixtures.shoots.create({
+            uid: 5,
+            name: 'orphan-shoot',
+            namespace: 'garden',
+            project: 'garden',
+            createdBy: 'admin@example.org',
+            secretBindingName: 'soil-orphan',
+            seed: 'soil-orphan',
+          }),
+        ]),
+      },
+      managedseeds: {
+        store: createStore([
+          ...fixtures.managedseeds.list(),
+          {
+            metadata: {
+              uid: 6,
+              name: 'foreign-managedseed',
+              namespace: 'garden-foo',
+            },
+            spec: {
+              shoot: {
+                name: 'foreign-managedseed',
+              },
+            },
+            status: {},
+          },
+        ]),
       },
     })
     agent = createAgent('io', cache)
@@ -128,8 +173,11 @@ describe('api', function () {
       let args
 
       beforeEach(async () => {
-        // authorization check for `canListProjects` and `canListSeeds`
+        // authorization check for `canListProjects`, `canListSeeds`,
+        // `canListManagedSeedsInGardenNamespace`, and `canListShootsInGardenNamespace`
         mockRequest
+          .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+          .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
           .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
           .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
         socket = await agent.connect({
@@ -138,8 +186,10 @@ describe('api', function () {
         defaultRooms = [
           socket.id,
           ioHelper.sha256(username),
+          'managedseeds;garden',
+          'managedseed-shoots;garden',
         ]
-        expect(mockRequest).toHaveBeenCalledTimes(2)
+        expect(mockRequest).toHaveBeenCalledTimes(4)
         mockRequest.mockClear()
       })
 
@@ -309,6 +359,56 @@ describe('api', function () {
           status: 'Failure',
         }])
       })
+
+      it('should fail to synchronize managed seeds without garden access', async function () {
+        mockRequest
+          .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+          .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+          .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess({ allowed: false }))
+          .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess({ allowed: false }))
+
+        const limitedSocket = await agent.connect({
+          cookie: await user.cookie,
+        })
+
+        try {
+          const items = await synchronize(limitedSocket, 'managedseeds', [4])
+          expect(items).toEqual([
+            notFoundStatus({
+              group: 'seedmanagement.gardener.cloud',
+              kind: 'ManagedSeed',
+              uid: 4,
+            }),
+          ])
+        } finally {
+          limitedSocket.destroy()
+        }
+      })
+
+      it('should fail to synchronize managed seed shoots without garden access', async function () {
+        mockRequest
+          .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+          .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+          .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess({ allowed: false }))
+          .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess({ allowed: false }))
+
+        const limitedSocket = await agent.connect({
+          cookie: await user.cookie,
+        })
+
+        try {
+          const items = await synchronize(limitedSocket, 'managedseed-shoots', [4])
+          expect(items).toEqual([
+            notFoundStatus({
+              group: 'core.gardener.cloud',
+              kind: 'Shoot',
+              uid: 4,
+            }),
+          ])
+        } finally {
+          limitedSocket.destroy()
+        }
+      })
     })
 
     describe('when user is "admin"', () => {
@@ -319,8 +419,11 @@ describe('api', function () {
       let defaultRooms
 
       beforeEach(async () => {
-        // authorization check for `canListProjects` and `canListSeeds`
+        // authorization check for `canListProjects`, `canListSeeds`,
+        // `canListManagedSeedsInGardenNamespace`, and `canListShootsInGardenNamespace`
         mockRequest
+          .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+          .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
           .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
           .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
         socket = await agent.connect({
@@ -329,8 +432,10 @@ describe('api', function () {
         defaultRooms = [
           socket.id,
           ioHelper.sha256(username),
+          'managedseeds;garden',
+          'managedseed-shoots;garden',
         ]
-        expect(mockRequest).toHaveBeenCalledTimes(2)
+        expect(mockRequest).toHaveBeenCalledTimes(4)
         mockRequest.mockClear()
       })
 
@@ -411,6 +516,42 @@ describe('api', function () {
           .toThrow('Invalid synchronization type - cats')
       })
 
+      it('should synchronize managed seeds in the garden namespace', async function () {
+        const items = await synchronize(socket, 'managedseeds', [4, 6, 999])
+
+        expect(items).toEqual([
+          fixtures.managedseeds.get('garden', 'infra1-seed'),
+          notFoundStatus({
+            group: 'seedmanagement.gardener.cloud',
+            kind: 'ManagedSeed',
+            uid: 6,
+          }),
+          notFoundStatus({
+            group: 'seedmanagement.gardener.cloud',
+            kind: 'ManagedSeed',
+            uid: 999,
+          }),
+        ])
+      })
+
+      it('should synchronize managed seed shoots in the garden namespace', async function () {
+        const items = await synchronize(socket, 'managedseed-shoots', [4, 1, 5])
+
+        expect(items).toEqual([
+          fixtures.shoots.get('garden', 'infra1-seed'),
+          notFoundStatus({
+            group: 'core.gardener.cloud',
+            kind: 'Shoot',
+            uid: 1,
+          }),
+          notFoundStatus({
+            group: 'core.gardener.cloud',
+            kind: 'Shoot',
+            uid: 5,
+          }),
+        ])
+      })
+
       it('should synchronize a project', async function () {
         const items = await synchronize(socket, 'projects', [2])
         expect(items).toMatchSnapshot()
@@ -422,7 +563,11 @@ describe('api', function () {
     let timestamp
 
     beforeEach(() => {
-      mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+      mockRequest
+        .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+        .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+        .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+        .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
       timestamp = Math.floor(Date.now() / 1000)
     })
 
@@ -490,10 +635,12 @@ describe('api', function () {
       mockRequest
         .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
         .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+        .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+        .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
       socket = await agent.connect({
         cookie: await user.cookie,
       })
-      expect(mockRequest).toHaveBeenCalledTimes(2)
+      expect(mockRequest).toHaveBeenCalledTimes(4)
       expect(mockSetDisconnectTimeout).toHaveBeenCalledTimes(1)
       expect(mockSetDisconnectTimeout.mock.calls[0]).toEqual([
         expect.objectContaining({

--- a/backend/__tests__/hooks.spec.cjs
+++ b/backend/__tests__/hooks.spec.cjs
@@ -88,7 +88,7 @@ describe('hooks', () => {
       const server = {}
       const ticketCache = {}
       const ioInstance = {}
-      const keys = ['leases', 'shoots', 'projects', 'seeds']
+      const keys = ['leases', 'shoots', 'projects', 'seeds', 'managedseeds']
       let informers
       let mockCreateInformers
 

--- a/backend/__tests__/security.spec.cjs
+++ b/backend/__tests__/security.spec.cjs
@@ -139,6 +139,8 @@ describe('security', function () {
         }))
         jest.mock('../dist/lib/services/authorization', () => ({
           isAdmin: jest.fn(),
+          canListManagedSeedsInGardenNamespace: jest.fn(),
+          canListShootsInGardenNamespace: jest.fn(),
         }))
         undici = require('undici')
         authentication = require('../dist/lib/services/authentication')
@@ -345,6 +347,8 @@ describe('security', function () {
 
         authentication.isAuthenticated.mockResolvedValue({ username: sub, groups: [] })
         authorization.isAdmin.mockResolvedValue(false)
+        authorization.canListManagedSeedsInGardenNamespace.mockResolvedValue(true)
+        authorization.canListShootsInGardenNamespace.mockResolvedValue(true)
 
         // Create an expired ID token and an access token
         const iat = Math.floor(Date.now() / 1000) - 3600
@@ -443,6 +447,7 @@ describe('security', function () {
             groups: [],
             aud: ['gardener'],
             isAdmin: false,
+            canGetManagedSeedAndShootInGardenNs: true,
           }),
         )
       })
@@ -459,6 +464,8 @@ describe('security', function () {
         })
         authentication.isAuthenticated.mockResolvedValue({ username: sub, groups: [] })
         authorization.isAdmin.mockResolvedValue(false)
+        authorization.canListManagedSeedsInGardenNamespace.mockResolvedValue(false)
+        authorization.canListShootsInGardenNamespace.mockResolvedValue(false)
 
         const req = {
           originalUrl: '/auth/callback?code=some-code',
@@ -534,6 +541,8 @@ describe('security', function () {
         discovery.mockResolvedValue({ code_challenge_methods_supported: ['S256'] })
         authentication.isAuthenticated.mockResolvedValue({ username: sub, groups: [] })
         authorization.isAdmin.mockResolvedValue(false)
+        authorization.canListManagedSeedsInGardenNamespace.mockResolvedValue(false)
+        authorization.canListShootsInGardenNamespace.mockResolvedValue(false)
 
         const req = {
           originalUrl: '/auth/callback?code=some-code',

--- a/backend/__tests__/services.managedseeds.spec.cjs
+++ b/backend/__tests__/services.managedseeds.spec.cjs
@@ -1,0 +1,92 @@
+//
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+'use strict'
+
+jest.mock('../dist/lib/cache', () => ({
+  getManagedSeedsInGardenNamespace: jest.fn(),
+}))
+
+jest.mock('../dist/lib/services/authorization', () => ({
+  canListManagedSeedsInGardenNamespace: jest.fn(),
+}))
+
+describe('services/managedseeds', () => {
+  const httpErrors = require('http-errors')
+  const cache = require('../dist/lib/cache')
+  const authorization = require('../dist/lib/services/authorization')
+  const managedseeds = require('../dist/lib/services/managedseeds')
+
+  const user = { id: 'admin@example.org' }
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    authorization.canListManagedSeedsInGardenNamespace.mockResolvedValue(true)
+  })
+
+  it('should reject non-garden namespaces', async () => {
+    await expect(managedseeds.list({ user, namespace: 'garden-foo' })).rejects.toThrow(httpErrors.UnprocessableEntity)
+    expect(authorization.canListManagedSeedsInGardenNamespace).not.toHaveBeenCalled()
+    expect(cache.getManagedSeedsInGardenNamespace).not.toHaveBeenCalled()
+  })
+
+  it('should reject unauthorized users', async () => {
+    authorization.canListManagedSeedsInGardenNamespace.mockResolvedValue(false)
+
+    await expect(managedseeds.list({ user, namespace: 'garden' })).rejects.toEqual(expect.objectContaining({
+      statusCode: 403,
+      message: 'You are not allowed to list managed seeds in the garden namespace',
+    }))
+
+    expect(authorization.canListManagedSeedsInGardenNamespace).toHaveBeenCalledWith(user)
+    expect(cache.getManagedSeedsInGardenNamespace).not.toHaveBeenCalled()
+  })
+
+  it('should return simplified managed seeds for the garden namespace', async () => {
+    cache.getManagedSeedsInGardenNamespace.mockReturnValue([
+      {
+        metadata: {
+          name: 'infra1-seed',
+          namespace: 'garden',
+          uid: 'managedseed-1',
+          annotations: {
+            foo: 'bar',
+          },
+        },
+        spec: {
+          shoot: {
+            name: 'infra1-shoot',
+          },
+        },
+        status: {
+          lastOperation: {
+            state: 'Succeeded',
+            type: 'Reconcile',
+          },
+        },
+      },
+    ])
+
+    const result = await managedseeds.list({ user, namespace: 'garden' })
+
+    expect(authorization.canListManagedSeedsInGardenNamespace).toHaveBeenCalledWith(user)
+    expect(cache.getManagedSeedsInGardenNamespace).toHaveBeenCalledTimes(1)
+    expect(result).toEqual([
+      {
+        metadata: {
+          name: 'infra1-seed',
+          namespace: 'garden',
+          uid: 'managedseed-1',
+        },
+        spec: {
+          shoot: {
+            name: 'infra1-shoot',
+          },
+        },
+      },
+    ])
+  })
+})

--- a/backend/__tests__/services.managedseedshoots.spec.cjs
+++ b/backend/__tests__/services.managedseedshoots.spec.cjs
@@ -1,0 +1,122 @@
+//
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+'use strict'
+
+jest.mock('../dist/lib/cache', () => ({
+  getManagedSeedsInGardenNamespace: jest.fn(),
+  getShoot: jest.fn(),
+}))
+
+jest.mock('../dist/lib/services/authorization', () => ({
+  canListManagedSeedsInGardenNamespace: jest.fn(),
+  canListShootsInGardenNamespace: jest.fn(),
+}))
+
+describe('services/managedseedshoots', () => {
+  const httpErrors = require('http-errors')
+  const cache = require('../dist/lib/cache')
+  const authorization = require('../dist/lib/services/authorization')
+  const managedseedshoots = require('../dist/lib/services/managedseedshoots')
+
+  const user = { id: 'admin@example.org' }
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    authorization.canListManagedSeedsInGardenNamespace.mockResolvedValue(true)
+    authorization.canListShootsInGardenNamespace.mockResolvedValue(true)
+  })
+
+  it('should reject non-garden namespaces', async () => {
+    await expect(managedseedshoots.list({ user, namespace: 'garden-foo' })).rejects.toThrow(httpErrors.UnprocessableEntity)
+    expect(authorization.canListManagedSeedsInGardenNamespace).not.toHaveBeenCalled()
+    expect(authorization.canListShootsInGardenNamespace).not.toHaveBeenCalled()
+  })
+
+  it('should reject unauthorized users', async () => {
+    authorization.canListManagedSeedsInGardenNamespace.mockResolvedValue(false)
+
+    await expect(managedseedshoots.list({ user, namespace: 'garden' })).rejects.toEqual(expect.objectContaining({
+      statusCode: 403,
+      message: 'You are not allowed to list managed seed shoots in the garden namespace',
+    }))
+
+    expect(authorization.canListManagedSeedsInGardenNamespace).toHaveBeenCalledWith(user)
+    expect(authorization.canListShootsInGardenNamespace).toHaveBeenCalledWith(user)
+    expect(cache.getManagedSeedsInGardenNamespace).not.toHaveBeenCalled()
+  })
+
+  it('should return managed seed shoots for the garden namespace', async () => {
+    cache.getManagedSeedsInGardenNamespace.mockReturnValue([
+      {
+        metadata: {
+          name: 'infra1-seed',
+          namespace: 'garden',
+          uid: 'managedseed-1',
+        },
+        spec: {
+          shoot: {
+            name: 'infra1-seed',
+          },
+        },
+      },
+      {
+        metadata: {
+          name: 'without-shoot-name',
+          namespace: 'garden',
+          uid: 'managedseed-2',
+        },
+        spec: {},
+      },
+      {
+        metadata: {
+          name: 'missing-shoot',
+          namespace: 'garden',
+          uid: 'managedseed-3',
+        },
+        spec: {
+          shoot: {
+            name: 'missing-shoot',
+          },
+        },
+      },
+    ])
+    cache.getShoot.mockImplementation((namespace, name) => {
+      if (namespace === 'garden' && name === 'infra1-seed') {
+        return {
+          metadata: {
+            name,
+            namespace,
+            uid: 'shoot-1',
+          },
+          status: {
+            conditions: [{ type: 'APIServerAvailable', status: 'True' }],
+          },
+        }
+      }
+    })
+
+    const result = await managedseedshoots.list({ user, namespace: 'garden' })
+
+    expect(authorization.canListManagedSeedsInGardenNamespace).toHaveBeenCalledWith(user)
+    expect(authorization.canListShootsInGardenNamespace).toHaveBeenCalledWith(user)
+    expect(cache.getManagedSeedsInGardenNamespace).toHaveBeenCalledTimes(1)
+    expect(cache.getShoot).toHaveBeenCalledWith('garden', 'infra1-seed')
+    expect(cache.getShoot).toHaveBeenCalledWith('garden', 'missing-shoot')
+    expect(result).toEqual([
+      {
+        metadata: {
+          name: 'infra1-seed',
+          namespace: 'garden',
+          uid: 'shoot-1',
+        },
+        status: {
+          conditions: [{ type: 'APIServerAvailable', status: 'True' }],
+        },
+      },
+    ])
+  })
+})

--- a/backend/__tests__/watches.spec.cjs
+++ b/backend/__tests__/watches.spec.cjs
@@ -234,6 +234,22 @@ describe('watches', function () {
         ['managedseed-shoots', { type: 'DELETED', uid: gardenManagedSeedShoot.metadata.uid }],
       ])
     })
+
+    it('should emit deleted garden shoots even if the managed seed is already gone from cache', async function () {
+      watches.shoots(io, informer)
+
+      informer.emit('delete', gardenManagedSeedShoot)
+
+      await flushPromises()
+
+      expect(cache.getManagedSeedForShootInGardenNamespace).not.toHaveBeenCalled()
+
+      const room = rooms.get('managedseed-shoots;garden')
+      expect(room.emit).toHaveBeenCalledTimes(1)
+      expect(room.emit.mock.calls).toEqual([
+        ['managedseed-shoots', { type: 'DELETED', uid: gardenManagedSeedShoot.metadata.uid }],
+      ])
+    })
   })
 
   describe('projects', function () {

--- a/backend/__tests__/watches.spec.cjs
+++ b/backend/__tests__/watches.spec.cjs
@@ -100,6 +100,7 @@ const io = {
 describe('watches', function () {
   const foobar = { metadata: { namespace: 'foo', name: 'bar', uid: 4 } }
   const foobaz = { metadata: { namespace: 'foo', name: 'baz', uid: 5 } }
+  const gardenManagedSeedShoot = { metadata: { namespace: 'garden', name: 'managed-seed-foo', uid: 6 } }
 
   let informer
 
@@ -126,6 +127,7 @@ describe('watches', function () {
 
     beforeEach(() => {
       shootsWithIssues = new Set()
+      jest.spyOn(cache, 'getManagedSeedForShootInGardenNamespace').mockReturnValue(undefined)
     })
 
     it('should watch shoots without issues', async function () {
@@ -204,6 +206,32 @@ describe('watches', function () {
           'shoots',
           { type: 'DELETED', uid: foobazUnhealthy.metadata.uid },
         ],
+      ])
+    })
+
+    it('should emit managed seed shoots to a dedicated garden room', async function () {
+      cache.getManagedSeedForShootInGardenNamespace.mockReturnValue({
+        metadata: {
+          namespace: 'garden',
+          name: 'managed-seed-foo',
+          uid: 7,
+        },
+      })
+
+      watches.shoots(io, informer)
+
+      informer.emit('add', gardenManagedSeedShoot)
+      informer.emit('update', gardenManagedSeedShoot)
+      informer.emit('delete', gardenManagedSeedShoot)
+
+      await flushPromises()
+
+      const room = rooms.get('managedseed-shoots;garden')
+      expect(room.emit).toHaveBeenCalledTimes(3)
+      expect(room.emit.mock.calls).toEqual([
+        ['managedseed-shoots', { type: 'ADDED', uid: gardenManagedSeedShoot.metadata.uid }],
+        ['managedseed-shoots', { type: 'MODIFIED', uid: gardenManagedSeedShoot.metadata.uid }],
+        ['managedseed-shoots', { type: 'DELETED', uid: gardenManagedSeedShoot.metadata.uid }],
       ])
     })
   })
@@ -293,6 +321,61 @@ describe('watches', function () {
         ['seeds', { type: 'MODIFIED', uid }],
         ['seeds', { type: 'DELETED', uid }],
       ])
+    })
+  })
+
+  describe('managedseeds', function () {
+    it('should watch managedseeds in the garden room', async function () {
+      watches.managedseeds(io, informer)
+
+      const uid = 8
+      const managedSeed = {
+        metadata: {
+          namespace: 'garden',
+          name: 'seed-foo',
+          uid,
+        },
+      }
+
+      informer.emit('add', managedSeed)
+      informer.emit('update', managedSeed)
+      informer.emit('delete', managedSeed)
+
+      await flushPromises()
+
+      const ids = ['managedseeds;garden']
+
+      expect(Array.from(rooms.keys())).toEqual(ids)
+      expect(nsp.to).toHaveBeenCalledTimes(3)
+
+      const managedSeedsRoom = rooms.get(ids[0])
+      expect(managedSeedsRoom.emit).toHaveBeenCalledTimes(3)
+      expect(managedSeedsRoom.emit.mock.calls).toEqual([
+        ['managedseeds', { type: 'ADDED', uid }],
+        ['managedseeds', { type: 'MODIFIED', uid }],
+        ['managedseeds', { type: 'DELETED', uid }],
+      ])
+    })
+
+    it('should ignore managedseeds outside the garden namespace', async function () {
+      watches.managedseeds(io, informer)
+
+      const managedSeed = {
+        metadata: {
+          namespace: 'foo',
+          name: 'seed-foo',
+          uid: 8,
+        },
+      }
+
+      informer.emit('add', managedSeed)
+      informer.emit('update', managedSeed)
+      informer.emit('delete', managedSeed)
+
+      await flushPromises()
+
+      expect(nsp.to).not.toHaveBeenCalled()
+      expect(Array.from(rooms.keys())).toEqual([])
     })
   })
 

--- a/backend/__tests__/watches.spec.cjs
+++ b/backend/__tests__/watches.spec.cjs
@@ -341,6 +341,10 @@ describe('watches', function () {
   })
 
   describe('managedseeds', function () {
+    beforeEach(() => {
+      jest.spyOn(cache, 'getShoot').mockReturnValue(undefined)
+    })
+
     it('should watch managedseeds in the garden room', async function () {
       watches.managedseeds(io, informer)
 
@@ -371,6 +375,46 @@ describe('watches', function () {
         ['managedseeds', { type: 'MODIFIED', uid }],
         ['managedseeds', { type: 'DELETED', uid }],
       ])
+
+      expect(cache.getShoot).not.toHaveBeenCalled()
+    })
+
+    it('should backfill managed seed shoots on managedseed add', async function () {
+      cache.getShoot.mockReturnValue(gardenManagedSeedShoot)
+
+      watches.managedseeds(io, informer)
+
+      const uid = 8
+      const managedSeed = {
+        metadata: {
+          namespace: 'garden',
+          name: 'seed-foo',
+          uid,
+        },
+        spec: {
+          shoot: {
+            name: gardenManagedSeedShoot.metadata.name,
+          },
+        },
+      }
+
+      informer.emit('add', managedSeed)
+
+      await flushPromises()
+
+      expect(cache.getShoot).toHaveBeenCalledTimes(1)
+      expect(cache.getShoot).toHaveBeenCalledWith('garden', gardenManagedSeedShoot.metadata.name)
+
+      const managedSeedsRoom = rooms.get('managedseeds;garden')
+      expect(managedSeedsRoom.emit).toHaveBeenCalledTimes(1)
+      expect(managedSeedsRoom.emit).toHaveBeenCalledWith('managedseeds', { type: 'ADDED', uid })
+
+      const managedSeedShootsRoom = rooms.get('managedseed-shoots;garden')
+      expect(managedSeedShootsRoom.emit).toHaveBeenCalledTimes(1)
+      expect(managedSeedShootsRoom.emit).toHaveBeenCalledWith('managedseed-shoots', {
+        type: 'ADDED',
+        uid: gardenManagedSeedShoot.metadata.uid,
+      })
     })
 
     it('should ignore managedseeds outside the garden namespace', async function () {
@@ -392,6 +436,7 @@ describe('watches', function () {
 
       expect(nsp.to).not.toHaveBeenCalled()
       expect(Array.from(rooms.keys())).toEqual([])
+      expect(cache.getShoot).not.toHaveBeenCalled()
     })
   })
 

--- a/backend/lib/cache/index.js
+++ b/backend/lib/cache/index.js
@@ -49,6 +49,13 @@ class Cache extends Map {
     return this.get('controllerregistrations').list()
   }
 
+  getManagedSeedsInGardenNamespace () {
+    return this
+      .get('managedseeds')
+      .list()
+      .filter(item => item?.metadata?.namespace === 'garden')
+  }
+
   getResourceQuotas () {
     return this.get('resourcequotas').list()
   }
@@ -139,6 +146,21 @@ export default {
     }
     return project
   },
+  getManagedSeedsInGardenNamespace () {
+    return cache.getManagedSeedsInGardenNamespace()
+  },
+  getManagedSeedByName (name) {
+    return cache.get('managedseeds').find({ metadata: { namespace: 'garden', name } })
+  },
+  getManagedSeedByUid (uid) {
+    return cache.get('managedseeds').find(['metadata.uid', uid])
+  },
+  getManagedSeedForShootInGardenNamespace (shootName) {
+    return cache.get('managedseeds').find({
+      metadata: { namespace: 'garden' },
+      spec: { shoot: { name: shootName } },
+    })
+  },
   getTicketCache () {
     return cache.getTicketCache()
   },
@@ -150,6 +172,8 @@ export default {
         return this.getShootByUid(uid)
       case 'Seed':
         return this.getSeedByUid(uid)
+      case 'ManagedSeed':
+        return this.getManagedSeedByUid(uid)
       default:
         throw new TypeError(`Kind '${kind}' not supported`)
     }

--- a/backend/lib/hooks.js
+++ b/backend/lib/hooks.js
@@ -75,6 +75,8 @@ class LifecycleHooks {
       quotas: client['core.gardener.cloud'].quotas.informerAllNamespaces(),
       seeds: client['core.gardener.cloud'].seeds.informer(),
       shoots: client['core.gardener.cloud'].shoots.informerAllNamespaces(),
+      // seedmanagement.gardener
+      managedseeds: client['seedmanagement.gardener.cloud'].managedseeds.informer('garden'),
       // core
       resourcequotas: client.core.resourcequotas.informerAllNamespaces(),
     }

--- a/backend/lib/io/dispatcher.js
+++ b/backend/lib/io/dispatcher.js
@@ -11,6 +11,8 @@ import {
 } from './shoots.js'
 import { synchronize as synchronizeProjects } from './projects.js'
 import { synchronize as synchronizeSeeds } from './seeds.js'
+import { synchronize as synchronizeManagedSeeds } from './managedseeds.js'
+import { synchronize as synchronizeManagedSeedShoots } from './managedseedshoots.js'
 
 async function subscribe (socket, key, options = {}) {
   switch (key) {
@@ -47,6 +49,16 @@ function synchronize (socket, key, ...args) {
       const [uids] = args
       assertArray(uids)
       return synchronizeSeeds(socket, uids)
+    }
+    case 'managedseeds': {
+      const [uids] = args
+      assertArray(uids)
+      return synchronizeManagedSeeds(socket, uids)
+    }
+    case 'managedseed-shoots': {
+      const [uids] = args
+      assertArray(uids)
+      return synchronizeManagedSeedShoots(socket, uids)
     }
     default:
       throw new TypeError(`Invalid synchronization type - ${key}`)

--- a/backend/lib/io/helper.js
+++ b/backend/lib/io/helper.js
@@ -67,13 +67,18 @@ async function userProfiles (req, res, next) {
     const [
       canListProjects,
       canListSeeds,
+      canListManagedSeedsInGardenNamespace,
+      canListShootsInGardenNamespace,
     ] = await Promise.all([
       authorization.canListProjects(req.user),
       authorization.canListSeeds(req.user),
+      authorization.canListManagedSeedsInGardenNamespace(req.user),
+      authorization.canListShootsInGardenNamespace(req.user),
     ])
     const profiles = Object.freeze({
       canListProjects,
       canListSeeds,
+      canGetManagedSeedAndShootInGardenNs: canListManagedSeedsInGardenNamespace && canListShootsInGardenNamespace,
     })
     Object.defineProperty(req.user, 'profiles', {
       value: profiles,

--- a/backend/lib/io/index.js
+++ b/backend/lib/io/index.js
@@ -65,6 +65,12 @@ function init (httpServer, cache) {
       logger.debug('Socket %s auto-joined seeds room', socket.id)
     }
 
+    if (_.get(user, ['profiles', 'canGetManagedSeedAndShootInGardenNs'], false)) {
+      socket.join('managedseeds;garden')
+      socket.join('managedseed-shoots;garden')
+      logger.debug('Socket %s auto-joined managed seed garden rooms', socket.id)
+    }
+
     // handle 'subscribe' events
     socket.on('subscribe', async (key, ...args) => {
       logger.debug('Socket %s subscribed to %s', socket.id, key)

--- a/backend/lib/io/managedseeds.js
+++ b/backend/lib/io/managedseeds.js
@@ -1,0 +1,36 @@
+//
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import { get } from 'lodash-es'
+import { simplifyManagedSeed } from '../utils/index.js'
+import helper from './helper.js'
+
+const { constants, getUserFromSocket, synchronizeFactory } = helper
+
+const synchronize = synchronizeFactory('ManagedSeed', {
+  group: 'seedmanagement.gardener.cloud',
+  accessResolver (socket, object) {
+    const user = getUserFromSocket(socket)
+
+    if (!get(user, ['profiles', 'canGetManagedSeedAndShootInGardenNs'], false)) {
+      return constants.OBJECT_NONE
+    }
+
+    // Access is garden-scoped via profile computation/informer setup, and we
+    // keep this namespace check as a sanity check in case wiring changes
+    // later.
+    if (get(object, ['metadata', 'namespace']) !== 'garden') {
+      return constants.OBJECT_NONE
+    }
+
+    return constants.OBJECT_SIMPLE
+  },
+  simplifyObject: simplifyManagedSeed,
+})
+
+export {
+  synchronize,
+}

--- a/backend/lib/io/managedseedshoots.js
+++ b/backend/lib/io/managedseedshoots.js
@@ -1,0 +1,41 @@
+//
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import { get } from 'lodash-es'
+import cache from '../cache/index.js'
+import { simplifyManagedSeedShoot } from '../utils/index.js'
+import helper from './helper.js'
+
+const { constants, getUserFromSocket, synchronizeFactory } = helper
+
+const synchronize = synchronizeFactory('Shoot', {
+  group: 'core.gardener.cloud',
+  accessResolver (socket, shoot) {
+    const user = getUserFromSocket(socket)
+    const canAccess = get(user, ['profiles', 'canGetManagedSeedAndShootInGardenNs'], false)
+    if (!canAccess) {
+      return constants.OBJECT_NONE
+    }
+
+    // Validate that this shoot is in the garden namespace and corresponds to a managed seed
+    const { namespace, name } = shoot.metadata
+    if (namespace !== 'garden') {
+      return constants.OBJECT_NONE
+    }
+
+    const managedSeed = cache.getManagedSeedForShootInGardenNamespace(name)
+    if (!managedSeed) {
+      return constants.OBJECT_NONE
+    }
+
+    return constants.OBJECT_SIMPLE
+  },
+  simplifyObject: simplifyManagedSeedShoot,
+})
+
+export {
+  synchronize,
+}

--- a/backend/lib/routes/index.js
+++ b/backend/lib/routes/index.js
@@ -12,6 +12,8 @@ import openapiRoute from '../openapi/index.js'
 import userRoute from './user.js'
 import cloudprofilesRoute from './cloudprofiles.js'
 import seedsRoute from './seeds.js'
+import managedSeedsRoute from './managedseeds.js'
+import managedSeedShootsRoute from './managedseedshoots.js'
 import gardenerExtensionsRoute from './gardenerExtensions.js'
 import projectsRoute from './projects.js'
 import shootsRoute from './shoots.js'
@@ -28,6 +30,8 @@ const routes = {
   '/user': userRoute,
   '/cloudprofiles': cloudprofilesRoute,
   '/seeds': seedsRoute,
+  '/namespaces/:namespace/managedseeds': managedSeedsRoute,
+  '/namespaces/:namespace/managedseed-shoots': managedSeedShootsRoute,
   '/gardenerextensions': gardenerExtensionsRoute,
   '/projects': projectsRoute,
   '/namespaces/:namespace/shoots': shootsRoute,

--- a/backend/lib/routes/managedseeds.js
+++ b/backend/lib/routes/managedseeds.js
@@ -1,0 +1,30 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import express from 'express'
+import services from '../services/index.js'
+import { metricsRoute } from '../middleware.js'
+const { managedseeds } = services
+
+const router = express.Router({
+  mergeParams: true,
+})
+
+const metricsMiddleware = metricsRoute('managedseeds')
+
+router.route('/')
+  .all(metricsMiddleware)
+  .get(async (req, res, next) => {
+    try {
+      const user = req.user
+      const namespace = req.params.namespace
+      res.send(await managedseeds.list({ user, namespace }))
+    } catch (err) {
+      next(err)
+    }
+  })
+
+export default router

--- a/backend/lib/routes/managedseedshoots.js
+++ b/backend/lib/routes/managedseedshoots.js
@@ -1,0 +1,30 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import express from 'express'
+import services from '../services/index.js'
+import { metricsRoute } from '../middleware.js'
+const { managedseedshoots } = services
+
+const router = express.Router({
+  mergeParams: true,
+})
+
+const metricsMiddleware = metricsRoute('managedseedshoots')
+
+router.route('/')
+  .all(metricsMiddleware)
+  .get(async (req, res, next) => {
+    try {
+      const user = req.user
+      const namespace = req.params.namespace
+      res.send(await managedseedshoots.list({ user, namespace }))
+    } catch (err) {
+      next(err)
+    }
+  })
+
+export default router

--- a/backend/lib/security/index.js
+++ b/backend/lib/security/index.js
@@ -245,6 +245,8 @@ async function createAccessToken (payload, idToken) {
   const results = await Promise.allSettled([
     authentication.isAuthenticated({ token: idToken }),
     authorization.isAdmin(user),
+    authorization.canListManagedSeedsInGardenNamespace(user),
+    authorization.canListShootsInGardenNamespace(user),
   ])
   // throw an error if any promise has been rejected
   for (const { status, reason: err } of results) {
@@ -255,12 +257,16 @@ async function createAccessToken (payload, idToken) {
   const [
     { value: { username, groups } },
     { value: isAdmin },
+    { value: canListManagedSeeds },
+    { value: canListShoots },
   ] = results
+  const canGetManagedSeedAndShootInGardenNs = canListManagedSeeds && canListShoots
   Object.assign(payload, {
     id: username,
     groups,
     aud: [GARDENER_AUDIENCE],
     isAdmin,
+    canGetManagedSeedAndShootInGardenNs,
   })
   const idTokenPayload = decode(idToken)
   if (idTokenPayload) {

--- a/backend/lib/services/authorization.js
+++ b/backend/lib/services/authorization.js
@@ -92,6 +92,28 @@ export function canListSeeds (user) {
   })
 }
 
+export function canListManagedSeedsInGardenNamespace (user) {
+  return hasAuthorization(user, {
+    resourceAttributes: {
+      verb: 'list',
+      group: 'seedmanagement.gardener.cloud',
+      resource: 'managedseeds',
+      namespace: 'garden',
+    },
+  })
+}
+
+export function canListShootsInGardenNamespace (user) {
+  return hasAuthorization(user, {
+    resourceAttributes: {
+      verb: 'list',
+      group: 'core.gardener.cloud',
+      resource: 'shoots',
+      namespace: 'garden',
+    },
+  })
+}
+
 export function canListCloudProfiles (user) {
   return hasAuthorization(user, {
     resourceAttributes: {

--- a/backend/lib/services/index.js
+++ b/backend/lib/services/index.js
@@ -6,6 +6,8 @@
 
 import * as cloudprofiles from './cloudprofiles.js'
 import * as seeds from './seeds.js'
+import * as managedseeds from './managedseeds.js'
+import * as managedseedshoots from './managedseedshoots.js'
 import * as projects from './projects.js'
 import * as shoots from './shoots.js'
 import * as cloudProviderCredentials from './cloudProviderCredentials.js'
@@ -22,6 +24,8 @@ const terminals = terminalsModule
 export default {
   cloudprofiles,
   seeds,
+  managedseeds,
+  managedseedshoots,
   projects,
   shoots,
   cloudProviderCredentials,

--- a/backend/lib/services/managedseeds.js
+++ b/backend/lib/services/managedseeds.js
@@ -1,0 +1,29 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import _ from 'lodash-es'
+import httpErrors from 'http-errors'
+import * as authorization from './authorization.js'
+import cache from '../cache/index.js'
+import { simplifyManagedSeed } from '../utils/index.js'
+const { Forbidden } = httpErrors
+
+export async function list ({ user, namespace }) {
+  if (namespace !== 'garden') {
+    throw new httpErrors.UnprocessableEntity('Managed seeds are restricted to the garden namespace')
+  }
+
+  const allowed = await authorization.canListManagedSeedsInGardenNamespace(user)
+  if (!allowed) {
+    throw new Forbidden('You are not allowed to list managed seeds in the garden namespace')
+  }
+
+  return _
+    .chain(cache.getManagedSeedsInGardenNamespace())
+    .map(_.cloneDeep)
+    .map(simplifyManagedSeed)
+    .value()
+}

--- a/backend/lib/services/managedseedshoots.js
+++ b/backend/lib/services/managedseedshoots.js
@@ -1,0 +1,36 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import _ from 'lodash-es'
+import httpErrors from 'http-errors'
+import * as authorization from './authorization.js'
+import cache from '../cache/index.js'
+import { simplifyManagedSeedShoot } from '../utils/index.js'
+const { Forbidden } = httpErrors
+
+export async function list ({ user, namespace }) {
+  if (namespace !== 'garden') {
+    throw new httpErrors.UnprocessableEntity('Managed seed shoots are restricted to the garden namespace')
+  }
+
+  const [canListManagedSeedsInGardenNamespace, canListShootsInGardenNamespace] = await Promise.all([
+    authorization.canListManagedSeedsInGardenNamespace(user),
+    authorization.canListShootsInGardenNamespace(user),
+  ])
+  if (!canListManagedSeedsInGardenNamespace || !canListShootsInGardenNamespace) {
+    throw new Forbidden('You are not allowed to list managed seed shoots in the garden namespace')
+  }
+
+  return _
+    .chain(cache.getManagedSeedsInGardenNamespace())
+    .map(managedSeed => _.get(managedSeed, ['spec', 'shoot', 'name']))
+    .compact()
+    .map(shootName => cache.getShoot('garden', shootName))
+    .compact()
+    .map(_.cloneDeep)
+    .map(simplifyManagedSeedShoot)
+    .value()
+}

--- a/backend/lib/utils/index.js
+++ b/backend/lib/utils/index.js
@@ -117,6 +117,35 @@ function simplifySeed (seed) {
   return simplifyObjectMetadata(seed)
 }
 
+function simplifyManagedSeed (managedSeed) {
+  return {
+    metadata: {
+      name: managedSeed.metadata.name,
+      namespace: managedSeed.metadata.namespace,
+      uid: managedSeed.metadata.uid,
+    },
+    spec: {
+      shoot: {
+        name: managedSeed.spec.shoot?.name,
+      },
+    },
+  }
+}
+
+function simplifyManagedSeedShoot (shoot) {
+  return {
+    metadata: {
+      name: shoot.metadata.name,
+      namespace: shoot.metadata.namespace,
+      uid: shoot.metadata.uid,
+    },
+    status: {
+      conditions: shoot.status?.conditions,
+      advertisedAddresses: shoot.status?.advertisedAddresses,
+    },
+  }
+}
+
 function parseSelector (selector = '') {
   let notOperator
   let key
@@ -255,6 +284,8 @@ export {
   simplifyObjectMetadata,
   simplifyProject,
   simplifySeed,
+  simplifyManagedSeed,
+  simplifyManagedSeedShoot,
   parseSelector,
   parseSelectors,
   filterBySelectors,

--- a/backend/lib/watches/index.js
+++ b/backend/lib/watches/index.js
@@ -8,5 +8,6 @@ import shoots from './shoots.js'
 import leases from './leases.js'
 import projects from './projects.js'
 import seeds from './seeds.js'
+import managedseeds from './managedseeds.js'
 
-export { shoots, leases, projects, seeds }
+export { shoots, leases, projects, seeds, managedseeds }

--- a/backend/lib/watches/managedseeds.js
+++ b/backend/lib/watches/managedseeds.js
@@ -6,6 +6,8 @@
 
 import { get } from 'lodash-es'
 
+import cache from '../cache/index.js'
+
 export default (io, informer) => {
   const nsp = io.of('/')
 
@@ -17,6 +19,25 @@ export default (io, informer) => {
     const uid = get(object, ['metadata', 'uid'])
     const event = { uid, type }
     nsp.to('managedseeds;garden').emit('managedseeds', event)
+
+    // Backfill the managed seed shoot once the ManagedSeed is ADDED to ensure
+    // the frontend can fetch it immediately instead of waiting for a later
+    // MODIFIED event on the shoot if that shoot event was processed before the
+    // ManagedSeed association reached the cache.
+    if (type === 'ADDED') {
+      const shootName = get(object, ['spec', 'shoot', 'name'])
+      if (!shootName) {
+        return
+      }
+
+      const shoot = cache.getShoot('garden', shootName)
+      const shootUid = get(shoot, ['metadata', 'uid'])
+      if (!shootUid) {
+        return
+      }
+
+      nsp.to('managedseed-shoots;garden').emit('managedseed-shoots', { type, uid: shootUid })
+    }
   }
 
   informer.on('add', object => handleEvent('ADDED', object))

--- a/backend/lib/watches/managedseeds.js
+++ b/backend/lib/watches/managedseeds.js
@@ -1,0 +1,25 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import { get } from 'lodash-es'
+
+export default (io, informer) => {
+  const nsp = io.of('/')
+
+  const handleEvent = (type, newObject, oldObject) => {
+    const object = newObject ?? oldObject
+    if (get(object, ['metadata', 'namespace']) !== 'garden') {
+      return
+    }
+    const uid = get(object, ['metadata', 'uid'])
+    const event = { uid, type }
+    nsp.to('managedseeds;garden').emit('managedseeds', event)
+  }
+
+  informer.on('add', object => handleEvent('ADDED', object))
+  informer.on('update', (object, oldObject) => handleEvent('MODIFIED', object, oldObject))
+  informer.on('delete', object => handleEvent('DELETED', object))
+}

--- a/backend/lib/watches/shoots.js
+++ b/backend/lib/watches/shoots.js
@@ -5,6 +5,7 @@
 //
 
 import { shootHasIssue } from '../utils/index.js'
+import cache from '../cache/index.js'
 
 export default (io, informer, options) => {
   const nsp = io.of('/')
@@ -45,9 +46,23 @@ export default (io, informer, options) => {
     nsp.to(rooms).emit('shoots', { type, uid })
   }
 
+  const publishManagedSeedShoots = event => {
+    const { type, object } = event
+    const { namespace, name, uid } = object.metadata
+    if (namespace !== 'garden') {
+      return
+    }
+    const managedSeed = cache.getManagedSeedForShootInGardenNamespace(name)
+    if (!managedSeed) {
+      return
+    }
+    nsp.to('managedseed-shoots;garden').emit('managedseed-shoots', { type, uid })
+  }
+
   const handleEvent = event => {
     publishShoots(event)
     publishUnhealthyShoots(event)
+    publishManagedSeedShoots(event)
   }
 
   informer.on('add', object => handleEvent({ type: 'ADDED', object }))

--- a/backend/lib/watches/shoots.js
+++ b/backend/lib/watches/shoots.js
@@ -52,10 +52,16 @@ export default (io, informer, options) => {
     if (namespace !== 'garden') {
       return
     }
-    const managedSeed = cache.getManagedSeedForShootInGardenNamespace(name)
-    if (!managedSeed) {
-      return
+    if (type !== 'DELETED') {
+      const managedSeed = cache.getManagedSeedForShootInGardenNamespace(name)
+      if (!managedSeed) {
+        return
+      }
     }
+    // Always emit DELETED events without consulting the managedSeed cache:
+    // the ManagedSeed may already be gone when the shoot delete arrives.
+    // This is safe because the managedSeed shoot reference is immutable and
+    // deleting an unknown UID is a no-op for the frontend
     nsp.to('managedseed-shoots;garden').emit('managedseed-shoots', { type, uid })
   }
 

--- a/charts/__tests__/gardener-dashboard/application/dashboard/__snapshots__/clusterrole.spec.js.snap
+++ b/charts/__tests__/gardener-dashboard/application/dashboard/__snapshots__/clusterrole.spec.js.snap
@@ -64,6 +64,18 @@ exports[`gardener-dashboard clusterrole should render the template with default 
     },
     {
       "apiGroups": [
+        "seedmanagement.gardener.cloud",
+      ],
+      "resources": [
+        "managedseeds",
+      ],
+      "verbs": [
+        "list",
+        "watch",
+      ],
+    },
+    {
+      "apiGroups": [
         "apiregistration.k8s.io",
       ],
       "resources": [

--- a/charts/gardener-dashboard/charts/application/templates/dashboard/clusterrole.yaml
+++ b/charts/gardener-dashboard/charts/application/templates/dashboard/clusterrole.yaml
@@ -38,6 +38,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - seedmanagement.gardener.cloud
+  resources:
+  - managedseeds
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - apiregistration.k8s.io
   resources:
   - apiservices

--- a/frontend/__tests__/composables/useApi.spec.js
+++ b/frontend/__tests__/composables/useApi.spec.js
@@ -33,6 +33,24 @@ describe('composables', () => {
         api = useApi()
       })
 
+      describe('#getManagedSeedShootsForGardenNamespace', () => {
+        it('should fetch managed seed shoots from the garden namespace endpoint', async () => {
+          fetch.mockResponseOnce(JSON.stringify([]), {
+            headers: {
+              'content-type': 'application/json; charset=UTF-8',
+            },
+          })
+
+          const res = await api.getManagedSeedShootsForGardenNamespace()
+
+          expect(res.status).toBe(200)
+          expect(res.data).toEqual([])
+          expect(fetch).toBeCalledTimes(1)
+          const [req] = fetch.mock.calls[0]
+          expect(req.url).toBe('http://localhost:3000/api/namespaces/garden/managedseed-shoots')
+        })
+      })
+
       describe('#getConfiguration', () => {
         it('should fetch the configuration', async () => {
           const { getConfiguration } = api

--- a/frontend/src/components/GManagedSeedShootLink.vue
+++ b/frontend/src/components/GManagedSeedShootLink.vue
@@ -1,0 +1,48 @@
+<!--
+SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+<template>
+  <g-text-router-link
+    v-if="managedSeedShootItemLink"
+    :to="managedSeedShootItemLink"
+    :text="managedSeedShootName"
+  />
+  <v-chip
+    v-else
+    v-tooltip:top="'This seed is not backed by a ManagedSeed / Shoot resource'"
+    size="small"
+    variant="tonal"
+  >
+    Unmanaged
+  </v-chip>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+import GTextRouterLink from '@/components/GTextRouterLink'
+
+const props = defineProps({
+  managedSeedShootName: {
+    type: String,
+    default: undefined,
+  },
+})
+
+const managedSeedShootItemLink = computed(() => {
+  if (!props.managedSeedShootName) {
+    return undefined
+  }
+
+  return {
+    name: 'ShootItem',
+    params: {
+      namespace: 'garden',
+      name: props.managedSeedShootName,
+    },
+  }
+})
+</script>

--- a/frontend/src/components/GManagedSeedShootLink.vue
+++ b/frontend/src/components/GManagedSeedShootLink.vue
@@ -11,7 +11,7 @@ SPDX-License-Identifier: Apache-2.0
     :text="managedSeedShootName"
   />
   <v-chip
-    v-else
+    v-else-if="showUnmanagedChip"
     v-tooltip:top="'This seed is not backed by a ManagedSeed / Shoot resource'"
     size="small"
     variant="tonal"
@@ -29,6 +29,10 @@ const props = defineProps({
   managedSeedShootName: {
     type: String,
     default: undefined,
+  },
+  showUnmanagedChip: {
+    type: Boolean,
+    default: true,
   },
 })
 

--- a/frontend/src/components/GManagedSeedShootLink.vue
+++ b/frontend/src/components/GManagedSeedShootLink.vue
@@ -12,7 +12,7 @@ SPDX-License-Identifier: Apache-2.0
       :text="managedSeedShootName"
     />
     <v-chip
-      v-else-if="showUnmanagedChip"
+      v-else-if="!hideUnmanagedChip"
       v-tooltip:top="'This seed is not backed by a ManagedSeed / Shoot resource'"
       size="small"
       variant="tonal"
@@ -36,9 +36,9 @@ const props = defineProps({
     type: String,
     default: undefined,
   },
-  showUnmanagedChip: {
+  hideUnmanagedChip: {
     type: Boolean,
-    default: true,
+    default: false,
   },
 })
 

--- a/frontend/src/components/GManagedSeedShootLink.vue
+++ b/frontend/src/components/GManagedSeedShootLink.vue
@@ -5,25 +5,31 @@ SPDX-License-Identifier: Apache-2.0
 -->
 
 <template>
-  <g-text-router-link
-    v-if="managedSeedShootItemLink"
-    :to="managedSeedShootItemLink"
-    :text="managedSeedShootName"
-  />
-  <v-chip
-    v-else-if="showUnmanagedChip"
-    v-tooltip:top="'This seed is not backed by a ManagedSeed / Shoot resource'"
-    size="small"
-    variant="tonal"
-  >
-    Unmanaged
-  </v-chip>
+  <template v-if="!managedSeedStore.isInitial">
+    <g-text-router-link
+      v-if="managedSeedShootItemLink"
+      :to="managedSeedShootItemLink"
+      :text="managedSeedShootName"
+    />
+    <v-chip
+      v-else-if="showUnmanagedChip"
+      v-tooltip:top="'This seed is not backed by a ManagedSeed / Shoot resource'"
+      size="small"
+      variant="tonal"
+    >
+      Unmanaged
+    </v-chip>
+  </template>
 </template>
 
 <script setup>
 import { computed } from 'vue'
 
+import { useManagedSeedStore } from '@/store/managedSeed'
+
 import GTextRouterLink from '@/components/GTextRouterLink'
+
+const managedSeedStore = useManagedSeedStore()
 
 const props = defineProps({
   managedSeedShootName: {

--- a/frontend/src/components/GSeedListRow.vue
+++ b/frontend/src/components/GSeedListRow.vue
@@ -22,7 +22,11 @@ SPDX-License-Identifier: Apache-2.0
         <g-vendor
           :provider-type="seedProviderType"
           :region="seedProviderRegion"
+          :zones="seedProviderZones"
         />
+      </template>
+      <template v-else-if="header.key === 'shoot'">
+        <g-managed-seed-shoot-link :managed-seed-shoot-name="managedSeedShootName" />
       </template>
       <template v-else-if="header.key === 'lastOperation'">
         <div class="d-flex align-center justify-center">
@@ -31,18 +35,8 @@ SPDX-License-Identifier: Apache-2.0
       </template>
       <template v-else-if="header.key === 'readiness'">
         <div class="d-flex">
-          <g-seed-status-tags :identifier="seedName" />
-        </div>
-      </template>
-      <template v-else-if="header.key === 'controlPlaneHighAvailability'">
-        <div class="d-flex justify-center flex-wrap">
-          <g-high-availability-tag
-            v-if="seedBestSupportedFailureToleranceType === 'zone'"
-            :popover-key="controlPlaneHighAvailabilityTagPopoverKey"
-            :failure-tolerance-type="seedBestSupportedFailureToleranceType"
-            size="small"
-            color="primary"
-            chip-class="mr-1"
+          <g-seed-status-tags
+            :identifier="seedName"
           />
         </div>
       </template>
@@ -98,16 +92,17 @@ import {
 } from 'vue'
 import { useRoute } from 'vue-router'
 
+import GManagedSeedShootLink from '@/components/GManagedSeedShootLink.vue'
+import GTextRouterLink from '@/components/GTextRouterLink.vue'
 import GVendor from '@/components/GVendor.vue'
 import GSeedStatus from '@/components/GSeedStatus.vue'
 import GSeedStatusTags from '@/components/GSeedStatusTags.vue'
 import GTimeString from '@/components/GTimeString.vue'
-import GTextRouterLink from '@/components/GTextRouterLink.vue'
 import GAccessRestrictionChip from '@/components/ShootAccessRestrictions/GAccessRestrictionChip.vue'
-import GHighAvailabilityTag from '@/components/ControlPlaneHighAvailability/GHighAvailabilityTag.vue'
 import GCollapsibleItems from '@/components/GCollapsibleItems'
 import GScrollContainer from '@/components/GScrollContainer'
 
+import { useProvideManagedSeedShoot } from '@/composables/useManagedSeedShootForSeed'
 import { useProvideSeedItem } from '@/composables/useSeedItem/index'
 
 const props = defineProps({
@@ -128,8 +123,8 @@ const {
   seedName,
   seedProviderType,
   seedProviderRegion,
+  seedProviderZones,
   seedUid,
-  seedBestSupportedFailureToleranceType,
   seedAccessRestrictions,
   seedSchedulingVisible,
   seedKubernetesVersion,
@@ -137,9 +132,9 @@ const {
   seedCreationTimestamp,
 } = useProvideSeedItem(seedItem)
 
-const controlPlaneHighAvailabilityTagPopoverKey = computed(() => {
-  return `g-seed-control-plane-high-availability-tag:${seedUid.value}`
-})
+const {
+  managedSeedShootName,
+} = useProvideManagedSeedShoot(seedName)
 
 const seedItemLink = computed(() => ({
   name: 'SeedItem',

--- a/frontend/src/components/GSeedListRow.vue
+++ b/frontend/src/components/GSeedListRow.vue
@@ -28,7 +28,7 @@ SPDX-License-Identifier: Apache-2.0
       <template v-else-if="header.key === 'shoot'">
         <g-managed-seed-shoot-link
           :managed-seed-shoot-name="managedSeedShootName"
-          :show-unmanaged-chip="false"
+          hide-unmanaged-chip
         />
       </template>
       <template v-else-if="header.key === 'lastOperation'">

--- a/frontend/src/components/GSeedListRow.vue
+++ b/frontend/src/components/GSeedListRow.vue
@@ -26,7 +26,10 @@ SPDX-License-Identifier: Apache-2.0
         />
       </template>
       <template v-else-if="header.key === 'shoot'">
-        <g-managed-seed-shoot-link :managed-seed-shoot-name="managedSeedShootName" />
+        <g-managed-seed-shoot-link
+          :managed-seed-shoot-name="managedSeedShootName"
+          :show-unmanaged-chip="false"
+        />
       </template>
       <template v-else-if="header.key === 'lastOperation'">
         <div class="d-flex align-center justify-center">

--- a/frontend/src/components/GSeedStatusTags.vue
+++ b/frontend/src/components/GSeedStatusTags.vue
@@ -43,10 +43,9 @@ import { toRefs } from 'vue'
 import GSeedStatusTag from '@/components/GSeedStatusTag.vue'
 import GExternalLink from '@/components/GExternalLink.vue'
 
-import {
-  useSeedItem,
-  useSeedConditions,
-} from '@/composables/useSeedItem/index'
+import { useManagedSeedShoot } from '@/composables/useManagedSeedShootForSeed'
+import { useSeedEffectiveConditions } from '@/composables/useSeedEffectiveConditions'
+import { useSeedItem } from '@/composables/useSeedItem/index'
 import { useStatusConditions } from '@/composables/useStatusConditions'
 
 const props = defineProps({
@@ -74,10 +73,18 @@ const {
 } = toRefs(props)
 
 const {
-  seedItem,
   seedName,
+  seedConditions,
 } = useSeedItem()
-const seedConditions = useSeedConditions(seedItem)
 
-const { conditions, errorCodeObjects } = useStatusConditions(seedConditions)
+const {
+  managedSeedShootConditions,
+} = useManagedSeedShoot()
+
+const effectiveConditions = useSeedEffectiveConditions(seedConditions, managedSeedShootConditions)
+
+const {
+  conditions,
+  errorCodeObjects,
+} = useStatusConditions(effectiveConditions)
 </script>

--- a/frontend/src/components/GShootListRow.vue
+++ b/frontend/src/components/GShootListRow.vue
@@ -265,6 +265,7 @@ import GCollapsibleItems from '@/components/GCollapsibleItems'
 import GScrollContainer from '@/components/GScrollContainer'
 import GProjectTooltip from '@/components/GProjectTooltip.vue'
 
+import { useProvideManagedSeedShoot } from '@/composables/useManagedSeedShootForSeed'
 import { useProvideSeedItem } from '@/composables/useSeedItem/index'
 import { useShootAction } from '@/composables/useShootAction'
 import { useProvideShootItem } from '@/composables/useShootItem'
@@ -346,6 +347,7 @@ useProvideShootHelper(shootItem, {
 
 const seedItem = computed(() => seedStore.seedByName(shootSeedName.value))
 useProvideSeedItem(seedItem)
+useProvideManagedSeedShoot(shootSeedName)
 
 const cloudProfile = computed(() => cloudProfileStore.cloudProfileByRef(shootCloudProfileRef.value))
 const { machineImages } = useMachineImages(cloudProfile)

--- a/frontend/src/components/SeedDetails/GSeedDetailsCard.vue
+++ b/frontend/src/components/SeedDetails/GSeedDetailsCard.vue
@@ -25,6 +25,17 @@ SPDX-License-Identifier: Apache-2.0
       <g-list-item>
         <template #prepend>
           <v-icon color="primary">
+            mdi-hexagon-multiple
+          </v-icon>
+        </template>
+        <g-list-item-content label="Shoot">
+          <g-managed-seed-shoot-link :managed-seed-shoot-name="managedSeedShootName" />
+        </g-list-item-content>
+      </g-list-item>
+      <v-divider inset />
+      <g-list-item>
+        <template #prepend>
+          <v-icon color="primary">
             mdi-cube-outline
           </v-icon>
         </template>
@@ -106,9 +117,11 @@ SPDX-License-Identifier: Apache-2.0
 
 <script setup>
 import GCopyBtn from '@/components/GCopyBtn'
+import GManagedSeedShootLink from '@/components/GManagedSeedShootLink'
 import GTimeString from '@/components/GTimeString'
 import GAccessRestrictionChip from '@/components/ShootAccessRestrictions/GAccessRestrictionChip'
 
+import { useManagedSeedShoot } from '@/composables/useManagedSeedShootForSeed'
 import { useSeedItem } from '@/composables/useSeedItem/index'
 
 const {
@@ -119,4 +132,6 @@ const {
   seedSchedulingVisible,
   seedCreationTimestamp,
 } = useSeedItem()
+
+const { managedSeedShootName } = useManagedSeedShoot()
 </script>

--- a/frontend/src/components/SeedDetails/GSeedInfrastructureCard.vue
+++ b/frontend/src/components/SeedDetails/GSeedInfrastructureCard.vue
@@ -49,26 +49,6 @@ SPDX-License-Identifier: Apache-2.0
       <g-list-item>
         <template #prepend>
           <v-icon color="primary">
-            mdi-spa
-          </v-icon>
-        </template>
-        <g-list-item-content label="High Availability">
-          <div class="d-flex flex-wrap align-center">
-            <span class="mr-1">Failure tolerance</span>
-            <g-high-availability-tag
-              :popover-key="controlPlaneHighAvailabilityTagPopoverKey"
-              :failure-tolerance-type="seedBestSupportedFailureToleranceType"
-              size="small"
-              color="primary"
-              chip-class="mr-1"
-            />
-          </div>
-        </g-list-item-content>
-      </g-list-item>
-      <v-divider inset />
-      <g-list-item>
-        <template #prepend>
-          <v-icon color="primary">
             mdi-ip-network
           </v-icon>
         </template>
@@ -108,7 +88,6 @@ SPDX-License-Identifier: Apache-2.0
 <script setup>
 import { computed } from 'vue'
 
-import GHighAvailabilityTag from '@/components/ControlPlaneHighAvailability/GHighAvailabilityTag.vue'
 import GVendor from '@/components/GVendor.vue'
 
 import { useSeedItem } from '@/composables/useSeedItem/index'
@@ -117,8 +96,6 @@ const {
   seedProviderType,
   seedProviderRegion,
   seedProviderZones,
-  seedUid,
-  seedBestSupportedFailureToleranceType,
   seedNetworksNodes,
   seedNetworksPods,
   seedNetworksServices,
@@ -127,10 +104,6 @@ const {
   seedNetworksBlockCIDRs,
   seedAllocatableShoots,
 } = useSeedItem()
-
-const controlPlaneHighAvailabilityTagPopoverKey = computed(() => {
-  return `g-seed-control-plane-high-availability-tag:${seedUid.value}`
-})
 
 const seedNetworksBlockCIDRsText = computed(() => {
   return seedNetworksBlockCIDRs.value?.join(', ') ?? ''

--- a/frontend/src/components/SeedDetails/GSeedMonitoringCard.vue
+++ b/frontend/src/components/SeedDetails/GSeedMonitoringCard.vue
@@ -56,6 +56,20 @@ SPDX-License-Identifier: Apache-2.0
           Not available
         </g-list-item-content>
       </g-list-item>
+      <g-link-list-tile
+        v-if="managedSeedShootPlutonoUrl"
+        app-title="Shoot Plutono"
+        :url="managedSeedShootPlutonoUrl"
+        :url-text="managedSeedShootPlutonoUrl"
+        content-class="pt-0"
+      />
+      <g-link-list-tile
+        v-if="managedSeedShootPrometheusUrl"
+        app-title="Shoot Prometheus"
+        :url="managedSeedShootPrometheusUrl"
+        :url-text="managedSeedShootPrometheusUrl"
+        content-class="pt-0"
+      />
     </g-list>
   </v-card>
 </template>
@@ -67,6 +81,7 @@ import GSeedStatus from '@/components/GSeedStatus.vue'
 import GSeedStatusTags from '@/components/GSeedStatusTags.vue'
 import GLinkListTile from '@/components/GLinkListTile.vue'
 
+import { useManagedSeedShoot } from '@/composables/useManagedSeedShootForSeed'
 import { useSeedItem } from '@/composables/useSeedItem/index'
 
 import { getSeedPlutonoUrl } from '@/utils'
@@ -76,5 +91,11 @@ const {
   seedIngressDomain,
 } = useSeedItem()
 
+const {
+  managedSeedShootPlutonoUrl,
+  managedSeedShootPrometheusUrl,
+} = useManagedSeedShoot()
+
 const seedPlutonoUrl = computed(() => getSeedPlutonoUrl(seedIngressDomain.value))
+
 </script>

--- a/frontend/src/composables/useApi/api.js
+++ b/frontend/src/composables/useApi/api.js
@@ -251,6 +251,18 @@ export function getSeeds () {
   return getResource('/api/seeds')
 }
 
+/* Managed Seeds */
+
+export function getManagedSeedsForGardenNamespace () {
+  return getResource('/api/namespaces/garden/managedseeds')
+}
+
+/* Managed Seed Shoots */
+
+export function getManagedSeedShootsForGardenNamespace () {
+  return getResource('/api/namespaces/garden/managedseed-shoots')
+}
+
 /* Projects */
 
 export function getProjects () {
@@ -450,6 +462,8 @@ export default {
   createShootAdminKubeconfig,
   getCloudProfiles,
   getSeeds,
+  getManagedSeedsForGardenNamespace,
+  getManagedSeedShootsForGardenNamespace,
   getProjects,
   createProject,
   patchProject,

--- a/frontend/src/composables/useManagedSeedShootForSeed.js
+++ b/frontend/src/composables/useManagedSeedShootForSeed.js
@@ -1,0 +1,72 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import {
+  computed,
+  inject,
+  isRef,
+  provide,
+} from 'vue'
+
+import { useManagedSeedStore } from '@/store/managedSeed'
+import { useManagedSeedShootStore } from '@/store/managedSeedShoot'
+
+import { useShootAdvertisedAddresses } from '@/composables/useShootAdvertisedAddresses'
+
+import get from 'lodash/get'
+
+export function createManagedSeedShootComposable (seedName) {
+  if (!isRef(seedName)) {
+    throw new TypeError('First argument `seedName` must be a ref object')
+  }
+
+  const managedSeedStore = useManagedSeedStore()
+  const managedSeedShootStore = useManagedSeedShootStore()
+
+  const managedSeedShootName = computed(() => {
+    return managedSeedStore.shootNameForSeed(seedName.value)
+  })
+
+  const managedSeedShoot = computed(() => {
+    if (!managedSeedShootName.value) {
+      return undefined
+    }
+
+    return managedSeedShootStore.shootByName('garden', managedSeedShootName.value)
+  })
+
+  const managedSeedShootConditions = computed(() => {
+    return get(managedSeedShoot.value, ['status', 'conditions'])
+  })
+
+  const {
+    shootPlutonoUrl: managedSeedShootPlutonoUrl,
+    shootPrometheusUrl: managedSeedShootPrometheusUrl,
+  } = useShootAdvertisedAddresses(managedSeedShoot)
+
+  return {
+    managedSeedShootName,
+    managedSeedShoot,
+    managedSeedShootConditions,
+    managedSeedShootPlutonoUrl,
+    managedSeedShootPrometheusUrl,
+  }
+}
+
+export function useManagedSeedShoot () {
+  const composable = inject('managed-seed-shoot', null)
+  if (!composable) {
+    throw new Error('Managed seed shoot composable has not been provided')
+  }
+
+  return composable
+}
+
+export function useProvideManagedSeedShoot (seedName) {
+  const composable = createManagedSeedShootComposable(seedName)
+  provide('managed-seed-shoot', composable)
+  return composable
+}

--- a/frontend/src/composables/useSeedEffectiveConditions.js
+++ b/frontend/src/composables/useSeedEffectiveConditions.js
@@ -1,0 +1,29 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import {
+  computed,
+  isRef,
+  ref,
+} from 'vue'
+
+export function useSeedEffectiveConditions (seedConditions, managedSeedShootConditions = ref(undefined)) {
+  if (!isRef(seedConditions)) {
+    throw new TypeError('First argument `seedConditions` must be a ref object')
+  }
+
+  if (!isRef(managedSeedShootConditions)) {
+    throw new TypeError('Second argument `managedSeedShootConditions` must be a ref object')
+  }
+
+  return computed(() => {
+    if (managedSeedShootConditions.value !== undefined) {
+      return managedSeedShootConditions.value
+    }
+
+    return seedConditions.value
+  })
+}

--- a/frontend/src/composables/useSeedItem/helper.js
+++ b/frontend/src/composables/useSeedItem/helper.js
@@ -9,9 +9,3 @@ import get from 'lodash/get'
 export function isFailureToleranceTypeZoneSupported (seedItem) {
   return get(seedItem, ['spec', 'provider', 'zones'], []).length >= 3
 }
-
-export function getBestSupportedFailureToleranceType (seedItem) {
-  return isFailureToleranceTypeZoneSupported(seedItem)
-    ? 'zone'
-    : 'node'
-}

--- a/frontend/src/composables/useSeedItem/index.js
+++ b/frontend/src/composables/useSeedItem/index.js
@@ -6,17 +6,14 @@
 
 import {
   computed,
-  isRef,
   inject,
+  isRef,
   provide,
 } from 'vue'
 
 import { useSeedMetadata } from '@/composables/useSeedMetadata'
 
-import {
-  getBestSupportedFailureToleranceType,
-  isFailureToleranceTypeZoneSupported,
-} from './helper'
+import { isFailureToleranceTypeZoneSupported } from './helper'
 
 import get from 'lodash/get'
 
@@ -49,8 +46,6 @@ export function createSeedItemComposable (seedItem) {
   const seedProviderRegion = useSeedProviderRegion(seedItem)
   const seedProviderZones = useSeedProviderZones(seedItem)
   const seedIsFailureToleranceTypeZoneSupported = useSeedIsFailureToleranceTypeZoneSupported(seedItem)
-  const seedSupportedFailureToleranceTypes = useSeedSupportedFailureToleranceTypes(seedItem)
-  const seedBestSupportedFailureToleranceType = useSeedBestSupportedFailureToleranceType(seedItem)
   const seedAccessRestrictions = useSeedAccessRestrictions(seedItem)
   const seedSchedulingVisible = useSeedSchedulingVisible(seedItem)
   const seedNetworksNodes = useSeedNetworksNodes(seedItem)
@@ -92,8 +87,6 @@ export function createSeedItemComposable (seedItem) {
     seedProviderRegion,
     seedProviderZones,
     seedIsFailureToleranceTypeZoneSupported,
-    seedSupportedFailureToleranceTypes,
-    seedBestSupportedFailureToleranceType,
     seedAccessRestrictions,
     seedSchedulingVisible,
     seedNetworksNodes,
@@ -144,22 +137,6 @@ export function useSeedProviderZones (seedItem) {
 export function useSeedIsFailureToleranceTypeZoneSupported (seedItem) {
   return computed(() => {
     return isFailureToleranceTypeZoneSupported(seedItem.value)
-  })
-}
-
-export function useSeedSupportedFailureToleranceTypes (seedItem) {
-  return computed(() => {
-    const supportedFailureToleranceTypes = ['node']
-    if (isFailureToleranceTypeZoneSupported(seedItem.value)) {
-      supportedFailureToleranceTypes.push('zone')
-    }
-    return supportedFailureToleranceTypes
-  })
-}
-
-export function useSeedBestSupportedFailureToleranceType (seedItem) {
-  return computed(() => {
-    return getBestSupportedFailureToleranceType(seedItem.value)
   })
 }
 

--- a/frontend/src/composables/useSeedTableSorting.js
+++ b/frontend/src/composables/useSeedTableSorting.js
@@ -55,30 +55,6 @@ function compareLastOperation (a, b, compareValues) {
   return compareValues(getSeedLastOperationSortVal(a), getSeedLastOperationSortVal(b))
 }
 
-function compareControlPlaneHighAvailability (a, b, compareValues) {
-  function getFailureToleranceTypeRank (value) {
-    const failureToleranceType = value?.failureToleranceType
-    switch (failureToleranceType) {
-      case 'zone':
-        return 0
-      case 'node':
-        return 1
-      default:
-        return 2
-    }
-  }
-
-  const compareFailureToleranceType = compareValues(
-    getFailureToleranceTypeRank(a),
-    getFailureToleranceTypeRank(b),
-  )
-  if (compareFailureToleranceType !== 0) {
-    return compareFailureToleranceType
-  }
-
-  return compareValues(a?.name, b?.name)
-}
-
 export function useSeedTableSorting (options = {}) {
   const {
     defaultSortBy = [{ key: 'name', order: 'asc' }],
@@ -102,10 +78,9 @@ export function useSeedTableSorting (options = {}) {
     lastOperation: (a, b) => compareLastOperation(a, b, compareValues),
     kubernetesVersion: (a, b) => compareSemanticVersions(a, b),
     gardenerVersion: (a, b) => compareSemanticVersions(a, b),
-    shoots: (a, b) => compareValues(a, b),
+    shoot: (a, b) => compareValues(a, b),
     createdAt: (a, b) => compareValues(a, b),
     readiness: (a, b) => compareReadiness(a, b, configStore),
-    controlPlaneHighAvailability: (a, b) => compareControlPlaneHighAvailability(a, b, compareValues),
   }
 
   return {

--- a/frontend/src/composables/useShootAdvertisedAddresses.js
+++ b/frontend/src/composables/useShootAdvertisedAddresses.js
@@ -1,0 +1,58 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import {
+  computed,
+  isRef,
+} from 'vue'
+
+import filter from 'lodash/filter'
+import get from 'lodash/get'
+import head from 'lodash/head'
+
+export function useShootAdvertisedAddresses (shootItem) {
+  if (!isRef(shootItem)) {
+    throw new TypeError('First argument `shootItem` must be a ref object')
+  }
+
+  const shootAdvertisedAddresses = computed(() => {
+    return get(shootItem.value, ['status', 'advertisedAddresses'], [])
+  })
+
+  function useAdvertisedAddressesForApplication (applicationName) {
+    const advertisedAddresses = computed(() => {
+      return filter(shootAdvertisedAddresses.value, { application: applicationName })
+    })
+
+    const url = computed(() => {
+      const advertisedAddress = head(advertisedAddresses.value)
+      return advertisedAddress?.url
+    })
+
+    return {
+      advertisedAddresses,
+      url,
+    }
+  }
+
+  const {
+    advertisedAddresses: shootPlutonoAdvertisedAddresses,
+    url: shootPlutonoUrl,
+  } = useAdvertisedAddressesForApplication('credativ--plutono')
+  const {
+    advertisedAddresses: shootPrometheusAdvertisedAddresses,
+    url: shootPrometheusUrl,
+  } = useAdvertisedAddressesForApplication('prometheus--prometheus')
+
+  return {
+    shootAdvertisedAddresses,
+    shootPlutonoAdvertisedAddresses,
+    shootPrometheusAdvertisedAddresses,
+    shootPlutonoUrl,
+    shootPrometheusUrl,
+    useAdvertisedAddressesForApplication,
+  }
+}

--- a/frontend/src/router/guards.js
+++ b/frontend/src/router/guards.js
@@ -15,6 +15,8 @@ import { useKubeconfigStore } from '@/store/kubeconfig'
 import { useMemberStore } from '@/store/member'
 import { useCredentialStore } from '@/store/credential'
 import { useSeedStore } from '@/store/seed'
+import { useManagedSeedStore } from '@/store/managedSeed'
+import { useManagedSeedShootStore } from '@/store/managedSeedShoot'
 import { useShootStore } from '@/store/shoot'
 import { useTerminalStore } from '@/store/terminal'
 
@@ -28,6 +30,8 @@ export function createGlobalBeforeGuards () {
   const projectStore = useProjectStore()
   const cloudProfileStore = useCloudProfileStore()
   const seedStore = useSeedStore()
+  const managedSeedStore = useManagedSeedStore()
+  const managedSeedShootStore = useManagedSeedShootStore()
   const gardenerExtensionStore = useGardenerExtensionStore()
   const kubeconfigStore = useKubeconfigStore()
 
@@ -70,14 +74,23 @@ export function createGlobalBeforeGuards () {
       }
 
       try {
-        await Promise.all([
+        const promises = [
           ensureConfigLoaded(configStore),
           ensureProjectsLoaded(projectStore),
           ensureCloudProfilesLoaded(cloudProfileStore),
           ensureSeedsLoaded(seedStore),
           ensureGardenerExtensionsLoaded(gardenerExtensionStore),
           ensureKubeconfigLoaded(kubeconfigStore),
-        ])
+        ]
+
+        if (authnStore.isAdmin) {
+          promises.push(
+            ensureManagedSeedsLoaded(managedSeedStore),
+            ensureManagedSeedShootsLoaded(managedSeedShootStore),
+          )
+        }
+
+        await Promise.all(promises)
       } catch (err) {
         appStore.setRouterError(err)
       }
@@ -224,6 +237,18 @@ function ensureCloudProfilesLoaded (store) {
 function ensureSeedsLoaded (store) {
   if (store.isInitial) {
     return store.fetchSeeds()
+  }
+}
+
+function ensureManagedSeedsLoaded (store) {
+  if (store.isInitial) {
+    return store.fetchManagedSeeds()
+  }
+}
+
+function ensureManagedSeedShootsLoaded (store) {
+  if (store.isInitial) {
+    return store.fetchManagedSeedShoots()
   }
 }
 

--- a/frontend/src/router/guards.js
+++ b/frontend/src/router/guards.js
@@ -83,7 +83,7 @@ export function createGlobalBeforeGuards () {
           ensureKubeconfigLoaded(kubeconfigStore),
         ]
 
-        if (authnStore.isAdmin) {
+        if (authnStore.canGetManagedSeedAndShootInGardenNs) {
           promises.push(
             ensureManagedSeedsLoaded(managedSeedStore),
             ensureManagedSeedShootsLoaded(managedSeedShootStore),

--- a/frontend/src/store/authn/index.js
+++ b/frontend/src/store/authn/index.js
@@ -65,6 +65,10 @@ export const useAuthnStore = defineStore('authn', () => {
     return user.value?.isAdmin === true
   })
 
+  const canGetManagedSeedAndShootInGardenNs = computed(() => {
+    return user.value?.canGetManagedSeedAndShootInGardenNs === true
+  })
+
   const username = computed(() => {
     return user.value?.email ?? user.value?.id ?? ''
   })
@@ -88,6 +92,7 @@ export const useAuthnStore = defineStore('authn', () => {
   return {
     user,
     isAdmin,
+    canGetManagedSeedAndShootInGardenNs,
     username,
     displayName,
     fullDisplayName,

--- a/frontend/src/store/managedSeed.js
+++ b/frontend/src/store/managedSeed.js
@@ -1,0 +1,78 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import {
+  defineStore,
+  acceptHMRUpdate,
+} from 'pinia'
+import {
+  ref,
+  computed,
+} from 'vue'
+
+import { useApi } from '@/composables/useApi'
+import { useLogger } from '@/composables/useLogger'
+import { useSocketEventHandler } from '@/composables/useSocketEventHandler'
+
+import find from 'lodash/find'
+import get from 'lodash/get'
+
+export const useManagedSeedStore = defineStore('managedseed', () => {
+  const api = useApi()
+  const logger = useLogger()
+
+  const list = ref(null)
+
+  const isInitial = computed(() => {
+    return list.value === null
+  })
+
+  const managedSeedList = computed(() => {
+    return list.value
+  })
+
+  async function fetchManagedSeeds () {
+    try {
+      const response = await api.getManagedSeedsForGardenNamespace()
+      list.value = response.data
+    } catch (err) {
+      // User may not have permission — gracefully handle 403
+      if (err.statusCode === 403 || err.status === 403) {
+        list.value = []
+      } else {
+        throw err
+      }
+    }
+  }
+
+  function managedSeedByName (name) {
+    return find(list.value, ['metadata.name', name])
+  }
+
+  function shootNameForSeed (seedName) {
+    const managedSeed = managedSeedByName(seedName)
+    return get(managedSeed, ['spec', 'shoot', 'name'])
+  }
+
+  const socketEventHandler = useSocketEventHandler(useManagedSeedStore, {
+    logger,
+  })
+  socketEventHandler.start(500)
+
+  return {
+    list,
+    isInitial,
+    managedSeedList,
+    fetchManagedSeeds,
+    managedSeedByName,
+    shootNameForSeed,
+    handleEvent: socketEventHandler.listener,
+  }
+})
+
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useManagedSeedStore, import.meta.hot))
+}

--- a/frontend/src/store/managedSeed.js
+++ b/frontend/src/store/managedSeed.js
@@ -35,17 +35,8 @@ export const useManagedSeedStore = defineStore('managedseed', () => {
   })
 
   async function fetchManagedSeeds () {
-    try {
-      const response = await api.getManagedSeedsForGardenNamespace()
-      list.value = response.data
-    } catch (err) {
-      // User may not have permission — gracefully handle 403
-      if (err.statusCode === 403 || err.status === 403) {
-        list.value = []
-      } else {
-        throw err
-      }
-    }
+    const response = await api.getManagedSeedsForGardenNamespace()
+    list.value = response.data
   }
 
   function managedSeedByName (name) {

--- a/frontend/src/store/managedSeedShoot.js
+++ b/frontend/src/store/managedSeedShoot.js
@@ -1,0 +1,71 @@
+//
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import {
+  defineStore,
+  acceptHMRUpdate,
+} from 'pinia'
+import {
+  ref,
+  computed,
+} from 'vue'
+
+import { useApi } from '@/composables/useApi'
+import { useLogger } from '@/composables/useLogger'
+import { useSocketEventHandler } from '@/composables/useSocketEventHandler'
+
+import find from 'lodash/find'
+
+export const useManagedSeedShootStore = defineStore('managedseed-shoot', () => {
+  const api = useApi()
+  const logger = useLogger()
+
+  const list = ref(null)
+
+  const isInitial = computed(() => {
+    return list.value === null
+  })
+
+  const managedSeedShootList = computed(() => {
+    return list.value
+  })
+
+  async function fetchManagedSeedShoots () {
+    try {
+      const response = await api.getManagedSeedShootsForGardenNamespace()
+      list.value = response.data
+    } catch (err) {
+      // User may not have permission — gracefully handle 403
+      if (err.statusCode === 403 || err.status === 403) {
+        list.value = []
+      } else {
+        throw err
+      }
+    }
+  }
+
+  function shootByName (namespace, name) {
+    return find(list.value, { metadata: { namespace, name } })
+  }
+
+  const socketEventHandler = useSocketEventHandler(useManagedSeedShootStore, {
+    logger,
+  })
+  socketEventHandler.start(500)
+
+  return {
+    list,
+    isInitial,
+    managedSeedShootList,
+    fetchManagedSeedShoots,
+    shootByName,
+    handleEvent: socketEventHandler.listener,
+  }
+})
+
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useManagedSeedShootStore, import.meta.hot))
+}

--- a/frontend/src/store/managedSeedShoot.js
+++ b/frontend/src/store/managedSeedShoot.js
@@ -34,17 +34,8 @@ export const useManagedSeedShootStore = defineStore('managedseed-shoot', () => {
   })
 
   async function fetchManagedSeedShoots () {
-    try {
-      const response = await api.getManagedSeedShootsForGardenNamespace()
-      list.value = response.data
-    } catch (err) {
-      // User may not have permission — gracefully handle 403
-      if (err.statusCode === 403 || err.status === 403) {
-        list.value = []
-      } else {
-        throw err
-      }
-    }
+    const response = await api.getManagedSeedShootsForGardenNamespace()
+    list.value = response.data
   }
 
   function shootByName (namespace, name) {

--- a/frontend/src/store/socket/helper.js
+++ b/frontend/src/store/socket/helper.js
@@ -19,6 +19,8 @@ export function createSocket (state, context) {
     ticketStore,
     projectStore,
     seedStore,
+    managedSeedStore,
+    managedSeedShootStore,
   } = context
 
   const socket = io({
@@ -218,6 +220,14 @@ export function createSocket (state, context) {
 
   socket.on('seeds', event => {
     seedStore.handleEvent(event)
+  })
+
+  socket.on('managedseeds', event => {
+    managedSeedStore.handleEvent(event)
+  })
+
+  socket.on('managedseed-shoots', event => {
+    managedSeedShootStore.handleEvent(event)
   })
 
   return socket

--- a/frontend/src/store/socket/index.js
+++ b/frontend/src/store/socket/index.js
@@ -24,6 +24,8 @@ import { useShootStore } from '../shoot'
 import { useTicketStore } from '../ticket'
 import { useProjectStore } from '../project'
 import { useSeedStore } from '../seed'
+import { useManagedSeedStore } from '../managedSeed'
+import { useManagedSeedShootStore } from '../managedSeedShoot'
 
 import { createSocket } from './helper'
 
@@ -37,6 +39,8 @@ export const useSocketStore = defineStore('socket', () => {
   const ticketStore = useTicketStore()
   const projectStore = useProjectStore()
   const seedStore = useSeedStore()
+  const managedSeedStore = useManagedSeedStore()
+  const managedSeedShootStore = useManagedSeedShootStore()
 
   const state = reactive({
     id: null,
@@ -58,6 +62,8 @@ export const useSocketStore = defineStore('socket', () => {
     ['shoots', false],
     ['projects', false],
     ['seeds', false],
+    ['managedseeds', false],
+    ['managedseed-shoots', false],
   ])
 
   const socket = createSocket(state, {
@@ -67,6 +73,8 @@ export const useSocketStore = defineStore('socket', () => {
     ticketStore,
     projectStore,
     seedStore,
+    managedSeedStore,
+    managedSeedShootStore,
   })
 
   const id = computed(() => {

--- a/frontend/src/views/GSeedItemPlaceholder.vue
+++ b/frontend/src/views/GSeedItemPlaceholder.vue
@@ -24,6 +24,7 @@ import { useSeedStore } from '@/store/seed'
 import GSeedItemLoading from '@/views/GSeedItemLoading.vue'
 import GSeedItemError from '@/views/GSeedItemError.vue'
 
+import { useProvideManagedSeedShoot } from '@/composables/useManagedSeedShootForSeed'
 import { useProvideSeedItem } from '@/composables/useSeedItem/index'
 import { useItemPlaceholder } from '@/composables/useItemPlaceholder'
 
@@ -86,5 +87,6 @@ const {
 })
 
 provide('activePopoverKey', activePopoverKey)
-useProvideSeedItem(seedItem)
+const { seedName } = useProvideSeedItem(seedItem)
+useProvideManagedSeedShoot(seedName)
 </script>

--- a/frontend/src/views/GSeedList.vue
+++ b/frontend/src/views/GSeedList.vue
@@ -75,6 +75,7 @@ import {
 import { storeToRefs } from 'pinia'
 
 import { useSeedStore } from '@/store/seed'
+import { useManagedSeedStore } from '@/store/managedSeed'
 import { useSocketStore } from '@/store/socket'
 import { useLocalStorageStore } from '@/store/localStorage'
 
@@ -88,7 +89,6 @@ import { useSeedTableSorting } from '@/composables/useSeedTableSorting'
 import { useTableFilter } from '@/composables/useTableFilter'
 import { parseSearch } from '@/composables/useTableFilter/helper'
 import { useUrlSearchSync } from '@/composables/useUrlSearchSync'
-import { getBestSupportedFailureToleranceType } from '@/composables/useSeedItem/helper'
 
 import { mapTableHeader } from '@/utils'
 import { errorCodesFromArray } from '@/utils/errorCodes'
@@ -99,6 +99,7 @@ import map from 'lodash/map'
 import join from 'lodash/join'
 
 const seedStore = useSeedStore()
+const managedSeedStore = useManagedSeedStore()
 const socketStore = useSocketStore()
 const localStorageStore = useLocalStorageStore()
 
@@ -139,6 +140,15 @@ const allHeaders = computed(() => [
     value: item => `${get(item, ['spec', 'provider', 'type'], '')} ${get(item, ['spec', 'provider', 'region'], '')}`,
   },
   {
+    title: 'SHOOT',
+    key: 'shoot',
+    sortable: true,
+    align: 'start',
+    defaultSelected: true,
+    hidden: false,
+    value: item => getManagedSeedShootName(item) || '',
+  },
+  {
     title: 'STATUS',
     key: 'lastOperation',
     sortable: true,
@@ -155,18 +165,6 @@ const allHeaders = computed(() => [
     defaultSelected: true,
     hidden: false,
     value: item => item,
-  },
-  {
-    title: 'HIGH AVAILABILITY',
-    key: 'controlPlaneHighAvailability',
-    sortable: true,
-    align: 'center',
-    defaultSelected: false,
-    hidden: false,
-    value: item => ({
-      failureToleranceType: getBestSupportedFailureToleranceType(item),
-      name: get(item, ['metadata', 'name'], ''),
-    }),
   },
   {
     title: 'ACCESS RESTRICTIONS',
@@ -239,16 +237,22 @@ const defaultSelectedColumns = computed(() => {
   return mapTableHeader(headers.value, 'defaultSelected')
 })
 
+function getManagedSeedShootName (item) {
+  const seedName = get(item, ['metadata', 'name'])
+  return managedSeedStore.shootNameForSeed(seedName)
+}
+
 function seedFilterFn (item, query) {
   const conditions = get(item, ['status', 'conditions'], [])
   const errorCodes = join(errorCodesFromArray(conditions), ' ')
   const accessRestrictionNames = join(map(get(item, ['spec', 'accessRestrictions'], []), 'name'), ' ')
+  const shootName = getManagedSeedShootName(item) || 'Unmanaged'
 
   const searchableFields = [
     get(item, ['metadata', 'name']),
+    shootName,
     get(item, ['spec', 'provider', 'type']),
     get(item, ['spec', 'provider', 'region']),
-    getBestSupportedFailureToleranceType(item),
     get(item, ['status', 'kubernetesVersion']),
     get(item, ['status', 'gardener', 'version']),
     get(item, ['spec', 'settings', 'scheduling', 'visible']) ? 'visible' : 'hidden',

--- a/frontend/src/views/GShootItemPlaceholder.vue
+++ b/frontend/src/views/GShootItemPlaceholder.vue
@@ -33,6 +33,7 @@ import { useTerminalStore } from '@/store/terminal'
 import GShootItemLoading from '@/views/GShootItemLoading.vue'
 import GShootItemError from '@/views/GShootItemError.vue'
 
+import { useProvideManagedSeedShoot } from '@/composables/useManagedSeedShootForSeed'
 import { useProvideSeedItem } from '@/composables/useSeedItem/index'
 import { useProvideProjectItem } from '@/composables/useProjectItem'
 import { useProvideShootItem } from '@/composables/useShootItem'
@@ -128,6 +129,7 @@ export default {
 
     const seedItem = computed(() => seedStore.seedByName(shootSeedName.value))
     useProvideSeedItem(seedItem)
+    useProvideManagedSeedShoot(shootSeedName)
 
     const {
       component,

--- a/frontend/src/views/GShootList.vue
+++ b/frontend/src/views/GShootList.vue
@@ -253,7 +253,7 @@ export default {
   data () {
     return {
       dialog: null,
-      selectedColumns: undefined,
+      selectedColumns: {},
     }
   },
   computed: {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
- Added Shoot column to seed list to link to shoot (in case of managed seed)
- Introduced monitoring links (Plutono and Prometheus) for (managed) seeds, using advertisedAdresses
- The Readiness column now shows the effective conditions
  - Seed: uses the Seed conditions.
  - Seed is Managed: uses the Shoot conditions, which provide more detail than the Seed conditions.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Related g/g change: https://github.com/gardener/gardener/pull/14321

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added managed seeds and managed-seed-shoots APIs, socket rooms/events, backend syncs, client stores, and UI links/tiles for Shoot details and monitoring (Plutono/Prometheus).

* **Tests**
  * Added comprehensive acceptance and unit tests covering APIs, real-time IO, services, watches, sockets, CORS and authorization flows.

* **Refactor**
  * New composables/utilities for managed-seed-shoot data; removed legacy failure-tolerance / control-plane high-availability UI and helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->