### PR TITLE
fix: tooltip not showing for readiness chips

### DIFF
--- a/frontend/src/components/GSeedStatusTag.vue
+++ b/frontend/src/components/GSeedStatusTag.vue
@@ -20,7 +20,6 @@ SPDX-License-Identifier: Apache-2.0
       <template #activator="{ props }">
         <v-chip
           v-bind="props"
-          ref="tagChipRef"
           :class="{ 'cursor-pointer': condition.message }"
           :variant="!isError ? 'tonal' : 'flat'"
           :text-color="textColor"
@@ -36,9 +35,10 @@ SPDX-License-Identifier: Apache-2.0
           />
           {{ chipText }}
           <v-tooltip
-            :activator="$refs.tagChipRef"
+            activator="parent"
             location="top"
             max-width="400px"
+            :open-delay="200"
             :disabled="internalValue"
           >
             <div class="font-weight-bold">

--- a/frontend/src/components/GStatusTag.vue
+++ b/frontend/src/components/GStatusTag.vue
@@ -16,7 +16,6 @@ SPDX-License-Identifier: Apache-2.0
       <template #activator="{ props }">
         <v-chip
           v-bind="props"
-          ref="tagChipRef"
           :class="{ 'cursor-pointer': condition.message }"
           :variant="!isError ? 'tonal' : 'flat'"
           :text-color="textColor"
@@ -32,9 +31,10 @@ SPDX-License-Identifier: Apache-2.0
           />
           {{ chipText }}
           <v-tooltip
-            :activator="$refs.tagChipRef"
+            activator="parent"
             location="top"
             max-width="400px"
+            :open-delay="200"
             :disabled="internalValue"
           >
             <div class="font-weight-bold">


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
This PR fixes a bug where tooltip was not showing for readiness chips

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated tooltip behavior with a 200-millisecond delay before opening on status tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->