### PR TITLE
Fix eager terminal config fetch on shoot details page

### DIFF
--- a/frontend/src/components/GTerminalSplitpanes.vue
+++ b/frontend/src/components/GTerminalSplitpanes.vue
@@ -31,11 +31,15 @@ SPDX-License-Identifier: Apache-2.0
         />
       </template>
     </g-splitpane>
-    <g-create-terminal-session-dialog />
+    <g-create-terminal-session-dialog v-if="hasShootTerminalAccess" />
   </div>
 </template>
 
 <script>
+import { storeToRefs } from 'pinia'
+
+import { useAuthzStore } from '@/store/authz'
+
 import GSplitpane from '@/components/GSplitpane.vue'
 import GTerminal from '@/components/GTerminal.vue'
 import GCreateTerminalSessionDialog from '@/components/dialogs/GCreateTerminalSessionDialog.vue'
@@ -52,6 +56,8 @@ export default {
   },
   inject: ['api'],
   setup () {
+    const authzStore = useAuthzStore()
+    const { hasShootTerminalAccess } = storeToRefs(authzStore)
     const {
       terminalCoordinates,
       hasShootWorkerGroups,
@@ -64,6 +70,7 @@ export default {
     } = useTerminalSplitpanes()
 
     return {
+      hasShootTerminalAccess,
       terminalCoordinates,
       hasShootWorkerGroups,
       splitpaneTree,

--- a/frontend/src/components/dialogs/GCreateTerminalSessionDialog.vue
+++ b/frontend/src/components/dialogs/GCreateTerminalSessionDialog.vue
@@ -296,7 +296,9 @@ export default {
       this.targetTab.selectedTarget = value
     },
     'targetTab.selectedTarget' () {
-      this.updateSettings()
+      if (this.newTerminalPrompt) {
+        this.updateSettings()
+      }
     },
   },
   methods: {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
- `GCreateTerminalSessionDialog` fetched `terminalConfig` eagerly on the shoot details page, triggered by a `defaultTarget` watcher chain, even when the dialog was not open
- Guard `updateSettings()` in the `targetTab.selectedTarget` watcher so it only runs when the creation dialog is actually open (`newTerminalPrompt`) 
- Gate `GCreateTerminalSessionDialog` with `v-if="hasShootTerminalAccess"` in `GTerminalSplitpanes` so it is not mounted for users without terminal access

**Root Cause**:
When shoot data loads, `defaultTarget` changes from `undefined` to `'shoot'`, which sets `targetTab.selectedTarget`, triggering `updateSettings()` -> `terminalConfig` API call. For viewers this results in a 403 on `shoots/adminkubeconfig`. For all users it is a wasted call since the terminal creation dialog is not open.
  
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
