### PR TITLE
fix(dashboard): skip resubscribe when shoot target unchanged

### DIFF
--- a/frontend/__tests__/stores/shoot.spec.js
+++ b/frontend/__tests__/stores/shoot.spec.js
@@ -415,5 +415,31 @@ describe('stores', () => {
         ])
       })
     })
+
+    describe('#subscribe', () => {
+      it('should not clear and resubscribe when the subscription target is unchanged', async () => {
+        const metadata = {
+          namespace: 'foo',
+          name: 'shoot2',
+        }
+
+        await shootStore.subscribe(metadata)
+
+        expect(shootStore.shootByNamespaceAndName(metadata)).toEqual(expect.objectContaining({
+          metadata: expect.objectContaining(metadata),
+        }))
+
+        vi.clearAllMocks()
+
+        await shootStore.subscribe({ ...metadata })
+
+        expect(mockEmitUnsubscribe).not.toHaveBeenCalled()
+        expect(mockEmitSubscribe).not.toHaveBeenCalled()
+        expect(mockGetShoot).not.toHaveBeenCalled()
+        expect(shootStore.shootByNamespaceAndName(metadata)).toEqual(expect.objectContaining({
+          metadata: expect.objectContaining(metadata),
+        }))
+      })
+    })
   })
 })

--- a/frontend/src/store/shoot/shoot.js
+++ b/frontend/src/store/shoot/shoot.js
@@ -47,6 +47,7 @@ import {
 
 import isEmpty from 'lodash/isEmpty'
 import includes from 'lodash/includes'
+import isEqual from 'lodash/isEqual'
 import find from 'lodash/find'
 import difference from 'lodash/difference'
 import map from 'lodash/map'
@@ -259,11 +260,15 @@ const useShootStore = defineStore('shoot', () => {
       namespace = authzStore.namespace,
       name,
     } = metadata
+    const nextSubscription = { namespace, name }
+    if (isEqual(state.subscription, nextSubscription) && !state.subscriptionError) {
+      return
+    }
     if (state.subscription) {
       await shootStore.unsubscribe()
     }
     shootStore.$patch(({ state }) => {
-      state.subscription = { namespace, name }
+      state.subscription = nextSubscription
       setSubscriptionState(state, constants.DEFINED)
     })
     await shootStore.synchronize()


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area quality
  /area usability
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto


"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|cost|dev-productivity|documentation|high-availability|logging|monitoring|networking|open-source|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area usability
/kind bug

**What this PR does / why we need it**:
Fix: `subscribe()` now short-circuits when called with the same namespace/name and no prior subscription error, preserving the cached item across same-target navigations.

**Which issue(s) this PR fixes**:
Fixes #2990

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fix transient "Cluster is gone" error page that briefly appeared when switching between sub-routes of the same cluster (e.g. overview to YAML editor).
```