### PR TITLE
fix(request): avoid duplicate session scale-down logs

### DIFF
--- a/packages/request/__tests__/session-pool.spec.js
+++ b/packages/request/__tests__/session-pool.spec.js
@@ -400,4 +400,37 @@ describe('SessionPool', () => {
       ])
     })
   })
+
+  describe('#deleteSession', () => {
+    // When deleteSession() is invoked imperatively (e.g. error path), the
+    // 'close' listener registered in createSession() can still fire later.
+    // The late delete must not emit another "(scaled down)" log for the
+    // current pool size.
+    it('should ignore a late close after imperative delete', () => {
+      const session = pool.getSession()
+      session.emit('connect')
+      session.destroy.mockImplementation(() => {
+        session.destroyed = true
+      })
+      expect(pool.sessions.size).toBe(1)
+
+      // Imperative delete (simulates error-path branch).
+      pool.deleteSession(session)
+      expect(pool.sessions.size).toBe(0)
+      expect(session.destroy).toHaveBeenCalledTimes(1)
+
+      // A second, unrelated session enters the pool.
+      const otherSession = pool.getSession()
+      otherSession.emit('connect')
+      expect(pool.sessions.size).toBe(1)
+
+      // Late 'close' from the first session must be tolerated.
+      session.emit('close')
+
+      expect(pool.sessions.size).toBe(1)
+      expect(pool.sessions.has(otherSession)).toBe(true)
+      expect(otherSession.destroy).not.toHaveBeenCalled()
+      expect(session.destroy).toHaveBeenCalledTimes(1)
+    })
+  })
 })

--- a/packages/request/lib/SessionPool.js
+++ b/packages/request/lib/SessionPool.js
@@ -358,10 +358,12 @@ class SessionPool {
     // stop heartbeat interval
     this.clearSessionHeartbeat(session)
     // remove session
-    this.sessions.delete(session)
-    logger.debug('Session %s - pool size is %d (scaled down)', this.id, this.sessions.size)
-    // destory session
-    session.destroy(...args)
+    if (this.sessions.delete(session)) {
+      logger.debug('Session %s - pool size is %d (scaled down)', this.id, this.sessions.size)
+    }
+    if (!session.destroyed) {
+      session.destroy(...args)
+    }
   }
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
/area robustness
/kind bug

**What this PR does / why we need it**:
A late `close` event could invoke `deleteSession()` after the session was already removed from the pool, producing a misleading `(scaled down)` debug log that reported the pool size of newer sessions.

This change makes `SessionPool#deleteSession` idempotent:
- the scale-down log is gated on the actual `Set.delete()` success, so it only fires when a session is truly removed
- `session.destroy()` is guarded by `session.destroyed`, the proper HTTP/2 lifecycle flag, to avoid redundant destroy calls

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This is a follow-up of #2981

**Release note**:
```bugfix user

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session pool robustness by properly handling edge cases when sessions are closed after deletion
  * Prevented redundant cleanup operations, reducing potential errors from duplicate destruction calls

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gardener/dashboard/pull/2988?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->