### PR TITLE
feat(dashboard): enhance landscape viewer UX with role badge and operator UI

### DIFF
--- a/frontend/__tests__/components/GStatusTag.spec.js
+++ b/frontend/__tests__/components/GStatusTag.spec.js
@@ -8,17 +8,31 @@ import { mount } from '@vue/test-utils'
 import { createPinia } from 'pinia'
 
 import { useAuthnStore } from '@/store/authn'
+import { useAuthzStore } from '@/store/authz'
 
 import GStatusTag from '@/components/GStatusTag.vue'
 
+import { useApi } from '@/composables/useApi'
+
 const { createVuetifyPlugin } = global.fixtures.helper
+
+function createRulesResponse (resourceRules = []) {
+  return {
+    data: {
+      resourceRules,
+    },
+  }
+}
 
 describe('components', () => {
   describe('g-status-tag', () => {
     const vuetifyPlugin = createVuetifyPlugin()
+    const api = useApi()
 
     let pinia
     let authnStore
+    let authzStore
+    let mockGetSubjectRules
 
     function mountStatusTag (condition) {
       return mount(GStatusTag, {
@@ -34,13 +48,23 @@ describe('components', () => {
       })
     }
 
+    async function grantLandscapeAccess () {
+      authnStore.user = { canListShootsAllNamespaces: true }
+      const clusterRules = [{
+        apiGroups: ['core.gardener.cloud'],
+        resources: ['seeds'],
+        verbs: ['list'],
+      }]
+      mockGetSubjectRules.mockResolvedValueOnce(createRulesResponse(clusterRules))
+      await authzStore.fetchRules()
+    }
+
     beforeEach(() => {
       pinia = createPinia()
       authnStore = useAuthnStore(pinia)
-      authnStore.user = {
-        email: 'test@example.org',
-        isAdmin: false,
-      }
+      authzStore = useAuthzStore(pinia)
+      mockGetSubjectRules = vi.spyOn(api, 'getSubjectRules')
+      mockGetSubjectRules.mockResolvedValue(createRulesResponse())
     })
 
     it('should render healthy condition object', () => {
@@ -49,7 +73,6 @@ describe('components', () => {
         name: 'foo-bar',
         status: 'True',
       })
-      authnStore.user.isAdmin = true
       const vm = wrapper.vm
       expect(vm.chipText).toBe('foo')
       expect(vm.chipStatus).toBe('Healthy')
@@ -79,12 +102,12 @@ describe('components', () => {
       expect(vm.visible).toBe(true)
     })
 
-    it('should render condition for a user without admin role', () => {
+    it('should hide landscape-viewer-only condition without landscape access', () => {
       const wrapper = mountStatusTag({
         shortName: 'foo',
         name: 'foo-bar',
         status: 'Progressing',
-        showAdminOnly: true,
+        showLandscapeViewerOnly: true,
       })
       const vm = wrapper.vm
       expect(vm.visible).toBe(false)
@@ -94,14 +117,14 @@ describe('components', () => {
       expect(vm.chipIcon).toBe('')
     })
 
-    it('should render condition for a user with admin role', () => {
+    it('should render landscape-viewer-only condition with landscape access', async () => {
+      await grantLandscapeAccess()
       const wrapper = mountStatusTag({
         shortName: 'foo',
         name: 'foo-bar',
         status: 'Progressing',
-        showAdminOnly: true,
+        showLandscapeViewerOnly: true,
       })
-      authnStore.user.isAdmin = true
       const vm = wrapper.vm
       expect(vm.visible).toBe(true)
       expect(vm.isProgressing).toBe(true)

--- a/frontend/__tests__/composables/useShootListFilters.spec.js
+++ b/frontend/__tests__/composables/useShootListFilters.spec.js
@@ -10,9 +10,11 @@ import {
 } from 'pinia'
 
 import { useAuthnStore } from '@/store/authn'
+import { useAuthzStore } from '@/store/authz'
 import { useConfigStore } from '@/store/config'
 import { useLocalStorageStore } from '@/store/localStorage'
 
+import { useApi } from '@/composables/useApi'
 import { useShootListFilters } from '@/composables/useShootListFilters'
 
 // Disable createSharedComposable so each test gets a fresh composable instance
@@ -24,22 +26,48 @@ vi.mock('@vueuse/core', async importOriginal => {
   }
 })
 
+function createRulesResponse (resourceRules = []) {
+  return {
+    data: {
+      resourceRules,
+    },
+  }
+}
+
 describe('composables', () => {
   describe('useShootListFilters', () => {
+    const api = useApi()
+
     let authnStore
+    let authzStore
     let configStore
     let localStorageStore
+    let mockGetSubjectRules
 
     beforeEach(() => {
       setActivePinia(createPinia())
       authnStore = useAuthnStore()
+      authzStore = useAuthzStore()
       configStore = useConfigStore()
       localStorageStore = useLocalStorageStore()
+      mockGetSubjectRules = vi.spyOn(api, 'getSubjectRules')
+      mockGetSubjectRules.mockResolvedValue(createRulesResponse())
       localStorageStore.allProjectsShootFilter = {}
     })
 
-    it('should return empty labels when onlyShootsWithIssues is false', () => {
-      authnStore.user = { isAdmin: true }
+    async function grantLandscapeAccess () {
+      authnStore.user = { canListShootsAllNamespaces: true }
+      const clusterRules = [{
+        apiGroups: ['core.gardener.cloud'],
+        resources: ['seeds'],
+        verbs: ['list'],
+      }]
+      mockGetSubjectRules.mockResolvedValueOnce(createRulesResponse(clusterRules))
+      await authzStore.fetchRules()
+    }
+
+    it('should return empty labels when onlyShootsWithIssues is false', async () => {
+      await grantLandscapeAccess()
       localStorageStore.allProjectsShootFilter = {
         onlyShootsWithIssues: false,
         progressing: true,
@@ -50,8 +78,8 @@ describe('composables', () => {
       expect(activeFilterLabels.value).toEqual([])
     })
 
-    it('should return active filter labels for admin defaults', () => {
-      authnStore.user = { isAdmin: true }
+    it('should return active filter labels for landscape defaults', async () => {
+      await grantLandscapeAccess()
 
       const { activeFilterLabels } = useShootListFilters()
       expect(activeFilterLabels.value).toEqual([
@@ -61,16 +89,13 @@ describe('composables', () => {
       ])
     })
 
-    it('should return only progressing for non-admin defaults', () => {
-      authnStore.user = { isAdmin: false }
-
+    it('should return empty labels without landscape access', () => {
       const { activeFilterLabels } = useShootListFilters()
-      // non-admin defaults: onlyShootsWithIssues=false, so no labels
       expect(activeFilterLabels.value).toEqual([])
     })
 
-    it('should return labels matching locally stored filters', () => {
-      authnStore.user = { isAdmin: true }
+    it('should return labels matching locally stored filters', async () => {
+      await grantLandscapeAccess()
       localStorageStore.allProjectsShootFilter = {
         onlyShootsWithIssues: true,
         progressing: true,
@@ -84,8 +109,8 @@ describe('composables', () => {
       ])
     })
 
-    it('should exclude hideTicketsWithLabel when ticket config is missing', () => {
-      authnStore.user = { isAdmin: true }
+    it('should exclude hideTicketsWithLabel when ticket config is missing', async () => {
+      await grantLandscapeAccess()
       configStore.setConfiguration({ ticket: {} })
       localStorageStore.allProjectsShootFilter = {
         onlyShootsWithIssues: true,
@@ -98,8 +123,8 @@ describe('composables', () => {
       expect(activeFilterLabels.value).toEqual([])
     })
 
-    it('should include hideTicketsWithLabel when ticket config is present', () => {
-      authnStore.user = { isAdmin: true }
+    it('should include hideTicketsWithLabel when ticket config is present', async () => {
+      await grantLandscapeAccess()
       configStore.setConfiguration({
         ticket: {
           gitHubRepoUrl: 'https://github.com/org/repo',

--- a/frontend/__tests__/stores/authz.spec.js
+++ b/frontend/__tests__/stores/authz.spec.js
@@ -26,21 +26,17 @@ describe('stores', () => {
   describe('authz', () => {
     const api = useApi()
     let authzStore
+    let authnStore
     let mockGetSubjectRules
 
     beforeEach(() => {
       setActivePinia(createPinia())
       authzStore = useAuthzStore()
+      authnStore = useAuthnStore()
       mockGetSubjectRules = vi.spyOn(api, 'getSubjectRules')
     })
 
-    describe('canAccessSeedStats', () => {
-      let authnStore
-
-      beforeEach(() => {
-        authnStore = useAuthnStore()
-      })
-
+    describe('canViewLandscape', () => {
       it('should return true when user can list seeds (SSRR) and list shoots cluster-wide (JWT)', async () => {
         authnStore.user = { canListShootsAllNamespaces: true }
         const rules = [{
@@ -50,7 +46,7 @@ describe('stores', () => {
         }]
         mockGetSubjectRules.mockResolvedValueOnce(createRulesResponse(rules))
         await authzStore.fetchRules()
-        expect(authzStore.canAccessSeedStats).toBe(true)
+        expect(authzStore.canViewLandscape).toBe(true)
       })
 
       it('should return false when user can list seeds but not shoots cluster-wide', async () => {
@@ -62,14 +58,14 @@ describe('stores', () => {
         }]
         mockGetSubjectRules.mockResolvedValueOnce(createRulesResponse(rules))
         await authzStore.fetchRules()
-        expect(authzStore.canAccessSeedStats).toBe(false)
+        expect(authzStore.canViewLandscape).toBe(false)
       })
 
       it('should return false when user can list shoots cluster-wide but not seeds', async () => {
         authnStore.user = { canListShootsAllNamespaces: true }
         mockGetSubjectRules.mockResolvedValueOnce(createRulesResponse([]))
         await authzStore.fetchRules()
-        expect(authzStore.canAccessSeedStats).toBe(false)
+        expect(authzStore.canViewLandscape).toBe(false)
       })
 
       it('should return false when SSRR shows list shoots in namespace but JWT lacks cluster-wide', async () => {
@@ -88,7 +84,28 @@ describe('stores', () => {
         ]
         mockGetSubjectRules.mockResolvedValueOnce(createRulesResponse(rules))
         await authzStore.fetchRules('garden-foo')
-        expect(authzStore.canAccessSeedStats).toBe(false)
+        expect(authzStore.canViewLandscape).toBe(false)
+      })
+
+      it('should return false when seed stats are not accessible', async () => {
+        authnStore.user = { canListShootsAllNamespaces: false }
+        const gardenRules = [
+          {
+            apiGroups: ['seedmanagement.gardener.cloud'],
+            resources: ['managedseeds'],
+            verbs: ['get'],
+          },
+          {
+            apiGroups: ['core.gardener.cloud'],
+            resources: ['shoots'],
+            verbs: ['get'],
+          },
+        ]
+
+        mockGetSubjectRules.mockResolvedValueOnce(createRulesResponse(gardenRules))
+        await authzStore.fetchGardenRules()
+
+        expect(authzStore.canViewLandscape).toBe(false)
       })
     })
   })

--- a/frontend/src/components/GClusterMetrics.vue
+++ b/frontend/src/components/GClusterMetrics.vue
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
     </g-list-item>
     <template v-else>
       <g-link-list-tile
-        v-if="isAdmin"
+        v-if="canViewLandscape"
         icon="mdi-developer-board"
         app-title="Seed Plutono"
         :url="seedPlutonoUrl"
@@ -75,7 +75,7 @@ SPDX-License-Identifier: Apache-2.0
 import { storeToRefs } from 'pinia'
 
 import { useConfigStore } from '@/store/config'
-import { useAuthnStore } from '@/store/authn'
+import { useAuthzStore } from '@/store/authz'
 
 import GUsernamePassword from '@/components/GUsernamePasswordListTile'
 import GLinkListTile from '@/components/GLinkListTile'
@@ -98,10 +98,10 @@ export default {
     GLinkListTile,
   },
   setup () {
-    const authnStore = useAuthnStore()
+    const authzStore = useAuthzStore()
     const {
-      isAdmin,
-    } = storeToRefs(authnStore)
+      canViewLandscape,
+    } = storeToRefs(authzStore)
 
     const {
       isOidcObservabilityUrlsEnabled,
@@ -129,14 +129,14 @@ export default {
       seedIngressDomain,
       shootTechnicalId,
       isOidcObservabilityUrlsEnabled,
-      isAdmin,
+      canViewLandscape,
       isTestingCluster,
     }
   },
   computed: {
     plutonoIcon () {
-      // Avoid duplicate icon when Seed Plutono tile is also shown for admins
-      return this.isAdmin
+      // Avoid duplicate icon when Seed Plutono tile is also shown
+      return this.canViewLandscape
         ? undefined
         : 'mdi-developer-board'
     },

--- a/frontend/src/components/GMainToolbar.vue
+++ b/frontend/src/components/GMainToolbar.vue
@@ -114,10 +114,10 @@ SPDX-License-Identifier: Apache-2.0
       >
         <template #activator="{ props }">
           <v-badge
-            v-if="isAdmin"
-            color="primary"
+            v-if="avatarRole"
+            :color="avatarRole.color"
             location="bottom right"
-            icon="mdi-account-supervisor"
+            :icon="avatarRole.icon"
           >
             <g-avatar
               v-bind="props"
@@ -132,18 +132,18 @@ SPDX-License-Identifier: Apache-2.0
             :alt="`avatar of ${avatarTitle}`"
           />
         </template>
-        <span v-if="isAdmin">
+        <span v-if="avatarRole">
           {{ avatarTitle }}
           <v-chip
             size="small"
-            color="primary"
+            :color="avatarRole.color"
             variant="elevated"
           >
             <v-icon
               start
-              icon="mdi-account-supervisor"
+              :icon="avatarRole.icon"
             />
-            <span class="operator">Operator</span>
+            <span class="role-label">{{ avatarRole.title }}</span>
           </v-chip>
         </span>
         <span v-else>{{ avatarTitle }}</span>
@@ -169,10 +169,10 @@ SPDX-License-Identifier: Apache-2.0
               {{ username }}
             </div>
             <div
-              v-if="isAdmin"
+              v-if="avatarRole"
               class="text-body-small"
             >
-              Operator
+              {{ avatarRole.title }}
             </div>
             <v-btn-toggle
               v-model="colorMode"
@@ -304,6 +304,7 @@ import { useRoute } from 'vue-router'
 
 import { useAppStore } from '@/store/app'
 import { useAuthnStore } from '@/store/authn'
+import { useAuthzStore } from '@/store/authz'
 import { useConfigStore } from '@/store/config'
 import { useLocalStorageStore } from '@/store/localStorage'
 
@@ -321,6 +322,7 @@ const route = useRoute()
 
 const appStore = useAppStore()
 const authnStore = useAuthnStore()
+const authzStore = useAuthzStore()
 const configStore = useConfigStore()
 const localStorageStore = useLocalStorageStore()
 
@@ -337,9 +339,30 @@ const autoLogin = toRef(localStorageStore, 'autoLogin')
 const colorMode = toRef(localStorageStore, 'colorScheme')
 
 const { isAdmin, username, displayName } = storeToRefs(authnStore)
+const { canViewLandscape: isLandscapeViewer } = storeToRefs(authzStore)
 
 const avatarTitle = computed(() => {
   return `${displayName.value} (${username.value})`
+})
+
+const avatarRole = computed(() => {
+  if (isAdmin.value) {
+    return {
+      title: 'Operator',
+      icon: 'mdi-account-supervisor',
+      color: 'primary',
+    }
+  }
+
+  if (isLandscapeViewer.value) {
+    return {
+      title: 'Landscape Viewer',
+      icon: 'mdi-eye-outline',
+      color: 'primary',
+    }
+  }
+
+  return null
 })
 
 const tabs = computed(() => {
@@ -397,7 +420,7 @@ function helpTarget (item) {
     padding-left: 4px;
   }
 
-  .operator {
+  .role-label {
     color: white;
     font-weight: bold;
   }

--- a/frontend/src/components/GSeedStatusTag.vue
+++ b/frontend/src/components/GSeedStatusTag.vue
@@ -67,7 +67,7 @@ SPDX-License-Identifier: Apache-2.0
 <script>
 import { mapState } from 'pinia'
 
-import { useAuthnStore } from '@/store/authn'
+import { useAuthzStore } from '@/store/authz'
 
 import GShootMessageDetails from '@/components/GShootMessageDetails.vue'
 
@@ -103,8 +103,8 @@ export default {
     },
   },
   computed: {
-    ...mapState(useAuthnStore, [
-      'isAdmin',
+    ...mapState(useAuthzStore, [
+      'canViewLandscape',
     ]),
     popoverKey () {
       return `g-seed-status-tag[${this.condition.type}]:${this.identifier}`
@@ -147,7 +147,7 @@ export default {
       if (this.isUnknown) {
         return 'mdi-help-circle-outline'
       }
-      if (this.isProgressing && this.isAdmin) {
+      if (this.isProgressing && this.canViewLandscape) {
         return 'mdi-progress-alert'
       }
 
@@ -201,7 +201,7 @@ export default {
       if (this.isError) {
         return 'error'
       }
-      if (this.isProgressing && this.isAdmin) {
+      if (this.isProgressing && this.canViewLandscape) {
         return 'info'
       }
       return 'primary'
@@ -213,8 +213,8 @@ export default {
       return this.color
     },
     visible () {
-      if (!this.isAdmin) {
-        return !get(this.condition, ['showAdminOnly'], false)
+      if (!this.canViewLandscape) {
+        return !get(this.condition, ['showLandscapeViewerOnly'], false)
       }
       return true
     },

--- a/frontend/src/components/GShootSeedName.vue
+++ b/frontend/src/components/GShootSeedName.vue
@@ -20,7 +20,7 @@ SPDX-License-Identifier: Apache-2.0
       class="mr-1"
     />
     <g-text-router-link
-      v-if="isAdmin"
+      v-if="canViewLandscape"
       :to="seedItemLink"
       :text="shootSeedName"
     />
@@ -32,7 +32,7 @@ SPDX-License-Identifier: Apache-2.0
 import { computed } from 'vue'
 import { storeToRefs } from 'pinia'
 
-import { useAuthnStore } from '@/store/authn'
+import { useAuthzStore } from '@/store/authz'
 
 import GTextRouterLink from '@/components/GTextRouterLink.vue'
 
@@ -45,8 +45,8 @@ const {
   shootLastOperationTypeControlPlaneMigrationMessage,
 } = useShootItem()
 
-const authnStore = useAuthnStore()
-const { isAdmin } = storeToRefs(authnStore)
+const authzStore = useAuthzStore()
+const { canViewLandscape } = storeToRefs(authzStore)
 
 const seedItemLink = computed(() => ({
   name: 'SeedItem',

--- a/frontend/src/components/GStatusTag.vue
+++ b/frontend/src/components/GStatusTag.vue
@@ -77,7 +77,7 @@ SPDX-License-Identifier: Apache-2.0
 <script>
 import { mapState } from 'pinia'
 
-import { useAuthnStore } from '@/store/authn'
+import { useAuthzStore } from '@/store/authz'
 
 import GShootMessageDetails from '@/components/GShootMessageDetails.vue'
 
@@ -119,8 +119,8 @@ export default {
     },
   },
   computed: {
-    ...mapState(useAuthnStore, [
-      'isAdmin',
+    ...mapState(useAuthzStore, [
+      'canViewLandscape',
     ]),
     popoverKey () {
       return `g-status-tag[${this.condition.type}]:${this.shootMetadata.uid}`
@@ -173,7 +173,7 @@ export default {
       if (this.isUnknown) {
         return 'mdi-help-circle-outline'
       }
-      if (this.isProgressing && this.isAdmin) {
+      if (this.isProgressing && this.canViewLandscape) {
         return 'mdi-progress-alert'
       }
 
@@ -224,7 +224,7 @@ export default {
       if (this.isError) {
         return 'error'
       }
-      if (this.isProgressing && this.isAdmin) {
+      if (this.isProgressing && this.canViewLandscape) {
         return 'info'
       }
       return 'primary'
@@ -236,8 +236,8 @@ export default {
       return this.color
     },
     visible () {
-      if (!this.isAdmin) {
-        return !get(this.condition, ['showAdminOnly'], false)
+      if (!this.canViewLandscape) {
+        return !get(this.condition, ['showLandscapeViewerOnly'], false)
       }
       return true
     },

--- a/frontend/src/components/ShootDetails/GShootMonitoringCard.vue
+++ b/frontend/src/components/ShootDetails/GShootMonitoringCard.vue
@@ -38,7 +38,7 @@ SPDX-License-Identifier: Apache-2.0
         </div>
       </g-list-item-content>
     </g-list-item>
-    <g-list-item v-if="isAdmin">
+    <g-list-item v-if="canViewLandscape">
       <g-list-item-content label="Seed Readiness">
         <div class="d-flex align-center pt-1">
           <span v-if="!shootConditions.length">-</span>
@@ -66,7 +66,6 @@ import { storeToRefs } from 'pinia'
 
 import { useAuthzStore } from '@/store/authz'
 import { useConfigStore } from '@/store/config'
-import { useAuthnStore } from '@/store/authn'
 
 import GShootStatus from '@/components/GShootStatus'
 import GStatusTags from '@/components/GStatusTags'
@@ -74,13 +73,10 @@ import GSeedStatusTags from '@/components/GSeedStatusTags'
 import GClusterMetrics from '@/components/GClusterMetrics'
 
 import { useShootItem } from '@/composables/useShootItem'
-const authnStore = useAuthnStore()
-const {
-  isAdmin,
-} = storeToRefs(authnStore)
 const authzStore = useAuthzStore()
 
 const {
+  canViewLandscape,
   canGetCloudProviderCredentials,
 } = storeToRefs(authzStore)
 
@@ -95,7 +91,7 @@ const {
 } = shootItem
 
 const showMetricsSection = computed(() => {
-  return isAdmin.value ||
+  return canViewLandscape.value ||
     isOidcObservabilityUrlsEnabled ||
     canGetCloudProviderCredentials.value
 })

--- a/frontend/src/components/dialogs/GInfoDialog.vue
+++ b/frontend/src/components/dialogs/GInfoDialog.vue
@@ -38,7 +38,7 @@ SPDX-License-Identifier: Apache-2.0
           <div v-if="!!dashboardVersion">
             Dashboard<span class="ml-1 font-weight-bold">{{ dashboardVersion }}</span>
           </div>
-          <template v-if="isAdmin">
+          <template v-if="canViewLandscape">
             <div v-if="!!gardenerVersion">
               Gardener API<span class="ml-1 font-weight-bold">{{ gardenerVersion }}</span>
             </div>
@@ -76,7 +76,7 @@ import {
 
 import { useAppStore } from '@/store/app'
 import { useConfigStore } from '@/store/config'
-import { useAuthnStore } from '@/store/authn'
+import { useAuthzStore } from '@/store/authz'
 import { useGardenerExtensionStore } from '@/store/gardenerExtension'
 
 import GDialog from './GDialog.vue'
@@ -106,8 +106,8 @@ export default {
     ...mapState(useGardenerExtensionStore, [
       'gardenerExtensionList',
     ]),
-    ...mapState(useAuthnStore, [
-      'isAdmin',
+    ...mapState(useAuthzStore, [
+      'canViewLandscape',
     ]),
     ...mapState(useConfigStore, [
       'branding',

--- a/frontend/src/composables/useShootListFilters.js
+++ b/frontend/src/composables/useShootListFilters.js
@@ -7,7 +7,7 @@
 import { computed } from 'vue'
 import { createSharedComposable } from '@vueuse/core'
 
-import { useAuthnStore } from '@/store/authn'
+import { useAuthzStore } from '@/store/authz'
 import { useConfigStore } from '@/store/config'
 import { useLocalStorageStore } from '@/store/localStorage'
 
@@ -26,12 +26,12 @@ const FILTER_KEYS = [
   'hideTicketsWithLabel',
 ]
 
-function getDefaultAllProjectsShootFilters (isAdmin) {
+function getDefaultAllProjectsShootFilters (canViewLandscape) {
   return {
-    onlyShootsWithIssues: isAdmin,
+    onlyShootsWithIssues: canViewLandscape,
     progressing: true,
-    noOperatorAction: isAdmin,
-    hideTicketsWithLabel: isAdmin,
+    noOperatorAction: canViewLandscape,
+    hideTicketsWithLabel: canViewLandscape,
   }
 }
 
@@ -54,14 +54,14 @@ export function getUnhealthyFilterMaskFromShootListFilters (shootListFilters = {
 }
 
 export const useShootListFilters = createSharedComposable(function useShootListFilters () {
-  const authnStore = useAuthnStore()
+  const authzStore = useAuthzStore()
   const configStore = useConfigStore()
   const localStorageStore = useLocalStorageStore()
 
   const shootListFilters = computed({
     get () {
       const filters = {
-        ...getDefaultAllProjectsShootFilters(authnStore.isAdmin),
+        ...getDefaultAllProjectsShootFilters(authzStore.canViewLandscape),
         ...localStorageStore.allProjectsShootFilter,
       }
 

--- a/frontend/src/router/routes.js
+++ b/frontend/src/router/routes.js
@@ -314,7 +314,7 @@ export function createRoutes () {
           title: 'Seeds',
           icon: 'mdi-sprout',
           get hidden () {
-            return !authzStore.canAccessSeedStats
+            return !authzStore.canViewLandscape
           },
         },
         title: 'Seeds',
@@ -545,7 +545,7 @@ export function createRoutes () {
 
   /* Helper functions */
   function getFallbackRedirectIfNoSeedAccess (to, from) {
-    if (authzStore.canAccessSeedStats) {
+    if (authzStore.canViewLandscape) {
       return
     }
 

--- a/frontend/src/store/authz.js
+++ b/frontend/src/store/authz.js
@@ -145,11 +145,15 @@ export const useAuthzStore = defineStore('authz', () => {
     canCreateServiceAccounts.value
   })
 
+  const canListSeeds = computed(() => {
+    return canI(status.value, 'list', 'core.gardener.cloud', 'seeds')
+  })
+
   const canAccessSeedStats = computed(() => {
     // Seeds are cluster-scoped — SSRR is reliable.
     // Shoots are namespace-scoped — SSRR can't distinguish namespace-only from
     // cluster-wide access, so use JWT-based canListShootsAllNamespaces (via SSAR) instead.
-    return canI(status.value, 'list', 'core.gardener.cloud', 'seeds') &&
+    return canListSeeds.value &&
       authnStore.canListShootsAllNamespaces
   })
 
@@ -157,6 +161,12 @@ export const useAuthzStore = defineStore('authz', () => {
   const canGetManagedSeedAndShootInGarden = computed(() => {
     return canI(gardenStatus.value, 'get', 'seedmanagement.gardener.cloud', 'managedseeds') &&
       canI(gardenStatus.value, 'get', 'core.gardener.cloud', 'shoots')
+  })
+
+  // Landscape-wide operator read views currently use the seed stats access
+  // contract: list access to seeds plus cluster-wide list access to shoots.
+  const canViewLandscape = computed(() => {
+    return canAccessSeedStats.value
   })
 
   const canCreateShootsAdminkubeconfigInGarden = computed(() => {
@@ -263,12 +273,12 @@ export const useAuthzStore = defineStore('authz', () => {
     canManageServiceAccountMembers,
     canGetProjectTerminalShortcuts,
     canUseProjectTerminalShortcuts,
-    canAccessSeedStats,
     hasGardenTerminalAccess,
     hasControlPlaneTerminalAccess,
     hasShootTerminalAccess,
     // Garden-namespace selectors
     canGetManagedSeedAndShootInGarden,
+    canViewLandscape,
     canCreateShootsAdminkubeconfigInGarden,
     canCreateShootsViewerkubeconfigInGarden,
     canGetConfigMapsInGarden,

--- a/frontend/src/store/config.js
+++ b/frontend/src/store/config.js
@@ -41,7 +41,7 @@ const wellKnownConditions = {
     name: 'Control Plane',
     shortName: 'CP',
     description: 'Indicates whether all control plane components are up and running.',
-    showAdminOnly: true,
+    showLandscapeViewerOnly: true,
     sortOrder: '1',
   },
   SystemComponentsHealthy: {

--- a/frontend/src/views/GMembers.vue
+++ b/frontend/src/views/GMembers.vue
@@ -351,13 +351,13 @@ const {
 } = storeToRefs(projectStore)
 const {
   namespace,
+  canViewLandscape,
   canManageMembers,
   canManageServiceAccountMembers,
   canCreateServiceAccounts,
 } = storeToRefs(authzStore)
 const {
   username: currentUsername,
-  isAdmin,
 } = storeToRefs(authnStore)
 const { list: memberList } = storeToRefs(memberStore)
 const {
@@ -621,7 +621,7 @@ async function onRemoveUser ({ username }) {
     return
   }
   await memberStore.deleteMember(username)
-  if (isCurrentUser(username) && !isAdmin.value) {
+  if (isCurrentUser(username) && !canViewLandscape.value) {
     if (projectsNotMarkedForDeletion.value.length > 0) {
       const project = projectsNotMarkedForDeletion.value[0]
       const namespace = project.spec.namespace

--- a/frontend/src/views/GShootList.vue
+++ b/frontend/src/views/GShootList.vue
@@ -137,7 +137,6 @@ import {
   mapActions,
 } from 'pinia'
 
-import { useAuthnStore } from '@/store/authn'
 import { useAuthzStore } from '@/store/authz'
 import { useShootStore } from '@/store/shoot'
 import { useSocketStore } from '@/store/socket'
@@ -260,15 +259,13 @@ export default {
     }
   },
   computed: {
-    ...mapState(useAuthnStore, [
-      'isAdmin',
-    ]),
     ...mapState(useAuthzStore, [
       'namespace',
       'canPatchShoots',
       'canDeleteShoots',
       'canCreateShoots',
       'canGetCloudProviderCredentials',
+      'canViewLandscape',
     ]),
     ...mapState(useConfigStore, {
       accessRestrictionConfig: 'accessRestriction',
@@ -371,7 +368,7 @@ export default {
           sortable: isSortable(true),
           align: 'start',
           defaultSelected: false,
-          hidden: !this.isAdmin,
+          hidden: !this.canViewLandscape,
         },
         {
           title: 'WORKERS',
@@ -446,7 +443,7 @@ export default {
           sortable: isSortable(true),
           align: 'start',
           defaultSelected: true,
-          hidden: !this.isAdmin,
+          hidden: !this.canViewLandscape,
           stalePointerEvents: true,
         },
         {
@@ -471,7 +468,7 @@ export default {
           sortable: false,
           align: 'start',
           defaultSelected: false,
-          hidden: !this.accessRestrictionConfig || !this.isAdmin,
+          hidden: !this.accessRestrictionConfig || !this.canViewLandscape,
         },
         {
           title: 'TICKET',
@@ -479,7 +476,7 @@ export default {
           sortable: isSortable(true),
           align: 'start',
           defaultSelected: false,
-          hidden: !this.gitHubRepoUrl || !this.isAdmin,
+          hidden: !this.gitHubRepoUrl || !this.canViewLandscape,
         },
         {
           title: 'TICKET LABELS',
@@ -487,7 +484,7 @@ export default {
           sortable: false,
           align: 'start',
           defaultSelected: true,
-          hidden: !this.gitHubRepoUrl || !this.isAdmin,
+          hidden: !this.gitHubRepoUrl || !this.canViewLandscape,
         },
         {
           title: 'ACTIONS',
@@ -573,14 +570,14 @@ export default {
           text: 'Hide progressing clusters',
           value: 'progressing',
           selected: this.isFilterActive('progressing'),
-          hidden: this.projectScope || !this.isAdmin || this.showAllShoots,
+          hidden: this.projectScope || !this.canViewLandscape || this.showAllShoots,
           disabled: this.changeFiltersDisabled,
         },
         {
           text: 'Hide no operator action required issues',
           value: 'noOperatorAction',
           selected: this.isFilterActive('noOperatorAction'),
-          hidden: this.projectScope || !this.isAdmin || this.showAllShoots,
+          hidden: this.projectScope || !this.canViewLandscape || this.showAllShoots,
           helpTooltip: [
             'Hide clusters that do not require action by an operator',
             '- Clusters with user issues',
@@ -593,7 +590,7 @@ export default {
           text: 'Hide clusters with configured ticket labels',
           value: 'hideTicketsWithLabel',
           selected: this.isFilterActive('hideTicketsWithLabel'),
-          hidden: this.projectScope || !this.isAdmin || !this.gitHubRepoUrl || !this.hideClustersWithLabels.length || this.showAllShoots,
+          hidden: this.projectScope || !this.canViewLandscape || !this.gitHubRepoUrl || !this.hideClustersWithLabels.length || this.showAllShoots,
           helpTooltip: this.hideTicketsWithLabelTooltip,
           disabled: this.changeFiltersDisabled,
         },
@@ -657,7 +654,7 @@ export default {
       return this.sortItems(this.filteredItems, this.sortByInternal)
     },
     issueSinceColumnVisible () {
-      return this.operatorFeatures || (!this.projectScope && this.isAdmin)
+      return this.operatorFeatures || (!this.projectScope && this.canViewLandscape)
     },
   },
   watch: {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area quality
  /area usability
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|cost|dev-productivity|documentation|high-availability|logging|monitoring|networking|open-source|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:

Broadens the visibility of operations-oriented UI to users with the `landscape-viewer` role. UI surfaces aimed at the operations team — control plane status chip, seed readiness tag, seed link on shoots, operator-only filters and columns on the shoot list, gardener version info — were previously gated by `isAdmin` and are now shown to any user satisfying the new `canViewLandscape` selector. `isAdmin` continues to gate mutating/admin-only capabilities such as terminal access.

The previously admin-only avatar role badge and chip in the main toolbar now also identify landscape viewers, with a dedicated title and icon. The internal flag `showAdminOnly` is renamed to `showLandscapeViewerOnly` to reflect the broader audience.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Prefer the new `canViewLandscape` authz selector over direct `isAdmin` checks for any UI that is informational/operational rather than mutating.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Landscape viewers now see operations-oriented UI elements such as the control plane (CP) chip, seed readiness, seed link on shoots, and a role badge in the main toolbar
```
```breaking operator
The condition visibility configuration field `showAdminOnly` has been replaced by `showLandscapeViewerOnly`. Landscape operators that define additional conditions or override condition configuration must update their configuration accordingly. Conditions marked with `showLandscapeViewerOnly` are now visible to users with landscape-viewer access, instead of being restricted to dashboard admins only
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated authorization model to support landscape viewer roles in addition to admin roles.
  * Permission-gated UI elements now controlled by landscape viewer access instead of admin status.
  * User role display updated to show "Operator" or "Landscape Viewer" designation.
  * Seed and cluster monitoring visibility tied to landscape viewer permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->