### PR TITLE
feat(seedstats): add seed shoot capacity and health stats with live updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ kubeconfig*
 
 # husky managed hooks
 .husky/user-config
+
+# Claude Code local settings
+.claude/settings.local.json

--- a/backend/__tests__/acceptance/api.members.spec.js
+++ b/backend/__tests__/acceptance/api.members.spec.js
@@ -13,6 +13,7 @@ import {
   beforeEach,
 } from 'vitest'
 import request from '@gardener-dashboard/request'
+import { seedProjectNamespaceIndex } from '../helpers/cache.js'
 
 const { mockRequest } = request
 
@@ -21,6 +22,7 @@ describe('api', function () {
 
   beforeAll(async () => {
     agent = await createAgent()
+    seedProjectNamespaceIndex()
   })
 
   afterAll(() => {

--- a/backend/__tests__/acceptance/api.seedstats.spec.js
+++ b/backend/__tests__/acceptance/api.seedstats.spec.js
@@ -1,0 +1,163 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+} from 'vitest'
+import request from '@gardener-dashboard/request'
+import { Store } from '@gardener-dashboard/kube-client'
+import cache from '../../lib/cache/index.js'
+
+const { mockRequest } = request
+
+function createStore (items) {
+  const store = new Store()
+  store.replace(items)
+  return store
+}
+
+function seedShootsBySeedNameIndex (shoots = fixtures.shoots.list()) {
+  const handlers = new Map()
+  cache.indexShootsBySeedName({
+    on (event, handler) {
+      handlers.set(event, handler)
+    },
+  })
+  const add = handlers.get('add')
+  for (const shoot of shoots) {
+    add(shoot)
+  }
+}
+
+describe('api', function () {
+  let agent
+
+  beforeAll(async () => {
+    agent = await createAgent()
+
+    const shoots = fixtures.shoots.list()
+
+    cache.initialize({
+      seeds: {
+        store: createStore(fixtures.seeds.list()),
+      },
+      shoots: {
+        store: createStore(shoots),
+      },
+    })
+    seedShootsBySeedNameIndex(shoots)
+  })
+
+  afterAll(() => {
+    return agent.close()
+  })
+
+  beforeEach(() => {
+    mockRequest.mockReset()
+  })
+
+  describe('seedstats', function () {
+    const user = fixtures.auth.createUser({ id: 'john.doe@example.org' })
+
+    it('should return stats for all seeds', async function () {
+      mockRequest
+        .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+        .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+
+      const res = await agent
+        .get('/api/seedstats?unhealthyFilterMask=0')
+        .set('cookie', await user.cookie)
+        .expect('content-type', /json/)
+        .expect(200)
+
+      expect(mockRequest).toHaveBeenCalledTimes(2)
+      expect(res.body).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          apiVersion: 'dashboard.gardener.cloud/v1alpha1',
+          kind: 'SeedStat',
+          metadata: expect.objectContaining({ name: 'infra1-seed' }),
+          counts: {
+            shootCount: 3,
+            unhealthyShoots: {
+              total: 0,
+              matching: 0,
+            },
+          },
+        }),
+      ]))
+    })
+
+    it('should return stats for one seed', async function () {
+      mockRequest
+        .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+        .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+
+      const res = await agent
+        .get('/api/seedstats/infra1-seed?unhealthyFilterMask=0')
+        .set('cookie', await user.cookie)
+        .expect('content-type', /json/)
+        .expect(200)
+
+      expect(mockRequest).toHaveBeenCalledTimes(2)
+      expect(res.body).toEqual(expect.objectContaining({
+        metadata: {
+          name: 'infra1-seed',
+          uid: 'seed--infra1-seed',
+        },
+        counts: {
+          shootCount: 3,
+          unhealthyShoots: {
+            total: 0,
+            matching: 0,
+          },
+        },
+      }))
+    })
+
+    it('should forbid listing seed stats without full access', async function () {
+      mockRequest
+        .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+        .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess({ allowed: false }))
+
+      const res = await agent
+        .get('/api/seedstats?unhealthyFilterMask=0')
+        .set('cookie', await user.cookie)
+        .expect('content-type', /json/)
+        .expect(403)
+
+      expect(mockRequest).toHaveBeenCalledTimes(2)
+      expect(res.body).toEqual(expect.objectContaining({
+        code: 403,
+        reason: 'Forbidden',
+        message: 'You are not allowed to list seed stats',
+      }))
+    })
+
+    it('should reject requests without unhealthyFilterMask', async function () {
+      mockRequest
+        .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+        .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+
+      const res = await agent
+        .get('/api/seedstats')
+        .set('cookie', await user.cookie)
+        .expect('content-type', /json/)
+        .expect(422)
+
+      expect(mockRequest).toHaveBeenCalledTimes(2)
+      expect(res.body).toEqual(expect.objectContaining({
+        code: 422,
+        reason: 'Unprocessable Entity',
+        message: "The 'unhealthyFilterMask' query parameter must be a non-negative integer with no bits set outside the known flags (0–7)",
+      }))
+    })
+  })
+})

--- a/backend/__tests__/acceptance/api.terminals.spec.js
+++ b/backend/__tests__/acceptance/api.terminals.spec.js
@@ -15,6 +15,7 @@ import {
 } from 'vitest'
 import { padStart } from 'lodash-es'
 import request from '@gardener-dashboard/request'
+import { seedProjectNamespaceIndex } from '../helpers/cache.js'
 import { converter } from '../../lib/services/terminals/index.js'
 
 const { mockRequest } = request
@@ -32,6 +33,7 @@ describe('api', function () {
 
   beforeAll(async () => {
     agent = await createAgent()
+    seedProjectNamespaceIndex()
   })
 
   afterAll(() => {

--- a/backend/__tests__/acceptance/api.tickets.spec.js
+++ b/backend/__tests__/acceptance/api.tickets.spec.js
@@ -19,6 +19,7 @@ import {
   mockListIssues,
   mockListComments,
 } from '@octokit/core'
+import { seedProjectNamespaceIndex } from '../helpers/cache.js'
 import * as tickets from '../../lib/services/tickets.js'
 
 const { mockRequest } = request
@@ -28,6 +29,7 @@ describe('api', function () {
 
   beforeAll(async () => {
     agent = await createAgent()
+    seedProjectNamespaceIndex()
   })
 
   afterAll(() => {

--- a/backend/__tests__/acceptance/io.cors.spec.js
+++ b/backend/__tests__/acceptance/io.cors.spec.js
@@ -43,6 +43,7 @@ describe('cors', () => {
       .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
       .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
       .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+      .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
     await expect(createAgent('io', cache))
       .rejects.toThrow('WebSocket allowed origins configuration is required')
   })
@@ -50,6 +51,7 @@ describe('cors', () => {
   it('should reject connections from disallowed origins', async () => {
     Object.defineProperty(config, 'websocketAllowedOrigins', { value: ['https://allowed.example.org'] })
     mockRequest
+      .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
       .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
       .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
       .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
@@ -68,6 +70,7 @@ describe('cors', () => {
       .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
       .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
       .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+      .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
     agent = await createAgent('io', cache)
     const cookie = await user.cookie
     await expect(
@@ -82,6 +85,7 @@ describe('cors', () => {
       .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
       .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
       .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+      .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
     agent = await createAgent('io', cache)
     const cookie = await user.cookie
     socket = await agent.connect({ cookie, originHeader: 'https://allowed.example.org' })
@@ -91,6 +95,7 @@ describe('cors', () => {
   it('should allow connections when "*" is configured', async () => {
     Object.defineProperty(config, 'websocketAllowedOrigins', { value: ['*'] })
     mockRequest
+      .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
       .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
       .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
       .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())

--- a/backend/__tests__/acceptance/io.spec.js
+++ b/backend/__tests__/acceptance/io.spec.js
@@ -88,6 +88,19 @@ function createStore (items) {
   return store
 }
 
+function seedShootsBySeedNameIndex (shoots = fixtures.shoots.list()) {
+  const handlers = new Map()
+  cache.indexShootsBySeedName({
+    on (event, handler) {
+      handlers.set(event, handler)
+    },
+  })
+  const add = handlers.get('add')
+  for (const shoot of shoots) {
+    add(shoot)
+  }
+}
+
 function notFoundStatus ({ group, kind, uid }) {
   return {
     kind: 'Status',
@@ -111,23 +124,27 @@ describe('api', function () {
 
   beforeAll(async () => {
     cache.cache.resetTicketCache()
+    const shoots = [
+      ...fixtures.shoots.list(),
+      fixtures.shoots.create({
+        uid: 5,
+        name: 'orphan-shoot',
+        namespace: 'garden',
+        project: 'garden',
+        createdBy: 'admin@example.org',
+        secretBindingName: 'soil-orphan',
+        seed: 'soil-orphan',
+      }),
+    ]
     cache.initialize({
       projects: {
         store: createStore(fixtures.projects.list()),
       },
+      seeds: {
+        store: createStore(fixtures.seeds.list()),
+      },
       shoots: {
-        store: createStore([
-          ...fixtures.shoots.list(),
-          fixtures.shoots.create({
-            uid: 5,
-            name: 'orphan-shoot',
-            namespace: 'garden',
-            project: 'garden',
-            createdBy: 'admin@example.org',
-            secretBindingName: 'soil-orphan',
-            seed: 'soil-orphan',
-          }),
-        ]),
+        store: createStore(shoots),
       },
       managedseeds: {
         store: createStore([
@@ -148,6 +165,7 @@ describe('api', function () {
         ]),
       },
     })
+    seedShootsBySeedNameIndex(shoots)
     agent = await createAgent('io', cache)
     nsp = agent.io.sockets
   })
@@ -185,9 +203,10 @@ describe('api', function () {
       let args
 
       beforeEach(async () => {
-        // authorization check for `canListProjects`, `canListSeeds`,
+        // authorization check for `canListProjects`, `canListSeeds`, `canListShoots`,
         // `canListManagedSeedsInGardenNamespace`, and `canListShootsInGardenNamespace`
         mockRequest
+          .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
           .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
           .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
           .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
@@ -198,11 +217,36 @@ describe('api', function () {
         defaultRooms = [
           socket.id,
           ioHelper.sha256(username),
+          'seeds',
           'managedseeds;garden',
           'managedseed-shoots;garden',
         ]
-        expect(mockRequest).toHaveBeenCalledTimes(4)
+        expect(mockRequest).toHaveBeenCalledTimes(5)
         mockRequest.mockClear()
+      })
+
+      it('should subscribe seedstats for all seeds', async function () {
+        await subscribe(socket, 'seedstats', { unhealthyFilterMask: 0 })
+
+        expect(mockRequest).not.toHaveBeenCalled()
+        expect(getRooms(socket, nsp)).toEqual(new Set([
+          ...defaultRooms,
+          'seedstats;uf=0',
+        ]))
+
+        await unsubscribe(socket, 'seedstats')
+        expect(getRooms(socket, nsp)).toEqual(new Set(defaultRooms))
+      })
+
+      it('should re-subscribe seedstats for a single seed', async function () {
+        await subscribe(socket, 'seedstats', { unhealthyFilterMask: 0 })
+        await subscribe(socket, 'seedstats', { name: 'infra1-seed', unhealthyFilterMask: 7 })
+
+        expect(mockRequest).not.toHaveBeenCalled()
+        expect(getRooms(socket, nsp)).toEqual(new Set([
+          ...defaultRooms,
+          'seedstats;seed=infra1-seed;uf=7',
+        ]))
       })
 
       it('should subscribe shoots for a single cluster', async function () {
@@ -355,6 +399,7 @@ describe('api', function () {
         mockRequest
           .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
           .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+          .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
           .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess({ allowed: false }))
           .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess({ allowed: false }))
 
@@ -378,6 +423,7 @@ describe('api', function () {
 
       it('should fail to synchronize managed seed shoots without garden access', async function () {
         mockRequest
+          .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
           .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
           .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
           .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess({ allowed: false }))
@@ -410,9 +456,10 @@ describe('api', function () {
       let defaultRooms
 
       beforeEach(async () => {
-        // authorization check for `canListProjects`, `canListSeeds`,
+        // authorization check for `canListProjects`, `canListSeeds`, `canListShoots`,
         // `canListManagedSeedsInGardenNamespace`, and `canListShootsInGardenNamespace`
         mockRequest
+          .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
           .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
           .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
           .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
@@ -423,11 +470,22 @@ describe('api', function () {
         defaultRooms = [
           socket.id,
           ioHelper.sha256(username),
+          'seeds',
           'managedseeds;garden',
           'managedseed-shoots;garden',
         ]
-        expect(mockRequest).toHaveBeenCalledTimes(4)
+        expect(mockRequest).toHaveBeenCalledTimes(5)
         mockRequest.mockClear()
+      })
+
+      it('should subscribe seedstats for all seeds', async function () {
+        await subscribe(socket, 'seedstats', { unhealthyFilterMask: 2 })
+
+        expect(mockRequest).not.toHaveBeenCalled()
+        expect(getRooms(socket, nsp)).toEqual(new Set([
+          ...defaultRooms,
+          'seedstats;uf=2',
+        ]))
       })
 
       it('should subscribe shoots for a single cluster', async function () {
@@ -547,6 +605,27 @@ describe('api', function () {
         const items = await synchronize(socket, 'projects', [2])
         expect(items).toMatchSnapshot()
       })
+
+      it('should synchronize seed stats', async function () {
+        const items = await synchronize(socket, 'seedstats', ['seed--infra1-seed'], { unhealthyFilterMask: 0 })
+        expect(items).toEqual([
+          {
+            apiVersion: 'dashboard.gardener.cloud/v1alpha1',
+            kind: 'SeedStat',
+            metadata: {
+              name: 'infra1-seed',
+              uid: 'seed--infra1-seed',
+            },
+            counts: {
+              shootCount: 3,
+              unhealthyShoots: {
+                total: 0,
+                matching: 0,
+              },
+            },
+          },
+        ])
+      })
     })
   })
 
@@ -622,8 +701,10 @@ describe('api', function () {
         refresh_at: Math.ceil(Date.now() / 1000) + 4,
       }
       const user = fixtures.auth.createUser(options)
-      // authorization check for `canListProjects` and `canListSeeds`
+      // authorization check for `canListProjects`, `canListSeeds`, `canListShoots`,
+      // `canListManagedSeedsInGardenNamespace`, and `canListShootsInGardenNamespace`
       mockRequest
+        .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
         .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
         .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
         .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
@@ -631,7 +712,7 @@ describe('api', function () {
       socket = await agent.connect({
         cookie: await user.cookie,
       })
-      expect(mockRequest).toHaveBeenCalledTimes(4)
+      expect(mockRequest).toHaveBeenCalledTimes(5)
       expect(mockSetDisconnectTimeout).toHaveBeenCalledTimes(1)
       expect(mockSetDisconnectTimeout.mock.calls[0]).toEqual([
         expect.objectContaining({

--- a/backend/__tests__/cache.spec.js
+++ b/backend/__tests__/cache.spec.js
@@ -120,5 +120,28 @@ describe('cache', function () {
         expect(cache.getTicketCache()).toBe(cache.ticketCache)
       })
     })
+
+    describe('#getShootsBySeedName', function () {
+      it('should return an empty iterable when no shoots are indexed for the seed', function () {
+        expect(Array.from(cache.getShootsBySeedName('missing-seed'))).toEqual([])
+      })
+
+      it('should return indexed shoots for the given seed name', function () {
+        const handlers = new Map()
+        cache.indexShootsBySeedName({
+          on (event, handler) {
+            handlers.set(event, handler)
+          },
+        })
+
+        const add = handlers.get('add')
+        for (const shoot of fixtures.shoots.list()) {
+          add(shoot)
+        }
+
+        expect(Array.from(cache.getShootsBySeedName('infra1-seed'))).toHaveLength(3)
+        expect(Array.from(cache.getShootsBySeedName('soil-infra1'))).toHaveLength(1)
+      })
+    })
   })
 })

--- a/backend/__tests__/cache.tickets.spec.js
+++ b/backend/__tests__/cache.tickets.spec.js
@@ -186,6 +186,39 @@ describe('cache', function () {
       })
     })
 
+    describe('#getIssuesForShoot', function () {
+      it('should return issues matching projectName and name', function () {
+        const result = cache.getIssuesForShoot({ projectName: 'test', name: 'foo' })
+        expect(result).toEqual([firstIssue, secondIssue])
+        expect(emitSpy).not.toHaveBeenCalled()
+      })
+
+      it('should return empty array for unknown shoot', function () {
+        const result = cache.getIssuesForShoot({ projectName: 'test', name: 'unknown' })
+        expect(result).toEqual([])
+      })
+
+      it('should update index when issue is removed', function () {
+        cache.removeIssue({ issue: firstIssue })
+        const result = cache.getIssuesForShoot({ projectName: 'test', name: 'foo' })
+        expect(result).toEqual([secondIssue])
+      })
+
+      it('should update index when issue is updated with new shoot', function () {
+        const updatedIssue = {
+          metadata: {
+            number: 1,
+            updated_at: new Date(Date.now() + 60000).toISOString(),
+            name: 'bar',
+            projectName: 'test',
+          },
+        }
+        cache.addOrUpdateIssue({ issue: updatedIssue })
+        expect(cache.getIssuesForShoot({ projectName: 'test', name: 'foo' })).toEqual([secondIssue])
+        expect(cache.getIssuesForShoot({ projectName: 'test', name: 'bar' })).toEqual([thirdIssue, updatedIssue])
+      })
+    })
+
     describe('#getCommentsForIssue', function () {
       it('should return the all comments for the first issue', function () {
         const comments = cache.getCommentsForIssue({ issueNumber: 1 })

--- a/backend/__tests__/helpers/cache.js
+++ b/backend/__tests__/helpers/cache.js
@@ -1,0 +1,24 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import cache from '../../lib/cache/index.js'
+
+function seedProjectNamespaceIndex (projects = fixtures.projects.list()) {
+  const handlers = new Map()
+  cache.indexProjectsByNamespace({
+    on (event, handler) {
+      handlers.set(event, handler)
+    },
+  })
+  const add = handlers.get('add')
+  for (const project of projects) {
+    add(project)
+  }
+}
+
+export {
+  seedProjectNamespaceIndex,
+}

--- a/backend/__tests__/hooks.spec.js
+++ b/backend/__tests__/hooks.spec.js
@@ -101,6 +101,7 @@ describe('hooks', () => {
         informers = keys.reduce((acc, key) => {
           return Object.assign(acc, {
             [key]: {
+              on: vi.fn(),
               run: vi.fn(),
               store: {
                 untilHasSynced: Promise.resolve(key),
@@ -110,6 +111,7 @@ describe('hooks', () => {
         }, {})
         hooks.constructor.createInformers = mockCreateInformers = vi.fn(() => informers)
         cache.initialize = vi.fn()
+        cache.indexProjectsByNamespace = vi.fn()
         cache.getTicketCache = vi.fn(() => ticketCache)
         io.mockReturnValue(ioInstance)
       })
@@ -130,6 +132,9 @@ describe('hooks', () => {
         expect(cache.initialize).toHaveBeenCalledTimes(1)
         expect(cache.initialize.mock.calls[0]).toHaveLength(1)
         expect(cache.initialize.mock.calls[0][0]).toBe(informers)
+
+        expect(cache.indexProjectsByNamespace).toHaveBeenCalledTimes(1)
+        expect(cache.indexProjectsByNamespace.mock.calls[0]).toEqual([informers.projects])
 
         expect(io).toHaveBeenCalledTimes(1)
         expect(io.mock.calls[0]).toEqual([server, expect.anything()])

--- a/backend/__tests__/hooks.spec.js
+++ b/backend/__tests__/hooks.spec.js
@@ -112,6 +112,7 @@ describe('hooks', () => {
         hooks.constructor.createInformers = mockCreateInformers = vi.fn(() => informers)
         cache.initialize = vi.fn()
         cache.indexProjectsByNamespace = vi.fn()
+        cache.indexShootsBySeedName = vi.fn()
         cache.getTicketCache = vi.fn(() => ticketCache)
         io.mockReturnValue(ioInstance)
       })
@@ -135,6 +136,9 @@ describe('hooks', () => {
 
         expect(cache.indexProjectsByNamespace).toHaveBeenCalledTimes(1)
         expect(cache.indexProjectsByNamespace.mock.calls[0]).toEqual([informers.projects])
+
+        expect(cache.indexShootsBySeedName).toHaveBeenCalledTimes(1)
+        expect(cache.indexShootsBySeedName.mock.calls[0]).toEqual([informers.shoots])
 
         expect(io).toHaveBeenCalledTimes(1)
         expect(io.mock.calls[0]).toEqual([server, expect.anything()])

--- a/backend/__tests__/io.seedstats.spec.js
+++ b/backend/__tests__/io.seedstats.spec.js
@@ -61,7 +61,7 @@ describe('io/seedstats', () => {
       },
     }
 
-    expect(() => getJoinedRooms(nsp)).toThrow(new TypeError('Invalid seedstats room: invalid-room'))
+    expect(() => getJoinedRooms(nsp, { seedName: 'seed-1' })).toThrow(new TypeError('Invalid seedstats room: invalid-room'))
   })
 
   it('should reject unauthorized seedstats subscriptions', async () => {

--- a/backend/__tests__/io.seedstats.spec.js
+++ b/backend/__tests__/io.seedstats.spec.js
@@ -1,0 +1,100 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  afterEach,
+} from 'vitest'
+import * as seedstatsService from '../lib/services/seedstats.js'
+import {
+  getJoinedRooms,
+  subscribe,
+  synchronize,
+} from '../lib/io/seedstats.js'
+
+describe('io/seedstats', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  function createSocket (user) {
+    return {
+      data: { user },
+      join: vi.fn(),
+      rooms: new Set(),
+    }
+  }
+
+  function notFound (uid) {
+    return {
+      kind: 'Status',
+      apiVersion: 'v1',
+      status: 'Failure',
+      message: `SeedStat with uid ${uid} does not exist`,
+      reason: 'NotFound',
+      details: {
+        uid,
+        group: 'dashboard.gardener.cloud',
+        kind: 'SeedStat',
+      },
+      code: 404,
+    }
+  }
+
+  it('should throw for invalid seedstats rooms while collecting joined rooms', () => {
+    let invocation = 0
+    const room = {
+      [Symbol.toPrimitive] () {
+        invocation += 1
+        return invocation === 1 ? 'seedstats;uf=0' : 'invalid-room'
+      },
+    }
+    const nsp = {
+      adapter: {
+        rooms: new Map([[room, new Set()]]),
+      },
+    }
+
+    expect(() => getJoinedRooms(nsp)).toThrow(new TypeError('Invalid seedstats room: invalid-room'))
+  })
+
+  it('should reject unauthorized seedstats subscriptions', async () => {
+    const socket = createSocket({
+      id: 'user@example.org',
+      profiles: {
+        canListSeeds: true,
+        canListShoots: false,
+      },
+    })
+
+    await expect(subscribe(socket, { unhealthyFilterMask: 0 })).rejects.toEqual(expect.objectContaining({
+      statusCode: 403,
+      message: 'Insufficient authorization for seedstats subscription',
+    }))
+    expect(socket.join).not.toHaveBeenCalled()
+  })
+
+  it('should return not found statuses for unauthorized seedstats synchronization', async () => {
+    const getByUidsSpy = vi.spyOn(seedstatsService, 'getByUids')
+    const socket = createSocket({
+      id: 'user@example.org',
+      profiles: {
+        canListSeeds: false,
+        canListShoots: true,
+      },
+    })
+    const uids = ['seed-1', 'seed-2']
+
+    await expect(synchronize(socket, uids, { unhealthyFilterMask: 0 })).resolves.toEqual([
+      notFound('seed-1'),
+      notFound('seed-2'),
+    ])
+    expect(getByUidsSpy).not.toHaveBeenCalled()
+  })
+})

--- a/backend/__tests__/services.seedstats.spec.js
+++ b/backend/__tests__/services.seedstats.spec.js
@@ -113,12 +113,16 @@ describe('services/seedstats', () => {
   ]
 
   const ticketCache = {
-    getIssues: vi.fn(() => issues),
+    getIssuesForShoot: vi.fn(({ name, projectName }) =>
+      issues.filter(issue => issue.metadata.projectName === projectName && issue.metadata.name === name),
+    ),
   }
 
   beforeEach(() => {
     vi.resetAllMocks()
-    ticketCache.getIssues.mockReturnValue(issues)
+    ticketCache.getIssuesForShoot.mockImplementation(({ name, projectName }) =>
+      issues.filter(issue => issue.metadata.projectName === projectName && issue.metadata.name === name),
+    )
     config.frontend.ticket = {
       hideClustersWithLabels: ['suppress'],
     }

--- a/backend/__tests__/services.seedstats.spec.js
+++ b/backend/__tests__/services.seedstats.spec.js
@@ -1,0 +1,254 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+} from 'vitest'
+
+vi.mock('../lib/cache/index.js', () => ({
+  default: {
+    getSeeds: vi.fn(),
+    getSeed: vi.fn(),
+    getSeedByUid: vi.fn(),
+    getShoots: vi.fn(),
+    getShootsBySeedName: vi.fn(),
+    getTicketCache: vi.fn(),
+    findProjectByNamespace: vi.fn(),
+  },
+}))
+
+vi.mock('../lib/services/authorization.js', () => ({
+  canListSeeds: vi.fn(),
+  canListShoots: vi.fn(),
+}))
+
+const { default: cache } = await import('../lib/cache/index.js')
+const { default: config } = await import('../lib/config/index.js')
+const authorization = await import('../lib/services/authorization.js')
+const seedstats = await import('../lib/services/seedstats.js')
+
+describe('services/seedstats', () => {
+  const user = { id: 'admin@example.org' }
+
+  function createSeed ({ name, uid }) {
+    return { metadata: { name, uid } }
+  }
+
+  function createShoot ({
+    name,
+    namespace,
+    seed,
+    status = 'unhealthy',
+    errorCodes,
+    ignored,
+  } = {}) {
+    const shoot = {
+      spec: seed ? { seedName: seed } : {},
+      metadata: {
+        labels: {
+          'shoot.gardener.cloud/status': status,
+        },
+      },
+    }
+    if (name) {
+      shoot.metadata.name = name
+    }
+    if (namespace) {
+      shoot.metadata.namespace = namespace
+    }
+    if (errorCodes) {
+      shoot.status = { lastErrors: [{ codes: errorCodes }] }
+    }
+    if (ignored) {
+      shoot.metadata.annotations = { 'shoot.gardener.cloud/ignore': 'true' }
+    }
+    return shoot
+  }
+
+  const seeds = [
+    createSeed({ name: 'infra1-seed', uid: 'seed-1' }),
+    createSeed({ name: 'infra2-seed', uid: 'seed-2' }),
+  ]
+
+  const shoots = [
+    createShoot({ seed: 'infra1-seed', status: 'healthy' }),
+    createShoot({ seed: 'infra1-seed' }),
+    createShoot({ seed: 'infra1-seed', status: 'progressing', name: 'progressing-shoot', namespace: 'garden-foo' }),
+    createShoot({ seed: 'infra1-seed', name: 'user-error-shoot', namespace: 'garden-foo', errorCodes: ['ERR_CONFIGURATION_PROBLEM'] }),
+    createShoot({ seed: 'infra1-seed', name: 'temporary-error-shoot', namespace: 'garden-foo', errorCodes: ['ERR_INFRA_RATE_LIMITS_EXCEEDED'] }),
+    createShoot({ seed: 'infra1-seed', name: 'deactivated-shoot', namespace: 'garden-foo', ignored: true }),
+    createShoot({ seed: 'infra1-seed', name: 'hidden-ticket-shoot', namespace: 'garden-foo' }),
+    createShoot({ seed: 'infra1-seed', name: 'visible-ticket-shoot', namespace: 'garden-foo' }),
+    createShoot({ seed: 'infra2-seed' }),
+    createShoot({ seed: 'unknown-seed' }),
+    createShoot({}),
+  ]
+
+  const issues = [
+    {
+      metadata: {
+        projectName: 'foo',
+        name: 'hidden-ticket-shoot',
+      },
+      data: {
+        labels: [{ name: 'suppress' }],
+      },
+    },
+    {
+      metadata: {
+        projectName: 'foo',
+        name: 'visible-ticket-shoot',
+      },
+      data: {
+        labels: [{ name: 'customer-visible' }],
+      },
+    },
+  ]
+
+  const ticketCache = {
+    getIssues: vi.fn(() => issues),
+  }
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    ticketCache.getIssues.mockReturnValue(issues)
+    config.frontend.ticket = {
+      hideClustersWithLabels: ['suppress'],
+    }
+    authorization.canListSeeds.mockResolvedValue(true)
+    authorization.canListShoots.mockResolvedValue(true)
+    cache.getSeeds.mockReturnValue(seeds)
+    cache.getShoots.mockReturnValue(shoots)
+    cache.getShootsBySeedName.mockImplementation(seedName => shoots.filter(s => s?.spec?.seedName === seedName).values())
+    cache.getSeed.mockImplementation(name => seeds.find(seed => seed.metadata.name === name))
+    cache.getSeedByUid.mockImplementation(uid => seeds.find(seed => seed.metadata.uid === uid))
+    cache.getTicketCache.mockReturnValue(ticketCache)
+    cache.findProjectByNamespace.mockImplementation(namespace => {
+      switch (namespace) {
+        case 'garden-foo':
+          return { metadata: { name: 'foo' } }
+        case 'garden-bar':
+          return { metadata: { name: 'bar' } }
+        default:
+          throw new Error(`Unknown namespace ${namespace}`)
+      }
+    })
+  })
+
+  it('should reject unauthorized users', async () => {
+    authorization.canListShoots.mockResolvedValue(false)
+
+    await expect(seedstats.list({ user, unhealthyFilterMask: 0 })).rejects.toEqual(expect.objectContaining({
+      statusCode: 403,
+      message: 'You are not allowed to list seed stats',
+    }))
+  })
+
+  it('should reject a missing unhealthyFilterMask on list', async () => {
+    await expect(seedstats.list({ user })).rejects.toEqual(expect.objectContaining({
+      statusCode: 422,
+      message: "The 'unhealthyFilterMask' query parameter must be a non-negative integer with no bits set outside the known flags (0–7)",
+    }))
+  })
+
+  it('should reject an invalid unhealthyFilterMask on read', async () => {
+    await expect(seedstats.read({ user, name: 'infra1-seed', unhealthyFilterMask: 'abc' })).rejects.toEqual(expect.objectContaining({
+      statusCode: 422,
+      message: "The 'unhealthyFilterMask' query parameter must be a non-negative integer with no bits set outside the known flags (0–7)",
+    }))
+  })
+
+  it('should return stats for all seeds', async () => {
+    const result = await seedstats.list({ user, unhealthyFilterMask: 0 })
+
+    expect(result).toEqual([
+      {
+        apiVersion: 'dashboard.gardener.cloud/v1alpha1',
+        kind: 'SeedStat',
+        metadata: {
+          name: 'infra1-seed',
+          uid: 'seed-1',
+        },
+        counts: {
+          shootCount: 8,
+          unhealthyShoots: {
+            total: 7,
+            matching: 7,
+          },
+        },
+      },
+      {
+        apiVersion: 'dashboard.gardener.cloud/v1alpha1',
+        kind: 'SeedStat',
+        metadata: {
+          name: 'infra2-seed',
+          uid: 'seed-2',
+        },
+        counts: {
+          shootCount: 1,
+          unhealthyShoots: {
+            total: 1,
+            matching: 1,
+          },
+        },
+      },
+    ])
+  })
+
+  it.each([
+    [1, { total: 7, matching: 6 }],
+    [2, { total: 7, matching: 5 }],
+    [4, { total: 7, matching: 6 }],
+    [7, { total: 7, matching: 3 }],
+  ])('should apply unhealthyFilterMask %s', async (unhealthyFilterMask, unhealthyShoots) => {
+    const result = await seedstats.read({ user, name: 'infra1-seed', unhealthyFilterMask })
+
+    expect(result).toEqual(expect.objectContaining({
+      counts: {
+        shootCount: 8,
+        unhealthyShoots,
+      },
+    }))
+  })
+
+  it('should return stats for a single seed', async () => {
+    const result = await seedstats.read({ user, name: 'infra1-seed', unhealthyFilterMask: 0 })
+
+    expect(result).toEqual({
+      apiVersion: 'dashboard.gardener.cloud/v1alpha1',
+      kind: 'SeedStat',
+      metadata: {
+        name: 'infra1-seed',
+        uid: 'seed-1',
+      },
+      counts: {
+        shootCount: 8,
+        unhealthyShoots: {
+          total: 7,
+          matching: 7,
+        },
+      },
+    })
+  })
+
+  it('should reject unknown seeds on read', async () => {
+    await expect(seedstats.read({ user, name: 'does-not-exist', unhealthyFilterMask: 0 })).rejects.toEqual(expect.objectContaining({
+      statusCode: 404,
+      message: "Seed with name 'does-not-exist' not found",
+    }))
+  })
+
+  it('should always return total unhealthy shoots greater than or equal to matching unhealthy shoots', async () => {
+    for (const unhealthyFilterMask of [0, 1, 2, 4, 7]) {
+      const result = await seedstats.read({ user, name: 'infra1-seed', unhealthyFilterMask })
+      expect(result.counts.unhealthyShoots.total).toBeGreaterThanOrEqual(result.counts.unhealthyShoots.matching)
+    }
+  })
+})

--- a/backend/__tests__/services.terminals.spec.js
+++ b/backend/__tests__/services.terminals.spec.js
@@ -35,6 +35,7 @@ import {
 } from '../lib/services/terminals/utils.js'
 
 import kubeClientModule from '@gardener-dashboard/kube-client'
+import { seedProjectNamespaceIndex } from './helpers/cache.js'
 
 const { cache } = cacheModule
 const { dashboardClient } = kubeClientModule
@@ -132,6 +133,7 @@ describe('services', function () {
       Object.defineProperty(config, 'terminal', { get: terminalStub })
       seedList = fixtures.seeds.list()
       vi.spyOn(cache, 'getSeeds').mockReturnValue(seedList)
+      seedProjectNamespaceIndex()
     })
 
     afterEach(function () {

--- a/backend/__tests__/utils.spec.js
+++ b/backend/__tests__/utils.spec.js
@@ -18,6 +18,7 @@ import {
   encodeBase64,
   decodeBase64,
   getConfigValue,
+  isTruthyValue,
   shootHasIssue,
   getSeedNameFromShoot,
   parseSelectors,
@@ -62,6 +63,15 @@ describe('utils', function () {
       expect(shootHasIssue(shoot)).toBe(false)
       shoot.metadata.labels['shoot.gardener.cloud/status'] = 'unhealthy'
       expect(shootHasIssue(shoot)).toBe(true)
+    })
+
+    it('should detect truthy values', function () {
+      expect(isTruthyValue('1')).toBe(true)
+      expect(isTruthyValue('true')).toBe(true)
+      expect(isTruthyValue('TRUE')).toBe(true)
+      expect(isTruthyValue('false')).toBe(false)
+      expect(isTruthyValue('')).toBe(false)
+      expect(isTruthyValue(undefined)).toBe(false)
     })
 
     it('should return the seed name for a shoot resource', function () {

--- a/backend/__tests__/watches.spec.js
+++ b/backend/__tests__/watches.spec.js
@@ -33,6 +33,11 @@ const { sha256 } = helper
 const flushPromises = () => new Promise(setImmediate)
 
 const rooms = new Map()
+const adapterRooms = new Map()
+
+function joinRoom (name, members = ['socket-1']) {
+  adapterRooms.set(name, new Set(members))
+}
 
 function getRoom (name) {
   if (!rooms.has(name)) {
@@ -44,6 +49,9 @@ function getRoom (name) {
 }
 
 const nsp = {
+  adapter: {
+    rooms: adapterRooms,
+  },
   to: vi.fn().mockImplementation(name => {
     if (Array.isArray(name)) {
       return {
@@ -114,6 +122,7 @@ describe('watches', function () {
   beforeEach(function () {
     informer = new EventEmitter()
     rooms.clear()
+    adapterRooms.clear()
     vi.clearAllMocks()
   })
 
@@ -133,6 +142,22 @@ describe('watches', function () {
     beforeEach(() => {
       shootsWithIssues = new Set()
       vi.spyOn(cache, 'getManagedSeedForShootInGardenNamespace').mockReturnValue(undefined)
+      vi.spyOn(cache, 'getSeed').mockImplementation(name => {
+        if (name === 'infra1-seed') {
+          return {
+            metadata: {
+              uid: 'seed-1',
+            },
+          }
+        }
+        if (name === 'infra1-seed2') {
+          return {
+            metadata: {
+              uid: 'seed-2',
+            },
+          }
+        }
+      })
     })
 
     it('should watch shoots without issues', async function () {
@@ -256,6 +281,197 @@ describe('watches', function () {
         ['managedseed-shoots', { type: 'DELETED', uid: gardenManagedSeedShoot.metadata.uid }],
       ])
     })
+
+    it('should emit seedstats updates for joined rooms whose total or filtered counts changed', async function () {
+      const oldShoot = {
+        metadata: {
+          namespace: 'garden-foo',
+          name: 'fooShoot',
+          uid: 9,
+          labels: {
+            'shoot.gardener.cloud/status': 'healthy',
+          },
+        },
+        spec: {
+          seedName: 'infra1-seed',
+        },
+      }
+      const updatedShoot = cloneDeep(oldShoot)
+      updatedShoot.metadata.labels['shoot.gardener.cloud/status'] = 'progressing'
+
+      joinRoom('seedstats;uf=0')
+      joinRoom('seedstats;uf=1')
+      joinRoom('seedstats;seed=infra1-seed;uf=0')
+      joinRoom('seedstats;seed=infra1-seed;uf=1')
+
+      watches.shoots(io, informer)
+
+      informer.emit('update', updatedShoot, oldShoot)
+
+      await flushPromises()
+
+      expect(rooms.get('seedstats;uf=0').emit).toHaveBeenCalledTimes(1)
+      expect(rooms.get('seedstats;uf=0').emit.mock.calls).toEqual([
+        ['seedstats', { type: 'MODIFIED', uid: 'seed-1' }],
+      ])
+      expect(rooms.get('seedstats;uf=1').emit).toHaveBeenCalledTimes(1)
+      expect(rooms.get('seedstats;uf=1').emit.mock.calls).toEqual([
+        ['seedstats', { type: 'MODIFIED', uid: 'seed-1' }],
+      ])
+      expect(rooms.get('seedstats;seed=infra1-seed;uf=0').emit).toHaveBeenCalledTimes(1)
+      expect(rooms.get('seedstats;seed=infra1-seed;uf=0').emit.mock.calls).toEqual([
+        ['seedstats', { type: 'MODIFIED', uid: 'seed-1' }],
+      ])
+      expect(rooms.get('seedstats;seed=infra1-seed;uf=1').emit).toHaveBeenCalledTimes(1)
+      expect(rooms.get('seedstats;seed=infra1-seed;uf=1').emit.mock.calls).toEqual([
+        ['seedstats', { type: 'MODIFIED', uid: 'seed-1' }],
+      ])
+    })
+
+    it('should emit seedstats for ADDED shoot', async function () {
+      const newShoot = {
+        metadata: {
+          namespace: 'garden-foo',
+          name: 'fooShoot',
+          uid: 9,
+          labels: { 'shoot.gardener.cloud/status': 'healthy' },
+        },
+        spec: { seedName: 'infra1-seed' },
+      }
+
+      joinRoom('seedstats;uf=0')
+      joinRoom('seedstats;seed=infra1-seed;uf=0')
+
+      watches.shoots(io, informer)
+
+      informer.emit('add', newShoot)
+
+      await flushPromises()
+
+      expect(rooms.get('seedstats;uf=0').emit.mock.calls).toEqual([
+        ['seedstats', { type: 'MODIFIED', uid: 'seed-1' }],
+      ])
+      expect(rooms.get('seedstats;seed=infra1-seed;uf=0').emit.mock.calls).toEqual([
+        ['seedstats', { type: 'MODIFIED', uid: 'seed-1' }],
+      ])
+    })
+
+    it('should emit seedstats for DELETED shoot', async function () {
+      const shoot = {
+        metadata: {
+          namespace: 'garden-foo',
+          name: 'fooShoot',
+          uid: 9,
+          labels: { 'shoot.gardener.cloud/status': 'healthy' },
+        },
+        spec: { seedName: 'infra1-seed' },
+      }
+
+      joinRoom('seedstats;uf=0')
+      joinRoom('seedstats;seed=infra1-seed;uf=0')
+
+      watches.shoots(io, informer)
+
+      informer.emit('delete', shoot)
+
+      await flushPromises()
+
+      expect(rooms.get('seedstats;uf=0').emit.mock.calls).toEqual([
+        ['seedstats', { type: 'MODIFIED', uid: 'seed-1' }],
+      ])
+      expect(rooms.get('seedstats;seed=infra1-seed;uf=0').emit.mock.calls).toEqual([
+        ['seedstats', { type: 'MODIFIED', uid: 'seed-1' }],
+      ])
+    })
+
+    it('should not emit seedstats when shoot MODIFIED but health state unchanged', async function () {
+      const oldShoot = {
+        metadata: {
+          namespace: 'garden-foo',
+          name: 'fooShoot',
+          uid: 9,
+          labels: { 'shoot.gardener.cloud/status': 'healthy' },
+        },
+        spec: { seedName: 'infra1-seed' },
+      }
+      // Same health state, different field that doesn't affect seedstats
+      const updatedShoot = cloneDeep(oldShoot)
+      updatedShoot.metadata.resourceVersion = '999'
+
+      joinRoom('seedstats;uf=0')
+      joinRoom('seedstats;seed=infra1-seed;uf=0')
+
+      watches.shoots(io, informer)
+
+      informer.emit('update', updatedShoot, oldShoot)
+
+      await flushPromises()
+
+      expect(rooms.get('seedstats;uf=0')).toBeUndefined()
+      expect(rooms.get('seedstats;seed=infra1-seed;uf=0')).toBeUndefined()
+    })
+
+    it('should not emit seedstats when seed is not found in cache', async function () {
+      const shoot = {
+        metadata: {
+          namespace: 'garden-foo',
+          name: 'fooShoot',
+          uid: 9,
+          labels: { 'shoot.gardener.cloud/status': 'healthy' },
+        },
+        spec: { seedName: 'unknown-seed' },
+      }
+
+      joinRoom('seedstats;uf=0')
+
+      watches.shoots(io, informer)
+
+      informer.emit('add', shoot)
+
+      await flushPromises()
+
+      expect(rooms.get('seedstats;uf=0')).toBeUndefined()
+    })
+
+    it('should emit seedstats updates for list and single-seed rooms when a shoot changes seeds', async function () {
+      const oldShoot = {
+        metadata: {
+          namespace: 'garden-foo',
+          name: 'fooShoot',
+          uid: 9,
+          labels: {
+            'shoot.gardener.cloud/status': 'healthy',
+          },
+        },
+        spec: {
+          seedName: 'infra1-seed',
+        },
+      }
+      const updatedShoot = cloneDeep(oldShoot)
+      updatedShoot.spec.seedName = 'infra1-seed2'
+      updatedShoot.metadata.labels['shoot.gardener.cloud/status'] = 'unhealthy'
+
+      joinRoom('seedstats;uf=0')
+      joinRoom('seedstats;seed=infra1-seed;uf=0')
+      joinRoom('seedstats;seed=infra1-seed2;uf=0')
+
+      watches.shoots(io, informer)
+
+      informer.emit('update', updatedShoot, oldShoot)
+
+      await flushPromises()
+
+      expect(rooms.get('seedstats;uf=0').emit.mock.calls).toEqual([
+        ['seedstats', { type: 'MODIFIED', uid: 'seed-1' }],
+        ['seedstats', { type: 'MODIFIED', uid: 'seed-2' }],
+      ])
+      expect(rooms.get('seedstats;seed=infra1-seed;uf=0').emit.mock.calls).toEqual([
+        ['seedstats', { type: 'MODIFIED', uid: 'seed-1' }],
+      ])
+      expect(rooms.get('seedstats;seed=infra1-seed2;uf=0').emit.mock.calls).toEqual([
+        ['seedstats', { type: 'MODIFIED', uid: 'seed-2' }],
+      ])
+    })
   })
 
   describe('projects', function () {
@@ -315,7 +531,7 @@ describe('watches', function () {
   })
 
   describe('seeds', function () {
-    it('should watch seeds', async function () {
+    it('should watch seeds only for joined seedstats rooms', async function () {
       watches.seeds(io, informer)
 
       const uid = 7
@@ -326,23 +542,54 @@ describe('watches', function () {
         },
       }
 
+      joinRoom('seedstats;uf=0')
+      joinRoom('seedstats;seed=seed-foo;uf=7')
+      joinRoom('seedstats;seed=other-seed;uf=7')
+
       informer.emit('add', seed)
       informer.emit('update', seed)
       informer.emit('delete', seed)
 
       await flushPromises()
 
-      const ids = ['seeds']
+      const ids = ['seeds', 'seedstats;uf=0', 'seedstats;seed=seed-foo;uf=7']
 
       expect(Array.from(rooms.keys())).toEqual(ids)
-      expect(nsp.to).toHaveBeenCalledTimes(3)
+      expect(nsp.to).toHaveBeenCalledTimes(9)
+      expect(nsp.to.mock.calls).toEqual([
+        ['seeds'],
+        ['seedstats;uf=0'],
+        ['seedstats;seed=seed-foo;uf=7'],
+        ['seeds'],
+        ['seedstats;uf=0'],
+        ['seedstats;seed=seed-foo;uf=7'],
+        ['seeds'],
+        ['seedstats;uf=0'],
+        ['seedstats;seed=seed-foo;uf=7'],
+      ])
 
-      const seedsRoom = rooms.get(ids[0])
+      const seedsRoom = rooms.get('seeds')
       expect(seedsRoom.emit).toHaveBeenCalledTimes(3)
       expect(seedsRoom.emit.mock.calls).toEqual([
         ['seeds', { type: 'ADDED', uid }],
         ['seeds', { type: 'MODIFIED', uid }],
         ['seeds', { type: 'DELETED', uid }],
+      ])
+
+      const seedStatsListRoom = rooms.get('seedstats;uf=0')
+      expect(seedStatsListRoom.emit).toHaveBeenCalledTimes(3)
+      expect(seedStatsListRoom.emit.mock.calls).toEqual([
+        ['seedstats', { type: 'ADDED', uid }],
+        ['seedstats', { type: 'MODIFIED', uid }],
+        ['seedstats', { type: 'DELETED', uid }],
+      ])
+
+      const seedStatsSeedRoom = rooms.get('seedstats;seed=seed-foo;uf=7')
+      expect(seedStatsSeedRoom.emit).toHaveBeenCalledTimes(3)
+      expect(seedStatsSeedRoom.emit.mock.calls).toEqual([
+        ['seedstats', { type: 'ADDED', uid }],
+        ['seedstats', { type: 'MODIFIED', uid }],
+        ['seedstats', { type: 'DELETED', uid }],
       ])
     })
   })
@@ -488,6 +735,16 @@ describe('watches', function () {
       signal = abortController.signal
 
       vi.spyOn(cache, 'getTicketCache').mockReturnValue(ticketCache)
+      vi.spyOn(cache, 'getShoot').mockReturnValue({
+        spec: {
+          seedName: 'infra1-seed',
+        },
+      })
+      vi.spyOn(cache, 'getSeed').mockReturnValue({
+        metadata: {
+          uid: 'seed-1',
+        },
+      })
     })
 
     it('should log a warning if gitHub config is missing and not continue', async function () {
@@ -569,7 +826,11 @@ describe('watches', function () {
       expect(pLimit).toHaveBeenCalledWith(42)
     })
 
-    it('should emit ticket cache events to socket io', async () => {
+    it('should emit ticket cache events to socket io and seedstats only for bit-2 rooms', async () => {
+      joinRoom('seedstats;uf=4')
+      joinRoom('seedstats;seed=infra1-seed;uf=4')
+      joinRoom('seedstats;uf=0')
+
       watches.leases(io, informer, { signal })
 
       expect(nsp.emit).toHaveBeenCalledTimes(1)
@@ -580,6 +841,62 @@ describe('watches', function () {
       expect(nsp.to).toHaveBeenCalledWith([room])
       expect(mockRoom.emit).toHaveBeenCalledTimes(1)
       expect(mockRoom.emit).toHaveBeenCalledWith('comments', issueEvent)
+
+      expect(rooms.get('seedstats;uf=4').emit).toHaveBeenCalledTimes(1)
+      expect(rooms.get('seedstats;uf=4').emit).toHaveBeenCalledWith('seedstats', { type: 'MODIFIED', uid: 'seed-1' })
+      expect(rooms.get('seedstats;seed=infra1-seed;uf=4').emit).toHaveBeenCalledTimes(1)
+      expect(rooms.get('seedstats;seed=infra1-seed;uf=4').emit).toHaveBeenCalledWith('seedstats', { type: 'MODIFIED', uid: 'seed-1' })
+      expect(rooms.has('seedstats;uf=0')).toBe(false)
+    })
+
+    it('should not emit seedstats for issue events when no joined rooms have FILTER_HIDE_TICKETS bit set', async () => {
+      joinRoom('seedstats;uf=0')
+      joinRoom('seedstats;uf=1')
+      joinRoom('seedstats;seed=infra1-seed;uf=0')
+
+      watches.leases(io, informer, { signal })
+
+      expect(rooms.has('seedstats;uf=0')).toBe(false)
+      expect(rooms.has('seedstats;uf=1')).toBe(false)
+      expect(rooms.has('seedstats;seed=infra1-seed;uf=0')).toBe(false)
+    })
+
+    it('should not emit seedstats for issue events when shoot is not found in cache', async () => {
+      cache.getShoot.mockReturnValue(undefined)
+
+      joinRoom('seedstats;uf=4')
+
+      watches.leases(io, informer, { signal })
+
+      expect(rooms.has('seedstats;uf=4')).toBe(false)
+    })
+
+    it('should not emit seedstats for issue events when seed is not found in cache', async () => {
+      cache.getSeed.mockReturnValue(undefined)
+
+      joinRoom('seedstats;uf=4')
+
+      watches.leases(io, informer, { signal })
+
+      expect(rooms.has('seedstats;uf=4')).toBe(false)
+    })
+
+    it('should not emit seedstats for issue events with missing metadata', async () => {
+      const badEvent = { object: { metadata: {} } }
+      const ticketCacheWithBadEvent = {
+        on (eventName, handler) {
+          if (eventName === 'issue') {
+            handler(badEvent)
+          }
+        },
+      }
+      cache.getTicketCache.mockReturnValue(ticketCacheWithBadEvent)
+
+      joinRoom('seedstats;uf=4')
+
+      watches.leases(io, informer, { signal })
+
+      expect(rooms.has('seedstats;uf=4')).toBe(false)
     })
 
     it('should listen to informer update events', async function () {

--- a/backend/lib/cache/index.js
+++ b/backend/lib/cache/index.js
@@ -7,6 +7,7 @@
 import _ from 'lodash-es'
 import httpErrors from 'http-errors'
 import createTicketCache from './tickets.js'
+import logger from '../logger/index.js'
 import {
   parseSelectors,
   filterBySelectors,
@@ -20,9 +21,77 @@ const { NotFound } = httpErrors
 */
 
 class Cache extends Map {
+  #namespaceToProject = new Map()
+  #seedNameToShoots = new Map()
+
   constructor () {
     super()
     this.ticketCache = createTicketCache()
+  }
+
+  indexProjectsByNamespace (informer) {
+    const set = obj => {
+      const ns = obj?.spec?.namespace
+      if (!ns) {
+        return
+      }
+      const existing = this.#namespaceToProject.get(ns)
+      if (existing && existing.metadata.uid !== obj.metadata.uid) {
+        logger.warn('Two projects claim namespace %s: %s and %s — namespace index may be inconsistent', ns, existing.metadata.name, obj.metadata.name)
+      }
+      this.#namespaceToProject.set(ns, obj)
+    }
+    const del = obj => {
+      const ns = obj?.spec?.namespace
+      if (ns) {
+        this.#namespaceToProject.delete(ns)
+      }
+    }
+    informer.on('add', set)
+    informer.on('update', (obj, old) => {
+      del(old)
+      set(obj)
+    })
+    informer.on('delete', del)
+  }
+
+  indexShootsBySeedName (informer) {
+    const add = shoot => {
+      const seedName = shoot?.spec?.seedName
+      if (!seedName) {
+        return
+      }
+      const uid = shoot?.metadata?.uid
+      if (!uid) {
+        return
+      }
+      let set = this.#seedNameToShoots.get(seedName)
+      if (!set) {
+        set = new Map()
+        this.#seedNameToShoots.set(seedName, set)
+      }
+      set.set(uid, shoot)
+    }
+    const del = shoot => {
+      const seedName = shoot?.spec?.seedName
+      const uid = shoot?.metadata?.uid
+      if (!seedName || !uid) {
+        return
+      }
+      const set = this.#seedNameToShoots.get(seedName)
+      if (set) {
+        set.delete(uid)
+        if (set.size === 0) {
+          this.#seedNameToShoots.delete(seedName)
+        }
+      }
+    }
+    informer.on('add', add)
+    informer.on('update', (obj, old) => {
+      del(old)
+      add(obj)
+    })
+    informer.on('delete', del)
   }
 
   getCloudProfiles () {
@@ -62,6 +131,14 @@ class Cache extends Map {
 
   getTicketCache () {
     return this.ticketCache
+  }
+
+  findProjectByNamespace (namespace) {
+    const project = this.#namespaceToProject.get(namespace)
+    if (!project) {
+      throw new NotFound(`Namespace '${namespace}' is not related to a gardener project`)
+    }
+    return project
   }
 }
 
@@ -140,11 +217,7 @@ export default {
     return cache.getResourceQuotas()
   },
   findProjectByNamespace (namespace) {
-    const project = cache.get('projects').find(['spec.namespace', namespace])
-    if (!project) {
-      throw new NotFound(`Namespace '${namespace}' is not related to a gardener project`)
-    }
-    return project
+    return cache.findProjectByNamespace(namespace)
   },
   getManagedSeedsInGardenNamespace () {
     return cache.getManagedSeedsInGardenNamespace()
@@ -177,5 +250,11 @@ export default {
       default:
         throw new TypeError(`Kind '${kind}' not supported`)
     }
+  },
+  indexProjectsByNamespace (informer) {
+    cache.indexProjectsByNamespace(informer)
+  },
+  indexShootsBySeedName (informer) {
+    cache.indexShootsBySeedName(informer)
   },
 }

--- a/backend/lib/cache/index.js
+++ b/backend/lib/cache/index.js
@@ -94,6 +94,10 @@ class Cache extends Map {
     informer.on('delete', del)
   }
 
+  getShootsBySeedName (seedName) {
+    return this.#seedNameToShoots.get(seedName)?.values() ?? []
+  }
+
   getCloudProfiles () {
     return this.get('cloudprofiles').list()
   }
@@ -236,6 +240,9 @@ export default {
   },
   getTicketCache () {
     return cache.getTicketCache()
+  },
+  getShootsBySeedName (seedName) {
+    return cache.getShootsBySeedName(seedName)
   },
   getByUid (kind, uid) {
     switch (kind) {

--- a/backend/lib/cache/tickets.js
+++ b/backend/lib/cache/tickets.js
@@ -8,8 +8,13 @@ import EventEmitter from 'events'
 import _ from 'lodash-es'
 import logger from '../logger/index.js'
 
+function shootKey (projectName, name) {
+  return JSON.stringify([projectName, name])
+}
+
 function init () {
   const issues = new Map()
+  const issuesByShoot = new Map() // Map<shootKey, Map<issueNumber, issue>>
   const commentsForIssues = new Map() // we could also think of getting rid of the comments cache
   const emitter = new EventEmitter()
 
@@ -55,11 +60,19 @@ function init () {
   }
 
   function getIssueNumbersForNameAndProjectName ({ name, projectName }) {
-    return _
-      .chain(getIssues())
-      .filter(_.matches({ metadata: { name, projectName } }))
-      .map('metadata.number')
-      .value()
+    const map = issuesByShoot.get(shootKey(projectName, name))
+    if (!map) {
+      return []
+    }
+    return Array.from(map.keys())
+  }
+
+  function getIssuesForShoot ({ name, projectName }) {
+    const map = issuesByShoot.get(shootKey(projectName, name))
+    if (!map) {
+      return []
+    }
+    return Array.from(map.values())
   }
 
   function getCommentsForIssueCache ({ issueNumber }) {
@@ -76,7 +89,14 @@ function init () {
   }
 
   function addOrUpdateIssue ({ issue }) {
+    const number = issue.metadata.number
+    const oldIssue = issues.get(number)
+    if (oldIssue) {
+      removeFromShootIndex(oldIssue)
+    }
     updateIfNewer('issue', issues, issue)
+    // Re-read from issues map — updateIfNewer may have kept the old item if it was newer
+    addToShootIndex(issues.get(number))
   }
 
   function addOrUpdateComment ({ issueNumber, comment }) {
@@ -87,6 +107,11 @@ function init () {
   function removeIssue ({ issue }) {
     const issueNumber = issue.metadata.number
     logger.trace('removing issue', issueNumber, 'and comments')
+
+    const cachedIssue = issues.get(issueNumber)
+    if (cachedIssue) {
+      removeFromShootIndex(cachedIssue)
+    }
 
     const comments = getCommentsForIssueCache({ issueNumber })
 
@@ -105,6 +130,36 @@ function init () {
     const commentsForIssuesCache = getCommentsForIssueCache({ issueNumber })
     commentsForIssuesCache.delete(identifier)
     emitCommmentDeleted(comment)
+  }
+
+  function addToShootIndex (issue) {
+    const { projectName, name, number } = issue?.metadata ?? {}
+    if (!projectName || !name) {
+      return
+    }
+    const key = shootKey(projectName, name)
+    let map = issuesByShoot.get(key)
+    if (!map) {
+      map = new Map()
+      issuesByShoot.set(key, map)
+    }
+    map.set(number, issue)
+  }
+
+  function removeFromShootIndex (issue) {
+    const { projectName, name, number } = issue?.metadata ?? {}
+    if (!projectName || !name) {
+      return
+    }
+    const key = shootKey(projectName, name)
+    const map = issuesByShoot.get(key)
+    if (!map) {
+      return
+    }
+    map.delete(number)
+    if (map.size === 0) {
+      issuesByShoot.delete(key)
+    }
   }
 
   function updateIfNewer (kind, cachedMap, item) {
@@ -142,6 +197,7 @@ function init () {
     getCommentsForIssue,
     getIssueNumbers,
     getIssueNumbersForNameAndProjectName,
+    getIssuesForShoot,
     addOrUpdateIssues,
     addOrUpdateIssue,
     addOrUpdateComment,

--- a/backend/lib/hooks.js
+++ b/backend/lib/hooks.js
@@ -40,6 +40,9 @@ class LifecycleHooks {
     const informers = this.constructor.createInformers(this.client)
     // initialize cache
     cache.initialize(informers)
+    // build derived indexes
+    cache.indexProjectsByNamespace(informers.projects)
+    cache.indexShootsBySeedName(informers.shoots)
     // run informers
     const untilHasSyncedList = []
     for (const informer of Object.values(informers)) {

--- a/backend/lib/io/dispatcher.js
+++ b/backend/lib/io/dispatcher.js
@@ -11,6 +11,11 @@ import {
 } from './shoots.js'
 import { synchronize as synchronizeProjects } from './projects.js'
 import { synchronize as synchronizeSeeds } from './seeds.js'
+import {
+  subscribe as subscribeSeedStats,
+  unsubscribe as unsubscribeSeedStats,
+  synchronize as synchronizeSeedStats,
+} from './seedstats.js'
 import { synchronize as synchronizeManagedSeeds } from './managedseeds.js'
 import { synchronize as synchronizeManagedSeedShoots } from './managedseedshoots.js'
 
@@ -19,6 +24,9 @@ async function subscribe (socket, key, options = {}) {
     case 'shoots':
       await unsubscribeShoots(socket)
       return subscribeShoots(socket, options)
+    case 'seedstats':
+      await unsubscribeSeedStats(socket)
+      return subscribeSeedStats(socket, options)
     default:
       throw new TypeError(`Invalid subscription type - ${key}`)
   }
@@ -28,6 +36,8 @@ async function unsubscribe (socket, key) {
   switch (key) {
     case 'shoots':
       return unsubscribeShoots(socket)
+    case 'seedstats':
+      return unsubscribeSeedStats(socket)
     default:
       throw new TypeError(`Invalid subscription type - ${key}`)
   }
@@ -49,6 +59,11 @@ function synchronize (socket, key, ...args) {
       const [uids] = args
       assertArray(uids)
       return synchronizeSeeds(socket, uids)
+    }
+    case 'seedstats': {
+      const [uids, options] = args
+      assertArray(uids)
+      return synchronizeSeedStats(socket, uids, options)
     }
     case 'managedseeds': {
       const [uids] = args

--- a/backend/lib/io/helper.js
+++ b/backend/lib/io/helper.js
@@ -67,17 +67,20 @@ async function userProfiles (req, res, next) {
     const [
       canListProjects,
       canListSeeds,
+      canListShoots,
       canListManagedSeedsInGardenNamespace,
       canListShootsInGardenNamespace,
     ] = await Promise.all([
       authorization.canListProjects(req.user),
       authorization.canListSeeds(req.user),
+      authorization.canListShoots(req.user),
       authorization.canListManagedSeedsInGardenNamespace(req.user),
       authorization.canListShootsInGardenNamespace(req.user),
     ])
     const profiles = Object.freeze({
       canListProjects,
       canListSeeds,
+      canListShoots,
       canGetManagedSeedAndShootInGardenNs: canListManagedSeedsInGardenNamespace && canListShootsInGardenNamespace,
     })
     Object.defineProperty(req.user, 'profiles', {

--- a/backend/lib/io/index.js
+++ b/backend/lib/io/index.js
@@ -52,22 +52,24 @@ function init (httpServer, cache) {
   io.use(helper.authenticationMiddleware())
 
   // handle connections (see https://socket.io/docs/v4/server-application-structure)
-  io.on('connection', socket => {
+  io.on('connection', async socket => {
     const socketId = socket.id
     const timeoutId = socket.data.timeoutId
     delete socket.data.timeoutId
 
-    helper.joinPrivateRoom(socket)
+    await helper.joinPrivateRoom(socket)
 
     const user = helper.getUserFromSocket(socket)
     if (_.get(user, ['profiles', 'canListSeeds'], false)) {
-      socket.join('seeds')
+      await socket.join('seeds')
       logger.debug('Socket %s auto-joined seeds room', socket.id)
     }
 
     if (_.get(user, ['profiles', 'canGetManagedSeedAndShootInGardenNs'], false)) {
-      socket.join('managedseeds;garden')
-      socket.join('managedseed-shoots;garden')
+      await Promise.all([
+        socket.join('managedseeds;garden'),
+        socket.join('managedseed-shoots;garden'),
+      ])
       logger.debug('Socket %s auto-joined managed seed garden rooms', socket.id)
     }
 

--- a/backend/lib/io/seedstats.js
+++ b/backend/lib/io/seedstats.js
@@ -76,7 +76,12 @@ function parseRoomName (room) {
   throw new TypeError(`Invalid seedstats room: ${room}`)
 }
 
-function getJoinedRooms (nsp, { seedName } = {}) {
+function getJoinedRooms (nsp, { seedName }) {
+  if (!seedName) {
+    logger.warn('getJoinedRooms called without seedName')
+    return []
+  }
+
   const adapterRooms = nsp?.adapter?.rooms
   if (!adapterRooms) {
     return []

--- a/backend/lib/io/seedstats.js
+++ b/backend/lib/io/seedstats.js
@@ -1,0 +1,135 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import createError from 'http-errors'
+import logger from '../logger/index.js'
+import helper from './helper.js'
+import * as seedstats from '../services/seedstats.js'
+
+const { getUserFromSocket } = helper
+
+const group = 'dashboard.gardener.cloud'
+const kind = 'SeedStat'
+const listRoomRegExp = /^seedstats;uf=(?<mask>[0-7])$/
+const seedRoomRegExp = /^seedstats;seed=(?<seedName>[^;]+);uf=(?<mask>[0-7])$/
+
+function notFound (uid) {
+  return {
+    kind: 'Status',
+    apiVersion: 'v1',
+    status: 'Failure',
+    message: `${kind} with uid ${uid} does not exist`,
+    reason: 'NotFound',
+    details: {
+      uid,
+      group,
+      kind,
+    },
+    code: 404,
+  }
+}
+
+function getListRoomName (unhealthyFilterMask) {
+  unhealthyFilterMask = seedstats.parseUnhealthyFilterMask(unhealthyFilterMask)
+  return `seedstats;uf=${unhealthyFilterMask}`
+}
+
+function getSeedRoomName (seedName, unhealthyFilterMask) {
+  unhealthyFilterMask = seedstats.parseUnhealthyFilterMask(unhealthyFilterMask)
+  return `seedstats;seed=${seedName};uf=${unhealthyFilterMask}`
+}
+
+function getRoomName ({ seedName, unhealthyFilterMask }) {
+  if (seedName) {
+    return getSeedRoomName(seedName, unhealthyFilterMask)
+  }
+  return getListRoomName(unhealthyFilterMask)
+}
+
+function isSeedStatsRoom (room) {
+  return listRoomRegExp.test(room) || seedRoomRegExp.test(room)
+}
+
+function parseRoomName (room) {
+  const listMatch = listRoomRegExp.exec(room)
+  if (listMatch) {
+    const { mask } = listMatch.groups
+    return {
+      room,
+      unhealthyFilterMask: Number(mask),
+    }
+  }
+
+  const seedMatch = seedRoomRegExp.exec(room)
+  if (seedMatch) {
+    const { seedName, mask } = seedMatch.groups
+    return {
+      room,
+      seedName,
+      unhealthyFilterMask: Number(mask),
+    }
+  }
+
+  throw new TypeError(`Invalid seedstats room: ${room}`)
+}
+
+function getJoinedRooms (nsp, { seedName } = {}) {
+  const adapterRooms = nsp?.adapter?.rooms
+  if (!adapterRooms) {
+    return []
+  }
+
+  const appliesToSeed = ({ seedName: roomSeedName }) => !roomSeedName || roomSeedName === seedName
+  return Array.from(adapterRooms.keys())
+    .filter(isSeedStatsRoom)
+    .map(parseRoomName)
+    .filter(appliesToSeed)
+}
+
+function hasSeedStatsAccess (user) {
+  return user?.profiles?.canListSeeds === true && user?.profiles?.canListShoots === true
+}
+
+async function subscribe (socket, options = {}) {
+  const user = getUserFromSocket(socket)
+
+  if (!hasSeedStatsAccess(user)) {
+    throw createError(403, 'Insufficient authorization for seedstats subscription')
+  }
+
+  const unhealthyFilterMask = seedstats.parseUnhealthyFilterMask(options.unhealthyFilterMask)
+  const room = getRoomName({
+    seedName: options.name,
+    unhealthyFilterMask,
+  })
+  logger.debug('User %s joined room [%s]', user.id, room)
+  return socket.join(room)
+}
+
+function unsubscribe (socket) {
+  const promises = Array.from(socket.rooms)
+    .filter(room => isSeedStatsRoom(room))
+    .map(room => socket.leave(room))
+  return Promise.all(promises)
+}
+
+async function synchronize (socket, uids = [], options = {}) {
+  const user = getUserFromSocket(socket)
+  const unhealthyFilterMask = seedstats.parseUnhealthyFilterMask(options.unhealthyFilterMask)
+
+  if (!hasSeedStatsAccess(user)) {
+    return uids.map(uid => notFound(uid))
+  }
+
+  return seedstats.getByUids(uids, unhealthyFilterMask).map((stat, i) => stat ?? notFound(uids[i])) // eslint-disable-line security/detect-object-injection -- i is the map index
+}
+
+export {
+  getJoinedRooms,
+  subscribe,
+  unsubscribe,
+  synchronize,
+}

--- a/backend/lib/io/shoots.js
+++ b/backend/lib/io/shoots.js
@@ -37,7 +37,7 @@ async function subscribe (socket, { namespace, name, labelSelector }) {
   const user = helper.getUserFromSocket(socket)
 
   const joinRoom = room => {
-    logger.debug('User %s joined rooms [%s]', user.id, room)
+    logger.debug('User %s joined room [%s]', user.id, room)
     return socket.join(room)
   }
 

--- a/backend/lib/routes/index.js
+++ b/backend/lib/routes/index.js
@@ -12,6 +12,7 @@ import openapiRoute from '../openapi/index.js'
 import userRoute from './user.js'
 import cloudprofilesRoute from './cloudprofiles.js'
 import seedsRoute from './seeds.js'
+import seedStatsRoute from './seedstats.js'
 import managedSeedsRoute from './managedseeds.js'
 import managedSeedShootsRoute from './managedseedshoots.js'
 import gardenerExtensionsRoute from './gardenerExtensions.js'
@@ -30,6 +31,7 @@ const routes = {
   '/user': userRoute,
   '/cloudprofiles': cloudprofilesRoute,
   '/seeds': seedsRoute,
+  '/seedstats': seedStatsRoute,
   '/namespaces/:namespace/managedseeds': managedSeedsRoute,
   '/namespaces/:namespace/managedseed-shoots': managedSeedShootsRoute,
   '/gardenerextensions': gardenerExtensionsRoute,

--- a/backend/lib/routes/seedstats.js
+++ b/backend/lib/routes/seedstats.js
@@ -1,0 +1,42 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import express from 'express'
+import services from '../services/index.js'
+import { metricsRoute } from '../middleware.js'
+
+const { seedstats } = services
+
+const router = express.Router()
+
+const metricsMiddleware = metricsRoute('seedstats')
+
+router.route('/')
+  .all(metricsMiddleware)
+  .get(async (req, res, next) => {
+    try {
+      const user = req.user
+      const unhealthyFilterMask = req.query.unhealthyFilterMask
+      res.send(await seedstats.list({ user, unhealthyFilterMask }))
+    } catch (err) {
+      next(err)
+    }
+  })
+
+router.route('/:name')
+  .all(metricsMiddleware)
+  .get(async (req, res, next) => {
+    try {
+      const user = req.user
+      const name = req.params.name
+      const unhealthyFilterMask = req.query.unhealthyFilterMask
+      res.send(await seedstats.read({ user, name, unhealthyFilterMask }))
+    } catch (err) {
+      next(err)
+    }
+  })
+
+export default router

--- a/backend/lib/services/index.js
+++ b/backend/lib/services/index.js
@@ -6,6 +6,7 @@
 
 import * as cloudprofiles from './cloudprofiles.js'
 import * as seeds from './seeds.js'
+import * as seedstats from './seedstats.js'
 import * as managedseeds from './managedseeds.js'
 import * as managedseedshoots from './managedseedshoots.js'
 import * as projects from './projects.js'
@@ -24,6 +25,7 @@ const terminals = terminalsModule
 export default {
   cloudprofiles,
   seeds,
+  seedstats,
   managedseeds,
   managedseedshoots,
   projects,

--- a/backend/lib/services/seedstats.js
+++ b/backend/lib/services/seedstats.js
@@ -1,0 +1,297 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import httpErrors from 'http-errors'
+import {
+  compact,
+  flatMap,
+  uniq,
+} from 'lodash-es'
+import * as authorization from './authorization.js'
+import cache from '../cache/index.js'
+import config from '../config/index.js'
+import logger from '../logger/index.js'
+import {
+  isTruthyValue,
+  shootHasIssue,
+} from '../utils/index.js'
+
+const { Forbidden, NotFound, UnprocessableEntity } = httpErrors
+
+const apiVersion = 'dashboard.gardener.cloud/v1alpha1'
+const kind = 'SeedStat'
+
+// unhealthyFilterMask is a bitmask controlling which unhealthy shoots are counted
+// in unhealthyShoots.matching. Each set bit *excludes* a category from matching:
+//   0 (000) — no filter: matching === total (every unhealthy shoot counts)
+//   1 (001) — exclude shoots whose status is 'progressing'
+//   2 (010) — exclude shoots where no operator action is required
+//             (ignored issues, temporary errors, or user-caused errors)
+//   4 (100) — exclude shoots whose only open tickets carry the hide label
+// Bits may be combined freely; 7 (111) gives the most filtered view.
+const FILTER_PROGRESSING = 1
+const FILTER_NO_OPERATOR_ACTION = 2
+const FILTER_HIDE_TICKETS = 4
+const ALL_UNHEALTHY_FILTER_FLAGS = FILTER_PROGRESSING | FILTER_NO_OPERATOR_ACTION | FILTER_HIDE_TICKETS
+
+// Keep this derived classification in sync with frontend/src/utils/errorCodes.js
+// (`userError` / `temporaryError` flags).
+const userErrorCodes = new Set([
+  'ERR_INFRA_UNAUTHENTICATED',
+  'ERR_INFRA_UNAUTHORIZED',
+  'ERR_INFRA_QUOTA_EXCEEDED',
+  'ERR_INFRA_DEPENDENCIES',
+  'ERR_CLEANUP_CLUSTER_RESOURCES',
+  'ERR_INFRA_RESOURCES_DEPLETED',
+  'ERR_CONFIGURATION_PROBLEM',
+  'ERR_RETRYABLE_CONFIGURATION_PROBLEM',
+  'ERR_PROBLEMATIC_WEBHOOK',
+])
+
+const temporaryErrorCodes = new Set([
+  'ERR_INFRA_RATE_LIMITS_EXCEEDED',
+  'ERR_RETRYABLE_INFRA_DEPENDENCIES',
+])
+
+async function list ({ user, unhealthyFilterMask }) {
+  await ensureAccess(user)
+
+  unhealthyFilterMask = parseUnhealthyFilterMask(unhealthyFilterMask)
+
+  const seeds = cache.getSeeds()
+  const statsMap = getSeedStatsMap(seeds, unhealthyFilterMask)
+
+  return seeds.map(seed => toSeedStat(seed, statsMap.get(seed.metadata.name)))
+}
+
+async function read ({ user, name, unhealthyFilterMask }) {
+  await ensureAccess(user)
+
+  unhealthyFilterMask = parseUnhealthyFilterMask(unhealthyFilterMask)
+
+  const seed = cache.getSeed(name)
+  if (!seed) {
+    throw new NotFound(`Seed with name '${name}' not found`)
+  }
+
+  const counts = getCountsForSeedName(name, unhealthyFilterMask)
+  return toSeedStat(seed, counts)
+}
+
+function getByUids (uids, unhealthyFilterMask) {
+  unhealthyFilterMask = parseUnhealthyFilterMask(unhealthyFilterMask)
+  return uids.map(uid => {
+    const seed = cache.getSeedByUid(uid)
+    if (!seed) {
+      return undefined
+    }
+    const counts = getCountsForSeedName(seed.metadata.name, unhealthyFilterMask)
+    return toSeedStat(seed, counts)
+  })
+}
+
+function toSeedStat (seed, counts = emptyCounts()) {
+  return {
+    apiVersion,
+    kind,
+    metadata: {
+      name: seed.metadata.name,
+      uid: seed.metadata.uid,
+    },
+    counts: {
+      shootCount: counts.shootCount ?? 0,
+      unhealthyShoots: {
+        total: counts.unhealthyShoots?.total ?? 0,
+        matching: counts.unhealthyShoots?.matching ?? 0,
+      },
+    },
+  }
+}
+
+function getSeedStatsMap (seeds, unhealthyFilterMask) {
+  const statsMap = new Map()
+  for (const seed of seeds) {
+    const counts = getCountsForSeedName(seed.metadata.name, unhealthyFilterMask)
+    statsMap.set(seed.metadata.name, counts)
+  }
+  return statsMap
+}
+
+function getCountsForSeedName (seedName, unhealthyFilterMask) {
+  const counts = emptyCounts()
+  for (const shoot of cache.getShootsBySeedName(seedName)) {
+    countShoot(counts, shoot, unhealthyFilterMask)
+  }
+  return counts
+}
+
+function emptyCounts () {
+  return {
+    shootCount: 0,
+    unhealthyShoots: {
+      total: 0,
+      matching: 0,
+    },
+  }
+}
+
+function countShoot (counts, shoot, unhealthyFilterMask) {
+  counts.shootCount += 1
+  if (!shootHasIssue(shoot)) {
+    return
+  }
+
+  counts.unhealthyShoots.total += 1
+  if (shouldCountAsUnhealthy(shoot, unhealthyFilterMask)) {
+    counts.unhealthyShoots.matching += 1
+  }
+}
+
+async function ensureAccess (user) {
+  const [canListSeeds, canListAllShoots] = await Promise.all([
+    authorization.canListSeeds(user),
+    authorization.canListShoots(user),
+  ])
+
+  if (!canListSeeds || !canListAllShoots) {
+    throw new Forbidden('You are not allowed to list seed stats')
+  }
+}
+
+function parseUnhealthyFilterMask (unhealthyFilterMask) {
+  if (typeof unhealthyFilterMask === 'undefined') {
+    throw invalidUnhealthyFilterMask()
+  }
+
+  if (typeof unhealthyFilterMask === 'string') {
+    unhealthyFilterMask = Number(unhealthyFilterMask)
+  }
+
+  if (!isValidUnhealthyFilterMask(unhealthyFilterMask)) {
+    throw invalidUnhealthyFilterMask()
+  }
+
+  return unhealthyFilterMask
+}
+
+function isValidUnhealthyFilterMask (value) {
+  return typeof value === 'number' &&
+    Number.isInteger(value) &&
+    (value & ~ALL_UNHEALTHY_FILTER_FLAGS) === 0 // rejects negatives and any bits not in 0b111 (7)
+}
+
+function shouldCountAsUnhealthy (shoot, unhealthyFilterMask) {
+  if (isFilterEnabled(unhealthyFilterMask, FILTER_PROGRESSING) && isStatusProgressing(shoot)) {
+    return false
+  }
+  if (isFilterEnabled(unhealthyFilterMask, FILTER_NO_OPERATOR_ACTION) && hasNoOperatorActionRequired(shoot)) {
+    return false
+  }
+  if (isFilterEnabled(unhealthyFilterMask, FILTER_HIDE_TICKETS) && hasOnlyTicketsWithHideLabel(shoot)) {
+    return false
+  }
+  return true
+}
+
+function isFilterEnabled (mask, flag) {
+  return (mask & flag) !== 0
+}
+
+function isStatusProgressing (shoot) {
+  return shoot?.metadata?.labels?.['shoot.gardener.cloud/status'] === 'progressing'
+}
+
+function hasNoOperatorActionRequired (shoot) {
+  if (isTruthyValue(shoot?.metadata?.annotations?.['dashboard.gardener.cloud/ignore-issues'])) {
+    return true
+  }
+
+  const lastErrorCodes = errorCodesFromArray(shoot?.status?.lastErrors)
+  if (hasAnyTemporaryError(lastErrorCodes)) {
+    return true
+  }
+
+  if (hasAnyUserError(lastErrorCodes)) {
+    return true
+  }
+
+  if (hasAnyUserError(errorCodesFromArray(shoot?.status?.conditions))) {
+    return true
+  }
+
+  return hasAnyUserError(errorCodesFromArray(shoot?.status?.constraints))
+}
+
+function hasOnlyTicketsWithHideLabel (shoot) {
+  const hideClustersWithLabels = config.frontend?.ticket?.hideClustersWithLabels
+  if (!Array.isArray(hideClustersWithLabels) || hideClustersWithLabels.length === 0) {
+    return false
+  }
+
+  const ticketsForShoot = getTicketsForShoot(shoot)
+  if (ticketsForShoot.length === 0) {
+    return false
+  }
+
+  return ticketsForShoot.every(ticket => {
+    const labelNames = ticket?.data?.labels?.map(({ name }) => name) ?? []
+    return hideClustersWithLabels.some(label => labelNames.includes(label))
+  })
+}
+
+function getTicketsForShoot (shoot) {
+  const projectName = getProjectNameForShoot(shoot)
+  const shootName = shoot?.metadata?.name
+  if (!projectName || !shootName) {
+    return []
+  }
+
+  return cache
+    .getTicketCache()
+    .getIssues()
+    .filter(issue => issue?.metadata?.projectName === projectName && issue?.metadata?.name === shootName)
+}
+
+function getProjectNameForShoot (shoot) {
+  const namespace = shoot?.metadata?.namespace
+  if (!namespace) {
+    return
+  }
+  try {
+    const project = cache.findProjectByNamespace(namespace)
+    return project?.metadata?.name
+  } catch (err) {
+    logger.warn('Failed to resolve project for namespace %s: %s', namespace, err.message)
+    return undefined
+  }
+}
+
+function errorCodesFromArray (items = []) {
+  return uniq(compact(flatMap(items, 'codes')))
+}
+
+function hasAnyUserError (codes = []) {
+  return codes.some(code => userErrorCodes.has(code))
+}
+
+function hasAnyTemporaryError (codes = []) {
+  return codes.some(code => temporaryErrorCodes.has(code))
+}
+
+function invalidUnhealthyFilterMask () {
+  return new UnprocessableEntity(`The 'unhealthyFilterMask' query parameter must be a non-negative integer with no bits set outside the known flags (0–${ALL_UNHEALTHY_FILTER_FLAGS})`)
+}
+
+export {
+  FILTER_PROGRESSING,
+  FILTER_NO_OPERATOR_ACTION,
+  FILTER_HIDE_TICKETS,
+  list,
+  read,
+  getByUids,
+  parseUnhealthyFilterMask,
+  shouldCountAsUnhealthy,
+}

--- a/backend/lib/services/seedstats.js
+++ b/backend/lib/services/seedstats.js
@@ -251,8 +251,7 @@ function getTicketsForShoot (shoot) {
 
   return cache
     .getTicketCache()
-    .getIssues()
-    .filter(issue => issue?.metadata?.projectName === projectName && issue?.metadata?.name === shootName)
+    .getIssuesForShoot({ projectName, name: shootName })
 }
 
 function getProjectNameForShoot (shoot) {

--- a/backend/lib/utils/index.js
+++ b/backend/lib/utils/index.js
@@ -262,6 +262,10 @@ function shootHasIssue (shoot) {
   return _.get(shoot, ['metadata', 'labels', 'shoot.gardener.cloud/status'], 'healthy') !== 'healthy'
 }
 
+function isTruthyValue (value) {
+  return ['1', 't', 'T', 'true', 'TRUE', 'True'].includes(value)
+}
+
 function getSeedIngressDomain (seed) {
   return _.get(seed, ['spec', 'ingress', 'domain'])
 }
@@ -292,6 +296,7 @@ export {
   getConfigValue,
   getSeedNameFromShoot,
   shootHasIssue,
+  isTruthyValue,
   getSeedIngressDomain,
   isSeedUnreachable,
 }

--- a/backend/lib/watches/leases.js
+++ b/backend/lib/watches/leases.js
@@ -9,6 +9,8 @@ import logger from '../logger/index.js'
 import config from '../config/index.js'
 import cache from '../cache/index.js'
 import * as tickets from '../services/tickets.js'
+import { getJoinedRooms } from '../io/seedstats.js'
+import { FILTER_HIDE_TICKETS } from '../services/seedstats.js'
 import SyncManager from '../github/SyncManager.js'
 
 // exported for testing
@@ -35,7 +37,10 @@ export default (io, informer, { signal }) => {
   const ticketCache = cache.getTicketCache()
   const nsp = io.of('/')
 
-  ticketCache.on('issue', event => nsp.emit('issues', event))
+  ticketCache.on('issue', event => {
+    nsp.emit('issues', event)
+    publishSeedStats(event)
+  })
   ticketCache.on('comment', event => {
     const { projectName, name } = event.object.metadata
     const namespace = cache.getProjectNamespace(projectName)
@@ -57,4 +62,33 @@ export default (io, informer, { signal }) => {
 
   const handleEvent = event => syncManager.sync()
   informer.on('update', object => handleEvent({ type: 'MODIFIED', object }))
+
+  function publishSeedStats (event) {
+    const { projectName, name } = event.object?.metadata ?? {}
+    if (!projectName || !name) {
+      return
+    }
+
+    const namespace = cache.getProjectNamespace(projectName)
+    if (!namespace) {
+      return
+    }
+
+    const seedName = cache.getShoot(namespace, name)?.spec?.seedName
+    if (!seedName) {
+      return
+    }
+
+    const seedUid = cache.getSeed(seedName)?.metadata?.uid
+    if (!seedUid) {
+      return
+    }
+
+    const hasHideTicketsFilterEnabled = room => (room.unhealthyFilterMask & FILTER_HIDE_TICKETS) !== 0
+    const joinedRooms = getJoinedRooms(nsp, { seedName })
+      .filter(hasHideTicketsFilterEnabled)
+    for (const room of joinedRooms) {
+      nsp.to(room.room).emit('seedstats', { type: 'MODIFIED', uid: seedUid })
+    }
+  }
 }

--- a/backend/lib/watches/seeds.js
+++ b/backend/lib/watches/seeds.js
@@ -5,15 +5,20 @@
 //
 
 import { get } from 'lodash-es'
+import { getJoinedRooms } from '../io/seedstats.js'
 
 export default (io, informer) => {
   const nsp = io.of('/')
 
-  const handleEvent = (type, newObject, oldObject) => {
-    const path = ['metadata', 'uid']
-    const uid = get(newObject, path, get(oldObject, path))
+  const handleEvent = (type, newObject) => {
+    const uid = get(newObject, ['metadata', 'uid'])
+    const seedName = get(newObject, ['metadata', 'name'])
     const event = { uid, type }
     nsp.to('seeds').emit('seeds', event)
+
+    for (const room of getJoinedRooms(nsp, { seedName })) {
+      nsp.to(room.room).emit('seedstats', event)
+    }
   }
 
   informer.on('add', object => handleEvent('ADDED', object))

--- a/backend/lib/watches/shoots.js
+++ b/backend/lib/watches/shoots.js
@@ -6,6 +6,8 @@
 
 import { shootHasIssue } from '../utils/index.js'
 import cache from '../cache/index.js'
+import { getJoinedRooms } from '../io/seedstats.js'
+import { shouldCountAsUnhealthy } from '../services/seedstats.js'
 
 export default (io, informer, options) => {
   const nsp = io.of('/')
@@ -65,13 +67,69 @@ export default (io, informer, options) => {
     nsp.to('managedseed-shoots;garden').emit('managedseed-shoots', { type, uid })
   }
 
+  const publishSeedStats = event => {
+    const { object, oldObject } = event
+    const oldSeedName = oldObject?.spec?.seedName
+    const newSeedName = object?.spec?.seedName
+    const affectedSeedNames = new Set([oldSeedName, newSeedName].filter(Boolean))
+
+    for (const seedName of affectedSeedNames) {
+      const seedUid = cache.getSeed(seedName)?.metadata?.uid
+      if (!seedUid) {
+        continue
+      }
+
+      const joinedRooms = getJoinedRooms(nsp, { seedName })
+      for (const { room, unhealthyFilterMask } of joinedRooms) {
+        if (!shouldEmitSeedStatsEvent(event, { unhealthyFilterMask })) {
+          continue
+        }
+        nsp.to(room).emit('seedstats', { type: 'MODIFIED', uid: seedUid })
+      }
+    }
+  }
+
   const handleEvent = event => {
     publishShoots(event)
     publishUnhealthyShoots(event)
     publishManagedSeedShoots(event)
+    publishSeedStats(event)
   }
 
   informer.on('add', object => handleEvent({ type: 'ADDED', object }))
-  informer.on('update', object => handleEvent({ type: 'MODIFIED', object }))
-  informer.on('delete', object => handleEvent({ type: 'DELETED', object }))
+  informer.on('update', (object, oldObject) => handleEvent({ type: 'MODIFIED', object, oldObject }))
+  informer.on('delete', object => handleEvent({ type: 'DELETED', object, oldObject: object }))
+}
+
+function shouldEmitSeedStatsEvent (event, { unhealthyFilterMask }) {
+  const { type, object, oldObject } = event
+  const oldSeedName = oldObject?.spec?.seedName
+  const newSeedName = object?.spec?.seedName
+
+  switch (type) {
+    case 'ADDED':
+    case 'DELETED':
+      return true
+    case 'MODIFIED': {
+      const seedChanged = oldSeedName !== newSeedName
+      if (seedChanged) {
+        return true
+      }
+      return didShootHealthStateChange(oldObject, object, unhealthyFilterMask)
+    }
+    default:
+      return false
+  }
+}
+
+function didShootHealthStateChange (oldObject, newObject, unhealthyFilterMask) {
+  const hadIssueBefore = shootHasIssue(oldObject)
+  const hasIssueNow = shootHasIssue(newObject)
+
+  if (hadIssueBefore !== hasIssueNow) {
+    return true
+  }
+
+  return shouldCountAsUnhealthy(oldObject, unhealthyFilterMask) !==
+    shouldCountAsUnhealthy(newObject, unhealthyFilterMask)
 }

--- a/frontend/__tests__/components/GSeedInfrastructureCard.spec.js
+++ b/frontend/__tests__/components/GSeedInfrastructureCard.spec.js
@@ -1,0 +1,135 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import { ref } from 'vue'
+import {
+  createPinia,
+  setActivePinia,
+} from 'pinia'
+import { shallowMount } from '@vue/test-utils'
+
+import { useSeedStatStore } from '@/store/seedStat'
+
+import GSeedInfrastructureCard from '@/components/SeedDetails/GSeedInfrastructureCard.vue'
+
+describe('components', () => {
+  describe('g-seed-infrastructure-card', () => {
+    function createSeedItem () {
+      return {
+        seedProviderType: ref('aws'),
+        seedProviderRegion: ref('eu-west-1'),
+        seedProviderZones: ref(['eu-west-1a']),
+        seedNetworksNodes: ref('10.250.0.0/16'),
+        seedNetworksPods: ref('100.96.0.0/11'),
+        seedNetworksServices: ref('100.64.0.0/13'),
+        seedNetworksShootDefaultsPods: ref('10.0.0.0/16'),
+        seedNetworksShootDefaultsServices: ref('10.1.0.0/16'),
+        seedNetworksBlockCIDRs: ref([]),
+        seedAllocatableShoots: ref(20),
+        seedShootCount: ref(7),
+        seedTotalUnhealthyShoots: ref(4),
+        seedUnhealthyShoots: ref(2),
+        seedName: ref('infra1-seed'),
+      }
+    }
+
+    function mountComponent () {
+      setActivePinia(createPinia())
+
+      const seedStatStore = useSeedStatStore()
+
+      const subscribeSpy = vi.spyOn(seedStatStore, 'subscribe').mockResolvedValue()
+      const unsubscribeSpy = vi.spyOn(seedStatStore, 'unsubscribe').mockResolvedValue()
+
+      const wrapper = shallowMount(GSeedInfrastructureCard, {
+        global: {
+          provide: {
+            'seed-item': createSeedItem(),
+          },
+          stubs: {
+            VCard: {
+              template: '<div class="v-card-stub"><slot /></div>',
+            },
+            VDivider: {
+              template: '<div class="v-divider-stub" />',
+            },
+            VIcon: {
+              template: '<i class="v-icon-stub"><slot /></i>',
+            },
+            GToolbar: {
+              props: ['title'],
+              template: '<div class="g-toolbar-stub">{{ title }}</div>',
+            },
+            GList: {
+              template: '<div class="g-list-stub"><slot /></div>',
+            },
+            GListItem: {
+              template: '<div class="g-list-item-stub"><slot name="prepend" /><slot /></div>',
+            },
+            GListItemContent: {
+              props: ['label'],
+              template: `
+                <div class="g-list-item-content-stub">
+                  <div class="g-list-item-content-label">{{ label }}</div>
+                  <div class="g-list-item-content-value"><slot /></div>
+                </div>
+              `,
+            },
+            GVendor: {
+              template: '<div class="g-vendor-stub" />',
+            },
+            GShootHealthDonut: {
+              props: ['shootCount', 'totalUnhealthyShoots', 'matchingUnhealthyShoots'],
+              template: '<div class="shoot-health-donut-stub" :data-shoot-count="shootCount" :data-unhealthy-total="totalUnhealthyShoots" :data-unhealthy-matching="matchingUnhealthyShoots" />',
+            },
+            GSeedCapacityIndicator: {
+              props: ['allocatableShoots', 'shootCount'],
+              template: '<div class="seed-capacity-indicator-stub" :data-allocatable-shoots="allocatableShoots" :data-shoot-count="shootCount" />',
+            },
+          },
+        },
+      })
+
+      return {
+        wrapper,
+        seedStatStore,
+        subscribeSpy,
+        unsubscribeSpy,
+      }
+    }
+
+    it('should render the shoot health donut and capacity in the infrastructure card', () => {
+      const {
+        wrapper,
+        seedStatStore,
+        subscribeSpy,
+        unsubscribeSpy,
+      } = mountComponent()
+
+      const healthDonut = wrapper.find('.shoot-health-donut-stub')
+      const capacityIndicator = wrapper.find('.seed-capacity-indicator-stub')
+
+      expect(wrapper.text()).toContain('Capacity')
+      expect(wrapper.text()).toContain('Shoot Health')
+      expect(capacityIndicator.exists()).toBe(true)
+      expect(capacityIndicator.attributes('data-allocatable-shoots')).toBe('20')
+      expect(capacityIndicator.attributes('data-shoot-count')).toBe('7')
+      expect(healthDonut.exists()).toBe(true)
+      expect(healthDonut.attributes('data-shoot-count')).toBe('7')
+      expect(healthDonut.attributes('data-unhealthy-total')).toBe('4')
+      expect(healthDonut.attributes('data-unhealthy-matching')).toBe('2')
+      expect(wrapper.text()).not.toContain('total unhealthy')
+      expect(subscribeSpy).toHaveBeenCalledWith({
+        name: 'infra1-seed',
+        unhealthyFilterMask: seedStatStore.currentUnhealthyFilterMask,
+      })
+
+      wrapper.unmount()
+
+      expect(unsubscribeSpy).toHaveBeenCalled()
+    })
+  })
+})

--- a/frontend/__tests__/components/GShootHealthDonut.spec.js
+++ b/frontend/__tests__/components/GShootHealthDonut.spec.js
@@ -1,0 +1,345 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import { shallowMount } from '@vue/test-utils'
+
+import GShootHealthDonut from '@/components/GShootHealthDonut.vue'
+
+describe('components', () => {
+  describe('g-shoot-health-donut', () => {
+    function mountComponent (props = {}) {
+      return shallowMount(GShootHealthDonut, {
+        props,
+        global: {
+          stubs: {
+            'v-tooltip': {
+              template: '<div><slot name="activator" :props="{}" /><slot /></div>',
+            },
+            'v-card': {
+              template: '<div><slot /></div>',
+            },
+            'v-icon': true,
+            'g-list': {
+              template: '<div class="g-list-stub"><slot /></div>',
+            },
+            'g-list-item': {
+              template: '<div class="g-list-item-stub"><slot name="prepend" /><slot /></div>',
+            },
+            'g-list-item-content': {
+              props: ['label', 'description'],
+              template: '<span class="g-list-item-content-stub" :data-label="label" :data-description="description"><slot /></span>',
+            },
+          },
+        },
+      })
+    }
+
+    describe('empty state', () => {
+      it('should show a dash when shootCount is 0', () => {
+        const wrapper = mountComponent({ shootCount: 0 })
+
+        expect(wrapper.find('.empty').exists()).toBe(true)
+        expect(wrapper.find('.empty').text()).toBe('-')
+        expect(wrapper.find('svg').exists()).toBe(false)
+      })
+
+      it('should show a dash when shootCount is not provided', () => {
+        const wrapper = mountComponent()
+
+        expect(wrapper.find('.empty').exists()).toBe(true)
+      })
+    })
+
+    describe('donut rendering', () => {
+      it('should render an SVG when there are shoots', () => {
+        const wrapper = mountComponent({
+          shootCount: 10,
+          totalUnhealthyShoots: 3,
+          matchingUnhealthyShoots: 1,
+        })
+
+        expect(wrapper.find('.empty').exists()).toBe(false)
+        expect(wrapper.find('svg').exists()).toBe(true)
+      })
+
+      it('should render base segments for unhealthy and healthy', () => {
+        const wrapper = mountComponent({
+          shootCount: 10,
+          totalUnhealthyShoots: 4,
+          matchingUnhealthyShoots: 2,
+        })
+
+        const segments = wrapper.findAll('circle.segment')
+        const keys = segments.map(s => {
+          if (s.classes().includes('matching')) {
+            return 'matching'
+          }
+          if (s.classes().includes('unhealthy')) {
+            return 'unhealthy'
+          }
+          if (s.classes().includes('healthy')) {
+            return 'healthy'
+          }
+          return 'unknown'
+        })
+
+        expect(keys).toContain('unhealthy')
+        expect(keys).toContain('healthy')
+        expect(keys).toContain('matching')
+      })
+
+      it('should not render overlay segment when matching is 0', () => {
+        const wrapper = mountComponent({
+          shootCount: 10,
+          totalUnhealthyShoots: 3,
+          matchingUnhealthyShoots: 0,
+        })
+
+        const segments = wrapper.findAll('circle.segment')
+        const keys = segments.map(s => {
+          if (s.classes().includes('matching')) {
+            return 'matching'
+          }
+          if (s.classes().includes('unhealthy')) {
+            return 'unhealthy'
+          }
+          if (s.classes().includes('healthy')) {
+            return 'healthy'
+          }
+          return 'unknown'
+        })
+
+        expect(keys).not.toContain('matching')
+        expect(keys).toContain('unhealthy')
+        expect(keys).toContain('healthy')
+      })
+
+      it('should render all healthy when no unhealthy shoots', () => {
+        const wrapper = mountComponent({
+          shootCount: 5,
+          totalUnhealthyShoots: 0,
+          matchingUnhealthyShoots: 0,
+        })
+
+        const segments = wrapper.findAll('circle.segment')
+
+        expect(segments).toHaveLength(1)
+        expect(segments[0].classes()).toContain('healthy')
+      })
+    })
+
+    describe('center text', () => {
+      it('should show the matching unhealthy count', () => {
+        const wrapper = mountComponent({
+          shootCount: 10,
+          totalUnhealthyShoots: 5,
+          matchingUnhealthyShoots: 3,
+        })
+
+        const text = wrapper.find('.center-text')
+        expect(text.text()).toBe('3')
+      })
+
+      it('should show 0 when no matching unhealthy', () => {
+        const wrapper = mountComponent({
+          shootCount: 10,
+          totalUnhealthyShoots: 0,
+          matchingUnhealthyShoots: 0,
+        })
+
+        const text = wrapper.find('.center-text')
+        expect(text.text()).toBe('0')
+      })
+
+      it('should use compact format for values >= 1000', () => {
+        const wrapper = mountComponent({
+          shootCount: 2000,
+          totalUnhealthyShoots: 1500,
+          matchingUnhealthyShoots: 1500,
+        })
+
+        const text = wrapper.find('.center-text')
+        expect(text.text()).toBe('1.5k')
+        expect(text.classes()).toContain('compact')
+      })
+
+      it('should use small class for values >= 100', () => {
+        const wrapper = mountComponent({
+          shootCount: 500,
+          totalUnhealthyShoots: 150,
+          matchingUnhealthyShoots: 150,
+        })
+
+        const text = wrapper.find('.center-text')
+        expect(text.text()).toBe('150')
+        expect(text.classes()).toContain('small')
+      })
+
+      it('should have error class when matching unhealthy > 0', () => {
+        const wrapper = mountComponent({
+          shootCount: 10,
+          totalUnhealthyShoots: 3,
+          matchingUnhealthyShoots: 2,
+        })
+
+        expect(wrapper.find('.center-text').classes()).toContain('error')
+      })
+
+      it('should not have error class when matching unhealthy is 0', () => {
+        const wrapper = mountComponent({
+          shootCount: 10,
+          totalUnhealthyShoots: 0,
+          matchingUnhealthyShoots: 0,
+        })
+
+        expect(wrapper.find('.center-text').classes()).not.toContain('error')
+      })
+    })
+
+    describe('tooltip legend', () => {
+      it('should show matching count when matching equals total', () => {
+        const wrapper = mountComponent({
+          shootCount: 10,
+          totalUnhealthyShoots: 5,
+          matchingUnhealthyShoots: 5,
+        })
+
+        const unhealthy = wrapper.find('.g-list-item-content-stub[data-label="Unhealthy"]')
+        expect(unhealthy.exists()).toBe(true)
+        expect(unhealthy.text()).toBe('5')
+
+        const excluded = wrapper.find('.g-list-item-content-stub[data-label="Excluded"]')
+        expect(excluded.exists()).toBe(false)
+      })
+
+      it('should show excluded row when matching differs from total', () => {
+        const wrapper = mountComponent({
+          shootCount: 10,
+          totalUnhealthyShoots: 5,
+          matchingUnhealthyShoots: 2,
+          activeFilterLabels: ['User Errors', 'Progressing Clusters'],
+        })
+
+        const unhealthy = wrapper.find('.g-list-item-content-stub[data-label="Unhealthy"]')
+        expect(unhealthy.text()).toBe('2')
+        expect(unhealthy.attributes('data-description')).toBeUndefined()
+
+        const excluded = wrapper.find('.g-list-item-content-stub[data-label="Excluded"]')
+        expect(excluded.exists()).toBe(true)
+        expect(excluded.text()).toBe('3')
+        expect(excluded.attributes('data-description')).toBe('User Errors, Progressing Clusters')
+      })
+
+      it('should truncate filter labels after 2 with "& N more"', () => {
+        const wrapper = mountComponent({
+          shootCount: 20,
+          totalUnhealthyShoots: 10,
+          matchingUnhealthyShoots: 4,
+          activeFilterLabels: ['Progressing Clusters', 'User Errors', 'Deactivated Reconciliation', 'Tickets with Ignore Labels'],
+        })
+
+        const excluded = wrapper.find('.g-list-item-content-stub[data-label="Excluded"]')
+        expect(excluded.text()).toBe('6')
+        expect(excluded.attributes('data-description')).toBe('Progressing Clusters, User Errors & 2 more')
+      })
+
+      it('should show excluded row without description when no filter labels provided', () => {
+        const wrapper = mountComponent({
+          shootCount: 10,
+          totalUnhealthyShoots: 5,
+          matchingUnhealthyShoots: 2,
+        })
+
+        const excluded = wrapper.find('.g-list-item-content-stub[data-label="Excluded"]')
+        expect(excluded.exists()).toBe(true)
+        expect(excluded.text()).toBe('3')
+        expect(excluded.attributes('data-description')).toBeUndefined()
+      })
+
+      it('should show healthy legend when there are healthy shoots', () => {
+        const wrapper = mountComponent({
+          shootCount: 10,
+          totalUnhealthyShoots: 3,
+          matchingUnhealthyShoots: 1,
+        })
+
+        const content = wrapper.find('.g-list-item-content-stub[data-label="Healthy"]')
+        expect(content.exists()).toBe(true)
+        expect(content.text()).toBe('7')
+      })
+    })
+
+    describe('accessibility', () => {
+      it('should have a descriptive aria-label on the SVG', () => {
+        const wrapper = mountComponent({
+          shootCount: 10,
+          totalUnhealthyShoots: 3,
+          matchingUnhealthyShoots: 1,
+          activeFilterLabels: ['User Errors'],
+        })
+
+        const svg = wrapper.find('svg')
+        const label = svg.attributes('aria-label')
+
+        expect(label).toContain('Shoot health distribution')
+        expect(label).toContain('10 shoots')
+        expect(label).toContain('1 unhealthy shoots')
+        expect(label).toContain('2 excluded by filter (User Errors)')
+        expect(label).toContain('7 healthy shoots')
+      })
+    })
+
+    describe('prop validators', () => {
+      it('should reject negative shootCount', () => {
+        const shootCountProp = GShootHealthDonut.props.shootCount
+        expect(shootCountProp.validator(-1)).toBe(false)
+      })
+
+      it('should reject non-integer shootCount', () => {
+        const shootCountProp = GShootHealthDonut.props.shootCount
+        expect(shootCountProp.validator(1.5)).toBe(false)
+      })
+
+      it('should accept valid shootCount', () => {
+        const shootCountProp = GShootHealthDonut.props.shootCount
+        expect(shootCountProp.validator(0)).toBe(true)
+        expect(shootCountProp.validator(10)).toBe(true)
+      })
+
+      it('should reject negative totalUnhealthyShoots', () => {
+        const prop = GShootHealthDonut.props.totalUnhealthyShoots
+        expect(prop.validator(-1)).toBe(false)
+      })
+
+      it('should reject non-integer totalUnhealthyShoots', () => {
+        const prop = GShootHealthDonut.props.totalUnhealthyShoots
+        expect(prop.validator(1.5)).toBe(false)
+      })
+
+      it('should accept valid totalUnhealthyShoots', () => {
+        const prop = GShootHealthDonut.props.totalUnhealthyShoots
+        expect(prop.validator(0)).toBe(true)
+        expect(prop.validator(5)).toBe(true)
+      })
+
+      it('should reject negative matchingUnhealthyShoots', () => {
+        const prop = GShootHealthDonut.props.matchingUnhealthyShoots
+        expect(prop.validator(-1)).toBe(false)
+      })
+
+      it('should reject non-integer matchingUnhealthyShoots', () => {
+        const prop = GShootHealthDonut.props.matchingUnhealthyShoots
+        expect(prop.validator(1.5)).toBe(false)
+      })
+
+      it('should accept valid matchingUnhealthyShoots', () => {
+        const prop = GShootHealthDonut.props.matchingUnhealthyShoots
+        expect(prop.validator(0)).toBe(true)
+        expect(prop.validator(3)).toBe(true)
+      })
+    })
+  })
+})

--- a/frontend/__tests__/components/GShootHealthDonut.spec.js
+++ b/frontend/__tests__/components/GShootHealthDonut.spec.js
@@ -22,18 +22,26 @@ describe('components', () => {
               template: '<div><slot /></div>',
             },
             'v-icon': true,
-            'g-list': {
-              template: '<div class="g-list-stub"><slot /></div>',
+            'v-list': {
+              template: '<div class="v-list-stub"><slot /></div>',
             },
-            'g-list-item': {
-              template: '<div class="g-list-item-stub"><slot name="prepend" /><slot /></div>',
+            'v-list-item': {
+              template: '<div class="v-list-item-stub"><slot name="prepend" /><slot /></div>',
             },
-            'g-list-item-content': {
-              props: ['label', 'description'],
-              template: '<span class="g-list-item-content-stub" :data-label="label" :data-description="description"><slot /></span>',
+            'v-list-item-title': {
+              template: '<span class="v-list-item-title-stub"><slot /></span>',
+            },
+            'v-list-item-subtitle': {
+              template: '<span class="v-list-item-subtitle-stub"><slot /></span>',
             },
           },
         },
+      })
+    }
+
+    function findRow (wrapper, label) {
+      return wrapper.findAll('.v-list-item-stub').find(item => {
+        return item.find('.v-list-item-subtitle-stub').text().startsWith(label)
       })
     }
 
@@ -207,12 +215,12 @@ describe('components', () => {
           matchingUnhealthyShoots: 5,
         })
 
-        const unhealthy = wrapper.find('.g-list-item-content-stub[data-label="Unhealthy"]')
-        expect(unhealthy.exists()).toBe(true)
-        expect(unhealthy.text()).toBe('5')
+        const unhealthy = findRow(wrapper, 'Unhealthy')
+        expect(unhealthy).toBeDefined()
+        expect(unhealthy.find('.v-list-item-title-stub').text()).toBe('5')
 
-        const excluded = wrapper.find('.g-list-item-content-stub[data-label="Excluded"]')
-        expect(excluded.exists()).toBe(false)
+        const excluded = findRow(wrapper, 'Excluded')
+        expect(excluded).toBeUndefined()
       })
 
       it('should show excluded row when matching differs from total', () => {
@@ -223,14 +231,13 @@ describe('components', () => {
           activeFilterLabels: ['User Errors', 'Progressing Clusters'],
         })
 
-        const unhealthy = wrapper.find('.g-list-item-content-stub[data-label="Unhealthy"]')
-        expect(unhealthy.text()).toBe('2')
-        expect(unhealthy.attributes('data-description')).toBeUndefined()
+        const unhealthy = findRow(wrapper, 'Unhealthy')
+        expect(unhealthy.find('.v-list-item-title-stub').text()).toBe('2')
 
-        const excluded = wrapper.find('.g-list-item-content-stub[data-label="Excluded"]')
-        expect(excluded.exists()).toBe(true)
-        expect(excluded.text()).toBe('3')
-        expect(excluded.attributes('data-description')).toBe('User Errors, Progressing Clusters')
+        const excluded = findRow(wrapper, 'Excluded')
+        expect(excluded).toBeDefined()
+        expect(excluded.find('.v-list-item-title-stub').text()).toBe('3')
+        expect(excluded.find('.v-list-item-subtitle-stub').text()).toContain('User Errors, Progressing Clusters')
       })
 
       it('should truncate filter labels after 2 with "& N more"', () => {
@@ -241,9 +248,9 @@ describe('components', () => {
           activeFilterLabels: ['Progressing Clusters', 'User Errors', 'Deactivated Reconciliation', 'Tickets with Ignore Labels'],
         })
 
-        const excluded = wrapper.find('.g-list-item-content-stub[data-label="Excluded"]')
-        expect(excluded.text()).toBe('6')
-        expect(excluded.attributes('data-description')).toBe('Progressing Clusters, User Errors & 2 more')
+        const excluded = findRow(wrapper, 'Excluded')
+        expect(excluded.find('.v-list-item-title-stub').text()).toBe('6')
+        expect(excluded.find('.v-list-item-subtitle-stub').text()).toContain('Progressing Clusters, User Errors & 2 more')
       })
 
       it('should show excluded row without description when no filter labels provided', () => {
@@ -253,10 +260,10 @@ describe('components', () => {
           matchingUnhealthyShoots: 2,
         })
 
-        const excluded = wrapper.find('.g-list-item-content-stub[data-label="Excluded"]')
-        expect(excluded.exists()).toBe(true)
-        expect(excluded.text()).toBe('3')
-        expect(excluded.attributes('data-description')).toBeUndefined()
+        const excluded = findRow(wrapper, 'Excluded')
+        expect(excluded).toBeDefined()
+        expect(excluded.find('.v-list-item-title-stub').text()).toBe('3')
+        expect(excluded.find('.v-list-item-subtitle-stub').text()).not.toContain('—')
       })
 
       it('should show healthy legend when there are healthy shoots', () => {
@@ -266,14 +273,14 @@ describe('components', () => {
           matchingUnhealthyShoots: 1,
         })
 
-        const content = wrapper.find('.g-list-item-content-stub[data-label="Healthy"]')
-        expect(content.exists()).toBe(true)
-        expect(content.text()).toBe('7')
+        const healthy = findRow(wrapper, 'Healthy')
+        expect(healthy).toBeDefined()
+        expect(healthy.find('.v-list-item-title-stub').text()).toBe('7')
       })
     })
 
     describe('accessibility', () => {
-      it('should have a descriptive aria-label on the SVG', () => {
+      it('should have a descriptive aria-label on the root', () => {
         const wrapper = mountComponent({
           shootCount: 10,
           totalUnhealthyShoots: 3,
@@ -281,8 +288,7 @@ describe('components', () => {
           activeFilterLabels: ['User Errors'],
         })
 
-        const svg = wrapper.find('svg')
-        const label = svg.attributes('aria-label')
+        const label = wrapper.attributes('aria-label')
 
         expect(label).toContain('Shoot health distribution')
         expect(label).toContain('10 shoots')

--- a/frontend/__tests__/composables/useDonutChart.spec.js
+++ b/frontend/__tests__/composables/useDonutChart.spec.js
@@ -1,0 +1,158 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import {
+  ref,
+  nextTick,
+} from 'vue'
+
+import { useDonutChart } from '@/composables/useDonutChart'
+
+describe('composables', () => {
+  describe('useDonutChart', () => {
+    it('should throw if segments are not provided as a ref', () => {
+      expect(() => useDonutChart([])).toThrow(new TypeError('First argument `segmentsDef` must be a ref object'))
+    })
+
+    it('should throw if total override is not provided as a ref', () => {
+      const segments = ref([])
+
+      expect(() => useDonutChart(segments, { total: 100 })).toThrow(new TypeError('Option `total` must be a ref object'))
+    })
+
+    it('should return correct static geometry for default options', () => {
+      const segments = ref([])
+      const donut = useDonutChart(segments)
+
+      expect(donut.size).toBe(30)
+      expect(donut.center).toBe(15)
+      expect(donut.strokeWidth).toBe(4)
+      expect(donut.radius).toBe(13)
+      expect(donut.viewBox).toBe('0 0 30 30')
+      expect(donut.rotateTransform).toBe('rotate(-90 15 15)')
+      expect(donut.circumference).toBeCloseTo(2 * Math.PI * 13)
+    })
+
+    it('should return correct geometry for custom size and strokeWidth', () => {
+      const segments = ref([])
+      const donut = useDonutChart(segments, { size: 64, strokeWidth: 8 })
+
+      expect(donut.size).toBe(64)
+      expect(donut.center).toBe(32)
+      expect(donut.strokeWidth).toBe(8)
+      expect(donut.radius).toBe(28)
+      expect(donut.viewBox).toBe('0 0 64 64')
+    })
+
+    it('should return empty visibleSegments when segments are empty', () => {
+      const segments = ref([])
+      const donut = useDonutChart(segments)
+
+      expect(donut.visibleSegments.value).toEqual([])
+    })
+
+    it('should filter out segments with value <= 0', () => {
+      const segments = ref([
+        { key: 'a', value: 10 },
+        { key: 'b', value: 0 },
+        { key: 'c', value: -5 },
+        { key: 'd', value: 5 },
+      ])
+      const donut = useDonutChart(segments)
+
+      const keys = donut.visibleSegments.value.map(s => s.key)
+      expect(keys).toEqual(['a', 'd'])
+    })
+
+    it('should compute correct dasharray for a single segment', () => {
+      const segments = ref([
+        { key: 'only', value: 100 },
+      ])
+      const donut = useDonutChart(segments)
+      const [seg] = donut.visibleSegments.value
+
+      // Single segment fills the entire circumference
+      expect(seg.dasharray).toBe(`${donut.circumference} 0`)
+      expect(seg.dashoffset).toBe('0')
+    })
+
+    it('should compute correct dasharray and dashoffset for multiple segments', () => {
+      const segments = ref([
+        { key: 'a', value: 75 },
+        { key: 'b', value: 25 },
+      ])
+      const donut = useDonutChart(segments)
+      const result = donut.visibleSegments.value
+      const c = donut.circumference
+
+      expect(result).toHaveLength(2)
+
+      // First segment: 75% of circumference
+      const lengthA = 0.75 * c
+      expect(result[0].dasharray).toBe(`${lengthA} ${c}`)
+      expect(result[0].dashoffset).toBe('0')
+
+      // Second segment: 25% of circumference, offset by first
+      const lengthB = 0.25 * c
+      expect(result[1].dasharray).toBe(`${lengthB} ${c}`)
+      expect(result[1].dashoffset).toBe(`${-lengthA}`)
+    })
+
+    it('should use total override when provided', () => {
+      const segments = ref([
+        { key: 'a', value: 20 },
+      ])
+      const total = ref(100)
+      const donut = useDonutChart(segments, { total })
+      const [seg] = donut.visibleSegments.value
+      const c = donut.circumference
+
+      // 20/100 = 20% of circumference
+      const expected = 0.2 * c
+      expect(seg.dasharray).toBe(`${expected} ${c}`)
+    })
+
+    it('should fall back to sum when total override is 0', () => {
+      const segments = ref([
+        { key: 'a', value: 50 },
+        { key: 'b', value: 50 },
+      ])
+      const donut = useDonutChart(segments, { total: ref(0) })
+      const result = donut.visibleSegments.value
+
+      // Falls back to sum = 100, each gets 50%
+      expect(result).toHaveLength(2)
+    })
+
+    it('should react to segment changes', async () => {
+      const segments = ref([
+        { key: 'a', value: 100 },
+      ])
+      const donut = useDonutChart(segments)
+
+      expect(donut.visibleSegments.value).toHaveLength(1)
+
+      segments.value = [
+        { key: 'a', value: 60 },
+        { key: 'b', value: 40 },
+      ]
+      await nextTick()
+
+      expect(donut.visibleSegments.value).toHaveLength(2)
+    })
+
+    it('should preserve extra properties on segments', () => {
+      const segments = ref([
+        { key: 'x', value: 10, color: 'red' },
+      ])
+      const donut = useDonutChart(segments)
+      const [seg] = donut.visibleSegments.value
+
+      expect(seg.color).toBe('red')
+      expect(seg.key).toBe('x')
+    })
+  })
+})

--- a/frontend/__tests__/composables/useSeedTableSorting.spec.js
+++ b/frontend/__tests__/composables/useSeedTableSorting.spec.js
@@ -121,5 +121,21 @@ describe('composables', () => {
         'error',
       ])
     })
+
+    it('should sort shoot count numerically', () => {
+      const { customKeySort } = useSeedTableSorting()
+
+      expect(customKeySort.shootCount(2, 10)).toBeLessThan(0)
+      expect(customKeySort.shootCount(10, 2)).toBeGreaterThan(0)
+      expect(customKeySort.shootCount(4, 4)).toBe(0)
+    })
+
+    it('should sort unhealthy shoots numerically', () => {
+      const { customKeySort } = useSeedTableSorting()
+
+      expect(customKeySort.unhealthyShoots(0, 1)).toBeLessThan(0)
+      expect(customKeySort.unhealthyShoots(3, 1)).toBeGreaterThan(0)
+      expect(customKeySort.unhealthyShoots(1, 1)).toBe(0)
+    })
   })
 })

--- a/frontend/__tests__/composables/useShootItem.spec.js
+++ b/frontend/__tests__/composables/useShootItem.spec.js
@@ -20,12 +20,22 @@ import { useProjectStore } from '@/store/project'
 import { useCloudProfileStore } from '@/store/cloudProfile'
 import { useSeedStore } from '@/store/seed'
 import { useCredentialStore } from '@/store/credential'
+import { useLocalStorageStore } from '@/store/localStorage'
 
 import { createShootItemComposable } from '@/composables/useShootItem'
 
 import set from 'lodash/set'
 import cloneDeep from 'lodash/cloneDeep'
 import unset from 'lodash/unset'
+
+// Disable createSharedComposable so each test gets a fresh composable instance
+vi.mock('@vueuse/core', async importOriginal => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    createSharedComposable: fn => fn,
+  }
+})
 
 describe('composables', () => {
   describe('useProvideShootItem', () => {
@@ -211,7 +221,8 @@ describe('composables', () => {
 
     it('should compute isStaleShoot correctly', () => {
       authzStore._setNamespace('_all')
-      shootStore.state.shootListFilters = {
+      const localStorageStore = useLocalStorageStore()
+      localStorageStore.allProjectsShootFilter = {
         onlyShootsWithIssues: true,
         progressing: true,
       }

--- a/frontend/__tests__/composables/useShootListFilters.spec.js
+++ b/frontend/__tests__/composables/useShootListFilters.spec.js
@@ -1,0 +1,122 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import {
+  createPinia,
+  setActivePinia,
+} from 'pinia'
+
+import { useAuthnStore } from '@/store/authn'
+import { useConfigStore } from '@/store/config'
+import { useLocalStorageStore } from '@/store/localStorage'
+
+import { useShootListFilters } from '@/composables/useShootListFilters'
+
+// Disable createSharedComposable so each test gets a fresh composable instance
+vi.mock('@vueuse/core', async importOriginal => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    createSharedComposable: fn => fn,
+  }
+})
+
+describe('composables', () => {
+  describe('useShootListFilters', () => {
+    let authnStore
+    let configStore
+    let localStorageStore
+
+    beforeEach(() => {
+      setActivePinia(createPinia())
+      authnStore = useAuthnStore()
+      configStore = useConfigStore()
+      localStorageStore = useLocalStorageStore()
+      localStorageStore.allProjectsShootFilter = {}
+    })
+
+    it('should return empty labels when onlyShootsWithIssues is false', () => {
+      authnStore.user = { isAdmin: true }
+      localStorageStore.allProjectsShootFilter = {
+        onlyShootsWithIssues: false,
+        progressing: true,
+        noOperatorAction: true,
+      }
+
+      const { activeFilterLabels } = useShootListFilters()
+      expect(activeFilterLabels.value).toEqual([])
+    })
+
+    it('should return active filter labels for admin defaults', () => {
+      authnStore.user = { isAdmin: true }
+
+      const { activeFilterLabels } = useShootListFilters()
+      expect(activeFilterLabels.value).toEqual([
+        'Progressing Clusters',
+        'User Errors',
+        'Tickets with Ignore Labels',
+      ])
+    })
+
+    it('should return only progressing for non-admin defaults', () => {
+      authnStore.user = { isAdmin: false }
+
+      const { activeFilterLabels } = useShootListFilters()
+      // non-admin defaults: onlyShootsWithIssues=false, so no labels
+      expect(activeFilterLabels.value).toEqual([])
+    })
+
+    it('should return labels matching locally stored filters', () => {
+      authnStore.user = { isAdmin: true }
+      localStorageStore.allProjectsShootFilter = {
+        onlyShootsWithIssues: true,
+        progressing: true,
+        noOperatorAction: false,
+        hideTicketsWithLabel: false,
+      }
+
+      const { activeFilterLabels } = useShootListFilters()
+      expect(activeFilterLabels.value).toEqual([
+        'Progressing Clusters',
+      ])
+    })
+
+    it('should exclude hideTicketsWithLabel when ticket config is missing', () => {
+      authnStore.user = { isAdmin: true }
+      configStore.setConfiguration({ ticket: {} })
+      localStorageStore.allProjectsShootFilter = {
+        onlyShootsWithIssues: true,
+        progressing: false,
+        noOperatorAction: false,
+        hideTicketsWithLabel: true,
+      }
+
+      const { activeFilterLabels } = useShootListFilters()
+      expect(activeFilterLabels.value).toEqual([])
+    })
+
+    it('should include hideTicketsWithLabel when ticket config is present', () => {
+      authnStore.user = { isAdmin: true }
+      configStore.setConfiguration({
+        ticket: {
+          gitHubRepoUrl: 'https://github.com/org/repo',
+          hideClustersWithLabels: ['ignore'],
+        },
+      })
+      localStorageStore.allProjectsShootFilter = {
+        onlyShootsWithIssues: true,
+        progressing: false,
+        noOperatorAction: false,
+        hideTicketsWithLabel: true,
+      }
+
+      const { activeFilterLabels } = useShootListFilters()
+      expect(activeFilterLabels.value).toEqual([
+        'Tickets with Ignore Labels',
+      ])
+    })
+  })
+})

--- a/frontend/__tests__/stores/seedStat.spec.js
+++ b/frontend/__tests__/stores/seedStat.spec.js
@@ -123,7 +123,9 @@ describe('stores', () => {
 
     it('should cancel in-flight subscribe on unsubscribe', async () => {
       let fetchResolve
-      const fetchPromise = new Promise(resolve => { fetchResolve = resolve })
+      const fetchPromise = new Promise(resolve => {
+        fetchResolve = resolve
+      })
       vi.spyOn(api, 'getSeedStats').mockReturnValue(fetchPromise)
       vi.spyOn(socketStore, 'connected', 'get').mockReturnValue(true)
       const emitSubscribe = vi.spyOn(socketStore, 'emitSubscribe').mockResolvedValue()
@@ -148,7 +150,9 @@ describe('stores', () => {
 
     it('should cancel in-flight subscribe(A) when subscribe(B) is called', async () => {
       let fetchResolveA
-      const fetchPromiseA = new Promise(resolve => { fetchResolveA = resolve })
+      const fetchPromiseA = new Promise(resolve => {
+        fetchResolveA = resolve
+      })
       const fetchResultB = { data: [{ metadata: { name: 'seed-b' } }] }
 
       vi.spyOn(api, 'getSeedStats')

--- a/frontend/__tests__/stores/seedStat.spec.js
+++ b/frontend/__tests__/stores/seedStat.spec.js
@@ -8,6 +8,7 @@ import {
   setActivePinia,
   createPinia,
 } from 'pinia'
+import { flushPromises } from '@vue/test-utils'
 
 import { useSeedStatStore } from '@/store/seedStat'
 import { useSocketStore } from '@/store/socket'
@@ -49,7 +50,8 @@ describe('stores', () => {
         }],
       })
 
-      await seedStatStore.subscribe({ unhealthyFilterMask: 0 })
+      seedStatStore.subscribe({ unhealthyFilterMask: 0 })
+      await flushPromises()
 
       expect(getSeedStats).toHaveBeenCalledWith({ unhealthyFilterMask: 0 })
       expect(seedStatStore.shootCountForSeed('infra1-seed')).toBe(3)
@@ -73,10 +75,11 @@ describe('stores', () => {
         },
       })
 
-      await seedStatStore.subscribe({
+      seedStatStore.subscribe({
         name: 'infra1-seed',
         unhealthyFilterMask: 3,
       })
+      await flushPromises()
 
       expect(getSeedStat).toHaveBeenCalledWith({
         name: 'infra1-seed',
@@ -100,7 +103,8 @@ describe('stores', () => {
       const emitSubscribe = vi.spyOn(socketStore, 'emitSubscribe').mockResolvedValue()
       const emitUnsubscribe = vi.spyOn(socketStore, 'emitUnsubscribe').mockResolvedValue()
 
-      await seedStatStore.subscribe({ unhealthyFilterMask: 3 })
+      seedStatStore.subscribe({ unhealthyFilterMask: 3 })
+      await flushPromises()
 
       expect(emitSubscribe).toHaveBeenCalledWith('seedstats', {
         unhealthyFilterMask: 3,
@@ -109,11 +113,88 @@ describe('stores', () => {
         unhealthyFilterMask: 3,
       })
 
-      await seedStatStore.unsubscribe()
+      seedStatStore.unsubscribe()
+      await flushPromises()
 
       expect(emitUnsubscribe).toHaveBeenCalledWith('seedstats')
       expect(seedStatStore.subscription).toBe(null)
       expect(seedStatStore.list).toBe(null)
+    })
+
+    it('should cancel in-flight subscribe on unsubscribe', async () => {
+      let fetchResolve
+      const fetchPromise = new Promise(resolve => { fetchResolve = resolve })
+      vi.spyOn(api, 'getSeedStats').mockReturnValue(fetchPromise)
+      vi.spyOn(socketStore, 'connected', 'get').mockReturnValue(true)
+      const emitSubscribe = vi.spyOn(socketStore, 'emitSubscribe').mockResolvedValue()
+      vi.spyOn(socketStore, 'emitUnsubscribe').mockResolvedValue()
+
+      // Start subscribe — fetch will hang
+      seedStatStore.subscribe({ unhealthyFilterMask: 0 })
+      await flushPromises()
+
+      // Unsubscribe while fetch is pending
+      seedStatStore.unsubscribe()
+      await flushPromises()
+
+      // Now resolve the fetch — stale subscribe should not call openSubscription
+      fetchResolve({ data: [{ metadata: { name: 'seed1' } }] })
+      await flushPromises()
+
+      expect(emitSubscribe).not.toHaveBeenCalled()
+      expect(seedStatStore.subscription).toBe(null)
+      expect(seedStatStore.list).toBe(null)
+    })
+
+    it('should cancel in-flight subscribe(A) when subscribe(B) is called', async () => {
+      let fetchResolveA
+      const fetchPromiseA = new Promise(resolve => { fetchResolveA = resolve })
+      const fetchResultB = { data: [{ metadata: { name: 'seed-b' } }] }
+
+      vi.spyOn(api, 'getSeedStats')
+        .mockReturnValueOnce(fetchPromiseA)
+        .mockResolvedValueOnce(fetchResultB)
+      vi.spyOn(socketStore, 'connected', 'get').mockReturnValue(true)
+      const emitSubscribe = vi.spyOn(socketStore, 'emitSubscribe').mockResolvedValue()
+      vi.spyOn(socketStore, 'emitUnsubscribe').mockResolvedValue()
+
+      // Start subscribe A — fetch will hang
+      seedStatStore.subscribe({ unhealthyFilterMask: 1 })
+      await flushPromises()
+
+      // Subscribe B before A completes
+      seedStatStore.subscribe({ unhealthyFilterMask: 2 })
+      await flushPromises()
+
+      // Resolve A's fetch — should be ignored
+      fetchResolveA({ data: [{ metadata: { name: 'seed-a' } }] })
+      await flushPromises()
+
+      // Final state should reflect B
+      expect(seedStatStore.subscription).toEqual({ unhealthyFilterMask: 2 })
+      expect(seedStatStore.list).toEqual([{ metadata: { name: 'seed-b' } }])
+      expect(emitSubscribe).toHaveBeenCalledWith('seedstats', { unhealthyFilterMask: 2 })
+    })
+
+    it('should re-fetch and re-open on synchronize', async () => {
+      const fetchData = [{ metadata: { name: 'seed1' }, counts: { shootCount: 5 } }]
+      const getSeedStats = vi.spyOn(api, 'getSeedStats').mockResolvedValue({ data: fetchData })
+      vi.spyOn(socketStore, 'connected', 'get').mockReturnValue(true)
+      const emitSubscribe = vi.spyOn(socketStore, 'emitSubscribe').mockResolvedValue()
+      vi.spyOn(socketStore, 'emitUnsubscribe').mockResolvedValue()
+
+      seedStatStore.subscribe({ unhealthyFilterMask: 0 })
+      await flushPromises()
+
+      expect(getSeedStats).toHaveBeenCalledTimes(1)
+      expect(emitSubscribe).toHaveBeenCalledTimes(1)
+
+      // Trigger synchronize
+      seedStatStore.synchronize()
+      await flushPromises()
+
+      expect(getSeedStats).toHaveBeenCalledTimes(2)
+      expect(emitSubscribe).toHaveBeenCalledTimes(2)
     })
 
     it('should derive the unhealthy filter mask from shoot list filters', () => {

--- a/frontend/__tests__/stores/seedStat.spec.js
+++ b/frontend/__tests__/stores/seedStat.spec.js
@@ -1,0 +1,135 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import {
+  setActivePinia,
+  createPinia,
+} from 'pinia'
+
+import { useSeedStatStore } from '@/store/seedStat'
+import { useSocketStore } from '@/store/socket'
+
+import { useApi } from '@/composables/useApi'
+import { getUnhealthyFilterMaskFromShootListFilters } from '@/composables/useShootListFilters'
+
+describe('stores', () => {
+  describe('seedStat', () => {
+    let api
+    let socketStore
+    let seedStatStore
+
+    beforeEach(() => {
+      setActivePinia(createPinia())
+      api = useApi()
+      socketStore = useSocketStore()
+      seedStatStore = useSeedStatStore()
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('should fetch seed stats', async () => {
+      const getSeedStats = vi.spyOn(api, 'getSeedStats').mockResolvedValue({
+        data: [{
+          metadata: {
+            name: 'infra1-seed',
+            uid: 'seed-1',
+          },
+          counts: {
+            shootCount: 3,
+            unhealthyShoots: {
+              total: 2,
+              matching: 1,
+            },
+          },
+        }],
+      })
+
+      await seedStatStore.subscribe({ unhealthyFilterMask: 0 })
+
+      expect(getSeedStats).toHaveBeenCalledWith({ unhealthyFilterMask: 0 })
+      expect(seedStatStore.shootCountForSeed('infra1-seed')).toBe(3)
+      expect(seedStatStore.unhealthyShootsForSeed('infra1-seed')).toBe(1)
+    })
+
+    it('should fetch a single seed stat', async () => {
+      const getSeedStat = vi.spyOn(api, 'getSeedStat').mockResolvedValue({
+        data: {
+          metadata: {
+            name: 'infra1-seed',
+            uid: 'seed-1',
+          },
+          counts: {
+            shootCount: 4,
+            unhealthyShoots: {
+              total: 4,
+              matching: 2,
+            },
+          },
+        },
+      })
+
+      await seedStatStore.subscribe({
+        name: 'infra1-seed',
+        unhealthyFilterMask: 3,
+      })
+
+      expect(getSeedStat).toHaveBeenCalledWith({
+        name: 'infra1-seed',
+        unhealthyFilterMask: 3,
+      })
+      expect(seedStatStore.list).toEqual([
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            name: 'infra1-seed',
+          }),
+        }),
+      ])
+      expect(seedStatStore.unhealthyShootsForSeed('infra1-seed')).toBe(2)
+    })
+
+    it('should subscribe and unsubscribe seed stats', async () => {
+      vi.spyOn(api, 'getSeedStats').mockResolvedValue({
+        data: [],
+      })
+      vi.spyOn(socketStore, 'connected', 'get').mockReturnValue(true)
+      const emitSubscribe = vi.spyOn(socketStore, 'emitSubscribe').mockResolvedValue()
+      const emitUnsubscribe = vi.spyOn(socketStore, 'emitUnsubscribe').mockResolvedValue()
+
+      await seedStatStore.subscribe({ unhealthyFilterMask: 3 })
+
+      expect(emitSubscribe).toHaveBeenCalledWith('seedstats', {
+        unhealthyFilterMask: 3,
+      })
+      expect(seedStatStore.synchronizeOptions).toEqual({
+        unhealthyFilterMask: 3,
+      })
+
+      await seedStatStore.unsubscribe()
+
+      expect(emitUnsubscribe).toHaveBeenCalledWith('seedstats')
+      expect(seedStatStore.subscription).toBe(null)
+      expect(seedStatStore.list).toBe(null)
+    })
+
+    it('should derive the unhealthy filter mask from shoot list filters', () => {
+      expect(getUnhealthyFilterMaskFromShootListFilters({
+        onlyShootsWithIssues: true,
+        progressing: true,
+        noOperatorAction: true,
+        hideTicketsWithLabel: true,
+      })).toBe(7)
+
+      expect(getUnhealthyFilterMaskFromShootListFilters({
+        onlyShootsWithIssues: false,
+        progressing: true,
+        noOperatorAction: true,
+        hideTicketsWithLabel: true,
+      })).toBe(0)
+    })
+  })
+})

--- a/frontend/__tests__/stores/shoot.spec.js
+++ b/frontend/__tests__/stores/shoot.spec.js
@@ -235,7 +235,6 @@ describe('stores', () => {
         }
       })
       mockSynchronize = vi.spyOn(socketStore, 'synchronize').mockImplementation((key, uids) => Promise.resolve(getShoots(uids)))
-      shootStore.initializeShootListFilters()
     })
 
     describe('#sortItems', () => {

--- a/frontend/src/components/GSeedListRow.vue
+++ b/frontend/src/components/GSeedListRow.vue
@@ -31,6 +31,22 @@ SPDX-License-Identifier: Apache-2.0
           hide-unmanaged-chip
         />
       </template>
+      <template v-else-if="header.key === 'shootCount'">
+        <g-seed-capacity-indicator
+          :allocatable-shoots="seedAllocatableShoots"
+          :shoot-count="seedShootCount"
+        />
+      </template>
+      <template v-else-if="header.key === 'unhealthyShoots'">
+        <div class="d-flex align-center justify-center">
+          <g-shoot-health-donut
+            :shoot-count="seedShootCount"
+            :total-unhealthy-shoots="seedTotalUnhealthyShoots"
+            :matching-unhealthy-shoots="seedUnhealthyShoots"
+            :active-filter-labels="activeFilterLabels"
+          />
+        </div>
+      </template>
       <template v-else-if="header.key === 'lastOperation'">
         <div class="d-flex align-center justify-center">
           <g-seed-status />
@@ -99,6 +115,8 @@ import {
 import { useRoute } from 'vue-router'
 
 import GManagedSeedShootLink from '@/components/GManagedSeedShootLink.vue'
+import GSeedCapacityIndicator from '@/components/Seeds/GSeedCapacityIndicator.vue'
+import GShootHealthDonut from '@/components/GShootHealthDonut.vue'
 import GTextRouterLink from '@/components/GTextRouterLink.vue'
 import GVendor from '@/components/GVendor.vue'
 import GSeedStatus from '@/components/GSeedStatus.vue'
@@ -110,6 +128,7 @@ import GScrollContainer from '@/components/GScrollContainer'
 
 import { useProvideManagedSeedShoot } from '@/composables/useManagedSeedShootForSeed'
 import { useProvideSeedItem } from '@/composables/useSeedItem/index'
+import { useShootListFilters } from '@/composables/useShootListFilters'
 
 const props = defineProps({
   modelValue: {
@@ -135,12 +154,18 @@ const {
   seedSchedulingVisible,
   seedKubernetesVersion,
   seedGardenerVersion,
+  seedAllocatableShoots,
+  seedShootCount,
+  seedTotalUnhealthyShoots,
+  seedUnhealthyShoots,
   seedCreationTimestamp,
 } = useProvideSeedItem(seedItem)
 
 const {
   managedSeedShootName,
 } = useProvideManagedSeedShoot(seedName)
+
+const { activeFilterLabels } = useShootListFilters()
 
 const seedItemLink = computed(() => ({
   name: 'SeedItem',

--- a/frontend/src/components/GShootHealthDonut.vue
+++ b/frontend/src/components/GShootHealthDonut.vue
@@ -1,0 +1,315 @@
+<!--
+SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+<template>
+  <div
+    class="d-inline-flex align-center justify-center"
+    :style="{ minWidth: `${donut.size}px`, minHeight: `${donut.size}px` }"
+  >
+    <span
+      v-if="shootCount === 0"
+      class="empty text-medium-emphasis"
+      aria-label="No shoots assigned to this seed"
+    >-</span>
+    <v-tooltip
+      v-else
+      location="top"
+      :open-delay="200"
+      content-class="pa-0"
+      :content-props="{ style: { background: 'transparent' } }"
+    >
+      <template #activator="{ props: tooltipProps }">
+        <span
+          v-bind="tooltipProps"
+          class="activator"
+          tabindex="0"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            :width="donut.size"
+            :height="donut.size"
+            :viewBox="donut.viewBox"
+            role="img"
+            :aria-label="ariaLabel"
+          >
+            <g :transform="donut.rotateTransform">
+              <circle
+                v-for="seg in donutVisibleSegments"
+                :key="seg.key"
+                :class="['segment', seg.key]"
+                :cx="donut.center"
+                :cy="donut.center"
+                :r="donut.radius"
+                fill="none"
+                :stroke-width="donut.strokeWidth"
+                :stroke-dasharray="seg.dasharray"
+                :stroke-dashoffset="seg.dashoffset"
+              />
+              <circle
+                v-for="seg in overlayVisibleSegments"
+                :key="seg.key"
+                :class="['segment', seg.key]"
+                :cx="donut.center"
+                :cy="donut.center"
+                :r="donut.radius"
+                fill="none"
+                :stroke-width="donut.strokeWidth"
+                :stroke-dasharray="seg.dasharray"
+                :stroke-dashoffset="seg.dashoffset"
+              />
+            </g>
+            <text
+              :class="['center-text', centerTextSizeClass, { error: matchingUnhealthy > 0 }]"
+              :x="donut.center"
+              :y="donut.center"
+              text-anchor="middle"
+              dominant-baseline="central"
+              aria-hidden="true"
+            >{{ centerText }}</text>
+          </svg>
+        </span>
+      </template>
+      <v-card
+        class="tooltip-card"
+        elevation="12"
+      >
+        <g-list class="tooltip-list">
+          <g-list-item>
+            <template #prepend>
+              <v-icon
+                color="error"
+                icon="mdi-alert-circle-outline"
+                size="28"
+              />
+            </template>
+            <g-list-item-content label="Unhealthy">
+              {{ matchingUnhealthy }}
+            </g-list-item-content>
+          </g-list-item>
+          <template v-if="hiddenUnhealthy > 0">
+            <v-divider inset />
+            <g-list-item>
+              <template #prepend>
+                <v-icon
+                  icon="mdi-filter-outline"
+                  size="28"
+                  class="text-error-lighten-3"
+                />
+              </template>
+              <g-list-item-content
+                label="Excluded"
+                :description="filterDescription"
+              >
+                {{ hiddenUnhealthy }}
+              </g-list-item-content>
+            </g-list-item>
+          </template>
+          <v-divider inset />
+          <g-list-item>
+            <template #prepend>
+              <v-icon
+                color="success"
+                icon="mdi-check-circle-outline"
+                size="28"
+              />
+            </template>
+            <g-list-item-content label="Healthy">
+              {{ healthyShoots }}
+            </g-list-item-content>
+          </g-list-item>
+        </g-list>
+      </v-card>
+    </v-tooltip>
+  </div>
+</template>
+
+<script setup>
+import {
+  computed,
+  toRefs,
+} from 'vue'
+
+import { useDonutChart } from '@/composables/useDonutChart'
+
+const props = defineProps({
+  shootCount: {
+    type: Number,
+    default: 0,
+    validator: v => Number.isInteger(v) && v >= 0,
+  },
+  totalUnhealthyShoots: {
+    type: Number,
+    default: 0,
+    validator: v => Number.isInteger(v) && v >= 0,
+  },
+  // Unhealthy shoots that pass the active filter mask (≤ totalUnhealthyShoots)
+  matchingUnhealthyShoots: {
+    type: Number,
+    default: 0,
+    validator: v => Number.isInteger(v) && v >= 0,
+  },
+  activeFilterLabels: {
+    type: Array,
+    default: () => [],
+  },
+})
+
+const {
+  shootCount,
+  totalUnhealthyShoots: totalUnhealthy,
+  matchingUnhealthyShoots: matchingUnhealthy,
+  activeFilterLabels,
+} = toRefs(props)
+
+const hiddenUnhealthy = computed(() => totalUnhealthy.value - matchingUnhealthy.value)
+const healthyShoots = computed(() => shootCount.value - totalUnhealthy.value)
+
+const filterDescription = computed(() => {
+  if (hiddenUnhealthy.value === 0) {
+    return undefined
+  }
+  const labels = activeFilterLabels.value
+  if (!labels.length) {
+    return undefined
+  }
+  const shown = labels.slice(0, 2).join(', ')
+  const remaining = labels.length - 2
+  const suffix = remaining > 0 ? ` & ${remaining} more` : ''
+  return `${shown}${suffix}`
+})
+
+// --- donut chart (two layers sharing the same total) ---
+
+const donutOptions = { total: shootCount }
+
+const baseSegments = computed(() => {
+  if (shootCount.value === 0) {
+    return []
+  }
+  return [
+    { key: 'unhealthy', value: totalUnhealthy.value },
+    { key: 'healthy', value: healthyShoots.value },
+  ]
+})
+
+const overlaySegments = computed(() => {
+  if (shootCount.value === 0 || matchingUnhealthy.value === 0) {
+    return []
+  }
+  return [
+    { key: 'matching', value: matchingUnhealthy.value },
+  ]
+})
+
+const {
+  visibleSegments: donutVisibleSegments,
+  ...donut
+} = useDonutChart(baseSegments, donutOptions)
+
+const {
+  visibleSegments: overlayVisibleSegments,
+} = useDonutChart(overlaySegments, donutOptions)
+
+// --- center text ---
+
+function formatCompact (value) {
+  if (value < 1000) {
+    return String(value)
+  }
+  if (value < 10000) {
+    const v = Math.floor(value / 100) / 10
+    return `${v.toFixed(v < 10 ? 1 : 0)}k`
+  }
+  return `${Math.floor(value / 1000)}k`
+}
+
+const centerText = computed(() => formatCompact(matchingUnhealthy.value))
+
+const centerTextSizeClass = computed(() => {
+  if (matchingUnhealthy.value >= 1000) {
+    return 'compact'
+  }
+  if (matchingUnhealthy.value >= 100) {
+    return 'small'
+  }
+  return ''
+})
+
+// --- accessibility ---
+
+const ariaLabel = computed(() => {
+  const parts = [
+    'Shoot health distribution',
+    `${shootCount.value} shoots`,
+    `${matchingUnhealthy.value} unhealthy shoots`,
+  ]
+  if (hiddenUnhealthy.value > 0) {
+    const desc = filterDescription.value
+      ? ` (${filterDescription.value})`
+      : ''
+    parts.push(`${hiddenUnhealthy.value} excluded by filter${desc}`)
+  }
+  parts.push(`${healthyShoots.value} healthy shoots`)
+  return parts.join(', ') + '.'
+})
+</script>
+
+<style lang="scss" scoped>
+  .activator {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 0;
+    border-radius: 50%;
+  }
+
+  .empty {
+    font-size: 0.875rem;
+  }
+
+  .tooltip-card,
+  .tooltip-list {
+    background-color: rgb(var(--v-theme-surface));
+    color: rgb(var(--v-theme-on-surface));
+  }
+
+  .center-text {
+    fill: rgba(var(--v-theme-on-surface), 0.72);
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 1;
+    pointer-events: none;
+
+    &.small {
+      font-size: 12px;
+    }
+
+    &.compact {
+      font-size: 10px;
+    }
+
+    &.error {
+      fill: rgb(var(--v-theme-error));
+    }
+  }
+
+  .segment {
+    stroke-linecap: butt;
+
+    &.matching {
+      stroke: rgb(var(--v-theme-error));
+      pointer-events: none;
+    }
+
+    &.unhealthy {
+      stroke: rgb(var(--v-theme-error-lighten-3));
+    }
+
+    &.healthy {
+      stroke: rgb(var(--v-theme-success));
+    }
+  }
+</style>

--- a/frontend/src/components/GShootHealthDonut.vue
+++ b/frontend/src/components/GShootHealthDonut.vue
@@ -76,34 +76,33 @@ SPDX-License-Identifier: Apache-2.0
           density="compact"
         >
           <template v-if="shootCount === 0">
-            <v-list-item>
+            <v-list-item :prepend-gap="8">
               <template #prepend>
                 <v-icon
                   icon="mdi-information-outline"
-                  class="text-medium-emphasis mr-2"
+                  class="text-medium-emphasis"
                 />
               </template>
               <v-list-item-title>No shoots assigned</v-list-item-title>
             </v-list-item>
           </template>
           <template v-else>
-            <v-list-item>
+            <v-list-item :prepend-gap="8">
               <template #prepend>
                 <v-icon
                   color="error"
                   icon="mdi-alert-circle-outline"
-                  class="mr-2"
                 />
               </template>
               <v-list-item-subtitle>Unhealthy</v-list-item-subtitle>
               <v-list-item-title>{{ matchingUnhealthy }}</v-list-item-title>
             </v-list-item>
             <template v-if="hiddenUnhealthy > 0">
-              <v-list-item>
+              <v-list-item :prepend-gap="8">
                 <template #prepend>
                   <v-icon
                     icon="mdi-filter-outline"
-                    class="text-error-lighten-3 mr-2"
+                    class="text-error-lighten-3"
                   />
                 </template>
                 <v-list-item-subtitle>
@@ -114,12 +113,11 @@ SPDX-License-Identifier: Apache-2.0
                 <v-list-item-title>{{ hiddenUnhealthy }}</v-list-item-title>
               </v-list-item>
             </template>
-            <v-list-item>
+            <v-list-item :prepend-gap="8">
               <template #prepend>
                 <v-icon
                   color="success"
                   icon="mdi-check-circle-outline"
-                  class="mr-2"
                 />
               </template>
               <v-list-item-subtitle>Healthy</v-list-item-subtitle>

--- a/frontend/src/components/GShootHealthDonut.vue
+++ b/frontend/src/components/GShootHealthDonut.vue
@@ -8,118 +8,127 @@ SPDX-License-Identifier: Apache-2.0
   <div
     class="d-inline-flex align-center justify-center"
     :style="{ minWidth: `${donut.size}px`, minHeight: `${donut.size}px` }"
+    tabindex="0"
+    role="img"
+    :aria-label="ariaLabel"
   >
     <span
       v-if="shootCount === 0"
       class="empty text-medium-emphasis"
-      aria-label="No shoots assigned to this seed"
+      aria-hidden="true"
     >-</span>
-    <v-tooltip
+    <svg
       v-else
+      xmlns="http://www.w3.org/2000/svg"
+      :width="donut.size"
+      :height="donut.size"
+      :viewBox="donut.viewBox"
+      aria-hidden="true"
+    >
+      <g :transform="donut.rotateTransform">
+        <circle
+          v-for="seg in donutVisibleSegments"
+          :key="seg.key"
+          :class="['segment', seg.key]"
+          :cx="donut.center"
+          :cy="donut.center"
+          :r="donut.radius"
+          fill="none"
+          :stroke-width="donut.strokeWidth"
+          :stroke-dasharray="seg.dasharray"
+          :stroke-dashoffset="seg.dashoffset"
+        />
+        <circle
+          v-for="seg in overlayVisibleSegments"
+          :key="seg.key"
+          :class="['segment', seg.key]"
+          :cx="donut.center"
+          :cy="donut.center"
+          :r="donut.radius"
+          fill="none"
+          :stroke-width="donut.strokeWidth"
+          :stroke-dasharray="seg.dasharray"
+          :stroke-dashoffset="seg.dashoffset"
+        />
+      </g>
+      <text
+        :class="['center-text', centerTextSizeClass, { error: matchingUnhealthy > 0 }]"
+        :x="donut.center"
+        :y="donut.center"
+        text-anchor="middle"
+        dominant-baseline="central"
+        aria-hidden="true"
+      >{{ centerText }}</text>
+    </svg>
+    <v-tooltip
+      activator="parent"
       location="top"
       :open-delay="200"
       content-class="pa-0"
       :content-props="{ style: { background: 'transparent' } }"
     >
-      <template #activator="{ props: tooltipProps }">
-        <span
-          v-bind="tooltipProps"
-          class="activator"
-          tabindex="0"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            :width="donut.size"
-            :height="donut.size"
-            :viewBox="donut.viewBox"
-            role="img"
-            :aria-label="ariaLabel"
-          >
-            <g :transform="donut.rotateTransform">
-              <circle
-                v-for="seg in donutVisibleSegments"
-                :key="seg.key"
-                :class="['segment', seg.key]"
-                :cx="donut.center"
-                :cy="donut.center"
-                :r="donut.radius"
-                fill="none"
-                :stroke-width="donut.strokeWidth"
-                :stroke-dasharray="seg.dasharray"
-                :stroke-dashoffset="seg.dashoffset"
-              />
-              <circle
-                v-for="seg in overlayVisibleSegments"
-                :key="seg.key"
-                :class="['segment', seg.key]"
-                :cx="donut.center"
-                :cy="donut.center"
-                :r="donut.radius"
-                fill="none"
-                :stroke-width="donut.strokeWidth"
-                :stroke-dasharray="seg.dasharray"
-                :stroke-dashoffset="seg.dashoffset"
-              />
-            </g>
-            <text
-              :class="['center-text', centerTextSizeClass, { error: matchingUnhealthy > 0 }]"
-              :x="donut.center"
-              :y="donut.center"
-              text-anchor="middle"
-              dominant-baseline="central"
-              aria-hidden="true"
-            >{{ centerText }}</text>
-          </svg>
-        </span>
-      </template>
       <v-card
         class="tooltip-card"
         elevation="12"
       >
         <g-list class="tooltip-list">
-          <g-list-item>
-            <template #prepend>
-              <v-icon
-                color="error"
-                icon="mdi-alert-circle-outline"
-                size="28"
-              />
+          <template v-if="shootCount === 0">
+            <g-list-item>
+              <template #prepend>
+                <v-icon
+                  icon="mdi-information-outline"
+                  size="28"
+                  class="text-medium-emphasis"
+                />
+              </template>
+              <g-list-item-content label="No shoots assigned" />
+            </g-list-item>
+          </template>
+          <template v-else>
+            <g-list-item>
+              <template #prepend>
+                <v-icon
+                  color="error"
+                  icon="mdi-alert-circle-outline"
+                  size="28"
+                />
+              </template>
+              <g-list-item-content label="Unhealthy">
+                {{ matchingUnhealthy }}
+              </g-list-item-content>
+            </g-list-item>
+            <template v-if="hiddenUnhealthy > 0">
+              <v-divider inset />
+              <g-list-item>
+                <template #prepend>
+                  <v-icon
+                    icon="mdi-filter-outline"
+                    size="28"
+                    class="text-error-lighten-3"
+                  />
+                </template>
+                <g-list-item-content
+                  label="Excluded"
+                  :description="filterDescription"
+                >
+                  {{ hiddenUnhealthy }}
+                </g-list-item-content>
+              </g-list-item>
             </template>
-            <g-list-item-content label="Unhealthy">
-              {{ matchingUnhealthy }}
-            </g-list-item-content>
-          </g-list-item>
-          <template v-if="hiddenUnhealthy > 0">
             <v-divider inset />
             <g-list-item>
               <template #prepend>
                 <v-icon
-                  icon="mdi-filter-outline"
+                  color="success"
+                  icon="mdi-check-circle-outline"
                   size="28"
-                  class="text-error-lighten-3"
                 />
               </template>
-              <g-list-item-content
-                label="Excluded"
-                :description="filterDescription"
-              >
-                {{ hiddenUnhealthy }}
+              <g-list-item-content label="Healthy">
+                {{ healthyShoots }}
               </g-list-item-content>
             </g-list-item>
           </template>
-          <v-divider inset />
-          <g-list-item>
-            <template #prepend>
-              <v-icon
-                color="success"
-                icon="mdi-check-circle-outline"
-                size="28"
-              />
-            </template>
-            <g-list-item-content label="Healthy">
-              {{ healthyShoots }}
-            </g-list-item-content>
-          </g-list-item>
         </g-list>
       </v-card>
     </v-tooltip>
@@ -241,6 +250,9 @@ const centerTextSizeClass = computed(() => {
 // --- accessibility ---
 
 const ariaLabel = computed(() => {
+  if (shootCount.value === 0) {
+    return 'No shoots assigned to this seed.'
+  }
   const parts = [
     'Shoot health distribution',
     `${shootCount.value} shoots`,
@@ -258,14 +270,6 @@ const ariaLabel = computed(() => {
 </script>
 
 <style lang="scss" scoped>
-  .activator {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    line-height: 0;
-    border-radius: 50%;
-  }
-
   .empty {
     font-size: 0.875rem;
   }

--- a/frontend/src/components/GShootHealthDonut.vue
+++ b/frontend/src/components/GShootHealthDonut.vue
@@ -71,13 +71,16 @@ SPDX-License-Identifier: Apache-2.0
         class="tooltip-card"
         elevation="12"
       >
-        <v-list class="tooltip-list">
+        <v-list
+          class="tooltip-list"
+          density="compact"
+        >
           <template v-if="shootCount === 0">
             <v-list-item>
               <template #prepend>
                 <v-icon
                   icon="mdi-information-outline"
-                  class="text-medium-emphasis mr-3"
+                  class="text-medium-emphasis mr-2"
                 />
               </template>
               <v-list-item-title>No shoots assigned</v-list-item-title>
@@ -89,7 +92,7 @@ SPDX-License-Identifier: Apache-2.0
                 <v-icon
                   color="error"
                   icon="mdi-alert-circle-outline"
-                  class="mr-3"
+                  class="mr-2"
                 />
               </template>
               <v-list-item-subtitle>Unhealthy</v-list-item-subtitle>
@@ -100,7 +103,7 @@ SPDX-License-Identifier: Apache-2.0
                 <template #prepend>
                   <v-icon
                     icon="mdi-filter-outline"
-                    class="text-error-lighten-3 mr-3"
+                    class="text-error-lighten-3 mr-2"
                   />
                 </template>
                 <v-list-item-subtitle>
@@ -116,7 +119,7 @@ SPDX-License-Identifier: Apache-2.0
                 <v-icon
                   color="success"
                   icon="mdi-check-circle-outline"
-                  class="mr-3"
+                  class="mr-2"
                 />
               </template>
               <v-list-item-subtitle>Healthy</v-list-item-subtitle>

--- a/frontend/src/components/GShootHealthDonut.vue
+++ b/frontend/src/components/GShootHealthDonut.vue
@@ -71,65 +71,59 @@ SPDX-License-Identifier: Apache-2.0
         class="tooltip-card"
         elevation="12"
       >
-        <g-list class="tooltip-list">
+        <v-list class="tooltip-list">
           <template v-if="shootCount === 0">
-            <g-list-item>
+            <v-list-item>
               <template #prepend>
                 <v-icon
                   icon="mdi-information-outline"
-                  size="28"
-                  class="text-medium-emphasis"
+                  class="text-medium-emphasis mr-3"
                 />
               </template>
-              <g-list-item-content label="No shoots assigned" />
-            </g-list-item>
+              <v-list-item-title>No shoots assigned</v-list-item-title>
+            </v-list-item>
           </template>
           <template v-else>
-            <g-list-item>
+            <v-list-item>
               <template #prepend>
                 <v-icon
                   color="error"
                   icon="mdi-alert-circle-outline"
-                  size="28"
+                  class="mr-3"
                 />
               </template>
-              <g-list-item-content label="Unhealthy">
-                {{ matchingUnhealthy }}
-              </g-list-item-content>
-            </g-list-item>
+              <v-list-item-subtitle>Unhealthy</v-list-item-subtitle>
+              <v-list-item-title>{{ matchingUnhealthy }}</v-list-item-title>
+            </v-list-item>
             <template v-if="hiddenUnhealthy > 0">
-              <v-divider inset />
-              <g-list-item>
+              <v-list-item>
                 <template #prepend>
                   <v-icon
                     icon="mdi-filter-outline"
-                    size="28"
-                    class="text-error-lighten-3"
+                    class="text-error-lighten-3 mr-3"
                   />
                 </template>
-                <g-list-item-content
-                  label="Excluded"
-                  :description="filterDescription"
-                >
-                  {{ hiddenUnhealthy }}
-                </g-list-item-content>
-              </g-list-item>
+                <v-list-item-subtitle>
+                  Excluded<template v-if="filterDescription">
+                    — {{ filterDescription }}
+                  </template>
+                </v-list-item-subtitle>
+                <v-list-item-title>{{ hiddenUnhealthy }}</v-list-item-title>
+              </v-list-item>
             </template>
-            <v-divider inset />
-            <g-list-item>
+            <v-list-item>
               <template #prepend>
                 <v-icon
                   color="success"
                   icon="mdi-check-circle-outline"
-                  size="28"
+                  class="mr-3"
                 />
               </template>
-              <g-list-item-content label="Healthy">
-                {{ healthyShoots }}
-              </g-list-item-content>
-            </g-list-item>
+              <v-list-item-subtitle>Healthy</v-list-item-subtitle>
+              <v-list-item-title>{{ healthyShoots }}</v-list-item-title>
+            </v-list-item>
           </template>
-        </g-list>
+        </v-list>
       </v-card>
     </v-tooltip>
   </div>

--- a/frontend/src/components/GVendor.vue
+++ b/frontend/src/components/GVendor.vue
@@ -17,6 +17,7 @@ SPDX-License-Identifier: Apache-2.0
     <template #activator="{ props }">
       <div
         class="d-flex align-center"
+        tabindex="0"
         v-bind="props"
       >
         <g-vendor-icon

--- a/frontend/src/components/SeedDetails/GSeedInfrastructureCard.vue
+++ b/frontend/src/components/SeedDetails/GSeedInfrastructureCard.vue
@@ -38,11 +38,24 @@ SPDX-License-Identifier: Apache-2.0
       <g-list-item>
         <template #prepend>
           <v-icon color="primary">
-            mdi-server
+            mdi-gauge
           </v-icon>
         </template>
-        <g-list-item-content label="Allocatable Shoots">
-          {{ seedAllocatableShoots ?? '-' }}
+        <g-list-item-content label="Capacity">
+          <g-seed-capacity-indicator
+            :allocatable-shoots="seedAllocatableShoots"
+            :shoot-count="seedShootCount"
+          />
+        </g-list-item-content>
+      </g-list-item>
+      <g-list-item>
+        <g-list-item-content label="Shoot Health">
+          <g-shoot-health-donut
+            :shoot-count="seedShootCount"
+            :total-unhealthy-shoots="seedTotalUnhealthyShoots"
+            :matching-unhealthy-shoots="seedUnhealthyShoots"
+            :active-filter-labels="activeFilterLabels"
+          />
         </g-list-item-content>
       </g-list-item>
       <v-divider inset />
@@ -86,11 +99,24 @@ SPDX-License-Identifier: Apache-2.0
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import {
+  computed,
+  onUnmounted,
+  watch,
+} from 'vue'
 
+import { useAppStore } from '@/store/app'
+import { useSeedStatStore } from '@/store/seedStat'
+
+import GSeedCapacityIndicator from '@/components/Seeds/GSeedCapacityIndicator.vue'
+import GShootHealthDonut from '@/components/GShootHealthDonut.vue'
 import GVendor from '@/components/GVendor.vue'
 
 import { useSeedItem } from '@/composables/useSeedItem/index'
+import { useShootListFilters } from '@/composables/useShootListFilters'
+
+const appStore = useAppStore()
+const seedStatStore = useSeedStatStore()
 
 const {
   seedProviderType,
@@ -103,9 +129,48 @@ const {
   seedNetworksShootDefaultsServices,
   seedNetworksBlockCIDRs,
   seedAllocatableShoots,
+  seedShootCount,
+  seedTotalUnhealthyShoots,
+  seedUnhealthyShoots,
+  seedName,
 } = useSeedItem()
+
+const { activeFilterLabels } = useShootListFilters()
 
 const seedNetworksBlockCIDRsText = computed(() => {
   return seedNetworksBlockCIDRs.value?.join(', ') ?? ''
+})
+
+const seedStatsSubscriptionOptions = computed(() => {
+  if (!seedName.value) {
+    return null
+  }
+
+  return {
+    name: seedName.value,
+    unhealthyFilterMask: seedStatStore.currentUnhealthyFilterMask,
+  }
+})
+
+watch(seedStatsSubscriptionOptions, async options => {
+  try {
+    if (options) {
+      await seedStatStore.subscribe(options)
+    } else {
+      await seedStatStore.unsubscribe()
+    }
+  } catch (err) {
+    appStore.setError(err)
+  }
+}, {
+  immediate: true,
+})
+
+onUnmounted(async () => {
+  try {
+    await seedStatStore.unsubscribe()
+  } catch (err) {
+    appStore.setError(err)
+  }
 })
 </script>

--- a/frontend/src/components/SeedDetails/GSeedInfrastructureCard.vue
+++ b/frontend/src/components/SeedDetails/GSeedInfrastructureCard.vue
@@ -105,7 +105,6 @@ import {
   watch,
 } from 'vue'
 
-import { useAppStore } from '@/store/app'
 import { useSeedStatStore } from '@/store/seedStat'
 
 import GSeedCapacityIndicator from '@/components/Seeds/GSeedCapacityIndicator.vue'
@@ -115,7 +114,6 @@ import GVendor from '@/components/GVendor.vue'
 import { useSeedItem } from '@/composables/useSeedItem/index'
 import { useShootListFilters } from '@/composables/useShootListFilters'
 
-const appStore = useAppStore()
 const seedStatStore = useSeedStatStore()
 
 const {
@@ -152,25 +150,17 @@ const seedStatsSubscriptionOptions = computed(() => {
   }
 })
 
-watch(seedStatsSubscriptionOptions, async options => {
-  try {
-    if (options) {
-      await seedStatStore.subscribe(options)
-    } else {
-      await seedStatStore.unsubscribe()
-    }
-  } catch (err) {
-    appStore.setError(err)
+watch(seedStatsSubscriptionOptions, options => {
+  if (options) {
+    seedStatStore.subscribe(options)
+  } else {
+    seedStatStore.unsubscribe()
   }
 }, {
   immediate: true,
 })
 
-onUnmounted(async () => {
-  try {
-    await seedStatStore.unsubscribe()
-  } catch (err) {
-    appStore.setError(err)
-  }
+onUnmounted(() => {
+  seedStatStore.unsubscribe()
 })
 </script>

--- a/frontend/src/components/Seeds/GSeedCapacityIndicator.vue
+++ b/frontend/src/components/Seeds/GSeedCapacityIndicator.vue
@@ -32,56 +32,45 @@ SPDX-License-Identifier: Apache-2.0
         class="tooltip-card"
         elevation="12"
       >
-        <g-list class="tooltip-list">
-          <g-list-item>
+        <v-list class="tooltip-list">
+          <v-list-item>
             <template #prepend>
               <v-icon
                 color="primary"
                 icon="mdi-vector-link"
-                size="28"
+                class="mr-3"
               />
             </template>
-            <g-list-item-content label="Assigned">
-              {{ props.shootCount }}
-            </g-list-item-content>
-          </g-list-item>
-          <template v-if="hasKnownCapacity">
-            <v-divider inset />
-            <g-list-item>
-              <template #prepend>
-                <v-icon
-                  color="primary"
-                  icon="mdi-chart-box-outline"
-                  size="28"
-                />
+            <v-list-item-subtitle>Assigned</v-list-item-subtitle>
+            <v-list-item-title>{{ props.shootCount }}</v-list-item-title>
+          </v-list-item>
+          <v-list-item>
+            <template #prepend>
+              <v-icon
+                color="primary"
+                :icon="hasKnownCapacity ? 'mdi-chart-box-outline' : 'mdi-information-outline'"
+                class="mr-3"
+              />
+            </template>
+            <v-list-item-subtitle>
+              <template v-if="hasKnownCapacity">
+                Allocatable — Total allocatable shoots for this seed
               </template>
-              <g-list-item-content
-                label="Allocatable"
-                description="Total allocatable shoots for this seed"
-              >
+              <template v-else>
+                Allocatable — This seed does not report allocatable shoot capacity
+              </template>
+            </v-list-item-subtitle>
+            <v-list-item-title>
+              <template v-if="hasKnownCapacity">
                 {{ props.allocatableShoots }}
-              </g-list-item-content>
-            </g-list-item>
-          </template>
-          <template v-else>
-            <v-divider inset />
-            <g-list-item>
-              <template #prepend>
-                <v-icon
-                  color="primary"
-                  icon="mdi-information-outline"
-                  size="28"
-                />
               </template>
-              <g-list-item-content
-                label="Allocatable"
-                description="This seed does not report allocatable shoot capacity"
-              >
-                <span class="text-medium-emphasis">Unknown</span>
-              </g-list-item-content>
-            </g-list-item>
-          </template>
-        </g-list>
+              <span
+                v-else
+                class="text-medium-emphasis"
+              >Unknown</span>
+            </v-list-item-title>
+          </v-list-item>
+        </v-list>
       </v-card>
     </v-tooltip>
   </div>

--- a/frontend/src/components/Seeds/GSeedCapacityIndicator.vue
+++ b/frontend/src/components/Seeds/GSeedCapacityIndicator.vue
@@ -36,23 +36,21 @@ SPDX-License-Identifier: Apache-2.0
           class="tooltip-list"
           density="compact"
         >
-          <v-list-item>
+          <v-list-item :prepend-gap="8">
             <template #prepend>
               <v-icon
                 color="primary"
                 icon="mdi-vector-link"
-                class="mr-2"
               />
             </template>
             <v-list-item-subtitle>Assigned</v-list-item-subtitle>
             <v-list-item-title>{{ props.shootCount }}</v-list-item-title>
           </v-list-item>
-          <v-list-item>
+          <v-list-item :prepend-gap="8">
             <template #prepend>
               <v-icon
                 color="primary"
                 :icon="hasKnownCapacity ? 'mdi-chart-box-outline' : 'mdi-information-outline'"
-                class="mr-2"
               />
             </template>
             <v-list-item-subtitle>

--- a/frontend/src/components/Seeds/GSeedCapacityIndicator.vue
+++ b/frontend/src/components/Seeds/GSeedCapacityIndicator.vue
@@ -1,0 +1,162 @@
+<!--
+SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+<template>
+  <v-tooltip
+    location="top"
+    :open-delay="200"
+    content-class="pa-0"
+    :content-props="{ style: { background: 'transparent' } }"
+  >
+    <template #activator="{ props: tooltipProps }">
+      <div
+        v-bind="tooltipProps"
+        class="activator"
+        tabindex="0"
+        :aria-label="ariaLabel"
+      >
+        <div class="capacity-indicator">
+          <span class="text">{{ capacityText }}</span>
+          <v-progress-linear
+            v-if="hasCapacityProgress"
+            class="progress"
+            :model-value="capacityUsagePercent"
+            color="primary"
+            :height="8"
+            rounded
+          />
+        </div>
+      </div>
+    </template>
+    <v-card
+      class="tooltip-card"
+      elevation="12"
+    >
+      <g-list class="tooltip-list">
+        <g-list-item>
+          <template #prepend>
+            <v-icon
+              color="primary"
+              icon="mdi-vector-link"
+              size="28"
+            />
+          </template>
+          <g-list-item-content label="Assigned">
+            {{ props.shootCount }}
+          </g-list-item-content>
+        </g-list-item>
+        <template v-if="hasKnownCapacity">
+          <v-divider inset />
+          <g-list-item>
+            <template #prepend>
+              <v-icon
+                color="primary"
+                icon="mdi-chart-box-outline"
+                size="28"
+              />
+            </template>
+            <g-list-item-content
+              label="Allocatable"
+              description="Total allocatable shoots for this seed"
+            >
+              {{ props.allocatableShoots }}
+            </g-list-item-content>
+          </g-list-item>
+        </template>
+        <template v-else>
+          <v-divider inset />
+          <g-list-item>
+            <template #prepend>
+              <v-icon
+                color="primary"
+                icon="mdi-information-outline"
+                size="28"
+              />
+            </template>
+            <g-list-item-content
+              label="Allocatable"
+              description="This seed does not report allocatable shoot capacity"
+            >
+              <span class="text-medium-emphasis">Unknown</span>
+            </g-list-item-content>
+          </g-list-item>
+        </template>
+      </g-list>
+    </v-card>
+  </v-tooltip>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  allocatableShoots: {
+    type: Number,
+  },
+  shootCount: {
+    type: Number,
+    default: 0,
+  },
+})
+
+const hasKnownCapacity = computed(() => {
+  return Number.isFinite(props.allocatableShoots)
+})
+
+const hasCapacityProgress = computed(() => {
+  return hasKnownCapacity.value && props.allocatableShoots > 0
+})
+
+const capacityUsagePercent = computed(() => {
+  if (!hasCapacityProgress.value) {
+    return 0
+  }
+
+  return Math.min(props.shootCount / props.allocatableShoots * 100, 100)
+})
+
+const capacityText = computed(() => {
+  if (!hasKnownCapacity.value) {
+    return `${props.shootCount}`
+  }
+
+  return `${props.shootCount} / ${props.allocatableShoots}`
+})
+
+const ariaLabel = computed(() => {
+  if (!hasKnownCapacity.value) {
+    return `Seed capacity: ${props.shootCount} assigned shoots, allocatable capacity unknown`
+  }
+  const percent = Math.round(capacityUsagePercent.value)
+  return `Seed capacity: ${props.shootCount} of ${props.allocatableShoots} allocatable shoots assigned (${percent}%)`
+})
+</script>
+
+<style lang="scss" scoped>
+  .activator {
+    display: inline-grid;
+  }
+
+  .capacity-indicator {
+    display: inline-grid;
+    gap: 0.25rem;
+    min-width: 88px;
+  }
+
+  .tooltip-card,
+  .tooltip-list {
+    background-color: rgb(var(--v-theme-surface));
+    color: rgb(var(--v-theme-on-surface));
+  }
+
+  .text {
+    white-space: nowrap;
+  }
+
+  .progress {
+    min-width: 88px;
+  }
+</style>

--- a/frontend/src/components/Seeds/GSeedCapacityIndicator.vue
+++ b/frontend/src/components/Seeds/GSeedCapacityIndicator.vue
@@ -32,13 +32,16 @@ SPDX-License-Identifier: Apache-2.0
         class="tooltip-card"
         elevation="12"
       >
-        <v-list class="tooltip-list">
+        <v-list
+          class="tooltip-list"
+          density="compact"
+        >
           <v-list-item>
             <template #prepend>
               <v-icon
                 color="primary"
                 icon="mdi-vector-link"
-                class="mr-3"
+                class="mr-2"
               />
             </template>
             <v-list-item-subtitle>Assigned</v-list-item-subtitle>
@@ -49,7 +52,7 @@ SPDX-License-Identifier: Apache-2.0
               <v-icon
                 color="primary"
                 :icon="hasKnownCapacity ? 'mdi-chart-box-outline' : 'mdi-information-outline'"
-                class="mr-3"
+                class="mr-2"
               />
             </template>
             <v-list-item-subtitle>

--- a/frontend/src/components/Seeds/GSeedCapacityIndicator.vue
+++ b/frontend/src/components/Seeds/GSeedCapacityIndicator.vue
@@ -5,88 +5,86 @@ SPDX-License-Identifier: Apache-2.0
 -->
 
 <template>
-  <v-tooltip
-    location="top"
-    :open-delay="200"
-    content-class="pa-0"
-    :content-props="{ style: { background: 'transparent' } }"
+  <div
+    class="activator"
+    tabindex="0"
+    :aria-label="ariaLabel"
   >
-    <template #activator="{ props: tooltipProps }">
-      <div
-        v-bind="tooltipProps"
-        class="activator"
-        tabindex="0"
-        :aria-label="ariaLabel"
-      >
-        <div class="capacity-indicator">
-          <span class="text">{{ capacityText }}</span>
-          <v-progress-linear
-            v-if="hasCapacityProgress"
-            class="progress"
-            :model-value="capacityUsagePercent"
-            color="primary"
-            :height="8"
-            rounded
-          />
-        </div>
-      </div>
-    </template>
-    <v-card
-      class="tooltip-card"
-      elevation="12"
+    <div class="capacity-indicator">
+      <span class="text">{{ capacityText }}</span>
+      <v-progress-linear
+        v-if="hasCapacityProgress"
+        class="progress"
+        :model-value="capacityUsagePercent"
+        color="primary"
+        :height="8"
+        rounded
+      />
+    </div>
+    <v-tooltip
+      activator="parent"
+      location="top"
+      :open-delay="200"
+      content-class="pa-0"
+      :content-props="{ style: { background: 'transparent' } }"
     >
-      <g-list class="tooltip-list">
-        <g-list-item>
-          <template #prepend>
-            <v-icon
-              color="primary"
-              icon="mdi-vector-link"
-              size="28"
-            />
+      <v-card
+        class="tooltip-card"
+        elevation="12"
+      >
+        <g-list class="tooltip-list">
+          <g-list-item>
+            <template #prepend>
+              <v-icon
+                color="primary"
+                icon="mdi-vector-link"
+                size="28"
+              />
+            </template>
+            <g-list-item-content label="Assigned">
+              {{ props.shootCount }}
+            </g-list-item-content>
+          </g-list-item>
+          <template v-if="hasKnownCapacity">
+            <v-divider inset />
+            <g-list-item>
+              <template #prepend>
+                <v-icon
+                  color="primary"
+                  icon="mdi-chart-box-outline"
+                  size="28"
+                />
+              </template>
+              <g-list-item-content
+                label="Allocatable"
+                description="Total allocatable shoots for this seed"
+              >
+                {{ props.allocatableShoots }}
+              </g-list-item-content>
+            </g-list-item>
           </template>
-          <g-list-item-content label="Assigned">
-            {{ props.shootCount }}
-          </g-list-item-content>
-        </g-list-item>
-        <template v-if="hasKnownCapacity">
-          <v-divider inset />
-          <g-list-item>
-            <template #prepend>
-              <v-icon
-                color="primary"
-                icon="mdi-chart-box-outline"
-                size="28"
-              />
-            </template>
-            <g-list-item-content
-              label="Allocatable"
-              description="Total allocatable shoots for this seed"
-            >
-              {{ props.allocatableShoots }}
-            </g-list-item-content>
-          </g-list-item>
-        </template>
-        <template v-else>
-          <v-divider inset />
-          <g-list-item>
-            <template #prepend>
-              <v-icon
-                color="primary"
-                icon="mdi-information-outline"
-                size="28"
-              />
-            </template>
-            <g-list-item-content
-              label="Allocatable"
-              description="This seed does not report allocatable shoot capacity"
-            >
-              <span class="text-medium-emphasis">Unknown</span>
-            </g-list-item-content>
-          </g-list-item>
-        </template>
-      </g-list>
-    </v-card>
-  </v-tooltip>
+          <template v-else>
+            <v-divider inset />
+            <g-list-item>
+              <template #prepend>
+                <v-icon
+                  color="primary"
+                  icon="mdi-information-outline"
+                  size="28"
+                />
+              </template>
+              <g-list-item-content
+                label="Allocatable"
+                description="This seed does not report allocatable shoot capacity"
+              >
+                <span class="text-medium-emphasis">Unknown</span>
+              </g-list-item-content>
+            </g-list-item>
+          </template>
+        </g-list>
+      </v-card>
+    </v-tooltip>
+  </div>
 </template>
 
 <script setup>

--- a/frontend/src/composables/useApi/api.js
+++ b/frontend/src/composables/useApi/api.js
@@ -259,6 +259,9 @@ export function getSeedStats ({ unhealthyFilterMask } = {}) {
 }
 
 export function getSeedStat ({ name, unhealthyFilterMask } = {}) {
+  if (!name) {
+    throw new TypeError('getSeedStat requires a name parameter')
+  }
   name = encodeURIComponent(name)
   return getResource(withQuery(`/api/seedstats/${name}`, {
     unhealthyFilterMask,

--- a/frontend/src/composables/useApi/api.js
+++ b/frontend/src/composables/useApi/api.js
@@ -21,6 +21,17 @@ function getResource (url) {
   return request('GET', url)
 }
 
+function withQuery (url, query = {}) {
+  const filteredQueryEntries = Object.entries(query)
+    .filter(([, value]) => typeof value !== 'undefined' && value !== null)
+
+  const search = new URLSearchParams(filteredQueryEntries).toString()
+
+  return search
+    ? `${url}?${search}`
+    : url
+}
+
 function deleteResource (url) {
   return request('DELETE', url)
 }
@@ -98,19 +109,9 @@ export function getIssuesAndComments ({ namespace, name }) {
 
 /* Shoot Clusters */
 
-export function getShoots ({ namespace, labelSelector, useCache }) {
-  const query = {}
-  if (labelSelector) {
-    query.labelSelector = labelSelector
-  }
-  if (useCache) {
-    query.useCache = true
-  }
-  const search = Object.keys(query).length
-    ? '?' + new URLSearchParams(query).toString()
-    : ''
+export function getShoots ({ namespace, labelSelector }) {
   namespace = encodeURIComponent(namespace)
-  return getResource(`/api/namespaces/${namespace}/shoots` + search)
+  return getResource(withQuery(`/api/namespaces/${namespace}/shoots`, { labelSelector }))
 }
 
 export function getShoot ({ namespace, name }) {

--- a/frontend/src/composables/useApi/api.js
+++ b/frontend/src/composables/useApi/api.js
@@ -252,6 +252,19 @@ export function getSeeds () {
   return getResource('/api/seeds')
 }
 
+export function getSeedStats ({ unhealthyFilterMask } = {}) {
+  return getResource(withQuery('/api/seedstats', {
+    unhealthyFilterMask,
+  }))
+}
+
+export function getSeedStat ({ name, unhealthyFilterMask } = {}) {
+  name = encodeURIComponent(name)
+  return getResource(withQuery(`/api/seedstats/${name}`, {
+    unhealthyFilterMask,
+  }))
+}
+
 /* Managed Seeds */
 
 export function getManagedSeedsForGardenNamespace () {
@@ -463,6 +476,8 @@ export default {
   createShootAdminKubeconfig,
   getCloudProfiles,
   getSeeds,
+  getSeedStats,
+  getSeedStat,
   getManagedSeedsForGardenNamespace,
   getManagedSeedShootsForGardenNamespace,
   getProjects,

--- a/frontend/src/composables/useDonutChart.js
+++ b/frontend/src/composables/useDonutChart.js
@@ -1,0 +1,90 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import {
+  computed,
+  isRef,
+} from 'vue'
+
+/**
+ * Composable for SVG donut chart geometry.
+ *
+ * @param {import('vue').Ref<Array<{ key: string, value: number }>>} segmentsDef
+ *   Reactive segment definitions. Each segment must have a `key` and a numeric `value`.
+ *   Segments with `value <= 0` are automatically filtered out.
+ * @param {object} [options]
+ * @param {number} [options.size=30]          Outer SVG size in px
+ * @param {number} [options.strokeWidth=4]    Stroke width of the donut ring
+ * @param {import('vue').Ref<number>} [options.total]
+ *   Override the total used for proportional calculation.
+ *   If omitted, total is computed as the sum of all segment values.
+ * @returns Reactive donut geometry
+ */
+export function useDonutChart (segmentsDef, options = {}) {
+  if (!isRef(segmentsDef)) {
+    throw new TypeError('First argument `segmentsDef` must be a ref object')
+  }
+
+  const {
+    size = 30,
+    strokeWidth = 4,
+    total: totalOverride,
+  } = options
+
+  if (totalOverride !== undefined && !isRef(totalOverride)) {
+    throw new TypeError('Option `total` must be a ref object')
+  }
+
+  const center = size / 2
+  const radius = center - strokeWidth / 2
+  const circumference = 2 * Math.PI * radius
+
+  const viewBox = `0 0 ${size} ${size}`
+  const rotateTransform = `rotate(-90 ${center} ${center})`
+
+  const visibleSegments = computed(() => {
+    const raw = segmentsDef.value
+    if (!raw?.length) {
+      return []
+    }
+
+    const override = totalOverride?.value
+    const total = override != null && override > 0
+      ? override
+      : raw.reduce((sum, s) => sum + Math.max(0, s.value), 0)
+    if (total === 0) {
+      return []
+    }
+
+    let offset = 0
+    return raw
+      .filter(s => s.value > 0)
+      .map(segment => {
+        const length = (segment.value / total) * circumference
+        const dasharray = length === circumference
+          ? `${circumference} 0`
+          : `${length} ${circumference}`
+        const dashoffset = `${-offset}`
+        offset += length
+        return {
+          ...segment,
+          dasharray,
+          dashoffset,
+        }
+      })
+  })
+
+  return {
+    size,
+    center,
+    radius,
+    strokeWidth,
+    circumference,
+    viewBox,
+    rotateTransform,
+    visibleSegments,
+  }
+}

--- a/frontend/src/composables/useSeedItem/index.js
+++ b/frontend/src/composables/useSeedItem/index.js
@@ -11,6 +11,8 @@ import {
   provide,
 } from 'vue'
 
+import { useSeedStatStore } from '@/store/seedStat'
+
 import { useSeedMetadata } from '@/composables/useSeedMetadata'
 
 import { isFailureToleranceTypeZoneSupported } from './helper'
@@ -61,6 +63,11 @@ export function createSeedItemComposable (seedItem) {
   const seedKubernetesVersion = useSeedKubernetesVersion(seedItem)
   const seedGardenerVersion = useSeedGardenerVersion(seedItem)
   const seedAllocatableShoots = useSeedAllocatableShoots(seedItem)
+  const {
+    seedShootCount,
+    seedTotalUnhealthyShoots,
+    seedUnhealthyShoots,
+  } = useSeedStats(seedItem)
   const seedLastOperation = useSeedLastOperation(seedItem)
 
   return {
@@ -101,6 +108,9 @@ export function createSeedItemComposable (seedItem) {
     seedKubernetesVersion,
     seedGardenerVersion,
     seedAllocatableShoots,
+    seedShootCount,
+    seedTotalUnhealthyShoots,
+    seedUnhealthyShoots,
     seedLastOperation,
   }
 }
@@ -229,8 +239,30 @@ export function useSeedGardenerVersion (seedItem) {
 
 export function useSeedAllocatableShoots (seedItem) {
   return computed(() => {
-    return get(seedItem.value, ['status', 'allocatable', 'shoots'])
+    const value = get(seedItem.value, ['status', 'allocatable', 'shoots'])
+    return value == null ? undefined : Number(value)
   })
+}
+
+export function useSeedStats (seedItem) {
+  if (!isRef(seedItem)) {
+    throw new TypeError('First argument `seedItem` must be a ref object')
+  }
+
+  const seedStatStore = useSeedStatStore()
+
+  const seedName = computed(() => get(seedItem.value, ['metadata', 'name']))
+  const seedStat = computed(() => seedStatStore.statByName(seedName.value))
+
+  const seedShootCount = computed(() => seedStat.value?.counts?.shootCount ?? 0)
+  const seedTotalUnhealthyShoots = computed(() => seedStat.value?.counts?.unhealthyShoots?.total ?? 0)
+  const seedUnhealthyShoots = computed(() => seedStat.value?.counts?.unhealthyShoots?.matching ?? 0)
+
+  return {
+    seedShootCount,
+    seedTotalUnhealthyShoots,
+    seedUnhealthyShoots,
+  }
 }
 
 export function useSeedLastOperation (seedItem) {

--- a/frontend/src/composables/useSeedItem/index.js
+++ b/frontend/src/composables/useSeedItem/index.js
@@ -254,9 +254,9 @@ export function useSeedStats (seedItem) {
   const seedName = computed(() => get(seedItem.value, ['metadata', 'name']))
   const seedStat = computed(() => seedStatStore.statByName(seedName.value))
 
-  const seedShootCount = computed(() => seedStat.value?.counts?.shootCount ?? 0)
-  const seedTotalUnhealthyShoots = computed(() => seedStat.value?.counts?.unhealthyShoots?.total ?? 0)
-  const seedUnhealthyShoots = computed(() => seedStat.value?.counts?.unhealthyShoots?.matching ?? 0)
+  const seedShootCount = computed(() => seedStat.value?.counts?.shootCount)
+  const seedTotalUnhealthyShoots = computed(() => seedStat.value?.counts?.unhealthyShoots?.total)
+  const seedUnhealthyShoots = computed(() => seedStat.value?.counts?.unhealthyShoots?.matching)
 
   return {
     seedShootCount,

--- a/frontend/src/composables/useSeedTableSorting.js
+++ b/frontend/src/composables/useSeedTableSorting.js
@@ -66,6 +66,8 @@ export function useSeedTableSorting () {
   const customKeySort = {
     name: compareValues,
     infrastructure: compareValues,
+    shootCount: compareValues,
+    unhealthyShoots: compareValues,
     lastOperation: (a, b) => compareLastOperation(a, b, compareValues),
     kubernetesVersion: compareSemanticVersions,
     gardenerVersion: compareSemanticVersions,

--- a/frontend/src/composables/useShootListFilters.js
+++ b/frontend/src/composables/useShootListFilters.js
@@ -1,0 +1,113 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import { computed } from 'vue'
+import { createSharedComposable } from '@vueuse/core'
+
+import { useAuthnStore } from '@/store/authn'
+import { useConfigStore } from '@/store/config'
+import { useLocalStorageStore } from '@/store/localStorage'
+
+import pick from 'lodash/pick'
+
+const FILTER_LABELS = [
+  { key: 'progressing', label: 'Progressing Clusters' },
+  { key: 'noOperatorAction', label: 'User Errors' },
+  { key: 'hideTicketsWithLabel', label: 'Tickets with Ignore Labels' },
+]
+
+const FILTER_KEYS = [
+  'onlyShootsWithIssues',
+  'progressing',
+  'noOperatorAction',
+  'hideTicketsWithLabel',
+]
+
+function getDefaultAllProjectsShootFilters (isAdmin) {
+  return {
+    onlyShootsWithIssues: isAdmin,
+    progressing: true,
+    noOperatorAction: isAdmin,
+    hideTicketsWithLabel: isAdmin,
+  }
+}
+
+export function getUnhealthyFilterMaskFromShootListFilters (shootListFilters = {}) {
+  if (!shootListFilters.onlyShootsWithIssues) {
+    return 0
+  }
+
+  let mask = 0
+  if (shootListFilters.progressing) {
+    mask |= 1
+  }
+  if (shootListFilters.noOperatorAction) {
+    mask |= 2
+  }
+  if (shootListFilters.hideTicketsWithLabel) {
+    mask |= 4
+  }
+  return mask
+}
+
+export const useShootListFilters = createSharedComposable(function useShootListFilters () {
+  const authnStore = useAuthnStore()
+  const configStore = useConfigStore()
+  const localStorageStore = useLocalStorageStore()
+
+  const shootListFilters = computed({
+    get () {
+      const filters = {
+        ...getDefaultAllProjectsShootFilters(authnStore.isAdmin),
+        ...localStorageStore.allProjectsShootFilter,
+      }
+
+      const { ticket } = configStore
+      if (ticket && (!ticket.gitHubRepoUrl || !ticket.hideClustersWithLabels?.length)) {
+        filters.hideTicketsWithLabel = false
+      }
+
+      return filters
+    },
+    set (value) {
+      localStorageStore.allProjectsShootFilter = pick(value, FILTER_KEYS)
+    },
+  })
+
+  const onlyShootsWithIssues = computed(() => {
+    return shootListFilters.value.onlyShootsWithIssues ?? true
+  })
+
+  function toggleShootListFilter (key) {
+    shootListFilters.value = {
+      ...shootListFilters.value,
+      [key]: !shootListFilters.value[key], // eslint-disable-line security/detect-object-injection -- key is a fixed set of strings, not user input
+    }
+  }
+
+  const unhealthyFilterMask = computed(() => {
+    return getUnhealthyFilterMaskFromShootListFilters(shootListFilters.value)
+  })
+
+  const activeFilterLabels = computed(() => {
+    const filters = shootListFilters.value
+    if (!filters.onlyShootsWithIssues) {
+      return []
+    }
+
+    return FILTER_LABELS
+      .filter(({ key }) => filters[key]) // eslint-disable-line security/detect-object-injection -- key is a fixed set of strings, not user input
+      .map(({ label }) => label)
+  })
+
+  return {
+    shootListFilters,
+    onlyShootsWithIssues,
+    toggleShootListFilter,
+    unhealthyFilterMask,
+    activeFilterLabels,
+  }
+})

--- a/frontend/src/composables/useSocketEventHandler.js
+++ b/frontend/src/composables/useSocketEventHandler.js
@@ -48,6 +48,7 @@ export function useSocketEventHandler (useStore, options = {}) {
     socketStore = useSocketStore(),
     visibility = useDocumentVisibility(),
     createOperator = createDefaultOperator,
+    getSynchronizeOptions,
   } = options
 
   const eventMap = new Map([])
@@ -67,7 +68,10 @@ export function useSocketEventHandler (useStore, options = {}) {
           uids.push(uid)
         }
       }
-      const items = await socketStore.synchronize(pluralName, uids)
+      const synchronizeOptions = getSynchronizeOptions
+        ? getSynchronizeOptions(store)
+        : undefined
+      const items = await socketStore.synchronize(pluralName, uids, synchronizeOptions)
       for (const item of items) {
         if (item.kind !== 'Status') {
           uidMap.set(item.metadata.uid, item)

--- a/frontend/src/router/guards.js
+++ b/frontend/src/router/guards.js
@@ -163,8 +163,6 @@ export function createGlobalResolveGuards () {
             break
           }
           case 'ShootList': {
-            // filter has to be set before subscribing shoots
-            shootStore.initializeShootListFilters()
             shootStore.subscribeShoots()
             const promises = []
             if (authzStore.canUseProjectTerminalShortcuts) {

--- a/frontend/src/store/helper.js
+++ b/frontend/src/store/helper.js
@@ -1,0 +1,30 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import { useLogger } from '@/composables/useLogger'
+
+import isEqual from 'lodash/isEqual'
+
+export function createSynchronizeLock (storeName) {
+  const logger = useLogger()
+  return {
+    expiresAt: 0,
+    options: null,
+    acquire (options) {
+      if (isEqual(this.options, options) && this.expiresAt > Date.now()) {
+        logger.warn('Detected concurrent synchronization attempts for the same %s subscription', storeName)
+        return false
+      }
+      this.expiresAt = Date.now() + 30_000
+      this.options = { ...options }
+      return true
+    },
+    release () {
+      this.expiresAt = 0
+      this.options = null
+    },
+  }
+}

--- a/frontend/src/store/localStorage.js
+++ b/frontend/src/store/localStorage.js
@@ -211,11 +211,6 @@ export const useLocalStorageStore = defineStore('localStorage', () => {
     writeDefaults: false,
   })
 
-  const shootListFetchFromCache = useLocalStorage('projects/shoot-list/fetch-from-cache', false, {
-    serializer: StorageSerializers.flag,
-    writeDefaults: false,
-  })
-
   const seedSelectedColumns = useLocalStorage('seeds/seed-list/selected-columns', {}, {
     serializer: StorageSerializers.json,
     writeDefaults: false,
@@ -278,7 +273,6 @@ export const useLocalStorageStore = defineStore('localStorage', () => {
     seedSelectedColumns,
     seedSortBy,
     allProjectsShootFilter,
-    shootListFetchFromCache,
     shootCustomSortBy,
     shootCustomSelectedColumns,
     terminalSplitpaneTreeRef,

--- a/frontend/src/store/seedStat.js
+++ b/frontend/src/store/seedStat.js
@@ -11,11 +11,11 @@ import {
 import {
   ref,
   computed,
+  watch,
 } from 'vue'
 
 import { useAppStore } from '@/store/app'
 import { useSocketStore } from '@/store/socket'
-import { createSynchronizeLock } from '@/store/helper'
 
 import { useApi } from '@/composables/useApi'
 import { useLogger } from '@/composables/useLogger'
@@ -36,8 +36,7 @@ export const useSeedStatStore = defineStore('seedstat', () => {
 
   const list = ref(null)
   const subscription = ref(null)
-
-  const synchronizeLock = createSynchronizeLock('seedstat')
+  const refreshNonce = ref(0)
   const subscribed = ref(false)
 
   const isInitial = computed(() => {
@@ -58,10 +57,10 @@ export const useSeedStatStore = defineStore('seedstat', () => {
     const response = options.name
       ? await api.getSeedStat(options)
       : await api.getSeedStats(options)
-    list.value = options.name
+    const data = options.name
       ? [response.data]
       : response.data
-    return list.value
+    return data
   }
 
   async function openSubscription (options) {
@@ -79,47 +78,57 @@ export const useSeedStatStore = defineStore('seedstat', () => {
     subscribed.value = false
   }
 
-  async function subscribe (options = {}) {
-    const sameSubscription = isEqual(subscription.value, options)
-    if (sameSubscription && list.value !== null) {
-      if (!subscribed.value && socketStore.connected) {
-        await openSubscription(options)
+  watch(
+    [subscription, refreshNonce],
+    async ([newSub], [oldSub], onCleanup) => {
+      let cancelled = false
+      onCleanup(() => {
+        cancelled = true
+      })
+
+      const subChanged = !isEqual(newSub, oldSub)
+      if (subChanged && oldSub) {
+        await closeSubscription()
+        if (cancelled) {
+          return
+        }
       }
-      return
-    }
 
-    if (subscribed.value || subscription.value) {
-      await closeSubscription()
-    }
+      if (!newSub) {
+        list.value = null
+        subscribed.value = false
+        return
+      }
 
+      try {
+        const data = await fetchSeedStats(newSub)
+        if (cancelled) {
+          return
+        }
+        list.value = data
+        await openSubscription(newSub)
+      } catch (err) {
+        if (!cancelled) {
+          appStore.setError(err)
+        }
+      }
+    },
+    { deep: true },
+  )
+
+  function subscribe (options = {}) {
     subscription.value = options
-    await fetchSeedStats(options)
-    await openSubscription(options)
   }
 
-  async function unsubscribe () {
-    if (subscribed.value || subscription.value) {
-      await closeSubscription()
-    }
+  function unsubscribe () {
     subscription.value = null
-    list.value = null
   }
 
-  async function synchronize () {
+  function synchronize () {
     if (!subscription.value) {
       return
     }
-    if (!synchronizeLock.acquire(subscription.value)) {
-      return
-    }
-    try {
-      await fetchSeedStats(subscription.value)
-      await openSubscription(subscription.value)
-    } catch (err) {
-      appStore.setError(err)
-    } finally {
-      synchronizeLock.release()
-    }
+    refreshNonce.value++
   }
 
   function statByName (name) {

--- a/frontend/src/store/seedStat.js
+++ b/frontend/src/store/seedStat.js
@@ -1,0 +1,165 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import {
+  defineStore,
+  acceptHMRUpdate,
+} from 'pinia'
+import {
+  ref,
+  computed,
+} from 'vue'
+
+import { useAppStore } from '@/store/app'
+import { useSocketStore } from '@/store/socket'
+import { createSynchronizeLock } from '@/store/helper'
+
+import { useApi } from '@/composables/useApi'
+import { useLogger } from '@/composables/useLogger'
+import { useShootListFilters } from '@/composables/useShootListFilters'
+import { useSocketEventHandler } from '@/composables/useSocketEventHandler'
+
+import find from 'lodash/find'
+import isEqual from 'lodash/isEqual'
+
+export const useSeedStatStore = defineStore('seedstat', () => {
+  const api = useApi()
+  const logger = useLogger()
+  const appStore = useAppStore()
+  const socketStore = useSocketStore()
+  const {
+    unhealthyFilterMask: currentUnhealthyFilterMask,
+  } = useShootListFilters()
+
+  const list = ref(null)
+  const subscription = ref(null)
+
+  const synchronizeLock = createSynchronizeLock('seedstat')
+  const subscribed = ref(false)
+
+  const isInitial = computed(() => {
+    return list.value === null
+  })
+
+  const synchronizeOptions = computed(() => {
+    if (!subscription.value) {
+      return undefined
+    }
+
+    return {
+      unhealthyFilterMask: subscription.value.unhealthyFilterMask,
+    }
+  })
+
+  async function fetchSeedStats (options = {}) {
+    const response = options.name
+      ? await api.getSeedStat(options)
+      : await api.getSeedStats(options)
+    list.value = options.name
+      ? [response.data]
+      : response.data
+    return list.value
+  }
+
+  async function openSubscription (options) {
+    if (!socketStore.connected) {
+      subscribed.value = false
+      return
+    }
+
+    await socketStore.emitSubscribe('seedstats', options)
+    subscribed.value = true
+  }
+
+  async function closeSubscription () {
+    await socketStore.emitUnsubscribe('seedstats')
+    subscribed.value = false
+  }
+
+  async function subscribe (options = {}) {
+    const sameSubscription = isEqual(subscription.value, options)
+    if (sameSubscription && list.value !== null) {
+      if (!subscribed.value && socketStore.connected) {
+        await openSubscription(options)
+      }
+      return
+    }
+
+    if (subscribed.value || subscription.value) {
+      await closeSubscription()
+    }
+
+    subscription.value = options
+    await fetchSeedStats(options)
+    await openSubscription(options)
+  }
+
+  async function unsubscribe () {
+    if (subscribed.value || subscription.value) {
+      await closeSubscription()
+    }
+    subscription.value = null
+    list.value = null
+  }
+
+  async function synchronize () {
+    if (!subscription.value) {
+      return
+    }
+    if (!synchronizeLock.acquire(subscription.value)) {
+      return
+    }
+    try {
+      await fetchSeedStats(subscription.value)
+      await openSubscription(subscription.value)
+    } catch (err) {
+      appStore.setError(err)
+    } finally {
+      synchronizeLock.release()
+    }
+  }
+
+  function statByName (name) {
+    return find(list.value, ['metadata.name', name])
+  }
+
+  function shootCountForSeed (name) {
+    return statByName(name)?.counts?.shootCount
+  }
+
+  function unhealthyShootsForSeed (name) {
+    const unhealthyShoots = statByName(name)?.counts?.unhealthyShoots
+
+    return unhealthyShoots?.matching
+  }
+
+  const socketEventHandler = useSocketEventHandler(useSeedStatStore, {
+    logger,
+    getSynchronizeOptions (store) {
+      return store.synchronizeOptions
+    },
+  })
+  socketEventHandler.start(500)
+
+  return {
+    list,
+    subscription,
+    currentUnhealthyFilterMask,
+    synchronizeOptions,
+    isInitial,
+    subscribe,
+    unsubscribe,
+    synchronize,
+    statByName,
+    shootCountForSeed,
+    unhealthyShootsForSeed,
+    handleEvent: socketEventHandler.listener,
+  }
+})
+
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useSeedStatStore, import.meta.hot))
+}

--- a/frontend/src/store/shoot/helper.js
+++ b/frontend/src/store/shoot/helper.js
@@ -56,8 +56,9 @@ export const constants = Object.freeze({
 export function onlyAllShootsWithIssues (state, context) {
   const {
     authzStore,
+    onlyShootsWithIssues,
   } = context
-  return authzStore.namespace === '_all' && get(state.shootListFilters, ['onlyShootsWithIssues'], true)
+  return authzStore.namespace === '_all' && (onlyShootsWithIssues.value ?? true)
 }
 
 export function getFilteredUids (state, context) {
@@ -114,13 +115,19 @@ export function getFilteredUids (state, context) {
   // list of active filter function
   const predicates = []
   if (onlyAllShootsWithIssues(state, context)) {
-    if (get(state, ['shootListFilters', 'progressing'], false)) {
+    const {
+      progressing,
+      noOperatorAction,
+      hideTicketsWithLabel,
+    } = context
+
+    if (progressing.value) {
       predicates.push(notProgressing)
     }
-    if (get(state, ['shootListFilters', 'noOperatorAction'], false)) {
+    if (noOperatorAction.value) {
       predicates.push(noUserError)
     }
-    if (get(state, ['shootListFilters', 'hideTicketsWithLabel'], false)) {
+    if (hideTicketsWithLabel.value) {
       predicates.push(hasTicketsWithoutHideLabel)
     }
   }
@@ -231,7 +238,7 @@ export function getSortVal (state, context, item, sortBy) {
       const conditions = item.status?.conditions ?? []
       const constraints = item.status?.constraints ?? []
       const readinessConditions = [...conditions, ...constraints]
-      const hideProgressingClusters = get(state.shootListFilters, ['progressing'], false)
+      const hideProgressingClusters = context.progressing.value ?? false
       const lastOperationTime = item.status?.lastOperation?.lastUpdateTime
       const creationTime = item.metadata.creationTimestamp
       const isErrorFn = status => status !== 'True' && !(hideProgressingClusters && status === 'Progressing')

--- a/frontend/src/store/shoot/helper.js
+++ b/frontend/src/store/shoot/helper.js
@@ -23,7 +23,6 @@ import { parseSearch } from '@/composables/useTableFilter/helper'
 import {
   isTruthyValue,
   isStatusProgressing,
-  isReconciliationDeactivated,
   getCreatedBy,
   getIssueSince,
 } from '@/utils'
@@ -92,10 +91,6 @@ export function getFilteredUids (state, context) {
     return !(isUserError(allLastErrorCodes) || isUserError(allConditionCodes) || isUserError(allConstraintCodes))
   }
 
-  const reconciliationNotDeactivated = item => {
-    return !isReconciliationDeactivated(get(item, ['metadata'], {}))
-  }
-
   const hasTicketsWithoutHideLabel = item => {
     const hideClustersWithLabels = get(configStore.ticket, ['hideClustersWithLabels'])
     if (!hideClustersWithLabels) {
@@ -124,9 +119,6 @@ export function getFilteredUids (state, context) {
     }
     if (get(state, ['shootListFilters', 'noOperatorAction'], false)) {
       predicates.push(noUserError)
-    }
-    if (get(state, ['shootListFilters', 'deactivatedReconciliation'], false)) {
-      predicates.push(reconciliationNotDeactivated)
     }
     if (get(state, ['shootListFilters', 'hideTicketsWithLabel'], false)) {
       predicates.push(hasTicketsWithoutHideLabel)

--- a/frontend/src/store/shoot/shoot.js
+++ b/frontend/src/store/shoot/shoot.js
@@ -11,7 +11,6 @@ import {
 import {
   computed,
   reactive,
-  watch,
   markRaw,
   toRaw,
   toRef,
@@ -20,12 +19,12 @@ import {
 import { useLogger } from '@/composables/useLogger'
 import { useApi } from '@/composables/useApi'
 import { useProjectShootCustomFields } from '@/composables/useProjectShootCustomFields'
+import { useShootListFilters } from '@/composables/useShootListFilters'
 import { useSocketEventHandler } from '@/composables/useSocketEventHandler'
 
 import { isNotFound } from '@/utils/error'
 
 import { useAppStore } from '../app'
-import { useAuthnStore } from '../authn'
 import { useAuthzStore } from '../authz'
 import { useProjectStore } from '../project'
 import { useCloudProfileStore } from '../cloudProfile'
@@ -50,7 +49,6 @@ import isEmpty from 'lodash/isEmpty'
 import includes from 'lodash/includes'
 import find from 'lodash/find'
 import difference from 'lodash/difference'
-import pick from 'lodash/pick'
 import map from 'lodash/map'
 import unset from 'lodash/unset'
 import set from 'lodash/set'
@@ -61,7 +59,6 @@ const useShootStore = defineStore('shoot', () => {
   const logger = useLogger()
 
   const appStore = useAppStore()
-  const authnStore = useAuthnStore()
   const authzStore = useAuthzStore()
   const projectStore = useProjectStore()
   const cloudProfileStore = useCloudProfileStore()
@@ -75,6 +72,14 @@ const useShootStore = defineStore('shoot', () => {
   const projectItem = toRef(projectStore, 'project')
 
   const shootCustomFieldsComposable = useProjectShootCustomFields(projectItem, { logger })
+  const {
+    shootListFilters,
+    onlyShootsWithIssues,
+  } = useShootListFilters()
+
+  const progressing = computed(() => shootListFilters.value.progressing)
+  const noOperatorAction = computed(() => shootListFilters.value.noOperatorAction)
+  const hideTicketsWithLabel = computed(() => shootListFilters.value.hideTicketsWithLabel)
 
   const context = {
     api,
@@ -90,6 +95,11 @@ const useShootStore = defineStore('shoot', () => {
     socketStore,
     seedStore,
     shootCustomFieldsComposable,
+    shootListFilters,
+    onlyShootsWithIssues,
+    progressing,
+    noOperatorAction,
+    hideTicketsWithLabel,
   }
 
   const state = reactive({
@@ -97,7 +107,6 @@ const useShootStore = defineStore('shoot', () => {
     shootInfos: {},
     staleShoots: {}, // shoots will be moved here when they are removed in case focus mode is active
     selection: undefined,
-    shootListFilters: undefined,
     focusMode: false,
     froozenUids: [],
     subscription: null,
@@ -119,10 +128,6 @@ const useShootStore = defineStore('shoot', () => {
 
   const activeUids = computed(() => {
     return getFilteredUids(state, context)
-  })
-
-  const shootListFilters = computed(() => {
-    return state.shootListFilters
   })
 
   const focusMode = computed(() => {
@@ -163,10 +168,6 @@ const useShootStore = defineStore('shoot', () => {
     return state.selectedUid
       ? assignShootInfo(state.shoots[state.selectedUid])
       : null
-  })
-
-  const onlyShootsWithIssues = computed(() => {
-    return get(state.shootListFilters, ['onlyShootsWithIssues'], true)
   })
 
   const loading = computed(() => {
@@ -444,37 +445,6 @@ const useShootStore = defineStore('shoot', () => {
     }
   }
 
-  function initializeShootListFilters () {
-    const isAdmin = authnStore.isAdmin
-    state.shootListFilters = {
-      onlyShootsWithIssues: isAdmin,
-      progressing: true,
-      noOperatorAction: isAdmin,
-      deactivatedReconciliation: isAdmin,
-      hideTicketsWithLabel: isAdmin,
-      ...localStorageStore.allProjectsShootFilter,
-    }
-  }
-
-  function toogleShootListFilter (key) {
-    if (state.shootListFilters) {
-      const value = get(state.shootListFilters, [key])
-      set(state.shootListFilters, [key], !value)
-    }
-  }
-
-  watch(() => state.shootListFilters, value => {
-    localStorageStore.allProjectsShootFilter = pick(value, [
-      'onlyShootsWithIssues',
-      'progressing',
-      'noOperatorAction',
-      'deactivatedReconciliation',
-      'hideTicketsWithLabel',
-    ])
-  }, {
-    deep: true,
-  })
-
   function setFocusMode (value) {
     const shootStore = this
     let uids = []
@@ -604,7 +574,6 @@ const useShootStore = defineStore('shoot', () => {
     // state
     state,
     staleShoots,
-    shootListFilters,
     subscriptionState,
     subscriptionError,
     focusMode,
@@ -613,7 +582,6 @@ const useShootStore = defineStore('shoot', () => {
     activeShoots,
     shootList,
     selectedShoot,
-    onlyShootsWithIssues,
     loading,
     subscribed,
     unsubscribed,
@@ -632,8 +600,6 @@ const useShootStore = defineStore('shoot', () => {
     deleteShoot,
     fetchInfo,
     setSelection,
-    initializeShootListFilters,
-    toogleShootListFilter,
     setFocusMode,
     shootByNamespaceAndName,
     searchItems,

--- a/frontend/src/store/shoot/shoot.js
+++ b/frontend/src/store/shoot/shoot.js
@@ -514,7 +514,7 @@ const useShootStore = defineStore('shoot', () => {
       state.subscriptionEventHandler = socketEventHandler.start(throttleDelay)
     })
     try {
-      await socketStore.emitSubscribe(value)
+      await socketStore.emitSubscribe('shoots', value)
       setSubscriptionState(state, constants.OPEN)
     } catch (err) {
       logger.error('Failed to open subscription: %s', err.message)
@@ -534,7 +534,7 @@ const useShootStore = defineStore('shoot', () => {
       state.subscriptionEventHandler = undefined
     })
     try {
-      await socketStore.emitUnsubscribe()
+      await socketStore.emitUnsubscribe('shoots')
       setSubscriptionState(state, constants.CLOSED)
     } catch (err) {
       logger.error('Failed to close subscription: %s', err.message)

--- a/frontend/src/store/shoot/shoot.js
+++ b/frontend/src/store/shoot/shoot.js
@@ -35,7 +35,6 @@ import { useCredentialStore } from '../credential'
 import { useSocketStore } from '../socket'
 import { useTicketStore } from '../ticket'
 import { useSeedStore } from '../seed'
-import { useLocalStorageStore } from '../localStorage'
 
 import {
   constants,
@@ -72,7 +71,6 @@ const useShootStore = defineStore('shoot', () => {
   const ticketStore = useTicketStore()
   const socketStore = useSocketStore()
   const seedStore = useSeedStore()
-  const localStorageStore = useLocalStorageStore()
 
   const projectItem = toRef(projectStore, 'project')
 
@@ -385,10 +383,7 @@ const useShootStore = defineStore('shoot', () => {
         setSubscriptionState(state, constants.LOADING)
         const promise = options.name
           ? fetchShoot(options)
-          : fetchShoots({
-            useCache: localStorageStore.shootListFetchFromCache,
-            ...options,
-          })
+          : fetchShoots(options)
         const { shoots, issues, comments } = await promise
         shootStore.receive(shoots)
         ticketStore.receiveIssues(issues)

--- a/frontend/src/store/shoot/shoot.js
+++ b/frontend/src/store/shoot/shoot.js
@@ -35,6 +35,7 @@ import { useCredentialStore } from '../credential'
 import { useSocketStore } from '../socket'
 import { useTicketStore } from '../ticket'
 import { useSeedStore } from '../seed'
+import { createSynchronizeLock } from '../helper'
 
 import {
   constants,
@@ -45,7 +46,6 @@ import {
   shootHasIssue,
 } from './helper'
 
-import isEqual from 'lodash/isEqual'
 import isEmpty from 'lodash/isEmpty'
 import includes from 'lodash/includes'
 import find from 'lodash/find'
@@ -294,23 +294,7 @@ const useShootStore = defineStore('shoot', () => {
     })(this)
   }
 
-  const synchronizeLock = {
-    expiresAt: 0,
-    options: null,
-    aquire (options) {
-      if (isEqual(this.options, options) && this.expiresAt > Date.now()) {
-        logger.warn('Detected concurrent synchronization attempts for the same shoot subscription')
-        return false
-      }
-      this.expiresAt = Date.now() + 30_000
-      this.options = { ...options }
-      return true
-    },
-    release () {
-      this.expiresAt = 0
-      this.options = null
-    },
-  }
+  const synchronizeLock = createSynchronizeLock('shoot')
 
   function synchronize () {
     const shootStore = this
@@ -376,7 +360,7 @@ const useShootStore = defineStore('shoot', () => {
     const fetchData = async options => {
       let throttleDelay
       // check if a synchronize operation with the same options is already in progress and hasn't expired.
-      if (!synchronizeLock.aquire(options)) {
+      if (!synchronizeLock.acquire(options)) {
         return
       }
       try {

--- a/frontend/src/store/socket/helper.js
+++ b/frontend/src/store/socket/helper.js
@@ -19,6 +19,7 @@ export function createSocket (state, context) {
     ticketStore,
     projectStore,
     seedStore,
+    seedStatStore,
     managedSeedStore,
     managedSeedShootStore,
   } = context
@@ -115,6 +116,7 @@ export function createSocket (state, context) {
     state.active = socket.active
     setConnected(socket.connected)
     shootStore.synchronize()
+    seedStatStore.synchronize()
   })
 
   socket.on('disconnect', reason => {
@@ -220,6 +222,10 @@ export function createSocket (state, context) {
 
   socket.on('seeds', event => {
     seedStore.handleEvent(event)
+  })
+
+  socket.on('seedstats', event => {
+    seedStatStore.handleEvent(event)
   })
 
   socket.on('managedseeds', event => {

--- a/frontend/src/store/socket/index.js
+++ b/frontend/src/store/socket/index.js
@@ -24,6 +24,7 @@ import { useShootStore } from '../shoot'
 import { useTicketStore } from '../ticket'
 import { useProjectStore } from '../project'
 import { useSeedStore } from '../seed'
+import { useSeedStatStore } from '../seedStat'
 import { useManagedSeedStore } from '../managedSeed'
 import { useManagedSeedShootStore } from '../managedSeedShoot'
 
@@ -39,6 +40,7 @@ export const useSocketStore = defineStore('socket', () => {
   const ticketStore = useTicketStore()
   const projectStore = useProjectStore()
   const seedStore = useSeedStore()
+  const seedStatStore = useSeedStatStore()
   const managedSeedStore = useManagedSeedStore()
   const managedSeedShootStore = useManagedSeedShootStore()
 
@@ -62,6 +64,7 @@ export const useSocketStore = defineStore('socket', () => {
     ['shoots', false],
     ['projects', false],
     ['seeds', false],
+    ['seedstats', false],
     ['managedseeds', false],
     ['managedseed-shoots', false],
   ])
@@ -73,6 +76,7 @@ export const useSocketStore = defineStore('socket', () => {
     ticketStore,
     projectStore,
     seedStore,
+    seedStatStore,
     managedSeedStore,
     managedSeedShootStore,
   })
@@ -112,14 +116,14 @@ export const useSocketStore = defineStore('socket', () => {
     socket.disconnect()
   }
 
-  async function emitSubscribe (options) {
+  async function emitSubscribe (key, options) {
     if (!socket.connected) {
       return
     }
     const {
       statusCode = 500,
-      message = 'Failed to subscribe shoots',
-    } = await socket.timeout(acknowledgementTimeout).emitWithAck('subscribe', 'shoots', options)
+      message = `Failed to subscribe ${key}`,
+    } = await socket.timeout(acknowledgementTimeout).emitWithAck('subscribe', key, options)
     if (statusCode !== 200) {
       logger.debug('Subscribe Error: %s', message)
       throw createError(statusCode, message, {
@@ -128,11 +132,14 @@ export const useSocketStore = defineStore('socket', () => {
     }
   }
 
-  async function emitUnsubscribe () {
+  async function emitUnsubscribe (key) {
+    if (!socket.connected) {
+      return
+    }
     const {
       statusCode = 500,
-      message = 'Failed to unsubscribe shoots',
-    } = await socket.timeout(acknowledgementTimeout).emitWithAck('unsubscribe', 'shoots')
+      message = `Failed to unsubscribe ${key}`,
+    } = await socket.timeout(acknowledgementTimeout).emitWithAck('unsubscribe', key)
     if (statusCode !== 200) {
       logger.debug('Unsubscribe Error: %s', message)
       throw createError(statusCode, message, {
@@ -141,7 +148,7 @@ export const useSocketStore = defineStore('socket', () => {
     }
   }
 
-  async function synchronize (key, uids) {
+  async function synchronize (key, uids, options) {
     if (!uids.length) {
       return []
     }
@@ -155,7 +162,7 @@ export const useSocketStore = defineStore('socket', () => {
         name = 'InternalError',
         message = `Failed to synchronize ${key}`,
         items = [],
-      } = await socket.timeout(acknowledgementTimeout).emitWithAck('synchronize', key, uids)
+      } = await socket.timeout(acknowledgementTimeout).emitWithAck('synchronize', key, uids, options)
       if (statusCode === 200) {
         return items
       }

--- a/frontend/src/utils/errorCodes.js
+++ b/frontend/src/utils/errorCodes.js
@@ -13,8 +13,8 @@ import flatMap from 'lodash/flatMap'
 import map from 'lodash/map'
 import some from 'lodash/some'
 
-export function errorCodesFromArray (array) {
-  return uniq(compact(flatMap(array, 'codes')))
+export function errorCodesFromArray (items) {
+  return uniq(compact(flatMap(items, 'codes')))
 }
 
 export function isUserError (errorCodesArray) {

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -395,8 +395,7 @@ export function isReconciliationDeactivated (metadata) {
 }
 
 export function isTruthyValue (value) {
-  const truthyValues = ['1', 't', 'T', 'true', 'TRUE', 'True']
-  return includes(truthyValues, value)
+  return ['1', 't', 'T', 'true', 'TRUE', 'True'].includes(value)
 }
 
 export function isStatusProgressing (metadata) {

--- a/frontend/src/views/GAdministration.vue
+++ b/frontend/src/views/GAdministration.vue
@@ -446,6 +446,7 @@ SPDX-License-Identifier: Apache-2.0
                             :model-value="resourceQuota.percentage"
                             :color="resourceQuota.progressColor"
                             :height="8"
+                            rounded
                           />
                         </div>
                       </td>

--- a/frontend/src/views/GSeedList.vue
+++ b/frontend/src/views/GSeedList.vue
@@ -77,7 +77,6 @@ import {
 } from 'vue'
 import { storeToRefs } from 'pinia'
 
-import { useAppStore } from '@/store/app'
 import { useSeedStore } from '@/store/seed'
 import { useSeedStatStore } from '@/store/seedStat'
 import { useManagedSeedStore } from '@/store/managedSeed'
@@ -104,7 +103,6 @@ import find from 'lodash/find'
 import map from 'lodash/map'
 import join from 'lodash/join'
 
-const appStore = useAppStore()
 const seedStore = useSeedStore()
 const seedStatStore = useSeedStatStore()
 const managedSeedStore = useManagedSeedStore()
@@ -330,25 +328,17 @@ const seedStatsSubscriptionOptions = computed(() => {
   }
 })
 
-watch(seedStatsSubscriptionOptions, async options => {
-  try {
-    if (options) {
-      await seedStatStore.subscribe(options)
-    } else {
-      await seedStatStore.unsubscribe()
-    }
-  } catch (err) {
-    appStore.setError(err)
+watch(seedStatsSubscriptionOptions, options => {
+  if (options) {
+    seedStatStore.subscribe(options)
+  } else {
+    seedStatStore.unsubscribe()
   }
 }, {
   immediate: true,
 })
 
 onUnmounted(async () => {
-  try {
-    await seedStatStore.unsubscribe()
-  } catch (err) {
-    appStore.setError(err)
-  }
+  await seedStatStore.unsubscribe()
 })
 </script>

--- a/frontend/src/views/GSeedList.vue
+++ b/frontend/src/views/GSeedList.vue
@@ -72,10 +72,14 @@ import {
   computed,
   reactive,
   provide,
+  onUnmounted,
+  watch,
 } from 'vue'
 import { storeToRefs } from 'pinia'
 
+import { useAppStore } from '@/store/app'
 import { useSeedStore } from '@/store/seed'
+import { useSeedStatStore } from '@/store/seedStat'
 import { useManagedSeedStore } from '@/store/managedSeed'
 import { useSocketStore } from '@/store/socket'
 import { useLocalStorageStore } from '@/store/localStorage'
@@ -96,10 +100,13 @@ import { errorCodesFromArray } from '@/utils/errorCodes'
 
 import get from 'lodash/get'
 import filter from 'lodash/filter'
+import find from 'lodash/find'
 import map from 'lodash/map'
 import join from 'lodash/join'
 
+const appStore = useAppStore()
 const seedStore = useSeedStore()
+const seedStatStore = useSeedStatStore()
 const managedSeedStore = useManagedSeedStore()
 const socketStore = useSocketStore()
 const localStorageStore = useLocalStorageStore()
@@ -164,6 +171,33 @@ const allHeaders = computed(() => [
     defaultSelected: true,
     hidden: false,
     value: item => item,
+  },
+  {
+    title: 'CAPACITY',
+    key: 'shootCount',
+    sortable: true,
+    align: 'center',
+    defaultSelected: true,
+    hidden: false,
+    value: item => {
+      const shootCount = seedStatStore.shootCountForSeed(get(item, ['metadata', 'name'])) ?? 0
+      const allocatableShoots = Number(get(item, ['status', 'allocatable', 'shoots']))
+
+      if (Number.isFinite(allocatableShoots) && allocatableShoots > 0) {
+        return shootCount / allocatableShoots
+      }
+
+      return shootCount
+    },
+  },
+  {
+    title: 'SHOOT HEALTH',
+    key: 'unhealthyShoots',
+    sortable: true,
+    align: 'center',
+    defaultSelected: true,
+    hidden: false,
+    value: item => seedStatStore.unhealthyShootsForSeed(get(item, ['metadata', 'name'])) ?? 0,
   },
   {
     title: 'ACCESS RESTRICTIONS',
@@ -279,4 +313,42 @@ function resetTableSettings () {
 function getItemKey (item, fallback) {
   return get(item, ['metadata', 'uid'], fallback)
 }
+
+function isHeaderSelected (key) {
+  const header = find(headers.value, ['key', key])
+  return header?.selected ?? false
+}
+
+const seedStatsSubscriptionOptions = computed(() => {
+  const shouldSubscribeToSeedStats = isHeaderSelected('unhealthyShoots') || isHeaderSelected('shootCount')
+  if (!shouldSubscribeToSeedStats) {
+    return null
+  }
+
+  return {
+    unhealthyFilterMask: seedStatStore.currentUnhealthyFilterMask,
+  }
+})
+
+watch(seedStatsSubscriptionOptions, async options => {
+  try {
+    if (options) {
+      await seedStatStore.subscribe(options)
+    } else {
+      await seedStatStore.unsubscribe()
+    }
+  } catch (err) {
+    appStore.setError(err)
+  }
+}, {
+  immediate: true,
+})
+
+onUnmounted(async () => {
+  try {
+    await seedStatStore.unsubscribe()
+  } catch (err) {
+    appStore.setError(err)
+  }
+})
 </script>

--- a/frontend/src/views/GShootList.vue
+++ b/frontend/src/views/GShootList.vue
@@ -156,6 +156,7 @@ import GTableSearch from '@/components/GTableSearch.vue'
 import { useProjectShootCustomFields } from '@/composables/useProjectShootCustomFields'
 import { isCustomField } from '@/composables/useProjectShootCustomFields/helper'
 import { useProvideShootAction } from '@/composables/useShootAction'
+import { useShootListFilters } from '@/composables/useShootListFilters'
 import { useUrlSearchSync } from '@/composables/useUrlSearchSync'
 
 import { mapTableHeader } from '@/utils'
@@ -164,7 +165,6 @@ import upperCase from 'lodash/upperCase'
 import sortBy from 'lodash/sortBy'
 import some from 'lodash/some'
 import map from 'lodash/map'
-import join from 'lodash/join'
 import isEmpty from 'lodash/isEmpty'
 import unset from 'lodash/unset'
 import get from 'lodash/get'
@@ -235,6 +235,13 @@ export default {
       setDebouncedShootSearch()
     }
 
+    const {
+      activeFilterLabels,
+      shootListFilters,
+      onlyShootsWithIssues,
+      toggleShootListFilter,
+    } = useShootListFilters()
+
     return {
       activePopoverKey,
       expandedWorkerGroups,
@@ -244,6 +251,10 @@ export default {
       debouncedShootSearch,
       setShootSearch,
       onUpdateShootSearch,
+      activeFilterLabels,
+      shootListFilters,
+      onlyShootsWithIssues,
+      toggleShootListFilter,
     }
   },
   data () {
@@ -275,10 +286,8 @@ export default {
     ]),
     ...mapState(useShootStore, [
       'shootList',
-      'shootListFilters',
       'loading',
       'selectedShoot',
-      'onlyShootsWithIssues',
       'numberOfNewItemsSinceFreeze',
       'focusMode',
       'sortBy',
@@ -288,7 +297,6 @@ export default {
       'shootSortBy',
       'shootCustomSelectedColumns',
       'shootCustomSortBy',
-      'allProjectsShootFilter',
       'operatorFeatures',
     ]),
     defaultSortBy () {
@@ -628,20 +636,14 @@ export default {
         : ''
     },
     headlineSubtitle () {
-      const subtitle = []
-      if (!this.projectScope && this.showOnlyShootsWithIssues) {
-        subtitle.push('Hide: Healthy Clusters')
-        if (this.isFilterActive('progressing')) {
-          subtitle.push('Progressing Clusters')
-        }
-        if (this.isFilterActive('noOperatorAction')) {
-          subtitle.push('User Errors')
-        }
-        if (this.isFilterActive('hideTicketsWithLabel')) {
-          subtitle.push('Tickets with Ignore Labels')
-        }
+      if (this.projectScope || !this.showOnlyShootsWithIssues) {
+        return ''
       }
-      return join(subtitle, ', ')
+      const all = ['Healthy Clusters', ...this.activeFilterLabels]
+      const shown = all.slice(0, 2).join(', ')
+      const remaining = all.length - 2
+      const suffix = remaining > 0 ? ` & ${remaining} more` : ''
+      return `Excluding: ${shown}${suffix}`
     },
     gitHubRepoUrl () {
       return get(this.ticketConfig, ['gitHubRepoUrl'])
@@ -684,7 +686,6 @@ export default {
   },
   methods: {
     ...mapActions(useShootStore, [
-      'toogleShootListFilter',
       'subscribeShoots',
       'sortItems',
       'searchItems',
@@ -728,7 +729,7 @@ export default {
       this.sortByInternal = this.defaultSortBy
     },
     toggleFilter ({ value: key }) {
-      this.toogleShootListFilter(key)
+      this.toggleShootListFilter(key)
       if (key === 'onlyShootsWithIssues') {
         this.subscribeShoots()
       }

--- a/frontend/src/views/GShootList.vue
+++ b/frontend/src/views/GShootList.vue
@@ -586,13 +586,6 @@ export default {
           disabled: this.changeFiltersDisabled,
         },
         {
-          text: 'Hide clusters with deactivated reconciliation',
-          value: 'deactivatedReconciliation',
-          selected: this.isFilterActive('deactivatedReconciliation'),
-          hidden: this.projectScope || !this.isAdmin || this.showAllShoots,
-          disabled: this.changeFiltersDisabled,
-        },
-        {
           text: 'Hide clusters with configured ticket labels',
           value: 'hideTicketsWithLabel',
           selected: this.isFilterActive('hideTicketsWithLabel'),
@@ -643,9 +636,6 @@ export default {
         }
         if (this.isFilterActive('noOperatorAction')) {
           subtitle.push('User Errors')
-        }
-        if (this.isFilterActive('deactivatedReconciliation')) {
-          subtitle.push('Deactivated Reconciliation')
         }
         if (this.isFilterActive('hideTicketsWithLabel')) {
           subtitle.push('Tickets with Ignore Labels')


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:

Adds per-seed shoot health statistics and capacity indicators to the seed list and seed detail views, with real-time updates via Socket.IO.

### Backend

- **Seedstats service**: computes per-seed `shootCount` and `unhealthyShoots: { total, matching }`. `total` counts all unhealthy shoots; `matching` counts only those not excluded by the active filter mask.
- **Filter mask**: a bitmask `unhealthyFilterMask` parameter controls which unhealthy shoots are excluded from `matching`:
  | Bit | Filter |
  |-----|--------|
  | 0 | Hide progressing |
  | 1 | Hide no-operator-action-required |
  | 2 | Hide clusters with configured ticket labels |
- **REST**: `GET /api/seedstats[/:name]?unhealthyFilterMask=<mask>`.
- **Socket.IO**: explicit `subscribe`/`unsubscribe` with filter-specific rooms (`seedstats;uf=<mask>`, `seedstats;seed=<name>;uf=<mask>`). Server emits pre-computed counts per room. Only rooms with members trigger recomputation.
- **Cache indexing**: projects indexed by namespace, shoots indexed by seed name for efficient per-seed iteration.

### Frontend

- **seedStat store**: on-demand lifecycle: subscribes on seed list/detail mount, re-subscribes on filter change, unsubscribes when stats columns are hidden or on unmount.
- **GShootHealthDonut**: SVG ring chart showing matching (red) / excluded (grey) / healthy (background) shoot distribution per seed.
- **GSeedCapacityIndicator**: shows assigned vs allocatable shoot count with progress bar. Reads `allocatableShoots` from the seed spec.
- **useShootListFilters**: shared composable for all-project filter state, reused between shoot list and seed stats.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```feature user
The seed list now displays per-seed shoot health statistics as donut charts and shoot capacity indicators, with real-time updates. Health stats respect the active Operations View exclusion criteria.
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Seed statistics API with real‑time subscribe/synchronize and a new "seedstats" socket channel; UI components for shoot health (donut) and seed capacity, plus client store/composables for live seed stats.

* **Improvements**
  * New cache indices for faster project/seed/shoot lookups; event publishing now emits seedstats updates; enhanced socket room handling, authorization checks, and filter-driven unhealthy masking.

* **Tests**
  * Extensive new unit and acceptance tests covering seedstats, realtime flows, cache, watches, and UI.

* **Chores**
  * Updated .gitignore to ignore local Claude settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->