### PR TITLE
chore(charts): deprecate helm charts in favor of gardener-operator

### DIFF
--- a/charts/gardener-dashboard/Chart.yaml
+++ b/charts/gardener-dashboard/Chart.yaml
@@ -2,3 +2,4 @@ apiVersion: v1
 description: A Helm chart to deploy the Gardener dashboard
 name: gardener-dashboard
 version: 0.1.0
+deprecated: true

--- a/charts/gardener-dashboard/README.md
+++ b/charts/gardener-dashboard/README.md
@@ -5,4 +5,4 @@
 > It will be removed earliest 6 months after deprecation (around November 2026).
 >
 > We urge you to switch to a [`gardener-operator`](https://github.com/gardener/gardener/blob/master/docs/concepts/operator.md)-based installation, which manages the Gardener Dashboard as part of the Gardener control plane.
-> Read all about it [here](https://github.com/gardener/gardener/blob/master/docs/concepts/operator.md).
+> Read all about it [here](https://github.com/gardener/gardener/blob/master/docs/concepts/operator.md#migrating-an-existing-gardener-landscape-to-gardener-operator).

--- a/charts/gardener-dashboard/README.md
+++ b/charts/gardener-dashboard/README.md
@@ -1,0 +1,8 @@
+# `gardener-dashboard` Helm Chart
+
+> [!CAUTION]
+> This Helm chart has been deprecated.
+> It will be removed earliest 6 months after deprecation (around November 2026).
+>
+> We urge you to switch to a [`gardener-operator`](https://github.com/gardener/gardener/blob/master/docs/concepts/operator.md)-based installation, which manages the Gardener Dashboard as part of the Gardener control plane.
+> Read all about it [here](https://github.com/gardener/gardener/blob/master/docs/concepts/operator.md).

--- a/charts/gardener-dashboard/charts/application/Chart.yaml
+++ b/charts/gardener-dashboard/charts/application/Chart.yaml
@@ -6,3 +6,4 @@ apiVersion: v1
 description: A Helm chart to deploy the Gardener dashboard application related components
 name: gardener-dashboard-application
 version: 0.1.0
+deprecated: true

--- a/charts/gardener-dashboard/charts/runtime/Chart.yaml
+++ b/charts/gardener-dashboard/charts/runtime/Chart.yaml
@@ -6,3 +6,4 @@ apiVersion: v1
 description: A Helm chart to deploy the Gardener dashboard runtime related components
 name: gardener-dashboard-runtime
 version: 0.1.0
+deprecated: true

--- a/charts/identity/Chart.yaml
+++ b/charts/identity/Chart.yaml
@@ -2,3 +2,4 @@ apiVersion: v1
 description: A Helm chart for kubernetes identity server
 name: identity
 version: 0.2.0
+deprecated: true

--- a/charts/identity/README.md
+++ b/charts/identity/README.md
@@ -1,0 +1,8 @@
+# `identity` Helm Chart
+
+> [!CAUTION]
+> This Helm chart has been deprecated.
+> It will be removed earliest 6 months after deprecation (around November 2026).
+>
+> We urge you to switch to a [`gardener-operator`](https://github.com/gardener/gardener/blob/master/docs/concepts/operator.md)-based installation, which manages the identity service as part of the Gardener control plane.
+> Read all about it [here](https://github.com/gardener/gardener/blob/master/docs/concepts/operator.md).

--- a/charts/identity/README.md
+++ b/charts/identity/README.md
@@ -5,4 +5,4 @@
 > It will be removed earliest 6 months after deprecation (around November 2026).
 >
 > We urge you to switch to a [`gardener-operator`](https://github.com/gardener/gardener/blob/master/docs/concepts/operator.md)-based installation, which manages the identity service as part of the Gardener control plane.
-> Read all about it [here](https://github.com/gardener/gardener/blob/master/docs/concepts/operator.md).
+> Read all about it [here](https://github.com/gardener/gardener/blob/master/docs/concepts/operator.md#migrating-an-existing-gardener-landscape-to-gardener-operator).

--- a/docs/operations/access-restrictions.md
+++ b/docs/operations/access-restrictions.md
@@ -15,6 +15,10 @@ The Dashboard can be installed and configured in two ways:
 
 #### 1. Installing via Helm Chart
 
+> [!CAUTION]
+> The Helm chart installation method has been deprecated and will be removed earliest 6 months after deprecation (around November 2026).
+> We urge you to switch to a [`gardener-operator`](https://github.com/gardener/gardener/blob/master/docs/concepts/operator.md)-based installation.
+
 When installing the Dashboard via Helm chart, access restrictions are configured in the `values.yaml` file.
 
 **Example `values.yaml`:**

--- a/docs/operations/customization.md
+++ b/docs/operations/customization.md
@@ -1,5 +1,10 @@
 # Theming and Branding
 
+> [!CAUTION]
+> The Helm chart installation method has been deprecated and will be removed earliest 6 months after deprecation (around November 2026).
+> We urge you to switch to a [`gardener-operator`](https://github.com/gardener/gardener/blob/master/docs/concepts/operator.md)-based installation.
+> When deploying the dashboard using the Gardener Operator, you can configure theming and branding via a `ConfigMap` referenced by `.spec.virtualCluster.gardener.gardenerDashboard.frontendConfigMapRef` within the `Garden` resource.
+
 ## Motivation
 Gardener landscape administrators should have the possibility to change the appearance and the branding of the Gardener Dashboard via configuration without the need to touch the code.
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area ops-productivity
/kind cleanup

**What this PR does / why we need it**:

Marks the `gardener-dashboard` and `identity` Helm charts as deprecated in favor
of the `gardener-operator` deployment approach.

Adds deprecation notices to Chart.yaml files and README.md documentation to inform
users that these charts will be removed earliest around November 2026.

This aligns with the Gardener project's move away from Helm chart–based deployments
of the controlplane, as announced in gardener/gardener#10706 and completed in
gardener/gardener#14614.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```doc operator
The `gardener-dashboard` Helm chart is deprecated in favor of `gardener-operator` managed deployments. The `identity` Helm chart is deprecated without replacement. Both will be removed earliest around November 2026.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecation Notice**
  * Gardener Dashboard and Identity Helm charts are now marked as deprecated with an expected removal window around November 2026.
  * Documentation updated with migration guidance directing users to transition to Gardener Operator-based installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->