### PR TITLE
fix(socket): guard against missing operator during store patch

### DIFF
--- a/frontend/__tests__/composables/useSocketEventHandler.spec.js
+++ b/frontend/__tests__/composables/useSocketEventHandler.spec.js
@@ -1,0 +1,276 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import { flushPromises } from '@vue/test-utils'
+import {
+  computed,
+  nextTick,
+  reactive,
+  ref,
+} from 'vue'
+
+import {
+  createListOperator,
+  useSocketEventHandler,
+} from '@/composables/useSocketEventHandler'
+
+function createLogger () {
+  return {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  }
+}
+
+function createListStore (id, initialList = null) {
+  const state = reactive({
+    list: initialList,
+  })
+  const isInitial = computed(() => state.list === null)
+  const store = {
+    $id: id,
+    get isInitial () {
+      return isInitial.value
+    },
+    $patch (fn) {
+      fn(state)
+    },
+  }
+
+  return {
+    state,
+    store,
+  }
+}
+
+function createDeferred () {
+  let resolvePromise
+  let rejectPromise
+  const promise = new Promise((resolve, reject) => {
+    resolvePromise = resolve
+    rejectPromise = reject
+  })
+  return {
+    promise,
+    resolve: resolvePromise,
+    reject: rejectPromise,
+  }
+}
+
+async function flushEvents () {
+  await nextTick()
+  await flushPromises()
+}
+
+describe('composables', () => {
+  describe('useSocketEventHandler', () => {
+    let logger
+    let socketStore
+    let visibility
+
+    beforeEach(() => {
+      logger = createLogger()
+      socketStore = {
+        synchronize: vi.fn(),
+      }
+      visibility = ref('visible')
+    })
+
+    it('defers socket events until the store is initialized', async () => {
+      const { state, store } = createListStore('seed')
+      const item = {
+        kind: 'Seed',
+        metadata: {
+          uid: 'uid-1',
+        },
+      }
+      socketStore.synchronize.mockResolvedValue([item])
+      const socketEventHandler = useSocketEventHandler(() => store, {
+        logger,
+        socketStore,
+        visibility,
+      })
+
+      socketEventHandler.start(0)
+      socketEventHandler.listener({
+        type: 'MODIFIED',
+        uid: 'uid-1',
+      })
+      await flushEvents()
+
+      expect(socketStore.synchronize).not.toBeCalled()
+      expect(state.list).toBeNull()
+
+      state.list = []
+      await flushEvents()
+
+      expect(socketStore.synchronize).toBeCalledTimes(1)
+      expect(socketStore.synchronize).toBeCalledWith('seeds', ['uid-1'])
+      expect(state.list).toEqual([item])
+    })
+
+    it('does not apply synchronized events when the store was reset before the response arrives', async () => {
+      const { state, store } = createListStore('seed', [])
+      const item = {
+        kind: 'Seed',
+        metadata: {
+          uid: 'uid-1',
+        },
+      }
+      const synchronize = createDeferred()
+      socketStore.synchronize
+        .mockReturnValueOnce(synchronize.promise)
+        .mockResolvedValueOnce([item])
+      const socketEventHandler = useSocketEventHandler(() => store, {
+        logger,
+        socketStore,
+        visibility,
+      })
+
+      socketEventHandler.start(0)
+      socketEventHandler.listener({
+        type: 'MODIFIED',
+        uid: 'uid-1',
+      })
+      await flushEvents()
+
+      state.list = null
+      synchronize.resolve([item])
+      await flushEvents()
+
+      expect(state.list).toBeNull()
+      expect(logger.error).not.toBeCalled()
+
+      state.list = []
+      await flushEvents()
+
+      expect(socketStore.synchronize).toBeCalledTimes(2)
+      expect(state.list).toEqual([item])
+    })
+
+    it('requeues synchronized events when the store is reset while applying them', async () => {
+      const { state, store } = createListStore('seed', [])
+      const item = {
+        kind: 'Seed',
+        metadata: {
+          uid: 'uid-1',
+        },
+      }
+      const patch = store.$patch
+      let resetBeforePatch = true
+      store.$patch = fn => {
+        if (resetBeforePatch) {
+          resetBeforePatch = false
+          state.list = null
+        }
+        patch(fn)
+      }
+      socketStore.synchronize.mockResolvedValue([item])
+      const socketEventHandler = useSocketEventHandler(() => store, {
+        logger,
+        socketStore,
+        visibility,
+      })
+
+      socketEventHandler.start(0)
+      socketEventHandler.listener({
+        type: 'MODIFIED',
+        uid: 'uid-1',
+      })
+      await flushEvents()
+
+      expect(socketStore.synchronize).toBeCalledTimes(1)
+      expect(state.list).toBeNull()
+      expect(logger.debug).toBeCalledWith(
+        'Skipped synchronization of %s: store not yet initialized',
+        'seeds',
+      )
+      expect(logger.error).not.toBeCalled()
+
+      state.list = []
+      await flushEvents()
+
+      expect(socketStore.synchronize).toBeCalledTimes(2)
+      expect(state.list).toEqual([item])
+    })
+
+    it('synchronizes socket events immediately when the store is initialized', async () => {
+      const { state, store } = createListStore('project', [])
+      const item = {
+        kind: 'Project',
+        metadata: {
+          uid: 'uid-1',
+        },
+      }
+      socketStore.synchronize.mockResolvedValue([item])
+      const socketEventHandler = useSocketEventHandler(() => store, {
+        logger,
+        socketStore,
+        visibility,
+      })
+
+      socketEventHandler.start(0)
+      socketEventHandler.listener({
+        type: 'ADDED',
+        uid: 'uid-1',
+      })
+      await flushEvents()
+
+      expect(socketStore.synchronize).toBeCalledTimes(1)
+      expect(socketStore.synchronize).toBeCalledWith('projects', ['uid-1'])
+      expect(state.list).toEqual([item])
+    })
+
+    it('does not retry operator failures as transient synchronization failures', async () => {
+      const { store } = createListStore('seed', [])
+      const item = {
+        kind: 'Seed',
+        metadata: {
+          uid: 'uid-1',
+        },
+      }
+      socketStore.synchronize.mockResolvedValue([item])
+      const socketEventHandler = useSocketEventHandler(() => store, {
+        logger,
+        socketStore,
+        visibility,
+        createOperator () {
+          return {
+            delete: vi.fn(),
+            set () {
+              throw new Error('operator failed')
+            },
+          }
+        },
+      })
+
+      socketEventHandler.start(0)
+      socketEventHandler.listener({
+        type: 'MODIFIED',
+        uid: 'uid-1',
+      })
+      await flushEvents()
+
+      expect(socketStore.synchronize).toBeCalledTimes(1)
+      expect(logger.error).toBeCalledWith(
+        'Failed to apply synchronized %s: %s',
+        'seeds',
+        'operator failed',
+      )
+
+      visibility.value = 'hidden'
+      await flushEvents()
+      visibility.value = 'visible'
+      await flushEvents()
+
+      expect(socketStore.synchronize).toBeCalledTimes(1)
+    })
+
+    it('requires an initialized array list for list operators', () => {
+      expect(() => createListOperator(null)).toThrow('Argument `list` must be an array')
+    })
+  })
+})

--- a/frontend/__tests__/composables/useSocketEventHandler.spec.js
+++ b/frontend/__tests__/composables/useSocketEventHandler.spec.js
@@ -112,6 +112,41 @@ describe('composables', () => {
       expect(state.list).toEqual([item])
     })
 
+    it('logs when handling queued events is deferred', async () => {
+      const { state, store } = createListStore('seed')
+      const item = {
+        kind: 'Seed',
+        metadata: {
+          uid: 'uid-1',
+        },
+      }
+      socketStore.synchronize.mockResolvedValue([item])
+      const socketEventHandler = useSocketEventHandler(() => store, {
+        logger,
+        socketStore,
+        visibility,
+      })
+
+      const handleEvents = socketEventHandler.start(0)
+      socketEventHandler.listener({
+        type: 'MODIFIED',
+        uid: 'uid-1',
+      })
+      await handleEvents()
+
+      expect(logger.debug).toBeCalledWith(
+        'Deferred synchronization of %s: store not yet initialized',
+        'seeds',
+      )
+      expect(socketStore.synchronize).not.toBeCalled()
+
+      state.list = []
+      await flushEvents()
+
+      expect(socketStore.synchronize).toBeCalledTimes(1)
+      expect(state.list).toEqual([item])
+    })
+
     it('does not apply synchronized events when the store was reset before the response arrives', async () => {
       const { state, store } = createListStore('seed', [])
       const item = {

--- a/frontend/__tests__/stores/shoot.spec.js
+++ b/frontend/__tests__/stores/shoot.spec.js
@@ -57,7 +57,7 @@ describe('stores', () => {
     let shootStore
 
     const flushEvents = () => {
-      shootStore.state.subscriptionEventHandler.flush()
+      shootStore.state.subscriptionEventHandler.flush?.()
       return new Promise(resolve => globalSetImmediate(resolve))
     }
 
@@ -307,6 +307,68 @@ describe('stores', () => {
         }]
         const sortedShoots = shootStore.sortItems(items, sortBy)
         expect(map(sortedShoots, 'metadata.name')).toEqual(['shoot3', 'shoot1', 'shoot2'])
+      })
+    })
+
+    describe('subscription initialization', () => {
+      it('should mark store initialized and process events when initial single-shoot fetch returns 404', async () => {
+        mockGetShoot.mockRejectedValueOnce(notFound)
+
+        await expect(shootStore.subscribe({
+          namespace: 'foo',
+          name: 'missing',
+        })).rejects.toThrow('Not found')
+
+        expect(shootStore.isInitial).toBe(false)
+
+        shootStore.handleEvent({
+          type: 'ADDED',
+          uid: '4',
+        })
+        await flushEvents()
+
+        expect(mockSynchronize).toHaveBeenCalledWith('shoots', ['4'])
+        expect(shootStore.shootByNamespaceAndName({
+          namespace: 'foo',
+          name: 'shoot4',
+        })).toEqual(expect.objectContaining({
+          metadata: expect.objectContaining({
+            uid: '4',
+          }),
+        }))
+      })
+
+      it('should reset initialization when unsubscribing after an initial single-shoot 404', async () => {
+        mockGetShoot.mockRejectedValueOnce(notFound)
+
+        await expect(shootStore.subscribe({
+          namespace: 'foo',
+          name: 'missing',
+        })).rejects.toThrow('Not found')
+
+        expect(shootStore.isInitial).toBe(false)
+
+        await shootStore.unsubscribe()
+
+        expect(shootStore.isInitial).toBe(true)
+      })
+
+      it('should remain initial when the initial single-shoot fetch fails permanently', async () => {
+        mockGetShoot.mockRejectedValueOnce(new Error('boom'))
+
+        await expect(shootStore.subscribe({
+          namespace: 'foo',
+          name: 'broken',
+        })).rejects.toThrow('boom')
+
+        expect(shootStore.isInitial).toBe(true)
+
+        shootStore.handleEvent({
+          type: 'ADDED',
+          uid: '4',
+        })
+
+        expect(mockSynchronize).not.toHaveBeenCalled()
       })
     })
 

--- a/frontend/src/composables/useSocketEventHandler.js
+++ b/frontend/src/composables/useSocketEventHandler.js
@@ -91,8 +91,13 @@ export function useSocketEventHandler (useStore, options = {}) {
 
         uidMap.set(uid, false)
       }
+      let patchResult = 'applied'
       store.$patch(state => {
         const operator = createOperator(state)
+        if (!operator) {
+          patchResult = state.list === null ? 'uninitialized' : 'invalid'
+          return
+        }
         // Delete items first
         for (const [uid, item] of uidMap) {
           if (typeof item === 'boolean' && !item) {
@@ -106,6 +111,17 @@ export function useSocketEventHandler (useStore, options = {}) {
           }
         }
       })
+      if (patchResult === 'uninitialized') {
+        logger.debug('Skipped synchronization of %s: store not yet initialized', pluralName)
+        for (const event of events) {
+          const { uid } = event
+          if (!eventMap.has(uid)) {
+            eventMap.set(uid, event)
+          }
+        }
+      } else if (patchResult === 'invalid') {
+        logger.error('Failed to synchronize %s: operator could not be created for current store state', pluralName)
+      }
     } catch (err) {
       if (isTooManyRequestsError(err)) {
         logger.info('Skipped synchronization of modified %s: %s', pluralName, err.message)

--- a/frontend/src/composables/useSocketEventHandler.js
+++ b/frontend/src/composables/useSocketEventHandler.js
@@ -17,13 +17,28 @@ import partial from 'lodash/partial'
 import throttle from 'lodash/throttle'
 import findIndex from 'lodash/findIndex'
 
-export function createDefaultOperator (state) {
-  if (Array.isArray(state.list)) {
-    return createListOperator(state.list)
+class StoreNotInitializedError extends Error {
+  constructor () {
+    super('store not yet initialized')
+    this.name = 'StoreNotInitializedError'
   }
 }
 
+function isStoreNotInitializedError (err) {
+  return err instanceof StoreNotInitializedError
+}
+
+export function createDefaultOperator (state) {
+  if (state.list === null) {
+    throw new StoreNotInitializedError()
+  }
+  return createListOperator(state.list)
+}
+
 export function createListOperator (list) {
+  if (!Array.isArray(list)) {
+    throw new TypeError('Argument `list` must be an array')
+  }
   return {
     delete (uid) {
       const index = findIndex(list, ['metadata.uid', uid])
@@ -42,6 +57,10 @@ export function createListOperator (list) {
   }
 }
 
+function isStoreInitialized (store) {
+  return store.isInitial !== true
+}
+
 export function useSocketEventHandler (useStore, options = {}) {
   const {
     logger = useLogger(),
@@ -49,6 +68,7 @@ export function useSocketEventHandler (useStore, options = {}) {
     visibility = useDocumentVisibility(),
     createOperator = createDefaultOperator,
     getSynchronizeOptions,
+    isInitialized = isStoreInitialized,
   } = options
 
   const eventMap = new Map([])
@@ -62,51 +82,80 @@ export function useSocketEventHandler (useStore, options = {}) {
     }
   }
 
+  function flushEvents (store) {
+    if (!eventMap.size) {
+      return
+    }
+    if (!isInitialized(store)) {
+      return
+    }
+    if (visibility.value !== 'visible') {
+      return
+    }
+    throttledHandleEvents()
+  }
+
   async function handleEvents (store) {
+    if (!isInitialized(store)) {
+      return
+    }
     const pluralName = store.$id + 's'
     const events = Array.from(eventMap.values())
+    if (!events.length) {
+      return
+    }
     eventMap.clear()
-    try {
-      const uidMap = new Map()
-      const uids = []
-      for (const { type, uid } of events) {
-        if (type === 'DELETED') {
-          uidMap.set(uid, false)
-        } else {
-          uidMap.set(uid, true)
-          uids.push(uid)
-        }
-      }
-      const synchronizeOptions = getSynchronizeOptions
-        ? getSynchronizeOptions(store)
-        : undefined
-      const items = await socketStore.synchronize(pluralName, uids, synchronizeOptions)
-      for (const item of items) {
-        if (item.kind !== 'Status') {
-          uidMap.set(item.metadata.uid, item)
-          continue
-        }
-
-        logger.info('Failed to synchronize a single %s: %s', store.$id, item.message)
-
-        if (item.code !== 404) {
-          continue
-        }
-
-        const uid = item.details?.uid
-        if (!uid) {
-          continue
-        }
-
+    const uidMap = new Map()
+    const uids = []
+    for (const { type, uid } of events) {
+      if (type === 'DELETED') {
         uidMap.set(uid, false)
+      } else {
+        uidMap.set(uid, true)
+        uids.push(uid)
       }
-      let patchResult = 'applied'
+    }
+    let items
+    try {
+      items = getSynchronizeOptions
+        ? await socketStore.synchronize(pluralName, uids, getSynchronizeOptions(store))
+        : await socketStore.synchronize(pluralName, uids)
+    } catch (err) {
+      if (isTooManyRequestsError(err)) {
+        logger.info('Skipped synchronization of modified %s: %s', pluralName, err.message)
+      } else {
+        logger.error('Failed to synchronize modified %s: %s', pluralName, err.message)
+      }
+      // Synchronization failed -> Rollback events
+      restoreEvents(events)
+      return
+    }
+    if (!isInitialized(store)) {
+      restoreEvents(events)
+      return
+    }
+    for (const item of items) {
+      if (item.kind !== 'Status') {
+        uidMap.set(item.metadata.uid, item)
+        continue
+      }
+
+      logger.info('Failed to synchronize a single %s: %s', store.$id, item.message)
+
+      if (item.code !== 404) {
+        continue
+      }
+
+      const uid = item.details?.uid
+      if (!uid) {
+        continue
+      }
+
+      uidMap.set(uid, false)
+    }
+    try {
       store.$patch(state => {
         const operator = createOperator(state)
-        if (!operator) {
-          patchResult = state.list === null ? 'uninitialized' : 'invalid'
-          return
-        }
         // Delete items first
         for (const [uid, item] of uidMap) {
           if (typeof item === 'boolean' && !item) {
@@ -120,24 +169,18 @@ export function useSocketEventHandler (useStore, options = {}) {
           }
         }
       })
-      if (patchResult === 'uninitialized') {
+    } catch (err) {
+      if (isStoreNotInitializedError(err)) {
         logger.debug('Skipped synchronization of %s: store not yet initialized', pluralName)
         restoreEvents(events)
-      } else if (patchResult === 'invalid') {
-        logger.error('Failed to synchronize %s: operator could not be created for current store state', pluralName)
+        return
       }
-    } catch (err) {
-      if (isTooManyRequestsError(err)) {
-        logger.info('Skipped synchronization of modified %s: %s', pluralName, err.message)
-      } else {
-        logger.error('Failed to synchronize modified %s: %s', pluralName, err.message)
-      }
-      // Synchronization failed -> Rollback events
-      restoreEvents(events)
+      logger.error('Failed to apply synchronized %s: %s', pluralName, err.message)
     }
   }
 
   let throttledHandleEvents
+  let stopInitializationWatcher
 
   function cancelTrailingInvocation () {
     if (typeof throttledHandleEvents?.cancel === 'function') {
@@ -145,19 +188,33 @@ export function useSocketEventHandler (useStore, options = {}) {
     }
   }
 
+  function stopWatchingInitialization () {
+    if (typeof stopInitializationWatcher === 'function') {
+      stopInitializationWatcher()
+      stopInitializationWatcher = undefined
+    }
+  }
+
   function start (wait = 500) {
     cancelTrailingInvocation()
+    stopWatchingInitialization()
     eventMap.clear()
     const store = useStore()
     const handleEventsWithParams = partial(handleEvents, store)
     throttledHandleEvents = wait > 0
       ? throttle(handleEventsWithParams, wait)
       : handleEventsWithParams
+    stopInitializationWatcher = watch(() => isInitialized(store), value => {
+      if (value) {
+        flushEvents(store)
+      }
+    })
     return throttledHandleEvents
   }
 
   function stop () {
     cancelTrailingInvocation()
+    stopWatchingInitialization()
     eventMap.clear()
     throttledHandleEvents = undefined
   }
@@ -172,10 +229,7 @@ export function useSocketEventHandler (useStore, options = {}) {
       return
     }
     eventMap.set(uid, event)
-    if (visibility.value !== 'visible') {
-      return
-    }
-    throttledHandleEvents()
+    flushEvents(useStore())
   }
 
   watch(visibility, (current, previous) => {
@@ -183,7 +237,7 @@ export function useSocketEventHandler (useStore, options = {}) {
       return
     }
     if (current === 'visible' && previous === 'hidden') {
-      throttledHandleEvents()
+      flushEvents(useStore())
     }
   })
 

--- a/frontend/src/composables/useSocketEventHandler.js
+++ b/frontend/src/composables/useSocketEventHandler.js
@@ -96,10 +96,11 @@ export function useSocketEventHandler (useStore, options = {}) {
   }
 
   async function handleEvents (store) {
+    const pluralName = store.$id + 's'
     if (!isInitialized(store)) {
+      logger.debug('Deferred synchronization of %s: store not yet initialized', pluralName)
       return
     }
-    const pluralName = store.$id + 's'
     const events = Array.from(eventMap.values())
     if (!events.length) {
       return

--- a/frontend/src/composables/useSocketEventHandler.js
+++ b/frontend/src/composables/useSocketEventHandler.js
@@ -180,7 +180,7 @@ export function useSocketEventHandler (useStore, options = {}) {
   }
 
   let throttledHandleEvents
-  let stopInitializationWatcher
+  let unwatchInitialization
 
   function cancelTrailingInvocation () {
     if (typeof throttledHandleEvents?.cancel === 'function') {
@@ -188,23 +188,23 @@ export function useSocketEventHandler (useStore, options = {}) {
     }
   }
 
-  function stopWatchingInitialization () {
-    if (typeof stopInitializationWatcher === 'function') {
-      stopInitializationWatcher()
-      stopInitializationWatcher = undefined
+  function teardownInitializationWatch () {
+    if (typeof unwatchInitialization === 'function') {
+      unwatchInitialization()
+      unwatchInitialization = undefined
     }
   }
 
   function start (wait = 500) {
     cancelTrailingInvocation()
-    stopWatchingInitialization()
+    teardownInitializationWatch()
     eventMap.clear()
     const store = useStore()
     const handleEventsWithParams = partial(handleEvents, store)
     throttledHandleEvents = wait > 0
       ? throttle(handleEventsWithParams, wait)
       : handleEventsWithParams
-    stopInitializationWatcher = watch(() => isInitialized(store), value => {
+    unwatchInitialization = watch(() => isInitialized(store), value => {
       if (value) {
         flushEvents(store)
       }
@@ -214,7 +214,7 @@ export function useSocketEventHandler (useStore, options = {}) {
 
   function stop () {
     cancelTrailingInvocation()
-    stopWatchingInitialization()
+    teardownInitializationWatch()
     eventMap.clear()
     throttledHandleEvents = undefined
   }

--- a/frontend/src/composables/useSocketEventHandler.js
+++ b/frontend/src/composables/useSocketEventHandler.js
@@ -53,6 +53,15 @@ export function useSocketEventHandler (useStore, options = {}) {
 
   const eventMap = new Map([])
 
+  function restoreEvents (events) {
+    for (const event of events) {
+      const { uid } = event
+      if (!eventMap.has(uid)) {
+        eventMap.set(uid, event)
+      }
+    }
+  }
+
   async function handleEvents (store) {
     const pluralName = store.$id + 's'
     const events = Array.from(eventMap.values())
@@ -113,12 +122,7 @@ export function useSocketEventHandler (useStore, options = {}) {
       })
       if (patchResult === 'uninitialized') {
         logger.debug('Skipped synchronization of %s: store not yet initialized', pluralName)
-        for (const event of events) {
-          const { uid } = event
-          if (!eventMap.has(uid)) {
-            eventMap.set(uid, event)
-          }
-        }
+        restoreEvents(events)
       } else if (patchResult === 'invalid') {
         logger.error('Failed to synchronize %s: operator could not be created for current store state', pluralName)
       }
@@ -129,12 +133,7 @@ export function useSocketEventHandler (useStore, options = {}) {
         logger.error('Failed to synchronize modified %s: %s', pluralName, err.message)
       }
       // Synchronization failed -> Rollback events
-      for (const event of events) {
-        const { uid } = event
-        if (!eventMap.has(uid)) {
-          eventMap.set(uid, event)
-        }
-      }
+      restoreEvents(events)
     }
   }
 

--- a/frontend/src/store/shoot/shoot.js
+++ b/frontend/src/store/shoot/shoot.js
@@ -11,6 +11,7 @@ import {
 import {
   computed,
   reactive,
+  ref,
   markRaw,
   toRaw,
   toRef,
@@ -118,6 +119,10 @@ const useShootStore = defineStore('shoot', () => {
   })
   const shootEvents = new Map()
 
+  const initializedNamespace = ref(null)
+
+  const isInitial = computed(() => initializedNamespace.value === null)
+
   // state
   const staleShoots = computed(() => {
     return state.staleShoots
@@ -221,6 +226,7 @@ const useShootStore = defineStore('shoot', () => {
       state.froozenUids = []
       state.focusMode = false
     })
+    initializedNamespace.value = null
     shootEvents.clear()
     ticketStore.clearIssues()
     ticketStore.clearComments()
@@ -510,6 +516,7 @@ const useShootStore = defineStore('shoot', () => {
       }
       state.shoots = shoots
     })
+    initializedNamespace.value = state.subscription?.namespace ?? null
   }
 
   async function openSubscription (value, throttleDelay) {
@@ -578,6 +585,7 @@ const useShootStore = defineStore('shoot', () => {
   return {
     // state
     state,
+    isInitial,
     staleShoots,
     subscriptionState,
     subscriptionError,

--- a/frontend/src/store/shoot/shoot.js
+++ b/frontend/src/store/shoot/shoot.js
@@ -119,9 +119,10 @@ const useShootStore = defineStore('shoot', () => {
   })
   const shootEvents = new Map()
 
-  const initializedNamespace = ref(null)
+  // Unlike list-based stores, shoots are kept in reactive maps; track init explicitly.
+  const initialSnapshotLoaded = ref(false)
 
-  const isInitial = computed(() => initializedNamespace.value === null)
+  const isInitial = computed(() => !initialSnapshotLoaded.value)
 
   // state
   const staleShoots = computed(() => {
@@ -226,7 +227,7 @@ const useShootStore = defineStore('shoot', () => {
       state.froozenUids = []
       state.focusMode = false
     })
-    initializedNamespace.value = null
+    initialSnapshotLoaded.value = false
     shootEvents.clear()
     ticketStore.clearIssues()
     ticketStore.clearComments()
@@ -389,6 +390,7 @@ const useShootStore = defineStore('shoot', () => {
       } catch (err) {
         shootStore.clearAll()
         if (isNotFound(err) && options.name) {
+          initialSnapshotLoaded.value = true
           setSubscriptionState(state, constants.LOADED)
           throttleDelay = getThrottleDelay(options, 1)
         } else {
@@ -516,7 +518,7 @@ const useShootStore = defineStore('shoot', () => {
       }
       state.shoots = shoots
     })
-    initializedNamespace.value = state.subscription?.namespace ?? null
+    initialSnapshotLoaded.value = true
   }
 
   async function openSubscription (value, throttleDelay) {


### PR DESCRIPTION
/area quality
/kind bug

**What this PR does / why we need it**:

Guards the socket event handler against a missing operator when the
store has not been initialized yet. Events arriving before store
initialization are deferred and requeued. If the operator cannot be
created for an already-initialized store (permanent misconfiguration),
an error is logged instead of silently swallowing events.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

The default operator returns undefined when `state.list` is not an
array. Stores initialize `list` as `null` and set it to an array after
fetching. The guard distinguishes these two cases to avoid hiding real
failures behind a debug log.

**Release note**:
```bugfix user
Fixed socket event handler crashing when events arrive before store initialization.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Socket events are deferred and re-queued when the local store isn’t initialized, preventing lost/incorrect updates; queued events are flushed only when the store is ready or visibility changes.
  * Synchronization failures are logged and roll back without causing repeated retries; certain not-found statuses still remove stale update references.

* **New Features**
  * Store exposes an initialization state to gate event processing.

* **Tests**
  * Added tests for deferred handling, re-queueing, visibility gating, initialization behavior, and operator error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->