### PR TITLE
fix: typo (occured -> occurred) in error UI strings

### DIFF
--- a/frontend/src/components/ShootHibernation/GManageHibernationSchedule.vue
+++ b/frontend/src/components/ShootHibernation/GManageHibernationSchedule.vue
@@ -56,7 +56,7 @@ SPDX-License-Identifier: Apache-2.0
         type="warning"
         variant="tonal"
       >
-        One or more errors occured while parsing hibernation schedules. Your configuration may still be valid - the Dashboard UI currently only supports basic schedules.<br>
+        One or more errors occurred while parsing hibernation schedules. Your configuration may still be valid - the Dashboard UI currently only supports basic schedules.<br>
         You probably configured crontab lines for your hibernation schedule manually. Please edit your schedules directly in the cluster specification. You can also delete it there and come back to this screen to configure your schedule via the Dashboard UI.
       </v-alert>
     </v-row>

--- a/frontend/src/views/GProjectError.vue
+++ b/frontend/src/views/GProjectError.vue
@@ -32,7 +32,7 @@ const props = defineProps({
   },
   message: {
     type: String,
-    default: 'The project you are looking for doesn\'t exist or an other error occurred!',
+    default: 'The project you are looking for doesn\'t exist or another error occurred!',
   },
   buttonText: {
     type: String,

--- a/frontend/src/views/GProjectError.vue
+++ b/frontend/src/views/GProjectError.vue
@@ -32,7 +32,7 @@ const props = defineProps({
   },
   message: {
     type: String,
-    default: 'The project you are looking for doesn\'t exist or an other error occured!',
+    default: 'The project you are looking for doesn\'t exist or an other error occurred!',
   },
   buttonText: {
     type: String,

--- a/frontend/src/views/GShootItemError.vue
+++ b/frontend/src/views/GShootItemError.vue
@@ -38,7 +38,7 @@ export default {
     },
     message: {
       type: String,
-      default: 'The cluster you are looking for doesn\'t exist or an other error occurred!',
+      default: 'The cluster you are looking for doesn\'t exist or another error occurred!',
     },
     buttonText: {
       type: String,

--- a/frontend/src/views/GShootItemError.vue
+++ b/frontend/src/views/GShootItemError.vue
@@ -38,7 +38,7 @@ export default {
     },
     message: {
       type: String,
-      default: 'The cluster you are looking for doesn\'t exist or an other error occured!',
+      default: 'The cluster you are looking for doesn\'t exist or an other error occurred!',
     },
     buttonText: {
       type: String,


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
Fixes three user-facing 'occured' -> 'occurred' typos in error UI strings (GProjectError.vue, GShootItemError.vue, GManageHibernationSchedule.vue).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
String/comment-only change, no functional impact.

**Release note**:
```other operator
NONE
```
