### PR TITLE
feat(frontend) Use new `rotate-etcd-encryption-key` annotation to perform ETCD Encryption Key

### DIFF
--- a/frontend/__tests__/components/GShootCredentialRotation.spec.js
+++ b/frontend/__tests__/components/GShootCredentialRotation.spec.js
@@ -94,12 +94,11 @@ describe('components', () => {
                 lastCompletionTime: '2022-07-05T10:01:42Z',
               },
               etcdEncryptionKey: {
-                phase: 'Completing',
                 lastInitiationTime: '2022-07-05T09:22:33Z',
                 lastCompletionTime: '2022-06-27T08:25:58Z',
               },
               serviceAccountKey: {
-                phase: 'Completed',
+                phase: 'Completing',
                 lastInitiationTime: '2022-07-05T09:22:33Z',
                 lastCompletionTime: '2022-07-05T09:47:32Z',
               },
@@ -162,11 +161,11 @@ describe('components', () => {
         expect(certificateAuthoritiesWrapper.vm.phase).toEqual({ type: 'Prepared' })
         expect(certificateAuthoritiesWrapper.vm.phaseColor).toBe('primary')
 
-        expect(etcdEncryptionKeyWrapper.vm.phase).toEqual({ type: 'Completing' })
+        expect(etcdEncryptionKeyWrapper.vm.phase).toEqual({ type: undefined })
         expect(etcdEncryptionKeyWrapper.vm.phaseColor).toBe('info')
 
-        expect(serviceAccountKeyWrapper.vm.phase).toEqual({ type: 'Completed' })
-        expect(serviceAccountKeyWrapper.vm.phaseColor).toBe('primary')
+        expect(serviceAccountKeyWrapper.vm.phase).toEqual({ type: 'Completing' })
+        expect(serviceAccountKeyWrapper.vm.phaseColor).toBe('info')
 
         expect(allWrapper.vm.phase).toEqual({ caption: 'Completing', type: 'Completing' })
         expect(allWrapper.vm.phaseCaption).toBe('Completing')
@@ -281,16 +280,16 @@ describe('components', () => {
       it('should compute operation', () => {
         expect(allRotationWrapper.vm.operation).toBe(allRotationWrapper.vm.completionOperation)
         expect(certificateAuthoritiesRotationWrapper.vm.operation).toBe(certificateAuthoritiesRotationWrapper.vm.completionOperation)
-        expect(etcdEncryptionKeyRotationWrapper.vm.operation).toBe(etcdEncryptionKeyRotationWrapper.vm.completionOperation)
-        expect(serviceAccountKeyRotationWrapper.vm.operation).toBe(serviceAccountKeyRotationWrapper.vm.startOperation)
+        expect(etcdEncryptionKeyRotationWrapper.vm.operation).toBe(etcdEncryptionKeyRotationWrapper.vm.startOperation)
+        expect(serviceAccountKeyRotationWrapper.vm.operation).toBe(serviceAccountKeyRotationWrapper.vm.completionOperation)
       })
 
       it('should compute mode', () => {
         expect(allRotationWrapper.vm.mode).toBe('COMPLETE')
         expect(certificateAuthoritiesRotationWrapper.vm.mode).toBe('COMPLETE')
         expect(observabilityRotationWrapper.vm.mode).toBe('ROTATE')
-        expect(etcdEncryptionKeyRotationWrapper.vm.mode).toBe('COMPLETE')
-        expect(serviceAccountKeyRotationWrapper.vm.mode).toBe('START')
+        expect(etcdEncryptionKeyRotationWrapper.vm.mode).toBe('ROTATE')
+        expect(serviceAccountKeyRotationWrapper.vm.mode).toBe('COMPLETE')
       })
     })
   })

--- a/frontend/__tests__/composables/useShootStatusCredentialRotation.spec.js
+++ b/frontend/__tests__/composables/useShootStatusCredentialRotation.spec.js
@@ -31,9 +31,6 @@ describe('composables', () => {
                 certificateAuthorities: {
                   phase: 'Prepared',
                 },
-                etcdEncryptionKey: {
-                  phase: 'Completing',
-                },
                 serviceAccountKey: {
                   phase: 'Completed',
                 },
@@ -44,6 +41,7 @@ describe('composables', () => {
       })
 
       it('should return progressing phase', () => {
+        set(shootItem.value, ['status', 'credentials', 'rotation', 'serviceAccountKey', 'phase'], 'Completing')
         expect(reactiveShootItem.shootCredentialsRotationAggregatedPhase).toEqual({
           type: 'Completing',
           caption: 'Completing',
@@ -74,10 +72,9 @@ describe('composables', () => {
 
         expect(reactiveShootItem.shootCredentialsRotationAggregatedPhase).toEqual({
           type: 'Prepared',
-          caption: 'Prepared 1/3',
+          caption: 'Prepared 1/2',
           incomplete: true,
           unpreparedRotations: [
-            find(rotationTypes, ['type', 'etcdEncryptionKey']),
             find(rotationTypes, ['type', 'serviceAccountKey']),
           ],
         })

--- a/frontend/src/components/GShootActionRotateCredentials.vue
+++ b/frontend/src/components/GShootActionRotateCredentials.vue
@@ -219,9 +219,8 @@ export default {
     const isHibernationPreventingRotation = computed(() => {
       return isShootStatusHibernated.value &&
         includes(['rotate-credentials-start',
-          'rotate-etcd-encryption-key-start',
           'rotate-credentials-complete',
-          'rotate-etcd-encryption-key-complete',
+          'rotate-etcd-encryption-key',
           'rotate-serviceaccount-key-start',
           'rotate-serviceaccount-key-complete'],
         operation.value)
@@ -305,7 +304,7 @@ export default {
             'The current observability passwords will be invalidated',
             'New observability passwords will be generated',
             authnStore.isAdmin
-              ? 'Note Operator: This will invalidate the user observability passwords. Operator passwords will be rotated automatically. There is no way to trigger the rotation manually'
+              ? 'Operator Note: This will invalidate the user observability passwords. Operator passwords will be rotated automatically. There is no way to trigger the rotation manually'
               : undefined,
           ]),
         },
@@ -317,31 +316,21 @@ export default {
           successMessage: `Rotation of SSH key pair started for ${shootName.value}`,
           heading: 'Do you want to start the rotation of SSH key pair for worker nodes?',
           actions: [
-            'The current SSH key pair will be revoked.',
+            'The current SSH key pair will be revoked',
             'A new SSH key pair will be generated',
           ],
         },
-        'rotate-etcd-encryption-key-start': {
+        'rotate-etcd-encryption-key': {
           caption: showLoadingIndicator.value
-            ? 'Preparing etcd encryption key rotation'
-            : 'Prepare ETCD Encryption Key Rotation',
-          errorMessage: 'Could not prepare the rotation of etcd encryption key',
-          successMessage: `Preparing rotation of etcd encryption key for ${shootName.value}`,
-          heading: 'Do you want to prepare the rotation of etcd encryption key?',
+            ? 'Rotating ETCD encryption key'
+            : 'Start ETCD Encryption Key Rotation',
+          errorMessage: 'Could not start the rotation of ETCD encryption key',
+          successMessage: `Rotation of ETCD encryption key started for ${shootName.value}`,
+          heading: 'Do you want to start the rotation of ETCD encryption key?',
           actions: [
-            'A new encryption key will be created and added to the bundle (old encryption key will remain in the bundle).',
-            'All Secrets in the cluster will be rewritten by the kube-apiserver so that they become encrypted with the new encryption key.',
-          ],
-        },
-        'rotate-etcd-encryption-key-complete': {
-          caption: showLoadingIndicator.value
-            ? 'Completing etcd encryption key rotation'
-            : 'Complete ETCD Encryption Key Rotation',
-          errorMessage: 'Could not complete the rotation of etcd encryption key',
-          successMessage: `Completing rotation of etcd encryption key for ${shootName.value}`,
-          heading: 'Do you want to complete the rotation of etcd encryption key?',
-          actions: [
-            'The old encryption will be dropped from the bundle.',
+            'A new encryption key will be created and added to the bundle',
+            'All Secrets in the cluster will be rewritten by the kube-apiserver so that they become encrypted with the new encryption key',
+            'The old encryption key will be dropped from the bundle',
           ],
         },
         'rotate-serviceaccount-key-start': {
@@ -382,7 +371,7 @@ export default {
           ...hasShootWorkerGroups.value && sshAccessEnabled.value
             ? allComponentTexts['rotate-ssh-keypair'].actions
             : [],
-          ...allComponentTexts['rotate-etcd-encryption-key-start'].actions,
+          ...allComponentTexts['rotate-etcd-encryption-key'].actions,
           ...allComponentTexts['rotate-serviceaccount-key-start'].actions,
         ],
       }
@@ -398,7 +387,6 @@ export default {
         heading: 'Do you want to complete the rotation of all credentials?',
         actions: [
           ...allComponentTexts['rotate-ca-complete'].actions,
-          ...allComponentTexts['rotate-etcd-encryption-key-complete'].actions,
           ...allComponentTexts['rotate-serviceaccount-key-complete'].actions,
         ],
       }

--- a/frontend/src/composables/useShootStatusCredentialRotation.js
+++ b/frontend/src/composables/useShootStatusCredentialRotation.js
@@ -37,9 +37,8 @@ export const rotationTypes = Object.freeze([
   {
     type: 'etcdEncryptionKey',
     hasRotationStatus: true,
-    startOperation: 'rotate-etcd-encryption-key-start',
-    completionOperation: 'rotate-etcd-encryption-key-complete',
-    twoStep: true,
+    startOperation: 'rotate-etcd-encryption-key',
+    twoStep: false,
     title: 'ETCD Encryption Key',
   },
   {


### PR DESCRIPTION

<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Required because of this change https://github.com/gardener/gardener/pull/12605

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Use the new `rotate-etcd-encryption-key` annotation to rotate the ETCD encryption key. This operation is no longer performed in two steps. This updated approach is required for clusters running Kubernetes version 1.34.0 and later
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Simplified etcd encryption key rotation from a two-step process to a single-step operation.
  * Improved operation detection for credential rotation workflows.

* **Improvements**
  * Updated credential rotation messaging for better clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->