### PR TITLE
ci: restrict workflow permissions to least privilege

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,6 +11,8 @@ on:
           the mode to use. either `snapshot` or `release`. Will affect effective version, as well
           as target-oci-registry.
 
+permissions: {}
+
 jobs:
   prepare:
     uses: gardener/cc-utils/.github/workflows/prepare.yaml@v1
@@ -73,6 +75,8 @@ jobs:
 
   verify:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:

--- a/.github/workflows/non-release.yaml
+++ b/.github/workflows/non-release.yaml
@@ -15,6 +15,8 @@ on:
     - labeled
   merge_group:
 
+permissions: {}
+
 jobs:
   build:
     if: ${{ github.event_name != 'pull_request_target' || (github.event_name == 'pull_request_target' && github.event.label.name == vars.DEFAULT_LABEL_OK_TO_TEST && vars.DEFAULT_LABEL_OK_TO_TEST != '') }}

--- a/.github/workflows/pr-release-notes-validation.yaml
+++ b/.github/workflows/pr-release-notes-validation.yaml
@@ -6,8 +6,7 @@ on:
       - edited
       - reopened
 
-permissions:
-  pull-requests: read
+permissions: {}
 
 jobs:
   validate-release-notes:

--- a/.github/workflows/prepare-hotfix-branch.yaml
+++ b/.github/workflows/prepare-hotfix-branch.yaml
@@ -22,12 +22,14 @@ on:
         type: string
         default: .github/actions/prepare-hotfix
 
-permissions:
-  id-token: write # required for GitHub OIDC Federation Service token
+permissions: {}
 
 jobs:
   prepare-hotfix:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     env:
       TAG: ${{ inputs.tag }}
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,7 @@ on:
           - bump-minor
           - bump-patch
 
+permissions: {}
 
 jobs:
   build:

--- a/.github/workflows/reuse-tool-lint.yaml
+++ b/.github/workflows/reuse-tool-lint.yaml
@@ -2,12 +2,13 @@ name: REUSE Compliance Check
 
 on: [push, pull_request]
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: REUSE Compliance Check


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area security
/kind enhancement

**What this PR does / why we need it**:

Adds top-level `permissions: {}` to all workflow files so no implicit grants leak to jobs. Each job must explicitly declare what it needs (least-privilege principle). Adds missing per-job `permissions` blocks where previously inherited from workflow-level defaults.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Jobs using OIDC federation (`gardener/cc-utils/.github/actions/github-auth`) already declare `id-token: write` per job. The `prepare-hotfix` job also needs `contents: read` for `actions/checkout` (the checkout token comes from the app, but the action itself requires read access to clone).

**Release note**:
```other operator
NONE
```