### PR TITLE
fix(request): tolerate missing socket in session heartbeat

### DIFF
--- a/packages/request/__tests__/session-pool.spec.js
+++ b/packages/request/__tests__/session-pool.spec.js
@@ -381,6 +381,21 @@ describe('SessionPool', () => {
       ])
     })
 
+    it('should tolerate a missing socket when checking idle reads', () => {
+      const session = new MockHttp2Session()
+      session.ping.mockImplementation(() => {})
+      pool.sessions.add(session)
+      pool.setSessionHeartbeat(session)
+
+      session.socket = undefined
+      expect(() => vi.advanceTimersByTime(options.readIdleTimeout)).not.toThrow()
+
+      expect(session.ping).toHaveBeenCalledTimes(1)
+      expect(pool.sessions.size).toBe(1)
+
+      pool.clearSessionHeartbeat(session)
+    })
+
     it('should rearm the heartbeat after a successful ping', () => {
       const session = new MockHttp2Session()
       pool.sessions.add(session)

--- a/packages/request/lib/SessionPool.js
+++ b/packages/request/lib/SessionPool.js
@@ -197,7 +197,7 @@ class SessionPool {
     let canceled = false
     let idleTimeoutId
     let pongTimeoutId
-    let lastBytesRead = session.socket.bytesRead ?? 0
+    let lastBytesRead = session.socket?.bytesRead ?? 0
 
     function clearIdleTimer () {
       if (idleTimeoutId) {
@@ -234,7 +234,7 @@ class SessionPool {
     }
 
     function onIdle () {
-      const bytesRead = session.socket.bytesRead ?? 0
+      const bytesRead = session.socket?.bytesRead ?? 0
       if (bytesRead > lastBytesRead) {
         lastBytesRead = bytesRead
         armIdleTimer()
@@ -265,7 +265,7 @@ class SessionPool {
       if (err) {
         cancel(err)
       } else {
-        lastBytesRead = session.socket.bytesRead ?? lastBytesRead
+        lastBytesRead = session.socket?.bytesRead ?? lastBytesRead
         logger.trace('Session %s - ping %d ms', pool.id, Math.round(duration))
         armIdleTimer()
       }


### PR DESCRIPTION
**How to categorize this PR?**
/area robustness
/kind bug

**What this PR does / why we need it**:
Guards `session.socket` access in HTTP/2 session heartbeat callbacks with optional chaining. The socket reference can become undefined (e.g. after the session is destroyed) while heartbeat timers are still scheduled, which previously caused:

```
TypeError: Cannot read properties of undefined (reading 'bytesRead')
```

The change makes the `bytesRead` reads tolerant of a missing socket without altering the heartbeat behavior.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Follow-up PR of #2981

**Release note**:
```bugfix user
Prevent a TypeError in the HTTP/2 session pool heartbeat when the underlying socket is no longer available.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session heartbeat mechanism to gracefully handle cases where a session's underlying connection becomes unavailable, preventing errors during idle timeout checks.

* **Tests**
  * Added test coverage for session heartbeat behavior in edge case scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->