### PR TITLE
Security: Missing authorization checks on ticket listing endpoints

### DIFF
--- a/backend/lib/routes/tickets.js
+++ b/backend/lib/routes/tickets.js
@@ -5,6 +5,7 @@
 //
 
 import express from 'express'
+import createError from 'http-errors'
 import _ from 'lodash-es'
 import cache from '../cache/index.js'
 import * as tickets from '../services/tickets.js'
@@ -38,11 +39,25 @@ async function getIssuesAndComments (namespace, name) {
   return [issues, comments]
 }
 
+async function authorize (req, namespace) {
+  if (namespace === '_all') {
+    if (!await req.user.canListIssues()) {
+      throw createError(403, 'Forbidden')
+    }
+    return
+  }
+  const projectName = getProjectName(namespace)
+  if (!await req.user.canGetProject({ name: projectName })) {
+    throw createError(403, 'Forbidden')
+  }
+}
+
 router.route('/')
   .all(metricsMiddleware)
-  .get((req, res, next) => {
+  .get(async (req, res, next) => {
     try {
       const namespace = req.params.namespace
+      await authorize(req, namespace)
       const issues = getIssues(namespace)
       res.send({ issues })
     } catch (err) {
@@ -55,6 +70,7 @@ router.route('/:name')
   .get(async (req, res, next) => {
     try {
       const namespace = req.params.namespace
+      await authorize(req, namespace)
       const name = req.params.name
       const [issues, comments] = await getIssuesAndComments(namespace, name)
       res.send({ issues, comments })


### PR DESCRIPTION
## Summary

Security: Missing authorization checks on ticket listing endpoints

## Problem

**Severity**: `High` | **File**: `backend/lib/routes/tickets.js:L14`

The tickets routes return issue/comment data based only on the `namespace` URL parameter and cache lookups, but do not perform any per-request authorization check (e.g., project membership or explicit RBAC verification). An authenticated user may query `/namespaces/_all/tickets` (or other namespaces) and potentially retrieve tickets for projects they should not access.

## Solution

Before returning tickets/comments, enforce authorization for the requesting user and namespace/project. For example, resolve namespace -> project, then call an authorization service (e.g., `canGetProject`/`canListIssues`) and return 403 on failure. Also explicitly forbid `_all` unless the user has a global admin/list permission.

## Changes

- `backend/lib/routes/tickets.js` (modified)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced API security by implementing access control on ticket endpoints. Authorization validation ensures only authorized users can access ticket data and operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->