### PR TITLE
fix(frontend) DNS spec leftovers when configuring custom cluster domain

### DIFF
--- a/frontend/src/components/ShootDns/GManageDns.vue
+++ b/frontend/src/components/ShootDns/GManageDns.vue
@@ -198,7 +198,7 @@ export default {
     const gardenerExtensionStore = useGardenerExtensionStore()
     const cloudProfileStore = useCloudProfileStore()
 
-    const customDomain = ref(!!dnsDomain.value && !!dnsPrimaryProviderType.value)
+    const customDomain = ref(!!dnsDomain.value || !!dnsPrimaryProviderType.value)
     const availableCredentialsForPrimaryDnsProvider = useCloudProviderEntityList(dnsPrimaryProviderType, { credentialStore, gardenerExtensionStore, cloudProfileStore })
 
     return {
@@ -315,8 +315,10 @@ export default {
         this.v$.dnsDomain.$reset()
       }
     },
-    dnsPrimaryProviderType () {
-      this.primaryDnsProviderCredential = head(this.availableCredentialsForPrimaryDnsProvider)
+    dnsPrimaryProviderType (value) {
+      if (value) {
+        this.primaryDnsProviderCredential = head(this.availableCredentialsForPrimaryDnsProvider)
+      }
     },
   },
   methods: {

--- a/frontend/src/components/ShootDns/GManageDns.vue
+++ b/frontend/src/components/ShootDns/GManageDns.vue
@@ -151,7 +151,10 @@ SPDX-License-Identifier: Apache-2.0
 import { requiredIf } from '@vuelidate/validators'
 import { useVuelidate } from '@vuelidate/core'
 import { mapState } from 'pinia'
-import { ref } from 'vue'
+import {
+  ref,
+  nextTick,
+} from 'vue'
 
 import { useGardenerExtensionStore } from '@/store/gardenerExtension'
 import { useCredentialStore } from '@/store/credential'
@@ -198,7 +201,10 @@ export default {
     const gardenerExtensionStore = useGardenerExtensionStore()
     const cloudProfileStore = useCloudProfileStore()
 
-    const customDomain = ref(!!dnsDomain.value || !!dnsPrimaryProviderType.value)
+    const customDomainEnabled = ref(
+      !!dnsDomain.value || !!dnsPrimaryProviderType.value || !!dnsPrimaryProviderCredentialsRef.value,
+    )
+
     const availableCredentialsForPrimaryDnsProvider = useCloudProviderEntityList(dnsPrimaryProviderType, { credentialStore, gardenerExtensionStore, cloudProfileStore })
 
     return {
@@ -214,7 +220,7 @@ export default {
       addDnsServiceExtensionProviderForCustomDomain,
       resetDnsPrimaryProvider,
       deleteDnsServiceExtensionProvider,
-      customDomain,
+      customDomainEnabled,
       availableCredentialsForPrimaryDnsProvider,
     }
   },
@@ -252,21 +258,6 @@ export default {
       return this.isNewCluster
         ? ''
         : 'Primary DNS Provider Type cannot be changed after cluster creation'
-    },
-    customDomainEnabled: {
-      get () {
-        return this.customDomain
-      },
-      set (value) {
-        this.customDomain = value
-
-        if (!value) {
-          this.dnsDomain = undefined
-          this.resetDnsPrimaryProvider()
-        } else {
-          this.$nextTick(() => this.$refs.dnsDomainRef.focus())
-        }
-      },
     },
     primaryDnsProviderCredential: {
       get () {
@@ -307,13 +298,23 @@ export default {
     },
   },
   watch: {
-    customDomainEnabled (value) {
-      if (value) {
-        const type = head(this.dnsProviderTypesWithPrimarySupport)
-        this.dnsPrimaryProviderType = type
-        this.primaryDnsProviderCredential = head(this.availableCredentialsForPrimaryDnsProvider)
+    customDomainEnabled (enabled) {
+      if (!enabled) {
+        this.dnsDomain = undefined
+        this.resetDnsPrimaryProvider()
         this.v$.dnsDomain.$reset()
+        return
       }
+
+      if (!this.dnsPrimaryProviderType) {
+        this.dnsPrimaryProviderType = head(this.dnsProviderTypesWithPrimarySupport)
+      }
+
+      if (!this.primaryDnsProviderCredential) {
+        this.primaryDnsProviderCredential = head(this.availableCredentialsForPrimaryDnsProvider)
+      }
+
+      nextTick(() => this.$refs.dnsDomainRef?.focus())
     },
     dnsPrimaryProviderType (value) {
       if (value) {

--- a/frontend/src/composables/useShootContext.js
+++ b/frontend/src/composables/useShootContext.js
@@ -107,12 +107,7 @@ export function createShootContextComposable (options = {}) {
     }, value)
     const dnsProviders = get(object, ['spec', 'dns', 'providers'])
     if (dnsProviders) {
-      const normalizedProviders = filter(normalizeDnsPrimaryProviderCredentialsRefs(dnsProviders), 'type')
-      if (normalizedProviders.length > 0) {
-        set(object, ['spec', 'dns', 'providers'], normalizedProviders)
-      } else {
-        unset(object, ['spec', 'dns', 'providers'])
-      }
+      set(object, ['spec', 'dns', 'providers'], normalizeDnsPrimaryProviderCredentialsRefs(dnsProviders))
     }
     const extensions = get(object, ['spec', 'extensions'])
     const dnsServiceExtension = find(extensions, ['type', 'shoot-dns-service'])

--- a/frontend/src/composables/useShootContext.js
+++ b/frontend/src/composables/useShootContext.js
@@ -107,7 +107,12 @@ export function createShootContextComposable (options = {}) {
     }, value)
     const dnsProviders = get(object, ['spec', 'dns', 'providers'])
     if (dnsProviders) {
-      set(object, ['spec', 'dns', 'providers'], normalizeDnsPrimaryProviderCredentialsRefs(dnsProviders))
+      const normalizedProviders = filter(normalizeDnsPrimaryProviderCredentialsRefs(dnsProviders), 'type')
+      if (normalizedProviders.length > 0) {
+        set(object, ['spec', 'dns', 'providers'], normalizedProviders)
+      } else {
+        unset(object, ['spec', 'dns', 'providers'])
+      }
     }
     const extensions = get(object, ['spec', 'extensions'])
     const dnsServiceExtension = find(extensions, ['type', 'shoot-dns-service'])


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Introduced with WorkloadIdentity Support for DNS (mostly) 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Refined custom domain activation logic to trigger based on partial DNS configuration
* Added automatic cleanup of DNS fields when custom domain is disabled
* Improved automatic initialization of DNS provider fields when custom domain is enabled
* Enhanced user experience with automatic focus on domain input field
<!-- end of auto-generated comment: release notes by coderabbit.ai -->