### PR TITLE
refactor(machineImages): replace distro name guessing with exact vendor lookup

### DIFF
--- a/frontend/src/composables/helper.js
+++ b/frontend/src/composables/helper.js
@@ -16,7 +16,6 @@ import get from 'lodash/get'
 import map from 'lodash/map'
 import isEqual from 'lodash/isEqual'
 import includes from 'lodash/includes'
-import lowerCase from 'lodash/lowerCase'
 
 export function cleanup (obj) {
   const cleanupObject = obj => {
@@ -71,26 +70,6 @@ export function matchesPropertyOrEmpty (path, srcValue) {
     }
     return isEqual(objValue, srcValue)
   }
-}
-
-export function getDistroFromImageName (imageName) {
-  const lowerCaseName = lowerCase(imageName)
-  if (lowerCaseName.includes('coreos')) {
-    return 'coreos'
-  } else if (lowerCaseName.includes('ubuntu')) {
-    return 'ubuntu'
-  } else if (lowerCaseName.includes('gardenlinux')) {
-    return 'gardenlinux'
-  } else if (lowerCaseName.includes('suse') && lowerCaseName.includes('jeos')) {
-    return 'suse-jeos'
-  } else if (lowerCaseName.includes('suse') && lowerCaseName.includes('chost')) {
-    return 'suse-chost'
-  } else if (lowerCaseName.includes('flatcar')) {
-    return 'flatcar'
-  } else if (lowerCaseName.includes('memoryone') || lowerCaseName.includes('vsmp')) {
-    return 'memoryone-chost'
-  }
-  return imageName
 }
 
 export function findVendorHint (vendorHints, vendorName) {

--- a/frontend/src/composables/useCloudProfile/useMachineImages.js
+++ b/frontend/src/composables/useCloudProfile/useMachineImages.js
@@ -15,7 +15,6 @@ import { useConfigStore } from '@/store/config'
 import {
   addClassificationHelpers,
   firstItemMatchingVersionClassification,
-  getDistroFromImageName,
   findVendorHint,
 } from '@/composables/helper.js'
 import { useLogger } from '@/composables/useLogger.js'
@@ -61,8 +60,7 @@ export function useMachineImages (cloudProfile) {
    */
   function flattenAndSortMachineImages (machineImages) {
     const machineImagesWithVendors = map(machineImages, machineImage => {
-      const imageDistro = getDistroFromImageName(machineImage.name)
-      const vendor = configStore.vendorDetails(imageDistro)
+      const vendor = configStore.vendorDetails(machineImage.name)
       return {
         ...machineImage,
         vendor,

--- a/frontend/src/store/config.js
+++ b/frontend/src/store/config.js
@@ -590,6 +590,12 @@ export const useConfigStore = defineStore('config', () => {
       icon: 'gardenlinux.svg',
     },
     {
+      name: 'gardenlinux-fips',
+      displayName: 'Garden Linux (FIPS)',
+      weight: 101,
+      icon: 'gardenlinux.svg',
+    },
+    {
       name: 'ubuntu',
       displayName: 'Ubuntu',
       weight: 200,
@@ -624,6 +630,12 @@ export const useConfigStore = defineStore('config', () => {
       displayName: 'MemoryOne Container Host configuration (Chost)',
       weight: 700,
       icon: 'suse.svg',
+    },
+    {
+      name: 'memoryone-gardenlinux',
+      displayName: 'MemoryOne Garden Linux',
+      weight: 701,
+      icon: 'gardenlinux.svg',
     },
   ]
 


### PR DESCRIPTION
**How to categorize this PR?**
/area quality
/kind cleanup

**What this PR does / why we need it**:

Removes `getDistroFromImageName` which used substring matching to map
machine image names to vendor identifiers. This caused bugs where
images like `memoryone-gardenlinux` were silently mapped to the
`gardenlinux` vendor due to greedy `includes()` checks.

Machine image names are now looked up directly by exact name in the
vendor config. Adds missing vendor entries for `gardenlinux-fips` and
`memoryone-gardenlinux`. Unknown images fall back to displaying their
raw name instead of being silently misclassified.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

The old `getDistroFromImageName` also matched `vsmp` — this only
appears as a machineType name, never as a machineImage name, so it
was dead code.

**Release note**:
```bugfix user
Fix machine image vendor matching to use exact names instead of substring matching, preventing misclassification of images like memorone-gardenlinux or gardenlinux-fips
```

```breaking operator
Machine image vendor matching no longer uses substring/wildcard patterns. Image names must now exactly match an entry in `knownMachineImageVendors` (or the branding config `vendors.machineImage` array). Images without an exact match will display their raw name without vendor icon or grouping
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for two new machine image vendors: Garden Linux (FIPS) and MemoryOne Garden Linux.

* **Refactor**
  * Simplified internal machine image vendor detection logic for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->