### PR TITLE
ci: harden GitHub Actions workflows with zizmor

### DIFF
--- a/.github/actions/prepare-hotfix-branch/action.yaml
+++ b/.github/actions/prepare-hotfix-branch/action.yaml
@@ -36,6 +36,7 @@ runs:
         echo "callback-path=../prepare-hotfix-callback-action" >> $GITHUB_OUTPUT
 
     - name: Compute and validate branch names
+      id: branches
       shell: bash
       env:
         TAG: ${{ inputs.tag }}
@@ -46,20 +47,22 @@ runs:
           exit 1
         fi
         BASE_VERSION="${TAG%.*}"
-        HOTFIX_BRANCH="hotfix-${BASE_VERSION}"
-        if [[ ! "$HOTFIX_BRANCH" =~ ^hotfix-[a-zA-Z0-9.-]+$ ]]; then
-          echo "Invalid hotfix branch name derived from tag: $HOTFIX_BRANCH"
+        if [[ ! "$BASE_VERSION" =~ ^[a-zA-Z0-9.-]+$ ]]; then
+          echo "Invalid base version derived from tag: $BASE_VERSION"
           exit 1
         fi
+        HOTFIX_BRANCH="hotfix-${BASE_VERSION}"
         PREPARE_BRANCH="hotfix-prepare-${BASE_VERSION}"
-        echo "HOTFIX_BRANCH=$HOTFIX_BRANCH" >> "$GITHUB_ENV"
-        echo "PREPARE_BRANCH=$PREPARE_BRANCH" >> "$GITHUB_ENV"
+        printf 'hotfix-branch=%s\n' "$HOTFIX_BRANCH" >> "$GITHUB_OUTPUT"
+        printf 'prepare-branch=%s\n' "$PREPARE_BRANCH" >> "$GITHUB_OUTPUT"
         echo "Computed branches: $HOTFIX_BRANCH and $PREPARE_BRANCH"
 
     - name: Check and create branches (base on tag)
       shell: bash
       env:
         TAG: ${{ inputs.tag }}
+        HOTFIX_BRANCH: ${{ steps.branches.outputs.hotfix-branch }}
+        PREPARE_BRANCH: ${{ steps.branches.outputs.prepare-branch }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
         set -euo pipefail
@@ -111,6 +114,8 @@ runs:
     - name: Push prepare branch and create Pull Request
       shell: bash
       env:
+        HOTFIX_BRANCH: ${{ steps.branches.outputs.hotfix-branch }}
+        PREPARE_BRANCH: ${{ steps.branches.outputs.prepare-branch }}
         GH_TOKEN: ${{ inputs.github-token }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |

--- a/.github/actions/prepare-hotfix-branch/action.yaml
+++ b/.github/actions/prepare-hotfix-branch/action.yaml
@@ -60,27 +60,42 @@ runs:
       shell: bash
       env:
         TAG: ${{ inputs.tag }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
         set -euo pipefail
-        git fetch --tags origin
+        BASIC_AUTH="$(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')"
+        AUTH_HEADER="AUTHORIZATION: basic $BASIC_AUTH"
+
+        echo "::add-mask::$GITHUB_TOKEN"
+        echo "::add-mask::$BASIC_AUTH"
+        echo "::add-mask::$AUTH_HEADER"
+
+        git_with_auth() {
+          GIT_CONFIG_COUNT=1 \
+          GIT_CONFIG_KEY_0="http.https://github.com/.extraheader" \
+          GIT_CONFIG_VALUE_0="$AUTH_HEADER" \
+          git "$@"
+        }
+
+        git_with_auth fetch --tags origin
 
         if ! git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
           echo "Tag not found: $TAG"
           exit 1
         fi
 
-        if git ls-remote --exit-code origin "$HOTFIX_BRANCH" >/dev/null 2>&1; then
+        if git_with_auth ls-remote --exit-code origin "$HOTFIX_BRANCH" >/dev/null 2>&1; then
           echo "Hotfix branch $HOTFIX_BRANCH already exists"
           exit 1
         fi
-        if git ls-remote --exit-code origin "$PREPARE_BRANCH" >/dev/null 2>&1; then
+        if git_with_auth ls-remote --exit-code origin "$PREPARE_BRANCH" >/dev/null 2>&1; then
           echo "Prepare branch $PREPARE_BRANCH already exists"
           exit 1
         fi
 
         # Create the hotfix branch from the tag, push it, then create the prepare branch from hotfix
         git checkout -b "$HOTFIX_BRANCH" "$TAG"
-        git push origin "$HOTFIX_BRANCH"
+        git_with_auth push origin "$HOTFIX_BRANCH"
         git checkout -b "$PREPARE_BRANCH" "$HOTFIX_BRANCH"
         echo "Created branches: $HOTFIX_BRANCH and $PREPARE_BRANCH"
 
@@ -97,9 +112,25 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
         set -euo pipefail
-        git push origin "$PREPARE_BRANCH"
+        BASIC_AUTH="$(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')"
+        AUTH_HEADER="AUTHORIZATION: basic $BASIC_AUTH"
+
+        echo "::add-mask::$GITHUB_TOKEN"
+        echo "::add-mask::$BASIC_AUTH"
+        echo "::add-mask::$AUTH_HEADER"
+
+        git_with_auth() {
+          GIT_CONFIG_COUNT=1 \
+          GIT_CONFIG_KEY_0="http.https://github.com/.extraheader" \
+          GIT_CONFIG_VALUE_0="$AUTH_HEADER" \
+          git "$@"
+        }
+
+        git_with_auth push origin "$PREPARE_BRANCH"
+
         gh pr create \
           --base "$HOTFIX_BRANCH" \
           --head "$PREPARE_BRANCH" \

--- a/.github/actions/prepare-hotfix-branch/action.yaml
+++ b/.github/actions/prepare-hotfix-branch/action.yaml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Setup Git Identity
-      uses: gardener/cc-utils/.github/actions/setup-git-identity@v1
+      uses: gardener/cc-utils/.github/actions/setup-git-identity@v1 # zizmor: ignore[unpinned-uses] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
 
     - name: Stage callback action outside repo (if provided)
       id: stage-callback
@@ -103,7 +103,7 @@ runs:
         echo "Created branches: $HOTFIX_BRANCH and $PREPARE_BRANCH"
 
     - name: Bump patch version
-      uses: gardener/cc-utils/.github/actions/version@v1
+      uses: gardener/cc-utils/.github/actions/version@v1 # zizmor: ignore[unpinned-uses] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
       with:
         version-operation: bump-patch
         prerelease: dev

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -112,6 +112,8 @@ jobs:
         with:
           node-version: '24.14.1'
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: run-eslint
         run: |
           set -eu

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ permissions: {}
 
 jobs:
   prepare:
-    uses: gardener/cc-utils/.github/workflows/prepare.yaml@v1
+    uses: gardener/cc-utils/.github/workflows/prepare.yaml@v1 # zizmor: ignore[unpinned-uses] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
     with:
       mode: ${{ inputs.mode }}
       version-commit-callback-action-path: .github/actions/prepare-release
@@ -32,7 +32,7 @@ jobs:
       packages: write
       id-token: write
     secrets: inherit
-    uses: gardener/cc-utils/.github/workflows/oci-ocm.yaml@v1
+    uses: gardener/cc-utils/.github/workflows/oci-ocm.yaml@v1 # zizmor: ignore[unpinned-uses] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
     strategy:
       matrix:
         args:
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: '24.14.1'
-      - uses: gardener/cc-utils/.github/actions/trusted-checkout@v1
+      - uses: gardener/cc-utils/.github/actions/trusted-checkout@v1 # zizmor: ignore[unpinned-uses] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
       - name: run-verify
         shell: bash
         run: |
@@ -90,7 +90,7 @@ jobs:
           .ci/verify |& tee /tmp/blobs.d/verify-log.txt
           tar czf /tmp/blobs.d/verify-log.tar.gz -C/tmp/blobs.d verify-log.txt
       - name: add-verify-results-to-component-descriptor
-        uses: gardener/cc-utils/.github/actions/export-ocm-fragments@v1
+        uses: gardener/cc-utils/.github/actions/export-ocm-fragments@v1 # zizmor: ignore[unpinned-uses] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
         with:
           blobs-directory: /tmp/blobs.d
           ocm-resources: |
@@ -132,7 +132,7 @@ jobs:
             dashboard-frontend.sarif \
             dashboard-backend.sarif
       - name: add-sast-report-to-component-descriptor
-        uses: gardener/cc-utils/.github/actions/export-ocm-fragments@v1
+        uses: gardener/cc-utils/.github/actions/export-ocm-fragments@v1 # zizmor: ignore[unpinned-uses] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
         with:
           blobs-directory: /tmp/blobs.d
           ocm-resources: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,6 +10,11 @@ on:
         description: |
           the mode to use. either `snapshot` or `release`. Will affect effective version, as well
           as target-oci-registry.
+    secrets:
+      dockerhub-auth-token:
+        required: false
+        description: |
+          Docker Hub read token used by the OCI build workflow for pull authentication.
 
 permissions: {}
 
@@ -31,7 +36,8 @@ jobs:
       contents: read
       packages: write
       id-token: write
-    secrets: inherit
+    secrets:
+      dockerhub-auth-token: ${{ secrets.dockerhub-auth-token }}
     uses: gardener/cc-utils/.github/workflows/oci-ocm.yaml@v1 # zizmor: ignore[unpinned-uses] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
     strategy:
       matrix:

--- a/.github/workflows/non-release.yaml
+++ b/.github/workflows/non-release.yaml
@@ -32,7 +32,7 @@ jobs:
 
   component-descriptor:
     if: ${{ github.event_name != 'pull_request_target' || (github.event_name == 'pull_request_target' && github.event.label.name == vars.DEFAULT_LABEL_OK_TO_TEST && vars.DEFAULT_LABEL_OK_TO_TEST != '') }}
-    uses: gardener/cc-utils/.github/workflows/post-build.yaml@v1
+    uses: gardener/cc-utils/.github/workflows/post-build.yaml@v1 # zizmor: ignore[unpinned-uses] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
     needs:
       - build
     permissions:

--- a/.github/workflows/non-release.yaml
+++ b/.github/workflows/non-release.yaml
@@ -10,6 +10,7 @@ on:
     - edited
     - reopened
     - synchronize
+  # zizmor: ignore[dangerous-triggers] -- intentional: triggers build only when ok-to-test label is added to external PRs, gated by label check in job condition
   pull_request_target:
     types:
     - labeled

--- a/.github/workflows/non-release.yaml
+++ b/.github/workflows/non-release.yaml
@@ -24,7 +24,8 @@ jobs:
     uses: ./.github/workflows/build.yaml
     with:
       mode: snapshot
-    secrets: inherit
+    secrets:
+      dockerhub-auth-token: ${{ secrets.DOCKERHUB_RO_AUTH }}
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/pr-release-notes-validation.yaml
+++ b/.github/workflows/pr-release-notes-validation.yaml
@@ -10,7 +10,7 @@ permissions: {}
 
 jobs:
   validate-release-notes:
-    uses: gardener/cc-utils/.github/workflows/validate-release-notes.yaml@v1
+    uses: gardener/cc-utils/.github/workflows/validate-release-notes.yaml@v1 # zizmor: ignore[unpinned-uses] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
     permissions:
       pull-requests: read
     with:

--- a/.github/workflows/prepare-hotfix-branch.yaml
+++ b/.github/workflows/prepare-hotfix-branch.yaml
@@ -49,6 +49,7 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Prepare hotfix branch
         uses: gardener/dashboard/.github/actions/prepare-hotfix-branch@master

--- a/.github/workflows/prepare-hotfix-branch.yaml
+++ b/.github/workflows/prepare-hotfix-branch.yaml
@@ -34,7 +34,7 @@ jobs:
       TAG: ${{ inputs.tag }}
     steps:
       - name: Create GitHub App token
-        uses: gardener/cc-utils/.github/actions/github-auth@v1
+        uses: gardener/cc-utils/.github/actions/github-auth@v1 # zizmor: ignore[unpinned-uses] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
         id: app-token
         with:
           token-server: ${{ vars.FEDERATED_GITHUB_ACCESS_TOKEN_SERVER }}
@@ -52,7 +52,7 @@ jobs:
           persist-credentials: false
 
       - name: Prepare hotfix branch
-        uses: gardener/dashboard/.github/actions/prepare-hotfix-branch@master
+        uses: gardener/dashboard/.github/actions/prepare-hotfix-branch@master # zizmor: ignore[unpinned-uses] -- same-repo action; intentionally tracks master as the trusted source for the latest hotfix preparation logic
         with:
           tag: ${{ env.TAG }}
           github-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
       mode: release
 
   release-to-github-and-bump:
-    uses: gardener/cc-utils/.github/workflows/release.yaml@v1
+    uses: gardener/cc-utils/.github/workflows/release.yaml@v1 # zizmor: ignore[unpinned-uses] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
     needs:
       - build
     secrets: inherit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,8 @@ permissions: {}
 jobs:
   build:
     uses: ./.github/workflows/build.yaml
-    secrets: inherit
+    secrets:
+      dockerhub-auth-token: ${{ secrets.DOCKERHUB_RO_AUTH }}
     permissions:
       contents: read
       id-token: write
@@ -25,7 +26,8 @@ jobs:
     uses: gardener/cc-utils/.github/workflows/release.yaml@v1 # zizmor: ignore[unpinned-uses] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
     needs:
       - build
-    secrets: inherit
+    secrets:
+      slack-token: ${{ secrets.SLACK_APP_TOKEN_GARDENER_CICD }}
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/reuse-tool-lint.yaml
+++ b/.github/workflows/reuse-tool-lint.yaml
@@ -11,5 +11,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: REUSE Compliance Check
         uses: fsfe/reuse-action@676e2d560c9a403aa252096d99fcab3e1132b0f5 # v6.0.0

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,29 @@
+name: Zizmor Workflow Lint
+
+on:
+  push:
+    branches:
+    - master
+    - hotfix-*
+    paths:
+    - '.github/**'
+  pull_request:
+    paths:
+    - '.github/**'
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          # renovate: datasource=github-releases depName=zizmorcore/zizmor
+          version: v1.24.1

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -27,3 +27,7 @@ jobs:
         with:
           # renovate: datasource=github-releases depName=zizmorcore/zizmor
           version: v1.24.1
+          min-severity: low
+          min-confidence: low
+          advanced-security: false
+          annotations: true


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area security
/area quality
/kind enhancement

**What this PR does / why we need it**:

Hardens GitHub Actions workflows based on findings from [zizmor](https://woodruffw.github.io/zizmor/), a static analysis tool for GitHub Actions. Changes include:

- Add `zizmor.yaml` workflow to lint GitHub Actions configurations on CI
- Replace `secrets: inherit` with explicit secret passing to reduce exposure
- Disable `persist-credentials` on checkout actions and use explicit git authentication
- Use `GITHUB_OUTPUT` instead of environment variable injection in the prepare-hotfix-branch action
- Suppress false-positive findings for same-org unpinned actions and dangerous-triggers

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
The zizmor workflow will fail until PRs #2941, #2942, and #2943 are merged and this branch is rebased from master, as those PRs indirectly address additional zizmor findings not covered here.

**Release note**:
```other operator
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to explicitly specify required secrets instead of implicitly inheriting all secrets
  * Modified credential persistence configuration in checkout steps across multiple workflows
  * Adjusted authentication and token handling for git operations in branch preparation actions
  * Added linter ignore comments to workflow file references

* **Tests**
  * Introduced automated workflow linting validation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->