### PR TITLE
fix(status-tags): increase tooltip open-delay to 750ms

### DIFF
--- a/frontend/src/components/GSeedStatusTag.vue
+++ b/frontend/src/components/GSeedStatusTag.vue
@@ -38,7 +38,7 @@ SPDX-License-Identifier: Apache-2.0
             activator="parent"
             location="top"
             max-width="400px"
-            :open-delay="200"
+            :open-delay="750"
             :disabled="internalValue"
           >
             <div class="font-weight-bold">

--- a/frontend/src/components/GStatusTag.vue
+++ b/frontend/src/components/GStatusTag.vue
@@ -34,7 +34,7 @@ SPDX-License-Identifier: Apache-2.0
             activator="parent"
             location="top"
             max-width="400px"
-            :open-delay="200"
+            :open-delay="750"
             :disabled="internalValue"
           >
             <div class="font-weight-bold">


### PR DESCRIPTION
**How to categorize this PR?**
/area usability
/kind bug

**What this PR does / why we need it**:
Increases tooltip `open-delay` on `GStatusTag` and `GSeedStatusTag` from 200ms to 750ms. The previous delay caused tooltips to appear too eagerly when users moved their cursor across status tags in lists, creating visual noise. The longer delay aligns with hover-intent expectations and reduces accidental tooltip flashes.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```bugfix user
Increased tooltip open-delay on shoot/seed status tags from 200ms to 750ms to reduce accidental tooltip flashes during list scanning.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted tooltip display timing across status components for improved user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->