### PR TITLE
refactor(frontend): bind table settings directly to store refs

### DIFF
--- a/frontend/__tests__/composables/useTableSorting.spec.js
+++ b/frontend/__tests__/composables/useTableSorting.spec.js
@@ -4,42 +4,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { nextTick } from 'vue'
-
 import { useTableSorting } from '@/composables/useTableSorting'
 import { getLastOperationSortVal } from '@/composables/useTableSorting/helper'
 
 describe('composables', () => {
   describe('useTableSorting', () => {
-    describe('sortBy', () => {
-      it('should use default sort by name ascending', () => {
-        const { sortBy } = useTableSorting()
-
-        expect(sortBy.value).toEqual([{ key: 'name', order: 'asc' }])
-      })
-
-      it('should use provided default sort config', () => {
-        const defaultSortBy = [{ key: 'createdAt', order: 'desc' }]
-        const { sortBy } = useTableSorting({ defaultSortBy })
-
-        expect(sortBy.value).toEqual(defaultSortBy)
-      })
-
-      it('should call onSortChange when sorting changes', async () => {
-        const onSortChange = vi.fn()
-        const { sortBy } = useTableSorting({ onSortChange })
-
-        sortBy.value = [{ key: 'createdAt', order: 'desc' }]
-        await nextTick()
-
-        expect(onSortChange).toHaveBeenCalledWith([{ key: 'createdAt', order: 'desc' }])
-      })
-
-      it('should throw if onSortChange is not a function', () => {
-        expect(() => useTableSorting({ onSortChange: 'invalid' })).toThrow(TypeError)
-      })
-    })
-
     describe('compareValues', () => {
       it('should compare strings case-insensitively', () => {
         const { compareValues } = useTableSorting()

--- a/frontend/src/composables/useSeedTableSorting.js
+++ b/frontend/src/composables/useSeedTableSorting.js
@@ -55,22 +55,13 @@ function compareLastOperation (a, b, compareValues) {
   return compareValues(getSeedLastOperationSortVal(a), getSeedLastOperationSortVal(b))
 }
 
-export function useSeedTableSorting (options = {}) {
-  const {
-    defaultSortBy = [{ key: 'name', order: 'asc' }],
-    onSortChange,
-  } = options
-
+export function useSeedTableSorting () {
   const configStore = useConfigStore()
 
   const {
-    sortBy,
     compareValues,
     compareSemanticVersions,
-  } = useTableSorting({
-    defaultSortBy,
-    onSortChange,
-  })
+  } = useTableSorting()
 
   const customKeySort = {
     name: (a, b) => compareValues(a, b),
@@ -84,7 +75,6 @@ export function useSeedTableSorting (options = {}) {
   }
 
   return {
-    sortBy,
     customKeySort,
   }
 }

--- a/frontend/src/composables/useSeedTableSorting.js
+++ b/frontend/src/composables/useSeedTableSorting.js
@@ -64,13 +64,13 @@ export function useSeedTableSorting () {
   } = useTableSorting()
 
   const customKeySort = {
-    name: (a, b) => compareValues(a, b),
-    infrastructure: (a, b) => compareValues(a, b),
+    name: compareValues,
+    infrastructure: compareValues,
     lastOperation: (a, b) => compareLastOperation(a, b, compareValues),
-    kubernetesVersion: (a, b) => compareSemanticVersions(a, b),
-    gardenerVersion: (a, b) => compareSemanticVersions(a, b),
-    shoot: (a, b) => compareValues(a, b),
-    createdAt: (a, b) => compareValues(a, b),
+    kubernetesVersion: compareSemanticVersions,
+    gardenerVersion: compareSemanticVersions,
+    shoot: compareValues,
+    createdAt: compareValues,
     readiness: (a, b) => compareReadiness(a, b, configStore),
   }
 

--- a/frontend/src/composables/useTableSorting/index.js
+++ b/frontend/src/composables/useTableSorting/index.js
@@ -4,24 +4,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import {
-  ref,
-  watch,
-} from 'vue'
 import semver from 'semver'
 
-export function useTableSorting (options = {}) {
-  const {
-    defaultSortBy = [{ key: 'name', order: 'asc' }],
-    onSortChange,
-  } = options
-
-  if (onSortChange && typeof onSortChange !== 'function') {
-    throw new TypeError('onSortChange must be a function')
-  }
-
-  const sortBy = ref(defaultSortBy)
-
+export function useTableSorting () {
   function compareValues (aVal, bVal) {
     if (aVal == null && bVal == null) {
       return 0
@@ -82,14 +67,7 @@ export function useTableSorting (options = {}) {
     })
   }
 
-  if (onSortChange) {
-    watch(sortBy, newValue => {
-      onSortChange(newValue)
-    }, { deep: true })
-  }
-
   return {
-    sortBy,
     compareValues,
     compareSemanticVersions,
   }

--- a/frontend/src/views/GSeedList.vue
+++ b/frontend/src/views/GSeedList.vue
@@ -28,7 +28,7 @@ SPDX-License-Identifier: Apache-2.0
         </template>
       </g-toolbar>
       <v-data-table-virtual
-        v-model:sort-by="sortBy"
+        v-model:sort-by="seedSortBy"
         :headers="visibleHeaders"
         :items="filteredSeeds"
         :loading="loading || !connected"
@@ -70,8 +70,6 @@ import {
   computed,
   reactive,
   provide,
-  watch,
-  onMounted,
 } from 'vue'
 import { storeToRefs } from 'pinia'
 
@@ -116,8 +114,6 @@ provide('activePopoverKey', activePopoverKey)
 
 const expandedAccessRestrictions = reactive({ default: false })
 provide('expandedAccessRestrictions', expandedAccessRestrictions)
-
-const selectedColumns = ref({})
 
 const { search: searchQuery } = useUrlSearchSync()
 
@@ -218,7 +214,7 @@ const headers = computed(() => {
   return map(allHeaders.value, header => ({
     ...header,
     class: 'nowrap',
-    selected: get(selectedColumns.value, header.key, header.defaultSelected),
+    selected: get(seedSelectedColumns.value, header.key, header.defaultSelected),
   }))
 })
 
@@ -228,10 +224,6 @@ const selectableHeaders = computed(() => {
 
 const visibleHeaders = computed(() => {
   return filter(selectableHeaders.value, ['selected', true])
-})
-
-const currentSelectedColumns = computed(() => {
-  return mapTableHeader(headers.value, 'selected')
 })
 
 const defaultSelectedColumns = computed(() => {
@@ -271,45 +263,18 @@ const { filteredItems: filteredSeeds } = useTableFilter({
   filterFn: seedFilterFn,
 })
 
-const {
-  sortBy,
-  customKeySort,
-} = useSeedTableSorting({
-  defaultSortBy: seedSortBy.value,
-  onSortChange: newSortBy => {
-    seedSortBy.value = newSortBy
-  },
-})
+const { customKeySort } = useSeedTableSorting()
 
 function setSelectedHeader (header) {
-  selectedColumns.value[header.key] = !header.selected
-  saveSelectedColumns()
-}
-
-function saveSelectedColumns () {
-  seedSelectedColumns.value = currentSelectedColumns.value
+  seedSelectedColumns.value[header.key] = !header.selected
 }
 
 function resetTableSettings () {
-  selectedColumns.value = { ...defaultSelectedColumns.value }
-  saveSelectedColumns()
-  sortBy.value = [{ key: 'name', order: 'asc' }]
-  seedSortBy.value = sortBy.value
-}
-
-function updateTableSettings () {
-  selectedColumns.value = { ...seedSelectedColumns.value }
+  seedSelectedColumns.value = defaultSelectedColumns.value
+  seedSortBy.value = [{ key: 'name', order: 'asc' }]
 }
 
 function getItemKey (item, fallback) {
   return get(item, ['metadata', 'uid'], fallback)
 }
-
-watch(seedSelectedColumns, updateTableSettings, { deep: true, immediate: true })
-
-onMounted(() => {
-  if (seedSortBy.value?.length) {
-    sortBy.value = [...seedSortBy.value]
-  }
-})
 </script>

--- a/frontend/src/views/GSeedList.vue
+++ b/frontend/src/views/GSeedList.vue
@@ -70,6 +70,7 @@ import {
   computed,
   reactive,
   provide,
+  watch,
   onMounted,
 } from 'vue'
 import { storeToRefs } from 'pinia'
@@ -304,8 +305,9 @@ function getItemKey (item, fallback) {
   return get(item, ['metadata', 'uid'], fallback)
 }
 
+watch(seedSelectedColumns, updateTableSettings, { deep: true, immediate: true })
+
 onMounted(() => {
-  updateTableSettings()
   if (seedSortBy.value?.length) {
     sortBy.value = [...seedSortBy.value]
   }

--- a/frontend/src/views/GShootList.vue
+++ b/frontend/src/views/GShootList.vue
@@ -180,16 +180,10 @@ export default {
     GTableSearch,
   },
   inject: ['logger'],
-  beforeRouteEnter (to, from, next) {
-    next(vm => {
-      vm.updateTableSettings()
-    })
-  },
   beforeRouteUpdate (to, from, next) {
     if (to.path !== from.path) {
       this.setShootSearch('')
     }
-    this.updateTableSettings()
     this.focusModeInternal = false
 
     // Reset expanded state in case project changes
@@ -677,6 +671,16 @@ export default {
     },
   },
   watch: {
+    shootCustomSelectedColumns: {
+      handler: 'updateTableSettings',
+      deep: true,
+      immediate: true,
+    },
+    shootCustomSortBy: {
+      handler: 'updateTableSettings',
+      deep: true,
+      immediate: true,
+    },
     sortBy (sortBy) {
       if (some(sortBy, value => isCustomField(value.key))) {
         this.shootCustomSortBy = sortBy


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:

- Replaces imperative `updateTableSettings()`, `saveSelectedColumns()`, and `onMounted` sync with direct store ref bindings (`seedSelectedColumns`, `seedSortBy`) in `GSeedList`
- Drops `sortBy`/`onSortChange` callback pattern from `useTableSorting` and `useSeedTableSorting` — composables now only expose comparison helpers; sort state lives in the store

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
```
