### PR TITLE
docs(charts): correct identity chart deprecation notice

### DIFF
--- a/charts/gardener-dashboard/README.md
+++ b/charts/gardener-dashboard/README.md
@@ -2,7 +2,7 @@
 
 > [!CAUTION]
 > This Helm chart has been deprecated.
-> It will be removed earliest 6 months after deprecation (around November 2026).
+> It will be removed earliest around November 2026.
 >
 > We urge you to switch to a [`gardener-operator`](https://github.com/gardener/gardener/blob/master/docs/concepts/operator.md)-based installation, which manages the Gardener Dashboard as part of the Gardener control plane.
 > Read all about it [here](https://github.com/gardener/gardener/blob/master/docs/concepts/operator.md#migrating-an-existing-gardener-landscape-to-gardener-operator).

--- a/charts/identity/README.md
+++ b/charts/identity/README.md
@@ -2,7 +2,4 @@
 
 > [!CAUTION]
 > This Helm chart has been deprecated.
-> It will be removed earliest 6 months after deprecation (around November 2026).
->
-> We urge you to switch to a [`gardener-operator`](https://github.com/gardener/gardener/blob/master/docs/concepts/operator.md)-based installation, which manages the identity service as part of the Gardener control plane.
-> Read all about it [here](https://github.com/gardener/gardener/blob/master/docs/concepts/operator.md#migrating-an-existing-gardener-landscape-to-gardener-operator).
+> It will be removed without replacement earliest 6 months after deprecation (around November 2026).

--- a/charts/identity/README.md
+++ b/charts/identity/README.md
@@ -2,4 +2,4 @@
 
 > [!CAUTION]
 > This Helm chart has been deprecated.
-> It will be removed without replacement earliest 6 months after deprecation (around November 2026).
+> It will be removed without replacement earliest around November 2026.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area documentation
/kind cleanup

**What this PR does / why we need it**:

Corrects the deprecation notice in the `identity` Helm chart README. The identity chart is removed without replacement, not migrated to gardener-operator.

**Which issue(s) this PR fixes**:
Ref #2935

**Special notes for your reviewer**:

**Release note**:
```doc operator
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated deprecation notice for the identity chart: clarified removal timeline to around November 2026 and removed prior migration guidance.
  * Updated deprecation callout for the dashboard chart to a CAUTION-style notice and adjusted wording to state removal earliest around November 2026.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gardener/dashboard/pull/2963)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->