### PR TITLE
fix(kube-client): add request timeout and forward abort signals

### DIFF
--- a/charts/__tests__/gardener-dashboard/runtime/dashboard/deployment.spec.js
+++ b/charts/__tests__/gardener-dashboard/runtime/dashboard/deployment.spec.js
@@ -116,6 +116,46 @@ describe('gardener-dashboard', function () {
       }]))
     })
 
+    it('should render the kube client request timeout environment variable', async function () {
+      const values = {
+        global: {
+          dashboard: {
+            kubeClient: {
+              requestTimeout: 30000,
+            },
+          },
+        },
+      }
+      const documents = await renderTemplates(templates, values)
+      expect(documents).toHaveLength(1)
+      const [deployment] = documents
+      const dashboardContainer = deployment.spec.template.spec.containers[0]
+      expect(dashboardContainer.env).toEqual(expect.arrayContaining([{
+        name: 'KUBE_CLIENT_REQUEST_TIMEOUT',
+        value: '30000',
+      }]))
+    })
+
+    it('should render kube client request timeout 0', async function () {
+      const values = {
+        global: {
+          dashboard: {
+            kubeClient: {
+              requestTimeout: 0,
+            },
+          },
+        },
+      }
+      const documents = await renderTemplates(templates, values)
+      expect(documents).toHaveLength(1)
+      const [deployment] = documents
+      const dashboardContainer = deployment.spec.template.spec.containers[0]
+      expect(dashboardContainer.env).toEqual(expect.arrayContaining([{
+        name: 'KUBE_CLIENT_REQUEST_TIMEOUT',
+        value: '0',
+      }]))
+    })
+
     it('should render the template with a sha256 tag', async function () {
       const tag = 'sha256:4d529c1'
       const values = {

--- a/charts/gardener-dashboard/charts/runtime/templates/dashboard/deployment.yaml
+++ b/charts/gardener-dashboard/charts/runtime/templates/dashboard/deployment.yaml
@@ -203,6 +203,10 @@ spec:
           - name: KUBE_CLIENT_PING_TIMEOUT
             value: {{ quote .pingTimeout }}
           {{- end }}
+          {{- if ne .requestTimeout nil }}
+          - name: KUBE_CLIENT_REQUEST_TIMEOUT
+            value: {{ quote .requestTimeout }}
+          {{- end }}
           {{- end }}
           - name: METRICS_PORT
             value: {{ quote .Values.global.dashboard.metricsContainerPort }}

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -36,6 +36,9 @@ global:
       # Optional HTTP/2 PING response timeout in milliseconds.
       # Defaults to 15000 when unset.
       pingTimeout: ~
+      # Optional total request timeout in milliseconds for Kubernetes API requests.
+      # Defaults to 300000 (5 minutes) when unset. Set to 0 to disable.
+      requestTimeout: ~
 
   # If configured, the dashboard deployment uses a projected volume which presents the kubeconfig to the garden cluster.
   # projectedKubeconfig:

--- a/packages/kube-client/__tests__/cache.list-watcher.spec.js
+++ b/packages/kube-client/__tests__/cache.list-watcher.spec.js
@@ -47,6 +47,17 @@ describe('kube-client', () => {
         }])
       })
 
+      it('#list with signal', () => {
+        const signal = {}
+        listWatcher.setAbortSignal(signal)
+        expect(listWatcher.list({ b: 2 })).toBe(body)
+        expect(listFunc).toHaveBeenCalledTimes(1)
+        expect(listFunc.mock.calls[0]).toEqual([{
+          signal,
+          searchParams: new URLSearchParams({ a: 1, b: 2 }),
+        }])
+      })
+
       it('#watch', () => {
         const signal = {}
         listWatcher.setAbortSignal(signal)

--- a/packages/kube-client/__tests__/index.spec.js
+++ b/packages/kube-client/__tests__/index.spec.js
@@ -9,6 +9,7 @@ import { vi } from 'vitest'
 const ENV_NAMES = {
   readIdleTimeout: 'KUBE_CLIENT_READ_IDLE_TIMEOUT',
   pingTimeout: 'KUBE_CLIENT_PING_TIMEOUT',
+  requestTimeout: 'KUBE_CLIENT_REQUEST_TIMEOUT',
 }
 const originalEnv = Object.fromEntries(
   Object.values(ENV_NAMES).map(envName => [envName, process.env[envName]]),
@@ -17,10 +18,12 @@ const originalEnv = Object.fromEntries(
 async function importKubeClientWithEnv ({
   readIdleTimeout,
   pingTimeout,
+  requestTimeout,
 } = {}) {
   vi.resetModules()
   setEnv(ENV_NAMES.readIdleTimeout, readIdleTimeout)
   setEnv(ENV_NAMES.pingTimeout, pingTimeout)
+  setEnv(ENV_NAMES.requestTimeout, requestTimeout)
 
   const { default: kubeClient } = await import('../lib/index.js')
   const { default: request } = await import('@gardener-dashboard/request')
@@ -45,6 +48,7 @@ function transportOptionsFromExtendCalls (request) {
   return request.extend.mock.calls.map(([clientConfig]) => ({
     readIdleTimeout: clientConfig.readIdleTimeout,
     pingTimeout: clientConfig.pingTimeout,
+    requestTimeout: clientConfig.requestTimeout,
   }))
 }
 
@@ -67,16 +71,18 @@ describe('kube-client package defaults', () => {
     const { request } = await importKubeClientWithEnv()
 
     expectAllClientsToUseTransportOptions(request, {
-      readIdleTimeout: 30000,
-      pingTimeout: 15000,
+      readIdleTimeout: 30_000,
+      pingTimeout: 15_000,
+      requestTimeout: 5 * 60 * 1_000,
     })
   })
 
-  it('should apply kube client heartbeat environment variables to user clients', async () => {
+  it('should apply kube client environment variables to user clients', async () => {
     expect.hasAssertions()
     const { kubeClient, request } = await importKubeClientWithEnv({
       readIdleTimeout: '1234',
       pingTimeout: '5678',
+      requestTimeout: '9012',
     })
 
     request.extend.mockClear()
@@ -85,14 +91,16 @@ describe('kube-client package defaults', () => {
     expectAllClientsToUseTransportOptions(request, {
       readIdleTimeout: 1234,
       pingTimeout: 5678,
+      requestTimeout: 9012,
     })
   })
 
-  it('should apply kube client heartbeat environment variables to dashboard clients', async () => {
+  it('should apply kube client environment variables to dashboard clients', async () => {
     expect.hasAssertions()
     const { kubeClient, request } = await importKubeClientWithEnv({
       readIdleTimeout: '2345',
       pingTimeout: '6789',
+      requestTimeout: '1023',
     })
 
     request.extend.mockClear()
@@ -101,80 +109,92 @@ describe('kube-client package defaults', () => {
     expectAllClientsToUseTransportOptions(request, {
       readIdleTimeout: 2345,
       pingTimeout: 6789,
+      requestTimeout: 1023,
     })
   })
 
-  it('should allow per-client options to override kube client heartbeat environment variables', async () => {
+  it('should allow per-client options to override kube client environment variables', async () => {
     expect.hasAssertions()
     const { kubeClient, request } = await importKubeClientWithEnv({
       readIdleTimeout: '3456',
       pingTimeout: '7890',
+      requestTimeout: '1234',
     })
 
     request.extend.mockClear()
     kubeClient.createDashboardClient({
       readIdleTimeout: 6543,
       pingTimeout: 9870,
+      requestTimeout: 4321,
     })
 
     expectAllClientsToUseTransportOptions(request, {
       readIdleTimeout: 6543,
       pingTimeout: 9870,
+      requestTimeout: 4321,
     })
   })
 
-  it('should allow per-client heartbeat option 0 to override kube client heartbeat environment variables', async () => {
+  it('should allow per-client option 0 to override kube client environment variables', async () => {
     expect.hasAssertions()
     const { kubeClient, request } = await importKubeClientWithEnv({
       readIdleTimeout: '4567',
       pingTimeout: '8901',
+      requestTimeout: '2345',
     })
 
     request.extend.mockClear()
     kubeClient.createDashboardClient({
       readIdleTimeout: 0,
       pingTimeout: 0,
+      requestTimeout: 0,
     })
 
     expectAllClientsToUseTransportOptions(request, {
       readIdleTimeout: 0,
       pingTimeout: 0,
+      requestTimeout: 0,
     })
   })
 
-  it('should allow kube client heartbeat environment variable 0 to disable heartbeat timers', async () => {
+  it('should allow kube client environment variable 0 to disable the corresponding timer', async () => {
     expect.hasAssertions()
     const { request } = await importKubeClientWithEnv({
       readIdleTimeout: '0',
       pingTimeout: '0',
+      requestTimeout: '0',
     })
 
     expectAllClientsToUseTransportOptions(request, {
       readIdleTimeout: 0,
       pingTimeout: 0,
+      requestTimeout: 0,
     })
   })
 
-  it('should ignore explicit undefined heartbeat options when applying kube client heartbeat defaults', async () => {
+  it('should ignore explicit undefined options when applying kube client defaults', async () => {
     expect.hasAssertions()
     const { kubeClient, request } = await importKubeClientWithEnv({
       readIdleTimeout: '5678',
       pingTimeout: '9012',
+      requestTimeout: '3456',
     })
 
     request.extend.mockClear()
     kubeClient.createDashboardClient({
       readIdleTimeout: undefined,
       pingTimeout: undefined,
+      requestTimeout: undefined,
     })
 
     expectAllClientsToUseTransportOptions(request, {
       readIdleTimeout: 5678,
       pingTimeout: 9012,
+      requestTimeout: 3456,
     })
   })
 
-  it.each(['readIdleTimeout', 'pingTimeout'])('should fail fast for invalid per-client %s option', async optionName => {
+  it.each(['readIdleTimeout', 'pingTimeout', 'requestTimeout'])('should fail fast for invalid per-client %s option', async optionName => {
     expect.hasAssertions()
     const { kubeClient } = await importKubeClientWithEnv()
 
@@ -185,11 +205,12 @@ describe('kube-client package defaults', () => {
     }
   })
 
-  it('should apply kube client heartbeat defaults to derived kubeconfig clients', async () => {
+  it('should apply kube client defaults to derived kubeconfig clients', async () => {
     expect.hasAssertions()
     const { kubeClient, request } = await importKubeClientWithEnv({
       readIdleTimeout: '6789',
       pingTimeout: '1234',
+      requestTimeout: '5432',
     })
     const { default: helper } = await import('./fixtures/helper.js')
     const client = kubeClient.createDashboardClient()
@@ -207,6 +228,7 @@ describe('kube-client package defaults', () => {
     expectAllClientsToUseTransportOptions(request, {
       readIdleTimeout: 6789,
       pingTimeout: 1234,
+      requestTimeout: 5432,
     })
   })
 

--- a/packages/kube-client/__tests__/mixins.spec.js
+++ b/packages/kube-client/__tests__/mixins.spec.js
@@ -94,10 +94,19 @@ describe('kube-client', () => {
       describe('Readable', () => {
         it('should get a resource', () => {
           const testObject = new TestObject()
-          const [url, { method, searchParams }] = testObject.get('name', {})
+          const signal = new AbortController().signal
+          const [url, { method, searchParams, signal: forwardedSignal }] = testObject.get('name', { signal })
           expect(url).toBe('dummies/name')
           expect(method).toBe('get')
           expect(searchParams.toString()).toBe('')
+          expect(forwardedSignal).toBe(signal)
+        })
+
+        it('should reject invalid get signals', () => {
+          const testObject = new TestObject()
+          expect(() => testObject.get('name', { signal: {} })).toThrow(
+            'The parameter "signal" must be empty or an instance of AbortSignal',
+          )
         })
 
         it('should list a resource', async () => {
@@ -272,10 +281,19 @@ describe('kube-client', () => {
       describe('Readable', () => {
         it('should get a resource', () => {
           const testObject = new TestObject()
-          const [url, { method, searchParams }] = testObject.get('namespace', 'name', {})
+          const signal = new AbortController().signal
+          const [url, { method, searchParams, signal: forwardedSignal }] = testObject.get('namespace', 'name', { signal })
           expect(url).toBe('namespaces/namespace/dummies/name')
           expect(method).toBe('get')
           expect(searchParams.toString()).toBe('')
+          expect(forwardedSignal).toBe(signal)
+        })
+
+        it('should reject invalid get signals', () => {
+          const testObject = new TestObject()
+          expect(() => testObject.get('namespace', 'name', { signal: {} })).toThrow(
+            'The parameter "signal" must be empty or an instance of AbortSignal',
+          )
         })
 
         it('should list a resource', async () => {

--- a/packages/kube-client/lib/cache/ListWatcher.js
+++ b/packages/kube-client/lib/cache/ListWatcher.js
@@ -37,6 +37,9 @@ class ListWatcher {
   list (query) {
     const searchParams = this.mergeSearchParams(query)
     const options = { searchParams }
+    if (this.signal) {
+      options.signal = this.signal
+    }
     return this.listFunc(options)
   }
 }

--- a/packages/kube-client/lib/index.js
+++ b/packages/kube-client/lib/index.js
@@ -12,8 +12,9 @@ import kubeConfig from '@gardener-dashboard/kube-config'
 
 const { load } = kubeConfig
 const MAX_TIMEOUT = 2_147_483_647 // Node.js TIMEOUT_MAX (2^31 - 1)
-const KUBE_CLIENT_DEFAULT_READ_IDLE_TIMEOUT = 30000
-const KUBE_CLIENT_DEFAULT_PING_TIMEOUT = 15000
+const KUBE_CLIENT_DEFAULT_READ_IDLE_TIMEOUT = 30_000
+const KUBE_CLIENT_DEFAULT_PING_TIMEOUT = 15_000
+const KUBE_CLIENT_DEFAULT_REQUEST_TIMEOUT = 5 * 60 * 1_000
 
 function parseTimeoutValue (value, name) {
   const timeout = typeof value === 'string' && /^\d+$/.test(value)
@@ -43,6 +44,11 @@ const defaultOptions = {
     'KUBE_CLIENT_PING_TIMEOUT',
     KUBE_CLIENT_DEFAULT_PING_TIMEOUT,
   ),
+  requestTimeout: parseEnvTimeoutValue(
+    process.env.KUBE_CLIENT_REQUEST_TIMEOUT,
+    'KUBE_CLIENT_REQUEST_TIMEOUT',
+    KUBE_CLIENT_DEFAULT_REQUEST_TIMEOUT,
+  ),
 }
 
 class Client extends BaseClient {
@@ -50,6 +56,7 @@ class Client extends BaseClient {
     const {
       readIdleTimeout,
       pingTimeout,
+      requestTimeout,
       ...rest
     } = options
 
@@ -63,6 +70,9 @@ class Client extends BaseClient {
     }
     if (pingTimeout !== undefined) {
       resolvedOptions.pingTimeout = parseTimeoutValue(pingTimeout, 'pingTimeout')
+    }
+    if (requestTimeout !== undefined) {
+      resolvedOptions.requestTimeout = parseTimeoutValue(requestTimeout, 'requestTimeout')
     }
 
     super(clientConfig, resolvedOptions)

--- a/packages/kube-client/lib/mixins.js
+++ b/packages/kube-client/lib/mixins.js
@@ -60,11 +60,12 @@ ClusterScoped.Readable = superclass => class extends superclass {
   get (name, { searchParams, signal, ...options } = {}) {
     assertName(name)
     assertSearchParams(searchParams)
+    assertSignal(signal)
     assertOptions(options)
     const method = 'get'
     const url = clusterScopedUrl(this.constructor.names, name)
     searchParams = normalizeSearchParams(method, searchParams, options)
-    return this[http.request](url, { method, searchParams })
+    return this[http.request](url, { method, searchParams, signal })
   }
 
   list ({ searchParams, signal, ...options } = {}) {
@@ -84,11 +85,12 @@ NamespaceScoped.Readable = superclass => class extends superclass {
     assertNamespace(namespace)
     assertName(name)
     assertSearchParams(searchParams)
+    assertSignal(signal)
     assertOptions(options)
     const method = 'get'
     const url = namespaceScopedUrl(this.constructor.names, namespace, name)
     searchParams = normalizeSearchParams(method, searchParams, options)
-    return this[http.request](url, { method, searchParams })
+    return this[http.request](url, { method, searchParams, signal })
   }
 
   list (namespace, { searchParams, signal, ...options } = {}) {

--- a/packages/kube-client/lib/mixins.js
+++ b/packages/kube-client/lib/mixins.js
@@ -69,6 +69,7 @@ ClusterScoped.Readable = superclass => class extends superclass {
 
   list ({ searchParams, signal, ...options } = {}) {
     assertSearchParams(searchParams)
+    assertSignal(signal)
     assertOptions(options)
     const method = 'get'
     const url = clusterScopedUrl(this.constructor.names)
@@ -93,6 +94,7 @@ NamespaceScoped.Readable = superclass => class extends superclass {
   list (namespace, { searchParams, signal, ...options } = {}) {
     assertNamespace(namespace)
     assertSearchParams(searchParams)
+    assertSignal(signal)
     assertOptions(options)
     const method = 'get'
     const url = namespaceScopedUrl(this.constructor.names, namespace)
@@ -103,6 +105,7 @@ NamespaceScoped.Readable = superclass => class extends superclass {
 
   listAllNamespaces ({ searchParams, signal, ...options } = {}) {
     assertSearchParams(searchParams)
+    assertSignal(signal)
     assertOptions(options)
     const method = 'get'
     const url = namespaceScopedUrl(this.constructor.names)

--- a/packages/request/__tests__/acceptance.spec.js
+++ b/packages/request/__tests__/acceptance.spec.js
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { vi } from 'vitest'
 import http from 'http'
 import http2 from 'http2'
 import zlib from 'zlib'
@@ -148,6 +147,18 @@ function createSecureServer ({ cert, key }) {
         }
         stream.respond(headers)
         await pipeline(streams)
+      } else if (path === '/delay') {
+        // Never respond — used to test requestTimeout with a real connection.
+      } else if (path === '/stall-body') {
+        stream.respond({
+          [HTTP2_HEADER_STATUS]: statusCode,
+          [HTTP2_HEADER_CONTENT_TYPE]: 'application/json',
+        })
+      } else if (path === '/stall-events') {
+        stream.respond({
+          [HTTP2_HEADER_STATUS]: statusCode,
+          [HTTP2_HEADER_CONTENT_TYPE]: 'application/json',
+        })
       } else {
         body = JSON.stringify({
           headers,
@@ -173,14 +184,6 @@ describe('Acceptance Tests', function () {
   let agent
   let client
   let server
-
-  beforeAll(() => {
-    vi.useFakeTimers({ legacyFakeTimers: true })
-  })
-
-  afterAll(() => {
-    vi.useRealTimers()
-  })
 
   beforeEach(async () => {
     server = await createSecureServer({ cert, key })
@@ -293,6 +296,66 @@ describe('Acceptance Tests', function () {
             'x-requested-with': 'XmlHttpRequest',
             [HTTP2_HEADER_CONTENT_TYPE]: 'application/json',
           },
+        })
+      })
+    })
+
+    describe('#request with requestTimeout', function () {
+      it('should timeout when response headers are not received in time', async function () {
+        const requestTimeout = 100
+        const timeoutClient = new Client({
+          url: server.origin,
+          agent,
+          ca: cert,
+          requestTimeout,
+        })
+
+        await expect(timeoutClient.request('delay')).rejects.toMatchObject({
+          name: 'TimeoutError',
+          code: 'ETIMEDOUT',
+          message: `Request exceeded ${requestTimeout} ms for GET /delay`,
+        })
+      })
+
+      it('should timeout when response body stalls', async function () {
+        const requestTimeout = 100
+        const timeoutClient = new Client({
+          url: server.origin,
+          agent,
+          ca: cert,
+          requestTimeout,
+        })
+
+        const response = await timeoutClient.fetch('stall-body')
+
+        await expect(response.body()).rejects.toMatchObject({
+          name: 'TimeoutError',
+          code: 'ETIMEDOUT',
+          message: `Request exceeded ${requestTimeout} ms for GET /stall-body`,
+        })
+      })
+
+      it('should timeout when the response iterator stalls', async function () {
+        const requestTimeout = 100
+        const timeoutClient = new Client({
+          url: server.origin,
+          agent,
+          ca: cert,
+          requestTimeout,
+        })
+
+        const response = await timeoutClient.fetch('stall-events')
+
+        const eventsPromise = (async () => {
+          for await (const event of response) {
+            expect(event).toBeDefined()
+          }
+        })()
+
+        await expect(eventsPromise).rejects.toMatchObject({
+          name: 'TimeoutError',
+          code: 'ETIMEDOUT',
+          message: `Request exceeded ${requestTimeout} ms for GET /stall-events`,
         })
       })
     })

--- a/packages/request/__tests__/client.spec.js
+++ b/packages/request/__tests__/client.spec.js
@@ -36,14 +36,6 @@ describe('Client', () => {
   let client
   let stream
 
-  beforeAll(() => {
-    vi.useFakeTimers({ legacyFakeTimers: true })
-  })
-
-  afterAll(() => {
-    vi.useRealTimers()
-  })
-
   beforeEach(() => {
     const mockBody = vi.fn().mockReturnValue({
       foo: 'bar',
@@ -98,7 +90,6 @@ describe('Client', () => {
     it('should create a new object', () => {
       expect(client).toBeInstanceOf(Client)
       expect(client.baseUrl.href).toBe(url.href)
-      expect(client.responseTimeout).toBe(15000)
     })
 
     it('should throw a type error', () => {
@@ -244,6 +235,65 @@ describe('Client', () => {
       expect(body).toEqual(stream.mockBody())
     })
 
+    it('should timeout when a request exceeds its deadline before headers arrive', async () => {
+      const requestTimeout = 10
+      const message = `Request exceeded ${requestTimeout} ms for GET /test/foo/bar`
+      client = new Client({
+        url,
+        agent,
+        requestTimeout,
+      })
+      let signal
+      let resolveGetHeadersCalled
+      const getHeadersCalled = new Promise(resolve => {
+        resolveGetHeadersCalled = resolve
+      })
+      agent.request.mockImplementation(async (headers, options) => {
+        signal = options.signal
+        signal.addEventListener('abort', () => {
+          const err = new Error('The operation was aborted')
+          err.name = 'AbortError'
+          err.code = 'ABORT_ERR'
+          err.cause = signal.reason
+          stream.destroy(err)
+        }, { once: true })
+        return stream
+      })
+      stream.getHeaders = vi.fn(() => {
+        resolveGetHeadersCalled()
+        return new Promise((resolve, reject) => {
+          stream.destroy.mockImplementation(reject)
+        })
+      })
+
+      const promise = client.fetch('foo/bar?token=secret')
+      await getHeadersCalled
+      const err = await promise.catch(err => err)
+
+      expect(err).toMatchObject({
+        name: 'TimeoutError',
+        code: 'ETIMEDOUT',
+        message,
+      })
+      expect(err.cause).toMatchObject({
+        name: 'AbortError',
+        code: 'ABORT_ERR',
+      })
+      expect(stream.getHeaders).toHaveBeenCalledTimes(1)
+      expect(stream.destroy).toHaveBeenCalledTimes(1)
+      expect(stream.destroy).toHaveBeenCalledWith(expect.objectContaining({
+        name: 'AbortError',
+        code: 'ABORT_ERR',
+      }))
+    })
+
+    it('should not create a timeout signal when requestTimeout is 0', async () => {
+      await client.fetch('foo/bar', { requestTimeout: 0 })
+
+      expect(agent.request).toHaveBeenCalledTimes(1)
+      expect(agent.request.mock.calls[0][1].signal).toBeUndefined()
+    })
+
     describe('when the server returns plain text for a JSON endpoint', () => {
       const contentType = 'text/plain'
       const chunks = ['foo', '-', 'bar']
@@ -317,6 +367,17 @@ describe('Client', () => {
       }
       client.fetch = vi.fn().mockResolvedValue(response)
       await expect(client.stream()).resolves.toBe(response)
+      expect(client.fetch).toHaveBeenCalledWith(undefined, { requestTimeout: 0 })
+    })
+
+    it('should allow direct stream callers to override requestTimeout', async () => {
+      const statusCode = 200
+      const response = {
+        statusCode,
+      }
+      client.fetch = vi.fn().mockResolvedValue(response)
+      await expect(client.stream('events', { requestTimeout: 100 })).resolves.toBe(response)
+      expect(client.fetch).toHaveBeenCalledWith('events', { requestTimeout: 100 })
     })
 
     it('should throw a NotFound error', async () => {

--- a/packages/request/__tests__/client.spec.js
+++ b/packages/request/__tests__/client.spec.js
@@ -9,6 +9,7 @@ import http2 from 'http2'
 import zlib from 'zlib'
 import { globalLogger as logger } from '@gardener-dashboard/logger'
 import client from '../lib/index.js'
+import { isRequestTimeoutAbort, mapTimeoutAbortError } from '../lib/Client.js'
 
 const { Client, extend } = client
 
@@ -294,6 +295,48 @@ describe('Client', () => {
       expect(agent.request.mock.calls[0][1].signal).toBeUndefined()
     })
 
+    it('should surface a caller-triggered abort as AbortError, not TimeoutError', async () => {
+      const requestTimeout = 60_000
+      client = new Client({
+        url,
+        agent,
+        requestTimeout,
+      })
+      const abortController = new AbortController()
+      let resolveGetHeadersCalled
+      const getHeadersCalled = new Promise(resolve => {
+        resolveGetHeadersCalled = resolve
+      })
+      agent.request.mockImplementation(async (headers, options) => {
+        const signal = options.signal
+        signal.addEventListener('abort', () => {
+          const err = new Error('The operation was aborted')
+          err.name = 'AbortError'
+          err.code = 'ABORT_ERR'
+          err.cause = signal.reason
+          stream.destroy(err)
+        }, { once: true })
+        return stream
+      })
+      stream.getHeaders = vi.fn(() => {
+        resolveGetHeadersCalled()
+        return new Promise((resolve, reject) => {
+          stream.destroy.mockImplementation(reject)
+        })
+      })
+
+      const promise = client.fetch('foo/bar', { signal: abortController.signal })
+      await getHeadersCalled
+      abortController.abort()
+      const err = await promise.catch(err => err)
+
+      expect(err).toMatchObject({
+        name: 'AbortError',
+        code: 'ABORT_ERR',
+      })
+      expect(err.name).not.toBe('TimeoutError')
+    })
+
     describe('when the server returns plain text for a JSON endpoint', () => {
       const contentType = 'text/plain'
       const chunks = ['foo', '-', 'bar']
@@ -434,6 +477,99 @@ describe('Client', () => {
       const buffer = Client.transformFactory(false)(data)
       expect(Buffer.isBuffer(buffer)).toBe(true)
       expect(buffer.toString('utf8')).toBe(data)
+    })
+  })
+
+  describe('isRequestTimeoutAbort', () => {
+    it('should return false when timeoutSignal is undefined', () => {
+      expect(isRequestTimeoutAbort(new Error('boom'), undefined)).toBe(false)
+    })
+
+    it('should return false when timeout has not fired (reason is undefined)', () => {
+      const signal = AbortSignal.timeout(60_000)
+      expect(signal.reason).toBeUndefined()
+      expect(isRequestTimeoutAbort(new Error('boom'), signal)).toBe(false)
+    })
+
+    it('should return false when reason is not a TimeoutError (e.g. caller AbortError)', () => {
+      const controller = new AbortController()
+      controller.abort()
+      expect(controller.signal.reason).toBeDefined()
+      expect(controller.signal.reason.name).not.toBe('TimeoutError')
+      expect(isRequestTimeoutAbort(new Error('boom'), controller.signal)).toBe(false)
+    })
+
+    it('should return true when err is the timeout reason itself (direct case)', async () => {
+      const signal = AbortSignal.timeout(1)
+      await new Promise(resolve => setTimeout(resolve, 5))
+      expect(signal.reason?.name).toBe('TimeoutError')
+      expect(isRequestTimeoutAbort(signal.reason, signal)).toBe(true)
+    })
+
+    it('should return true when err wraps the timeout reason as cause (ABORT_ERR case)', async () => {
+      const signal = AbortSignal.timeout(1)
+      await new Promise(resolve => setTimeout(resolve, 5))
+      const wrapped = new Error('The operation was aborted')
+      wrapped.name = 'AbortError'
+      wrapped.code = 'ABORT_ERR'
+      wrapped.cause = signal.reason
+      expect(isRequestTimeoutAbort(wrapped, signal)).toBe(true)
+    })
+
+    it('should return false when err has ABORT_ERR code but cause is a different reason', async () => {
+      const signal = AbortSignal.timeout(1)
+      await new Promise(resolve => setTimeout(resolve, 5))
+      const otherReason = new DOMException('other', 'TimeoutError')
+      const wrapped = new Error('The operation was aborted')
+      wrapped.name = 'AbortError'
+      wrapped.code = 'ABORT_ERR'
+      wrapped.cause = otherReason
+      expect(isRequestTimeoutAbort(wrapped, signal)).toBe(false)
+    })
+
+    it('should return false for unrelated errors when timeout has fired', async () => {
+      const signal = AbortSignal.timeout(1)
+      await new Promise(resolve => setTimeout(resolve, 5))
+      const networkErr = Object.assign(new Error('socket reset'), { code: 'ECONNRESET' })
+      expect(isRequestTimeoutAbort(networkErr, signal)).toBe(false)
+    })
+  })
+
+  describe('mapTimeoutAbortError', () => {
+    const requestOptions = { method: 'GET', url: new URL('https://example.org/foo/bar') }
+
+    it('should rewrite a timeout-triggered error as TimeoutError with descriptive message', async () => {
+      const signal = AbortSignal.timeout(1)
+      await new Promise(resolve => setTimeout(resolve, 5))
+      const wrapped = Object.assign(new Error('The operation was aborted'), {
+        name: 'AbortError',
+        code: 'ABORT_ERR',
+        cause: signal.reason,
+      })
+      const mapped = mapTimeoutAbortError(wrapped, requestOptions, 1, signal)
+      expect(mapped).toMatchObject({
+        name: 'TimeoutError',
+        message: 'Request exceeded 1 ms for GET /foo/bar',
+      })
+      expect(mapped.cause).toBe(wrapped)
+    })
+
+    it('should pass through caller AbortError unchanged', () => {
+      const controller = new AbortController()
+      controller.abort()
+      const timeoutSignal = AbortSignal.timeout(60_000)
+      const callerErr = Object.assign(new Error('aborted'), {
+        name: 'AbortError',
+        code: 'ABORT_ERR',
+        cause: controller.signal.reason,
+      })
+      expect(mapTimeoutAbortError(callerErr, requestOptions, 60_000, timeoutSignal)).toBe(callerErr)
+    })
+
+    it('should pass through unrelated errors unchanged', () => {
+      const timeoutSignal = AbortSignal.timeout(60_000)
+      const err = new Error('boom')
+      expect(mapTimeoutAbortError(err, requestOptions, 60_000, timeoutSignal)).toBe(err)
     })
   })
 })

--- a/packages/request/lib/Client.js
+++ b/packages/request/lib/Client.js
@@ -67,11 +67,28 @@ function createTimeoutSignal (requestTimeout) {
   return AbortSignal.timeout(requestTimeout)
 }
 
+/**
+ * Detects whether an error originated from our requestTimeout firing,
+ * as opposed to a caller-supplied abort or unrelated failure.
+ *
+ * Used by mapTimeoutAbortError to decide whether to rewrite the error
+ * as a domain-level TimeoutError. Caller aborts stay as AbortError so
+ * consumers can distinguish "I cancelled" from "server too slow".
+ */
 function isRequestTimeoutAbort (err, timeoutSignal) {
+  // AbortSignal.timeout() sets signal.reason to a TimeoutError DOMException
+  // only after firing. Undefined reason or non-TimeoutError name means our
+  // timeout never triggered — the error must be from something else.
   const reason = timeoutSignal?.reason
   if (!reason || reason.name !== 'TimeoutError') {
     return false
   }
+
+  // Node delivers timeout-triggered aborts in two shapes depending on which
+  // await throws (stream creation vs getHeaders vs body read):
+  //   1. The promise rejects with signal.reason directly.
+  //   2. Node wraps it in an AbortError with code 'ABORT_ERR' and cause=reason.
+  // Match both forms.
   return err === reason ||
     (err?.code === 'ABORT_ERR' && err.cause === reason)
 }
@@ -454,3 +471,4 @@ class Client {
 }
 
 export default Client
+export { isRequestTimeoutAbort, mapTimeoutAbortError }

--- a/packages/request/lib/Client.js
+++ b/packages/request/lib/Client.js
@@ -12,7 +12,7 @@ import zlib from 'zlib'
 import typeis from 'type-is/index.js'
 import { pick, omit } from 'lodash-es'
 import { globalLogger as logger } from '@gardener-dashboard/logger'
-import { createHttpError, ParseError } from './errors.js'
+import { createHttpError, ParseError, TimeoutError } from './errors.js'
 import agent from './Agent.js'
 import { pipeline } from 'stream'
 
@@ -41,6 +41,50 @@ function setHeader (headers, key, value) {
 }
 
 const EOL = '\n'
+const MAX_TIMEOUT = 2_147_483_647 // Node.js TIMEOUT_MAX (2^31 - 1)
+
+function combineSignals (a, b) {
+  if (!a) {
+    return b
+  }
+  if (!b) {
+    return a
+  }
+  return AbortSignal.any([a, b])
+}
+
+function createTimeoutSignal (requestTimeout) {
+  if (requestTimeout === 0) {
+    return undefined
+  }
+  if (
+    !Number.isInteger(requestTimeout) ||
+    requestTimeout < 0 ||
+    requestTimeout > MAX_TIMEOUT
+  ) {
+    throw new TypeError(`requestTimeout must be a non-negative integer <= ${MAX_TIMEOUT}`)
+  }
+  return AbortSignal.timeout(requestTimeout)
+}
+
+function isRequestTimeoutAbort (err, timeoutSignal) {
+  const reason = timeoutSignal?.reason
+  if (!reason || reason.name !== 'TimeoutError') {
+    return false
+  }
+  return err === reason ||
+    (err?.code === 'ABORT_ERR' && err.cause === reason)
+}
+
+function mapTimeoutAbortError (err, { method, url } = {}, requestTimeout, timeoutSignal) {
+  if (isRequestTimeoutAbort(err, timeoutSignal)) {
+    return new TimeoutError(
+      `Request exceeded ${requestTimeout} ms for ${method} ${url?.pathname ?? ''}`,
+      { cause: err },
+    )
+  }
+  return err
+}
 
 class Client {
   #options
@@ -63,10 +107,6 @@ class Client {
     return relativeUrl
       ? new URL(relativeUrl, url.endsWith('/') ? url : url + '/')
       : new URL(url)
-  }
-
-  get responseTimeout () {
-    return this.#options.responseTimeout || 15 * 1000
   }
 
   get responseType () {
@@ -164,7 +204,16 @@ class Client {
     )
   }
 
-  async fetch (path, { method, searchParams, headers, body, responseType = this.responseType, signal, ...options } = {}) {
+  async fetch (path, {
+    method,
+    searchParams,
+    headers,
+    body,
+    responseType = this.responseType,
+    signal,
+    requestTimeout = this.#options.requestTimeout ?? 60 * 1000,
+    ...options
+  } = {}) {
     headers = this.getRequestHeaders(path, {
       method,
       searchParams,
@@ -181,117 +230,129 @@ class Client {
     }
     this.executeHooks('beforeRequest', requestOptions)
 
-    const stream = await this.#agent.request(headers, {
-      ...this.#defaultOptions,
-      ...options,
-      signal,
-    })
-    if (body) {
-      stream.write(body)
-    }
-    stream.end()
+    const timeoutSignal = createTimeoutSignal(requestTimeout)
+    const effectiveSignal = combineSignals(signal, timeoutSignal)
+    const mapError = err => mapTimeoutAbortError(err, requestOptions, requestTimeout, timeoutSignal)
 
-    const { createDecompressor, concat, transformFactory } = this.constructor
+    try {
+      const stream = await this.#agent.request(headers, {
+        ...this.#defaultOptions,
+        ...options,
+        signal: effectiveSignal,
+      })
+      if (body) {
+        stream.write(body)
+      }
+      stream.end()
 
-    headers = await stream.getHeaders()
-    const decompressor = createDecompressor(getHeader(headers, HTTP2_HEADER_CONTENT_ENCODING))
+      const { createDecompressor, concat, transformFactory } = this.constructor
 
-    return {
-      request: { options: requestOptions },
-      headers,
-      get statusCode () {
-        return getHeader(this.headers, HTTP2_HEADER_STATUS)
-      },
-      get ok () {
-        return this.statusCode >= 200 && this.statusCode < 300
-      },
-      get redirected () {
-        return this.statusCode >= 300 && this.statusCode < 400
-      },
-      get contentType () {
-        return getHeader(this.headers, HTTP2_HEADER_CONTENT_TYPE)
-      },
-      get contentLength () {
-        return getHeader(this.headers, HTTP2_HEADER_CONTENT_LENGTH)
-      },
-      get type () {
-        if (['json', 'text'].includes(responseType)) {
-          return responseType
-        }
-        return typeis.is(this.contentType, ['json', 'text'])
-      },
-      destroy (error) {
-        stream.destroy(error)
-      },
-      body () {
-        const streams = [
-          stream,
-          async source => {
-            const text = await concat(source)
-            switch (this.type) {
-              case 'text':
-                return text
-              case 'json':
-                try {
-                  return JSON.parse(text)
-                } catch (err) {
-                  logger.error('Failed to parse response body: %s', text)
-                  if (this.ok) {
-                    throw new ParseError(err.message, {
-                      headers,
-                      rawBody: text,
-                    })
-                  }
-                  // return the raw body text if the response status is not ok (keep the original http error in this case)
-                  return text
-                }
-              default:
-                return Buffer.from(text, 'utf8')
-            }
-          },
-        ]
-        if (decompressor) {
-          streams.splice(1, 0, decompressor)
-        }
-        return new Promise((resolve, reject) => {
-          pipeline(streams, (err, body) => {
-            if (err) {
-              reject(err)
-            } else {
-              resolve(body)
-            }
-          })
-        })
-      },
-      async * [Symbol.asyncIterator] () {
-        let data = ''
-        const transform = transformFactory(this.type)
-        let readable = stream
-        if (decompressor) {
-          readable = pipeline(stream, decompressor, err => {
-            if (err) {
-              logger.debug('Stream decompress pipeline error: %s', err.message)
-            }
-          })
-        }
-        readable.setEncoding('utf8')
-        for await (const chunk of readable) {
-          data += chunk
-          let index
-          while ((index = data.indexOf(EOL)) !== -1) {
-            yield transform(data.slice(0, index))
-            data = data.slice(index + 1)
+      headers = await stream.getHeaders()
+      const decompressor = createDecompressor(getHeader(headers, HTTP2_HEADER_CONTENT_ENCODING))
+
+      return {
+        request: { options: requestOptions },
+        headers,
+        get statusCode () {
+          return getHeader(this.headers, HTTP2_HEADER_STATUS)
+        },
+        get ok () {
+          return this.statusCode >= 200 && this.statusCode < 300
+        },
+        get redirected () {
+          return this.statusCode >= 300 && this.statusCode < 400
+        },
+        get contentType () {
+          return getHeader(this.headers, HTTP2_HEADER_CONTENT_TYPE)
+        },
+        get contentLength () {
+          return getHeader(this.headers, HTTP2_HEADER_CONTENT_LENGTH)
+        },
+        get type () {
+          if (['json', 'text'].includes(responseType)) {
+            return responseType
           }
-        }
-        if (data && data.length) {
-          yield transform(data)
-        }
-      },
+          return typeis.is(this.contentType, ['json', 'text'])
+        },
+        destroy (error) {
+          stream.destroy(error)
+        },
+        body () {
+          const streams = [
+            stream,
+            async source => {
+              const text = await concat(source)
+              switch (this.type) {
+                case 'text':
+                  return text
+                case 'json':
+                  try {
+                    return JSON.parse(text)
+                  } catch (err) {
+                    logger.error('Failed to parse response body: %s', text)
+                    if (this.ok) {
+                      throw new ParseError(err.message, {
+                        headers,
+                        rawBody: text,
+                      })
+                    }
+                    // return the raw body text if the response status is not ok (keep the original http error in this case)
+                    return text
+                  }
+                default:
+                  return Buffer.from(text, 'utf8')
+              }
+            },
+          ]
+          if (decompressor) {
+            streams.splice(1, 0, decompressor)
+          }
+          return new Promise((resolve, reject) => {
+            pipeline(streams, (err, body) => {
+              if (err) {
+                reject(mapError(err))
+              } else {
+                resolve(body)
+              }
+            })
+          })
+        },
+        async * [Symbol.asyncIterator] () {
+          let data = ''
+          const transform = transformFactory(this.type)
+          let readable = stream
+          if (decompressor) {
+            readable = pipeline(stream, decompressor, err => {
+              if (err) {
+                logger.debug('Stream decompress pipeline error: %s', err.message)
+              }
+            })
+          }
+          readable.setEncoding('utf8')
+          try {
+            for await (const chunk of readable) {
+              data += chunk
+              let index
+              while ((index = data.indexOf(EOL)) !== -1) {
+                yield transform(data.slice(0, index))
+                data = data.slice(index + 1)
+              }
+            }
+            if (data && data.length) {
+              yield transform(data)
+            }
+          } catch (err) {
+            throw mapError(err)
+          }
+        },
+      }
+    } catch (err) {
+      throw mapError(err)
     }
   }
 
   async stream (path, options) {
-    const response = await this.fetch(path, options)
+    const response = await this.fetch(path, { requestTimeout: 0, ...options })
     const statusCode = response.statusCode
     if (statusCode >= 400) {
       throw createHttpError({

--- a/packages/request/lib/errors.js
+++ b/packages/request/lib/errors.js
@@ -9,8 +9,8 @@ import createError from 'http-errors'
 import { get } from 'lodash-es'
 
 class TimeoutError extends Error {
-  constructor (message) {
-    super(message)
+  constructor (message, options) {
+    super(message, options)
     this.name = this.constructor.name
     this.code = 'ETIMEDOUT'
     Error.captureStackTrace(this, this.constructor)


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area robustness
/kind bug

**What this PR does / why we need it**:

This PR addresses two gaps in `kube-client` that came to light while investigating a silent stall of the Shoot cache reflector on dashboard startup. Neither gap can be claimed as the confirmed root cause of that incident — like #2981, this PR should be read as *adding missing safety nets*, not as a verified fix for a specific reproduction.

**1. Abort signal not forwarded through `list` and `get`**

`ListWatcher.list()` accepted a `signal` but did not pass it to the underlying list function — unlike `watch()`, which already forwarded it correctly. The `get` mixins (`ClusterScoped.Readable.get` / `NamespaceScoped.Readable.get`) destructured `signal` and then discarded it. Either bug means a hung request cannot be cancelled by the caller, regardless of any transport-level timeout.

**2. No total request timeout**

`Client.fetch()` had a `responseTimeout` option defined but never wired up. There was no enforced ceiling on how long a request could take from session establishment through body completion. #2981 added a read-idle / PING heartbeat that catches half-open sessions, but a session that delivers `:status` and then trickles body bytes slowly — or sends a small payload and stalls — would not trip that detector. A total request timeout covers that case.

**The fix**

- Forward the abort signal through `ListWatcher.list()` and the cluster-/namespace-scoped `get` mixins.
- Replace `responseTimeout` with a total `requestTimeout` covering session establishment, headers, and body. Implementation uses `AbortSignal.timeout(ms)` combined with the caller's signal via `AbortSignal.any([...])`.
- Map Node HTTP/2's generic `AbortError` to `TimeoutError` (`code: 'ETIMEDOUT'`) at every delayed-error surface — `getHeaders()`, `body()`, and async iterator — by identity-matching the package-created timeout signal's reason; the raw abort is preserved as `cause`.
- `stream()` opts out via `requestTimeout: 0` so watches stay long-lived. Per-call options still override.

**Configuration**

`requestTimeout` is owned by `kube-client` end-to-end and joins the two timeouts introduced in #2981 (`readIdleTimeout`, `pingTimeout`) under the same shape:

- Default 5 minutes (300000 ms). Conservative compared to the previous "no timeout"; can be tightened later.
- Env var `KUBE_CLIENT_REQUEST_TIMEOUT`. Per-client option override. `0` disables.
- Parsed and validated through the shared `parseTimeoutValue` / `parseEnvTimeoutValue` helpers from #2981. Malformed values throw at module load so misconfiguration surfaces immediately.
- Helm value `.Values.global.dashboard.kubeClient.requestTimeout` renders into the container environment; `0` is rendered (disable) rather than skipped as falsy.

**Relationship to #2981**

#2981 detects half-open HTTP/2 sessions via PING. This PR detects slow / stalled individual requests via a total deadline, and lets callers cancel hung requests via `AbortSignal`. The two mechanisms catch different failure modes; either or both may have been relevant to the original Shoot-cache stall, which we were never able to reproduce deterministically.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This branch was rebased onto master after #2981 merged. The original commit added a narrow `parseRequestTimeout` helper; that has been dropped in favor of the generic `parseTimeoutValue` / `parseEnvTimeoutValue` helpers from #2981. Side-effect: per-client `requestTimeout` is now also validated (it wasn't in the original version of this branch).

As a possible future follow-up, we could evaluate whether the package-level config-dependent singletons should be replaced by an explicit `createClientSet()` factory that receives `requestTimeout` and other transport options as constructor arguments. In that model, the backend would instantiate the client set at startup from its loaded config and inject it into route handlers, services, and hooks. This is intentionally not part of this PR: it would touch every backend module that imports from `@gardener-dashboard/kube-client` and should only be considered as a separate refactoring effort if we decide the reduced coupling is worth the larger change surface.

**Release note**:
```bugfix developer
Forward caller-provided abort signals through `list` and `get` operations in the kube-client so hung requests can be cancelled.
```

```feature operator
Add `KUBE_CLIENT_REQUEST_TIMEOUT` environment variable to configure a total per-request timeout (in milliseconds) for Kubernetes API requests made by the dashboard backend. Defaults to 300000 (5 minutes); set to 0 to disable. When using the Helm chart, this can be configured via `.Values.global.dashboard.kubeClient.requestTimeout`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduce configurable request timeout (env/config) with default 300000ms (5 minutes); can be set to 0 to disable.
  * Dashboard deployment now exposes KUBE_CLIENT_REQUEST_TIMEOUT to the container.

* **Bug Fixes**
  * List and get operations now forward caller abort signals.
  * Total request timeout enforced across session establishment, headers, and body.
  * More consistent timeout handling and error mapping for timed-out requests.

* **Tests**
  * Added/updated tests for timeout behavior, abort-signal forwarding, and env parsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gardener/dashboard/pull/2954?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
