### PR TITLE
feat(backend): support TLS termination in dashboard server

### DIFF
--- a/backend/__tests__/config.spec.js
+++ b/backend/__tests__/config.spec.js
@@ -337,11 +337,21 @@ describe('config', function () {
           },
         })
 
+        readFileSyncSpy.mockImplementation(filePath => {
+          if (filePath === '/etc/gardener-dashboard/secrets/tls/tls.crt') {
+            return 'mock-cert-content'
+          }
+          if (filePath === '/etc/gardener-dashboard/secrets/tls/tls.key') {
+            return 'mock-key-content'
+          }
+          throw new Error(filePath + ': not found')
+        })
+
         const env = { NODE_ENV: 'test' }
         const config = gardener.loadConfig(filename, { env })
         expect(config.tls).toEqual({
-          certFile: '/etc/gardener-dashboard/secrets/tls/tls.crt',
-          privateKeyFile: '/etc/gardener-dashboard/secrets/tls/tls.key',
+          cert: 'mock-cert-content',
+          key: 'mock-key-content',
         })
       })
 

--- a/backend/__tests__/config.spec.js
+++ b/backend/__tests__/config.spec.js
@@ -324,6 +324,58 @@ describe('config', function () {
         expect(() => gardener.loadConfig(filename, { env }))
           .toThrow("Configuration value 'frontend.ticket.avatarSource' must be one of: gravatar, none, github")
       })
+
+      it('should set tls config from YAML config file', function () {
+        const filename = '/etc/gardener/config-with-tls.yaml'
+        gardener.readConfig.mockReturnValueOnce({
+          apiServerUrl: 'https://api.example.com',
+          sessionSecret: 'secret',
+          websocketAllowedOrigins: ['*'],
+          tls: {
+            certFile: '/etc/gardener-dashboard/secrets/tls/tls.crt',
+            privateKeyFile: '/etc/gardener-dashboard/secrets/tls/tls.key',
+          },
+        })
+
+        const env = { NODE_ENV: 'test' }
+        const config = gardener.loadConfig(filename, { env })
+        expect(config.tls).toEqual({
+          certFile: '/etc/gardener-dashboard/secrets/tls/tls.crt',
+          privateKeyFile: '/etc/gardener-dashboard/secrets/tls/tls.key',
+        })
+      })
+
+      it('should throw when YAML config has tls with only certFile', function () {
+        const filename = '/etc/gardener/config-with-tls.yaml'
+        gardener.readConfig.mockReturnValueOnce({
+          apiServerUrl: 'https://api.example.com',
+          sessionSecret: 'secret',
+          websocketAllowedOrigins: ['*'],
+          tls: {
+            certFile: '/path/to/cert.pem',
+          },
+        })
+
+        const env = { NODE_ENV: 'test' }
+        expect(() => gardener.loadConfig(filename, { env }))
+          .toThrow("Both 'tls.certFile' and 'tls.privateKeyFile' must be configured for TLS")
+      })
+
+      it('should throw when YAML config has tls with only privateKeyFile', function () {
+        const filename = '/etc/gardener/config-with-tls.yaml'
+        gardener.readConfig.mockReturnValueOnce({
+          apiServerUrl: 'https://api.example.com',
+          sessionSecret: 'secret',
+          websocketAllowedOrigins: ['*'],
+          tls: {
+            privateKeyFile: '/path/to/key.pem',
+          },
+        })
+
+        const env = { NODE_ENV: 'test' }
+        expect(() => gardener.loadConfig(filename, { env }))
+          .toThrow("Both 'tls.certFile' and 'tls.privateKeyFile' must be configured for TLS")
+      })
     })
   })
 })

--- a/backend/__tests__/server.spec.js
+++ b/backend/__tests__/server.spec.js
@@ -14,11 +14,13 @@ import {
   beforeEach,
 } from 'vitest'
 import http from 'http'
+import https from 'https'
+import fs from 'fs'
 import terminus from '@godaddy/terminus'
 import metricsApp from '@gardener-dashboard/monitor'
 import createServer from '../lib/server.js'
 
-function createApplication (port, metricsPort) {
+function createApplication (port, metricsPort, { tls } = {}) {
   const app = (req, res) => {
     res.writeHead(200, { 'Content-Type': 'text/plain' })
     res.end('ok', 'utf8')
@@ -26,6 +28,7 @@ function createApplication (port, metricsPort) {
   const map = new Map()
   map.set('port', port)
   map.set('metricsPort', metricsPort)
+  map.set('tls', tls)
   map.set('periodSeconds', 1)
   map.set('healthCheck', vi.fn())
   map.set('hooks', {
@@ -107,7 +110,7 @@ describe('server', () => {
     expect(logger.log.mock.calls).toEqual([
       ['info', 'Metrics server listening on port %d', metricsPort],
       ['debug', 'Before listen hook succeeded after %d ms', expect.any(Number)],
-      ['info', 'Server listening on port %d', 1234],
+      ['info', '%s server listening on port %d', 'HTTP', 1234],
     ])
   })
 
@@ -142,5 +145,74 @@ describe('server', () => {
     error('Failed')
     expect(logger.log).toHaveBeenCalledTimes(1)
     expect(logger.log.mock.calls).toEqual([['error', 'Failed']])
+  })
+})
+
+describe('server (https)', () => {
+  const port = 1234
+  const metricsPort = 5678
+  const tls = {
+    certFile: '/path/to/cert.pem',
+    privateKeyFile: '/path/to/key.pem',
+  }
+  const mockServer = {
+    listen: vi.fn((_, callback) => setImmediate(callback)),
+  }
+  let app
+  let logger
+  let server
+  let mockHttpCreateServer
+  let mockHttpsCreateServer
+  let readFileSyncSpy
+
+  let setTimeoutSpy
+
+  beforeAll(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true, toFake: ['setTimeout', 'clearTimeout'] })
+    setTimeoutSpy = vi.spyOn(global, 'setTimeout')
+  })
+
+  afterAll(() => {
+    vi.useRealTimers()
+  })
+
+  beforeEach(() => {
+    setTimeoutSpy.mockClear()
+    mockHttpCreateServer = vi.spyOn(http, 'createServer').mockReturnValue(mockServer)
+    mockHttpsCreateServer = vi.spyOn(https, 'createServer').mockReturnValue(mockServer)
+    readFileSyncSpy = vi.spyOn(fs, 'readFileSync').mockImplementation(path => {
+      if (path === tls.certFile) {
+        return 'mock-cert-content'
+      }
+      if (path === tls.privateKeyFile) {
+        return 'mock-key-content'
+      }
+      throw new Error(`Unexpected readFileSync call: ${path}`)
+    })
+    app = createApplication(port, metricsPort, { tls })
+    logger = app.get('logger')
+    server = createServer(app, metricsApp)
+  })
+
+  it('should create an HTTPS server when TLS is configured', async () => {
+    expect(mockHttpsCreateServer).toHaveBeenCalledTimes(1)
+    expect(mockHttpsCreateServer.mock.calls[0][0]).toEqual({
+      cert: 'mock-cert-content',
+      key: 'mock-key-content',
+    })
+    expect(mockHttpsCreateServer.mock.calls[0][1]).toBe(app)
+    expect(mockHttpCreateServer).toHaveBeenCalledTimes(1)
+    expect(mockHttpCreateServer.mock.calls[0][0]).toBe(metricsApp)
+    expect(readFileSyncSpy).toHaveBeenCalledWith(tls.certFile)
+    expect(readFileSyncSpy).toHaveBeenCalledWith(tls.privateKeyFile)
+  })
+
+  it('should log HTTPS protocol on startup', async () => {
+    await server.run()
+    expect(logger.log.mock.calls).toEqual([
+      ['info', 'Metrics server listening on port %d', metricsPort],
+      ['debug', 'Before listen hook succeeded after %d ms', expect.any(Number)],
+      ['info', '%s server listening on port %d', 'HTTPS', port],
+    ])
   })
 })

--- a/backend/__tests__/server.spec.js
+++ b/backend/__tests__/server.spec.js
@@ -114,6 +114,22 @@ describe('server', () => {
     ])
   })
 
+  it('should use HTTP when the TLS configuration is incomplete', async () => {
+    const app = createApplication(port, metricsPort, {
+      tls: { certFile: '/path/to/cert.pem' },
+    })
+    const logger = app.get('logger')
+    const server = createServer(app, metricsApp)
+
+    await server.run()
+
+    expect(logger.log.mock.calls).toEqual([
+      ['info', 'Metrics server listening on port %d', metricsPort],
+      ['debug', 'Before listen hook succeeded after %d ms', expect.any(Number)],
+      ['info', '%s server listening on port %d', 'HTTP', port],
+    ])
+  })
+
   it('should initialize terminus', async () => {
     expect(terminus.createTerminus).toHaveBeenCalledTimes(1)
     expect(terminus.createTerminus.mock.calls[0]).toHaveLength(2)

--- a/backend/__tests__/server.spec.js
+++ b/backend/__tests__/server.spec.js
@@ -15,7 +15,6 @@ import {
 } from 'vitest'
 import http from 'http'
 import https from 'https'
-import fs from 'fs'
 import terminus from '@godaddy/terminus'
 import metricsApp from '@gardener-dashboard/monitor'
 import createServer from '../lib/server.js'
@@ -116,7 +115,7 @@ describe('server', () => {
 
   it('should use HTTP when the TLS configuration is incomplete', async () => {
     const app = createApplication(port, metricsPort, {
-      tls: { certFile: '/path/to/cert.pem' },
+      tls: { cert: 'mock-cert-content' },
     })
     const logger = app.get('logger')
     const server = createServer(app, metricsApp)
@@ -168,8 +167,8 @@ describe('server (https)', () => {
   const port = 1234
   const metricsPort = 5678
   const tls = {
-    certFile: '/path/to/cert.pem',
-    privateKeyFile: '/path/to/key.pem',
+    cert: 'mock-cert-content',
+    key: 'mock-key-content',
   }
   const mockServer = {
     listen: vi.fn((_, callback) => setImmediate(callback)),
@@ -179,7 +178,6 @@ describe('server (https)', () => {
   let server
   let mockHttpCreateServer
   let mockHttpsCreateServer
-  let readFileSyncSpy
 
   let setTimeoutSpy
 
@@ -196,15 +194,6 @@ describe('server (https)', () => {
     setTimeoutSpy.mockClear()
     mockHttpCreateServer = vi.spyOn(http, 'createServer').mockReturnValue(mockServer)
     mockHttpsCreateServer = vi.spyOn(https, 'createServer').mockReturnValue(mockServer)
-    readFileSyncSpy = vi.spyOn(fs, 'readFileSync').mockImplementation(path => {
-      if (path === tls.certFile) {
-        return 'mock-cert-content'
-      }
-      if (path === tls.privateKeyFile) {
-        return 'mock-key-content'
-      }
-      throw new Error(`Unexpected readFileSync call: ${path}`)
-    })
     app = createApplication(port, metricsPort, { tls })
     logger = app.get('logger')
     server = createServer(app, metricsApp)
@@ -219,8 +208,6 @@ describe('server (https)', () => {
     expect(mockHttpsCreateServer.mock.calls[0][1]).toBe(app)
     expect(mockHttpCreateServer).toHaveBeenCalledTimes(1)
     expect(mockHttpCreateServer.mock.calls[0][0]).toBe(metricsApp)
-    expect(readFileSyncSpy).toHaveBeenCalledWith(tls.certFile)
-    expect(readFileSyncSpy).toHaveBeenCalledWith(tls.privateKeyFile)
   })
 
   it('should log HTTPS protocol on startup', async () => {

--- a/backend/lib/app.js
+++ b/backend/lib/app.js
@@ -72,6 +72,7 @@ if (gitHubRepoUrl) {
 const app = express()
 app.set('port', port)
 app.set('metricsPort', metricsPort)
+app.set('tls', config.tls)
 app.set('logger', logger)
 app.set('healthCheck', healthCheck)
 app.set('periodSeconds', periodSeconds)

--- a/backend/lib/config/gardener.js
+++ b/backend/lib/config/gardener.js
@@ -224,8 +224,8 @@ export default {
         assert.fail("Both 'tls.certFile' and 'tls.privateKeyFile' must be configured for TLS")
       }
       config.tls = {
-        cert: fs.readFileSync(certFile), // eslint-disable-line security/detect-non-literal-fs-filename
-        key: fs.readFileSync(privateKeyFile), // eslint-disable-line security/detect-non-literal-fs-filename
+        cert: fs.readFileSync(certFile), // eslint-disable-line security/detect-non-literal-fs-filename --- from config, not user controlled
+        key: fs.readFileSync(privateKeyFile), // eslint-disable-line security/detect-non-literal-fs-filename --- from config, not user controlled
       }
     }
 

--- a/backend/lib/config/gardener.js
+++ b/backend/lib/config/gardener.js
@@ -223,6 +223,10 @@ export default {
       if (!certFile || !privateKeyFile) {
         assert.fail("Both 'tls.certFile' and 'tls.privateKeyFile' must be configured for TLS")
       }
+      config.tls = {
+        cert: fs.readFileSync(certFile), // eslint-disable-line security/detect-non-literal-fs-filename
+        key: fs.readFileSync(privateKeyFile), // eslint-disable-line security/detect-non-literal-fs-filename
+      }
     }
 
     const sessionSecrets = [config.sessionSecret]

--- a/backend/lib/config/gardener.js
+++ b/backend/lib/config/gardener.js
@@ -218,6 +218,13 @@ export default {
       assert.fail('Configuration value \'websocketAllowedOrigins\' must not be empty')
     }
 
+    if (config.tls) {
+      const { certFile, privateKeyFile } = config.tls
+      if (!certFile || !privateKeyFile) {
+        assert.fail("Both 'tls.certFile' and 'tls.privateKeyFile' must be configured for TLS")
+      }
+    }
+
     const sessionSecrets = [config.sessionSecret]
     if (config.sessionSecretPrevious) {
       sessionSecrets.push(config.sessionSecretPrevious)

--- a/backend/lib/server.js
+++ b/backend/lib/server.js
@@ -5,6 +5,8 @@
 //
 
 import http from 'http'
+import https from 'https'
+import fs from 'fs'
 import { pTimeout } from './utils/p-timeout.js'
 import terminus from '@godaddy/terminus'
 
@@ -19,13 +21,23 @@ function toMilliseconds (seconds) {
 function createServer (app, metricsApp) {
   const port = app.get('port')
   const metricsPort = app.get('metricsPort')
+  const tls = app.get('tls')
   const periodSeconds = app.get('periodSeconds')
   const healthCheckFunc = app.get('healthCheck')
   const logger = app.get('logger')
   const hooks = app.get('hooks')
 
   // create server
-  const server = http.createServer(app)
+  let server
+  if (tls?.certFile && tls?.privateKeyFile) {
+    const tlsOptions = {
+      cert: fs.readFileSync(tls.certFile), // eslint-disable-line security/detect-non-literal-fs-filename -- path from validated config
+      key: fs.readFileSync(tls.privateKeyFile), // eslint-disable-line security/detect-non-literal-fs-filename -- path from validated config
+    }
+    server = https.createServer(tlsOptions, app)
+  } else {
+    server = http.createServer(app)
+  }
   const metricsServer = http.createServer(metricsApp)
 
   // create terminus
@@ -73,7 +85,7 @@ function createServer (app, metricsApp) {
         logger.warn('Before listen hook timed out: %s', err.message)
       }
       await new Promise(resolve => server.listen(port, resolve))
-      logger.info('Server listening on port %d', port)
+      logger.info('%s server listening on port %d', tls ? 'HTTPS' : 'HTTP', port)
     },
   }
 }

--- a/backend/lib/server.js
+++ b/backend/lib/server.js
@@ -6,7 +6,6 @@
 
 import http from 'http'
 import https from 'https'
-import fs from 'fs'
 import { pTimeout } from './utils/p-timeout.js'
 import terminus from '@godaddy/terminus'
 
@@ -26,16 +25,12 @@ function createServer (app, metricsApp) {
   const healthCheckFunc = app.get('healthCheck')
   const logger = app.get('logger')
   const hooks = app.get('hooks')
-  const isHttps = Boolean(tls?.certFile && tls?.privateKeyFile)
+  const isHttps = Boolean(tls?.cert && tls?.key)
 
   // create server
   let server
   if (isHttps) {
-    const tlsOptions = {
-      cert: fs.readFileSync(tls.certFile), // eslint-disable-line security/detect-non-literal-fs-filename -- path from validated config
-      key: fs.readFileSync(tls.privateKeyFile), // eslint-disable-line security/detect-non-literal-fs-filename -- path from validated config
-    }
-    server = https.createServer(tlsOptions, app)
+    server = https.createServer(tls, app)
   } else {
     server = http.createServer(app)
   }

--- a/backend/lib/server.js
+++ b/backend/lib/server.js
@@ -26,10 +26,11 @@ function createServer (app, metricsApp) {
   const healthCheckFunc = app.get('healthCheck')
   const logger = app.get('logger')
   const hooks = app.get('hooks')
+  const isHttps = Boolean(tls?.certFile && tls?.privateKeyFile)
 
   // create server
   let server
-  if (tls?.certFile && tls?.privateKeyFile) {
+  if (isHttps) {
     const tlsOptions = {
       cert: fs.readFileSync(tls.certFile), // eslint-disable-line security/detect-non-literal-fs-filename -- path from validated config
       key: fs.readFileSync(tls.privateKeyFile), // eslint-disable-line security/detect-non-literal-fs-filename -- path from validated config
@@ -85,7 +86,7 @@ function createServer (app, metricsApp) {
         logger.warn('Before listen hook timed out: %s', err.message)
       }
       await new Promise(resolve => server.listen(port, resolve))
-      logger.info('%s server listening on port %d', tls ? 'HTTPS' : 'HTTP', port)
+      logger.info('%s server listening on port %d', isHttps ? 'HTTPS' : 'HTTP', port)
     },
   }
 }


### PR DESCRIPTION
/area security
/kind enhancement

**What this PR does / why we need it**:

Adds optional TLS termination support to the Gardener dashboard backend server. When `tls.certFile` and `tls.privateKeyFile` are configured, the server starts as HTTPS instead of plain HTTP.

- Validates that both `certFile` and `privateKeyFile` are provided together
- Creates an `https.Server` with the configured cert/key when TLS is enabled
- Falls back to plain `http.Server` when TLS is not configured
- Logs protocol (HTTP/HTTPS) on startup for observability

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Certificate and key files are read synchronously at server startup via `fs.readFileSync`. The file paths come from validated config, not user input.

**Release note**:
```feature operator
The Gardener dashboard backend now supports optional TLS termination. Configure `tls.certFile` and `tls.privateKeyFile` in the dashboard configuration to enable HTTPS.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional HTTPS/TLS support: the server can start in HTTPS mode when both a certificate file and private key file are configured.

* **Bug Fixes**
  * TLS configuration is validated: if either the certificate or private key is missing, startup fails with a clear error instead of silently misconfiguring TLS.
  * Startup logging now accurately reports whether the service is running as HTTP or HTTPS.

* **Tests**
  * Added test coverage for TLS validation, HTTP fallback behavior, and HTTPS startup (including correct server options and protocol logging).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->