### PR TITLE
chore: harden build and CI supply chain

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -31,6 +31,12 @@
   ],
   packageRules: [
     {
+      matchDatasources: [
+        'npm',
+      ],
+      minimumReleaseAge: '3 days',
+    },
+    {
       matchDepTypes: [
         'devDependencies',
       ],

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: '24.14.1'
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: run-eslint
         run: |
           set -eu

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,17 @@ scripts/bin
 # GitGuardian
 .cache_ggshield
 
+# Ignore AI assistant workspace config unless explicitly reviewed
+# To whitelist specific files use: !.claude/CLAUDE.md
+.aider/
+.claude/
+.cline/
+.codeium/
+.continue/
+.copilot/
+.cursor/
+.windsurf/
+
 # other files to ignore
 .DS_Store
 node_modules/

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,5 +1,4 @@
-approvedGitRepositories:
-  - "**"
+approvedGitRepositories: []
 
 compressionLevel: 0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ COPY . .
 
 # validate zero-installs project and disable network
 RUN yarn config set enableNetwork false
-RUN YARN_ENABLE_SCRIPTS=0 yarn install --immutable --immutable-cache
+RUN YARN_ENABLE_SCRIPTS=0 yarn install --immutable --immutable-cache --check-cache
 
 ############# node-scratch #############
 FROM scratch AS node-scratch

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,11 @@ WORKDIR /app
 
 COPY . .
 
-# validate zero-installs project and disable network
+# Validate zero-installs project and disable network.
+# --check-cache is omitted (requires network) and runs in the CI verify job instead.
+# This assumes pushed images are not consumed from failed workflows.
 RUN yarn config set enableNetwork false
-RUN YARN_ENABLE_SCRIPTS=0 yarn install --immutable --immutable-cache --check-cache
+RUN YARN_ENABLE_SCRIPTS=0 yarn install --immutable --immutable-cache
 
 ############# node-scratch #############
 FROM scratch AS node-scratch


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**

/area security
/kind enhancement

**What this PR does / why we need it**:

Adds multiple layers of supply chain hardening to the build and CI pipeline as additional protective measures against dependency-based attacks (such as the recent Shai-Hulud npm supply chain campaign targeting SAP packages):

- Pin GitHub Actions to commit hashes to prevent tag-based hijacking
- Restrict yarn-approved git repositories to an empty list, blocking unexpected git-hosted dependencies
- Verify yarn cache integrity via CI verify job (`--check-cache`); Docker build stays offline since the flag requires network access
- Require a 3-day minimum release age for npm packages via Renovate, reducing exposure to compromised freshly-published versions
  - > Security updates bypass any minimumReleaseAge checks, and so will be raised as soon as Renovate detects them. ([source](https://docs.renovatebot.com/key-concepts/minimum-release-age/#what-happens-to-security-updates))
- Gitignore AI assistant workspace directories to prevent IDE automation persistence attacks

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

These are incremental hardening measures building on top of existing supply chain protections already in place. Each commit is independently reviewable and addresses a distinct attack vector.

The `--check-cache` flag was removed from the Dockerfile because it requires network access, which conflicts with the offline build validation (`enableNetwork false`). Cache integrity is instead verified in the CI verify job, which runs in the same workflow. This assumes pushed images are not directly consumed from failed workflows.

**Release note**:
```other dependency
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Implemented more conservative dependency update policy requiring a 3-day release age
  * Pinned CI workflow actions for more reproducible builds
  * Clarified build cache/verification behavior in build process notes
  * Updated development environment configs (ignores for local assistant workspaces; tightened repository approval settings)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->