### PR TITLE
feat: show "Target Control Plane" based on actual permissions

### DIFF
--- a/backend/__tests__/acceptance/auth.spec.js
+++ b/backend/__tests__/acceptance/auth.spec.js
@@ -220,7 +220,6 @@ describe('auth', function () {
     mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewToken())
     mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
     mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
-    mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
 
     authorizationCodeGrant.mockImplementationOnce((config, currentUrl, checks) => {
       assert.strictEqual(currentUrl.searchParams.get('code'), OTAC)
@@ -232,7 +231,7 @@ describe('auth', function () {
       .redirects(0)
       .expect(302)
 
-    expect(mockRequest).toHaveBeenCalledTimes(4)
+    expect(mockRequest).toHaveBeenCalledTimes(3)
     expect(mockRequest.mock.calls[0]).toEqual([
       {
         ...pick(fixtures.kube, [':scheme', ':authority', 'authorization']),
@@ -253,7 +252,7 @@ describe('auth', function () {
     expect(mockRequest.mock.calls[1]).toMatchSnapshot()
 
     expect(res.headers).toHaveProperty('location', '/')
-    expect(mockRequest).toHaveBeenCalledTimes(4)
+    expect(mockRequest).toHaveBeenCalledTimes(3)
     expect(authorizationCodeGrant).toHaveBeenCalledTimes(1)
   })
 
@@ -289,7 +288,6 @@ describe('auth', function () {
     mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewToken())
     mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
     mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
-    mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
 
     const res = await agent
       .post('/auth')
@@ -297,7 +295,7 @@ describe('auth', function () {
       .expect('content-type', /json/)
       .expect(200)
 
-    expect(mockRequest).toHaveBeenCalledTimes(4)
+    expect(mockRequest).toHaveBeenCalledTimes(3)
     expect(mockRequest.mock.calls[0]).toEqual([
       {
         ...pick(fixtures.kube, [':scheme', ':authority', 'authorization']),
@@ -394,7 +392,6 @@ describe('auth', function () {
     mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewToken())
     mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
     mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
-    mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
 
     const res = await agent
       .post('/auth/token')
@@ -402,7 +399,7 @@ describe('auth', function () {
       .expect('content-type', /json/)
       .expect(200)
 
-    expect(mockRequest).toHaveBeenCalledTimes(4)
+    expect(mockRequest).toHaveBeenCalledTimes(3)
     expect(mockRequest.mock.calls).toEqual([[
       {
         ...pick(fixtures.kube, [':scheme', ':authority', 'authorization']),
@@ -451,30 +448,9 @@ describe('auth', function () {
         spec: {
           nonResourceAttributes: undefined,
           resourceAttributes: {
-            group: 'seedmanagement.gardener.cloud',
-            resource: 'managedseeds',
-            verb: 'list',
-            namespace: 'garden',
-          },
-        },
-      },
-    ], [
-      {
-        ...pick(fixtures.kube, [':scheme', ':authority']),
-        authorization: `Bearer ${tokenSet.refresh_token}`,
-        ':method': 'post',
-        ':path': '/apis/authorization.k8s.io/v1/selfsubjectaccessreviews',
-      },
-      {
-        apiVersion: 'authorization.k8s.io/v1',
-        kind: 'SelfSubjectAccessReview',
-        spec: {
-          nonResourceAttributes: undefined,
-          resourceAttributes: {
             group: 'core.gardener.cloud',
             resource: 'shoots',
             verb: 'list',
-            namespace: 'garden',
           },
         },
       },
@@ -499,7 +475,7 @@ describe('auth', function () {
       exp: accessTokenPayload.exp,
       aud: accessTokenPayload.aud,
       isAdmin: false,
-      canGetManagedSeedAndShootInGardenNs: true,
+      canListShootsAllNamespaces: true,
       refresh_at: refreshTokenPayload.exp,
       rti: expect.stringMatching(/^[a-z0-9]{7}$/),
     })

--- a/backend/__tests__/security.spec.js
+++ b/backend/__tests__/security.spec.js
@@ -160,17 +160,14 @@ describe('security', function () {
         isAuthenticated: isAuthenticatedMock,
       }))
       const isAdminMock = vi.fn()
-      const canListManagedSeedsInGardenNamespaceMock = vi.fn()
-      const canListShootsInGardenNamespaceMock = vi.fn()
+      const canListShootsMock = vi.fn()
       vi.doMock('../lib/services/authorization.js', () => ({
         default: {
           isAdmin: isAdminMock,
-          canListManagedSeedsInGardenNamespace: canListManagedSeedsInGardenNamespaceMock,
-          canListShootsInGardenNamespace: canListShootsInGardenNamespaceMock,
+          canListShoots: canListShootsMock,
         },
         isAdmin: isAdminMock,
-        canListManagedSeedsInGardenNamespace: canListManagedSeedsInGardenNamespaceMock,
-        canListShootsInGardenNamespace: canListShootsInGardenNamespaceMock,
+        canListShoots: canListShootsMock,
       }))
 
       const undiciMod = await import('undici')
@@ -380,8 +377,7 @@ describe('security', function () {
 
         authentication.isAuthenticated.mockResolvedValue({ username: sub, groups: [] })
         authorization.isAdmin.mockResolvedValue(false)
-        authorization.canListManagedSeedsInGardenNamespace.mockResolvedValue(true)
-        authorization.canListShootsInGardenNamespace.mockResolvedValue(true)
+        authorization.canListShoots.mockResolvedValue(true)
 
         // Create an expired ID token and an access token
         const iat = Math.floor(Date.now() / 1000) - 3600
@@ -480,7 +476,7 @@ describe('security', function () {
             groups: [],
             aud: ['gardener'],
             isAdmin: false,
-            canGetManagedSeedAndShootInGardenNs: true,
+            canListShootsAllNamespaces: true,
           }),
         )
       })
@@ -497,8 +493,7 @@ describe('security', function () {
         })
         authentication.isAuthenticated.mockResolvedValue({ username: sub, groups: [] })
         authorization.isAdmin.mockResolvedValue(false)
-        authorization.canListManagedSeedsInGardenNamespace.mockResolvedValue(false)
-        authorization.canListShootsInGardenNamespace.mockResolvedValue(false)
+        authorization.canListShoots.mockResolvedValue(false)
 
         const req = {
           originalUrl: '/auth/callback?code=some-code',
@@ -572,8 +567,7 @@ describe('security', function () {
         discovery.mockResolvedValue({ code_challenge_methods_supported: ['S256'] })
         authentication.isAuthenticated.mockResolvedValue({ username: sub, groups: [] })
         authorization.isAdmin.mockResolvedValue(false)
-        authorization.canListManagedSeedsInGardenNamespace.mockResolvedValue(false)
-        authorization.canListShootsInGardenNamespace.mockResolvedValue(false)
+        authorization.canListShoots.mockResolvedValue(false)
 
         const req = {
           originalUrl: '/auth/callback?code=some-code',

--- a/backend/lib/security/index.js
+++ b/backend/lib/security/index.js
@@ -245,8 +245,10 @@ async function createAccessToken (payload, idToken) {
   const results = await Promise.allSettled([
     authentication.isAuthenticated({ token: idToken }),
     authorization.isAdmin(user),
-    authorization.canListManagedSeedsInGardenNamespace(user),
-    authorization.canListShootsInGardenNamespace(user),
+    // SSRR cannot distinguish namespace-scoped from cluster-wide bindings for
+    // namespace-scoped resources. Use SSAR here and bake result into the JWT
+    // so the frontend can reliably check cluster-wide "list shoots" permission.
+    authorization.canListShoots(user),
   ])
   // throw an error if any promise has been rejected
   for (const { status, reason: err } of results) {
@@ -257,16 +259,14 @@ async function createAccessToken (payload, idToken) {
   const [
     { value: { username, groups } },
     { value: isAdmin },
-    { value: canListManagedSeeds },
-    { value: canListShoots },
+    { value: canListShootsAllNamespaces },
   ] = results
-  const canGetManagedSeedAndShootInGardenNs = canListManagedSeeds && canListShoots
   Object.assign(payload, {
     id: username,
     groups,
     aud: [GARDENER_AUDIENCE],
     isAdmin,
-    canGetManagedSeedAndShootInGardenNs,
+    canListShootsAllNamespaces,
   })
   const idTokenPayload = decode(idToken)
   if (idTokenPayload) {

--- a/frontend/__tests__/composables/useCredentialsBindingContext.spec.js
+++ b/frontend/__tests__/composables/useCredentialsBindingContext.spec.js
@@ -22,7 +22,7 @@ describe('composables', () => {
     beforeEach(() => {
       setActivePinia(createPinia())
       const authzStore = useAuthzStore()
-      authzStore.setNamespace(testNamespace)
+      authzStore._setNamespace(testNamespace)
 
       const composable = useCredentialsBindingContext()
       credentialsBindingContext = reactive(composable)

--- a/frontend/__tests__/composables/useSecretBindingContext.spec.js
+++ b/frontend/__tests__/composables/useSecretBindingContext.spec.js
@@ -22,7 +22,7 @@ describe('composables', () => {
     beforeEach(() => {
       setActivePinia(createPinia())
       const authzStore = useAuthzStore()
-      authzStore.setNamespace(testNamespace)
+      authzStore._setNamespace(testNamespace)
 
       const composable = useSecretBindingContext()
       secretBindingContext = reactive(composable)

--- a/frontend/__tests__/composables/useSecretContext.spec.js
+++ b/frontend/__tests__/composables/useSecretContext.spec.js
@@ -27,7 +27,7 @@ describe('composables', () => {
     beforeEach(() => {
       setActivePinia(createPinia())
       const authzStore = useAuthzStore()
-      authzStore.setNamespace(testNamespace)
+      authzStore._setNamespace(testNamespace)
 
       const composable = createSecretContextComposable()
       secretContext = reactive(composable)

--- a/frontend/__tests__/composables/useShootContext.spec.js
+++ b/frontend/__tests__/composables/useShootContext.spec.js
@@ -41,7 +41,7 @@ describe('composables', () => {
     appStore.location = 'Europe/Berlin'
     appStore.timezone = '+01:00'
     const authzStore = useAuthzStore()
-    authzStore.setNamespace('garden-test')
+    authzStore._setNamespace('garden-test')
     const configStore = useConfigStore()
     configStore.setConfiguration(global.fixtures.config)
     const credentialStore = useCredentialStore()

--- a/frontend/__tests__/composables/useShootItem.spec.js
+++ b/frontend/__tests__/composables/useShootItem.spec.js
@@ -63,7 +63,7 @@ describe('composables', () => {
       })
 
       authzStore = useAuthzStore()
-      authzStore.setNamespace(shootItem.value.metadata.namespace)
+      authzStore._setNamespace(shootItem.value.metadata.namespace)
       shootStore = useShootStore()
       projectStore = useProjectStore()
       cloudProfileStore = useCloudProfileStore()
@@ -210,7 +210,7 @@ describe('composables', () => {
     })
 
     it('should compute isStaleShoot correctly', () => {
-      authzStore.setNamespace('_all')
+      authzStore._setNamespace('_all')
       shootStore.state.shootListFilters = {
         onlyShootsWithIssues: true,
         progressing: true,

--- a/frontend/__tests__/stores/authz.spec.js
+++ b/frontend/__tests__/stores/authz.spec.js
@@ -1,0 +1,95 @@
+//
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import {
+  setActivePinia,
+  createPinia,
+} from 'pinia'
+
+import { useAuthzStore } from '@/store/authz'
+import { useAuthnStore } from '@/store/authn'
+
+import { useApi } from '@/composables/useApi'
+
+function createRulesResponse (resourceRules = []) {
+  return {
+    data: {
+      resourceRules,
+    },
+  }
+}
+
+describe('stores', () => {
+  describe('authz', () => {
+    const api = useApi()
+    let authzStore
+    let mockGetSubjectRules
+
+    beforeEach(() => {
+      setActivePinia(createPinia())
+      authzStore = useAuthzStore()
+      mockGetSubjectRules = vi.spyOn(api, 'getSubjectRules')
+    })
+
+    describe('canAccessSeedStats', () => {
+      let authnStore
+
+      beforeEach(() => {
+        authnStore = useAuthnStore()
+      })
+
+      it('should return true when user can list seeds (SSRR) and list shoots cluster-wide (JWT)', async () => {
+        authnStore.user = { canListShootsAllNamespaces: true }
+        const rules = [{
+          apiGroups: ['core.gardener.cloud'],
+          resources: ['seeds'],
+          verbs: ['list'],
+        }]
+        mockGetSubjectRules.mockResolvedValueOnce(createRulesResponse(rules))
+        await authzStore.fetchRules()
+        expect(authzStore.canAccessSeedStats).toBe(true)
+      })
+
+      it('should return false when user can list seeds but not shoots cluster-wide', async () => {
+        authnStore.user = { canListShootsAllNamespaces: false }
+        const rules = [{
+          apiGroups: ['core.gardener.cloud'],
+          resources: ['seeds'],
+          verbs: ['list'],
+        }]
+        mockGetSubjectRules.mockResolvedValueOnce(createRulesResponse(rules))
+        await authzStore.fetchRules()
+        expect(authzStore.canAccessSeedStats).toBe(false)
+      })
+
+      it('should return false when user can list shoots cluster-wide but not seeds', async () => {
+        authnStore.user = { canListShootsAllNamespaces: true }
+        mockGetSubjectRules.mockResolvedValueOnce(createRulesResponse([]))
+        await authzStore.fetchRules()
+        expect(authzStore.canAccessSeedStats).toBe(false)
+      })
+
+      it('should return false when SSRR shows list shoots in namespace but JWT lacks cluster-wide', async () => {
+        authnStore.user = { canListShootsAllNamespaces: false }
+        const rules = [
+          {
+            apiGroups: ['core.gardener.cloud'],
+            resources: ['seeds'],
+            verbs: ['list'],
+          },
+          {
+            apiGroups: ['core.gardener.cloud'],
+            resources: ['shoots'],
+            verbs: ['list'],
+          },
+        ]
+        mockGetSubjectRules.mockResolvedValueOnce(createRulesResponse(rules))
+        await authzStore.fetchRules('garden-foo')
+        expect(authzStore.canAccessSeedStats).toBe(false)
+      })
+    })
+  })
+})

--- a/frontend/__tests__/stores/cloudProfile.spec.js
+++ b/frontend/__tests__/stores/cloudProfile.spec.js
@@ -35,7 +35,7 @@ describe('stores', () => {
     beforeEach(async () => {
       setActivePinia(createPinia())
       authzStore = useAuthzStore()
-      authzStore.setNamespace(namespace)
+      authzStore._setNamespace(namespace)
       configStore = useConfigStore()
       configStore.setConfiguration({
         defaultNodesCIDR: '10.10.0.0/16',

--- a/frontend/__tests__/stores/credential.spec.js
+++ b/frontend/__tests__/stores/credential.spec.js
@@ -91,7 +91,7 @@ describe('stores', () => {
       appStore = useAppStore()
       vi.spyOn(appStore, 'setSuccess')
       authzStore = useAuthzStore()
-      authzStore.setNamespace(testNamespace)
+      authzStore._setNamespace(testNamespace)
       cloudProfileStore = useCloudProfileStore()
       cloudProfileStore.list = fixtures.cloudprofiles
       gardenerExtensionStore = useGardenerExtensionStore()
@@ -280,7 +280,7 @@ describe('stores', () => {
 
     it('store should be resetted in case of a fetch error', async () => {
       const namespace = 'invalid'
-      authzStore.setNamespace(namespace)
+      authzStore._setNamespace(namespace)
 
       expect(credentialStore.infrastructureBindingList.length).toBeGreaterThan(0)
       expect(credentialStore.dnsCredentialList.length).toBeGreaterThan(0)
@@ -290,7 +290,7 @@ describe('stores', () => {
     })
     it('store should be resetted after setting new data', async () => {
       const namespace = 'invalid'
-      authzStore.setNamespace(namespace)
+      authzStore._setNamespace(namespace)
 
       expect(credentialStore.infrastructureBindingList.length).toBeGreaterThan(0)
       expect(credentialStore.dnsCredentialList.length).toBeGreaterThan(0)

--- a/frontend/__tests__/stores/quota.spec.js
+++ b/frontend/__tests__/stores/quota.spec.js
@@ -29,7 +29,7 @@ describe('stores', () => {
     beforeEach(async () => {
       setActivePinia(createPinia())
       authzStore = useAuthzStore()
-      authzStore.setNamespace(namespace)
+      authzStore._setNamespace(namespace)
       quotaStore = useQuotaStore()
       quotaStore.quotas = {}
     })

--- a/frontend/__tests__/stores/shoot.spec.js
+++ b/frontend/__tests__/stores/shoot.spec.js
@@ -210,7 +210,7 @@ describe('stores', () => {
         email: 'john.doe@example.org',
       }
       authzStore = useAuthzStore()
-      authzStore.setNamespace('foo')
+      authzStore._setNamespace('foo')
       projectStore = useProjectStore()
       setProjectData({
         shootCustomFields: [

--- a/frontend/src/components/ShootDetails/GShootGardenctlCommands.vue
+++ b/frontend/src/components/ShootDetails/GShootGardenctlCommands.vue
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 <script>
 import { mapState } from 'pinia'
 
-import { useAuthnStore } from '@/store/authn'
+import { useAuthzStore } from '@/store/authz'
 import { useConfigStore } from '@/store/config'
 
 import GGardenctlCommand from '@/components/GGardenctlCommand.vue'
@@ -33,20 +33,28 @@ export default {
     const {
       shootName,
       shootProjectName,
+      seedIsManagedSeed,
     } = useShootItem()
 
     return {
       shootName,
       shootProjectName,
+      seedIsManagedSeed,
     }
   },
   computed: {
     ...mapState(useConfigStore, [
       'clusterIdentity',
     ]),
-    ...mapState(useAuthnStore, [
-      'isAdmin',
+    ...mapState(useAuthzStore, [
+      'canCreateShootsViewerkubeconfigInGarden',
+      'canGetConfigMapsInGarden',
     ]),
+    showControlPlaneCommand () {
+      return this.seedIsManagedSeed
+        ? this.canCreateShootsViewerkubeconfigInGarden
+        : this.canGetConfigMapsInGarden
+    },
     commands () {
       const cmds = [
         {
@@ -56,7 +64,7 @@ export default {
         },
       ]
 
-      if (this.isAdmin) {
+      if (this.showControlPlaneCommand) {
         cmds.unshift({
           title: 'Target Control Plane',
           subtitle: 'Gardenctl command to target the control plane of the shoot cluster',

--- a/frontend/src/router/guards.js
+++ b/frontend/src/router/guards.js
@@ -26,6 +26,7 @@ export function createGlobalBeforeGuards () {
   const logger = useLogger()
   const appStore = useAppStore()
   const authnStore = useAuthnStore()
+  const authzStore = useAuthzStore()
   const configStore = useConfigStore()
   const projectStore = useProjectStore()
   const cloudProfileStore = useCloudProfileStore()
@@ -74,23 +75,26 @@ export function createGlobalBeforeGuards () {
       }
 
       try {
-        const promises = [
+        // Load garden rules, then conditionally load managed seeds once resolved
+        const gardenRulesAndManagedSeeds = async () => {
+          await ensureGardenRulesLoaded(authzStore)
+          if (authzStore.canGetManagedSeedAndShootInGarden) {
+            await Promise.all([
+              ensureManagedSeedsLoaded(managedSeedStore),
+              ensureManagedSeedShootsLoaded(managedSeedShootStore),
+            ])
+          }
+        }
+
+        await Promise.all([
           ensureConfigLoaded(configStore),
           ensureProjectsLoaded(projectStore),
           ensureCloudProfilesLoaded(cloudProfileStore),
           ensureSeedsLoaded(seedStore),
           ensureGardenerExtensionsLoaded(gardenerExtensionStore),
           ensureKubeconfigLoaded(kubeconfigStore),
-        ]
-
-        if (authnStore.canGetManagedSeedAndShootInGardenNs) {
-          promises.push(
-            ensureManagedSeedsLoaded(managedSeedStore),
-            ensureManagedSeedShootsLoaded(managedSeedShootStore),
-          )
-        }
-
-        await Promise.all(promises)
+          gardenRulesAndManagedSeeds(),
+        ])
       } catch (err) {
         appStore.setRouterError(err)
       }
@@ -261,5 +265,11 @@ function ensureGardenerExtensionsLoaded (store) {
 function ensureKubeconfigLoaded (store) {
   if (store.isInitial) {
     return store.fetchKubeconfig()
+  }
+}
+
+function ensureGardenRulesLoaded (store) {
+  if (store.isGardenInitial) {
+    return store.fetchGardenRules()
   }
 }

--- a/frontend/src/router/routes.js
+++ b/frontend/src/router/routes.js
@@ -314,7 +314,7 @@ export function createRoutes () {
           title: 'Seeds',
           icon: 'mdi-sprout',
           get hidden () {
-            return !authnStore.isAdmin
+            return !authzStore.canAccessSeedStats
           },
         },
         title: 'Seeds',
@@ -322,7 +322,7 @@ export function createRoutes () {
         breadcrumbs: seedListBreadcrumbs,
       },
       beforeEnter (to, from) {
-        const fallbackRedirect = getFallbackRedirectIfNotAdmin(to, from)
+        const fallbackRedirect = getFallbackRedirectIfNoSeedAccess(to, from)
         if (fallbackRedirect) {
           return fallbackRedirect
         }
@@ -359,7 +359,7 @@ export function createRoutes () {
         tabs: seedItemTabs,
       },
       beforeEnter (to, from) {
-        const fallbackRedirect = getFallbackRedirectIfNotAdmin(to, from)
+        const fallbackRedirect = getFallbackRedirectIfNoSeedAccess(to, from)
         if (fallbackRedirect) {
           return fallbackRedirect
         }
@@ -382,7 +382,7 @@ export function createRoutes () {
         tabs: seedItemTabs,
       },
       beforeEnter (to, from) {
-        const fallbackRedirect = getFallbackRedirectIfNotAdmin(to, from)
+        const fallbackRedirect = getFallbackRedirectIfNoSeedAccess(to, from)
         if (fallbackRedirect) {
           return fallbackRedirect
         }
@@ -544,8 +544,8 @@ export function createRoutes () {
   }
 
   /* Helper functions */
-  function getFallbackRedirectIfNotAdmin (to, from) {
-    if (authnStore.isAdmin) {
+  function getFallbackRedirectIfNoSeedAccess (to, from) {
+    if (authzStore.canAccessSeedStats) {
       return
     }
 

--- a/frontend/src/store/authn/index.js
+++ b/frontend/src/store/authn/index.js
@@ -65,8 +65,8 @@ export const useAuthnStore = defineStore('authn', () => {
     return user.value?.isAdmin === true
   })
 
-  const canGetManagedSeedAndShootInGardenNs = computed(() => {
-    return user.value?.canGetManagedSeedAndShootInGardenNs === true
+  const canListShootsAllNamespaces = computed(() => {
+    return user.value?.canListShootsAllNamespaces === true
   })
 
   const username = computed(() => {
@@ -92,7 +92,7 @@ export const useAuthnStore = defineStore('authn', () => {
   return {
     user,
     isAdmin,
-    canGetManagedSeedAndShootInGardenNs,
+    canListShootsAllNamespaces,
     username,
     displayName,
     fullDisplayName,

--- a/frontend/src/store/authz.js
+++ b/frontend/src/store/authz.js
@@ -21,17 +21,31 @@ import { useConfigStore } from './config'
 import { useAuthnStore } from './authn'
 import { useProjectStore } from './project'
 
+const GARDEN_NAMESPACE = 'garden'
+
 export const useAuthzStore = defineStore('authz', () => {
   const api = useApi()
   const authnStore = useAuthnStore()
   const configStore = useConfigStore()
   const projectStore = useProjectStore()
 
-  const spec = ref(null)
-  const status = ref(null)
+  const rulesMap = ref(new Map())
+  const currentNamespace = ref(undefined)
 
   const namespace = computed(() => {
-    return spec.value?.namespace
+    return currentNamespace.value
+  })
+
+  const status = computed(() => {
+    return rulesMap.value.get(currentNamespace.value)
+  })
+
+  const gardenStatus = computed(() => {
+    return rulesMap.value.get(GARDEN_NAMESPACE)
+  })
+
+  const isGardenInitial = computed(() => {
+    return !rulesMap.value.get(GARDEN_NAMESPACE)
   })
 
   const canCreateTerminals = computed(() => {
@@ -131,10 +145,36 @@ export const useAuthzStore = defineStore('authz', () => {
     canCreateServiceAccounts.value
   })
 
+  const canAccessSeedStats = computed(() => {
+    // Seeds are cluster-scoped — SSRR is reliable.
+    // Shoots are namespace-scoped — SSRR can't distinguish namespace-only from
+    // cluster-wide access, so use JWT-based canListShootsAllNamespaces (via SSAR) instead.
+    return canI(status.value, 'list', 'core.gardener.cloud', 'seeds') &&
+      authnStore.canListShootsAllNamespaces
+  })
+
+  // Garden-namespace selectors
+  const canGetManagedSeedAndShootInGarden = computed(() => {
+    return canI(gardenStatus.value, 'get', 'seedmanagement.gardener.cloud', 'managedseeds') &&
+      canI(gardenStatus.value, 'get', 'core.gardener.cloud', 'shoots')
+  })
+
+  const canCreateShootsAdminkubeconfigInGarden = computed(() => {
+    return canI(gardenStatus.value, 'create', 'core.gardener.cloud', 'shoots/adminkubeconfig')
+  })
+
+  const canCreateShootsViewerkubeconfigInGarden = computed(() => {
+    return canI(gardenStatus.value, 'create', 'core.gardener.cloud', 'shoots/viewerkubeconfig')
+  })
+
+  const canGetConfigMapsInGarden = computed(() => {
+    return canI(gardenStatus.value, 'get', '', 'configmaps')
+  })
+
   const hasControlPlaneTerminalAccess = computed(() => {
     return configStore.isTerminalEnabled &&
       canCreateTerminals.value &&
-      authnStore.isAdmin
+      canCreateShootsAdminkubeconfigInGarden.value
   })
 
   const hasShootTerminalAccess = computed(() => {
@@ -142,45 +182,65 @@ export const useAuthzStore = defineStore('authz', () => {
       canCreateTerminals.value
   })
 
-  // reuse function not exported
   async function getRules (namespace) {
     const body = { namespace }
     const response = await api.getSubjectRules(body)
-    status.value = response.data
+    return response.data
   }
 
   async function fetchRules (namespace) {
     /**
-     * The value of `spec.value?.namespace` is:
+     * The value of `currentNamespace` is:
      * - undefined if no rules have been fetched yet
-     * - null if only cluster scoped rules have been fetched
-     * - a non-empty string if both cluster scoped rules and the rules for the namespace have been fetched
+     * - null if only cluster-scoped rules have been fetched
+     * - a non-empty string if both cluster-scoped rules and the rules for the namespace have been fetched
      */
     if (!namespace) {
       namespace = null
     }
-    if (spec.value?.namespace !== namespace) {
-      await getRules(namespace)
-      this.setNamespace(namespace)
+    if (currentNamespace.value !== namespace) {
+      const data = await getRules(namespace)
+      setRules(namespace, data)
     }
   }
 
-  function refreshRules () {
-    return getRules(spec.value?.namespace)
+  async function fetchGardenRules () {
+    const data = await getRules(GARDEN_NAMESPACE)
+    rulesMap.value.set(GARDEN_NAMESPACE, data)
   }
 
-  function setNamespace (namespace) {
-    spec.value = { namespace }
+  // Unconditionally re-fetch rules for the current namespace.
+  // Used after own-role changes (e.g. GMemberDialog) where the namespace
+  // hasn't changed but the permissions have.
+  async function refreshRules () {
+    const namespace = currentNamespace.value
+    const data = await getRules(namespace)
+    setRules(namespace, data)
+  }
+
+  function setRules (namespace, data) {
+    for (const key of rulesMap.value.keys()) {
+      if (key !== GARDEN_NAMESPACE) { // preserve garden rules across project switches
+        rulesMap.value.delete(key)
+      }
+    }
+    rulesMap.value.set(namespace, data)
+    currentNamespace.value = namespace
+  }
+
+  // Test-only helper — production code should use fetchRules instead
+  function _setNamespace (namespace) {
+    currentNamespace.value = namespace
   }
 
   function $reset () {
-    spec.value = null
-    status.value = null
+    rulesMap.value = new Map()
+    currentNamespace.value = undefined
   }
 
   return {
     namespace,
-    setNamespace,
+    _setNamespace,
     canCreateTerminals,
     canCreateShoots,
     canPatchShoots,
@@ -203,10 +263,18 @@ export const useAuthzStore = defineStore('authz', () => {
     canManageServiceAccountMembers,
     canGetProjectTerminalShortcuts,
     canUseProjectTerminalShortcuts,
+    canAccessSeedStats,
     hasGardenTerminalAccess,
     hasControlPlaneTerminalAccess,
     hasShootTerminalAccess,
+    // Garden-namespace selectors
+    canGetManagedSeedAndShootInGarden,
+    canCreateShootsAdminkubeconfigInGarden,
+    canCreateShootsViewerkubeconfigInGarden,
+    canGetConfigMapsInGarden,
+    isGardenInitial,
     fetchRules,
+    fetchGardenRules,
     refreshRules,
     $reset,
   }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
Replace `isAdmin` checks with fine-grained permission checks:
- "Target Control Plane" gardenctl command: `canCreateShootsViewerkubeconfigInGarden` (managed seed) or `canGetConfigMapsInGarden` (non-managed seed)
- Seed list/detail route access: `canAccessSeedStats` (can list seeds via SSRR + cluster-wide shoots via JWT)

To support garden-namespace permission checks without extra per-project API calls, the authz store now caches garden-namespace SSRR separately (`rulesMap`) and fetches it once on router init via `fetchGardenRules()`.

**Which issue(s) this PR fixes**:
Fixes #2865

**Special notes for your reviewer**:
Garden rules are fetched once on initial navigation (before project rules). Managed-seed loading is now gated on `canGetManagedSeedAndShootInGarden` derived from those cached garden rules rather than the `canGetManagedSeedAndShootInGardenNs` JWT claim.

**Release note**:
```feature user
Landscape viewers with `create` `shoots/viewerkubeconfig` (in case of managed seeds) or `get` `configmaps` permission (in case of non-managed seeds) in the `garden` namespace now see the "Target Control Plane" gardenctl command without requiring admin access.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined authorization checks for garden namespace resources and seed statistics access
  * Enhanced control plane command visibility based on user permissions and managed seed status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->