### PR TITLE
refactor(ui): separate column selection and filter into distinct menus

### DIFF
--- a/frontend/src/components/GTableColumnSelection.vue
+++ b/frontend/src/components/GTableColumnSelection.vue
@@ -16,9 +16,9 @@ SPDX-License-Identifier: Apache-2.0
   >
     <template #activator="{ props: menuProps }">
       <v-btn
-        v-tooltip:top="'Table Options'"
+        v-tooltip:top="'Column Selection'"
         v-bind="menuProps"
-        icon="mdi-dots-vertical"
+        icon="mdi-view-column"
       />
     </template>
     <v-card>
@@ -38,7 +38,7 @@ SPDX-License-Identifier: Apache-2.0
         </div>
         <v-checkbox-btn
           v-for="header in headers"
-          :key="header.value"
+          :key="header.key"
           :model-value="header.selected"
           :color="checkboxColor(header.selected)"
           density="compact"
@@ -67,49 +67,66 @@ SPDX-License-Identifier: Apache-2.0
           </template>
         </v-checkbox-btn>
       </v-card-text>
-      <template v-if="filters && filters.length">
-        <v-divider />
-        <v-card-text
-          v-tooltip:bottom="{
-            text: filterTooltip,
-            disabled: !filterTooltip, maxWidth: 300
-          }"
-          class="pt-1"
+    </v-card>
+  </v-menu>
+  <v-menu
+    v-if="hasFilters"
+    v-model="filterSelectionMenu"
+    location="left"
+    offset="5"
+    :close-on-content-click="false"
+    absolute
+    min-width="240"
+    style="max-height: 80%"
+  >
+    <template #activator="{ props: menuProps }">
+      <v-btn
+        v-tooltip:top="'Filter Selection'"
+        v-bind="menuProps"
+        icon="mdi-filter-outline"
+      />
+    </template>
+    <v-card>
+      <v-card-text
+        v-tooltip:bottom="{
+          text: filterTooltip,
+          disabled: !filterTooltip, maxWidth: 300
+        }"
+        class="pt-1"
+      >
+        <div class="text-title-small text-medium-emphasis py-2">
+          Filter Selection
+        </div>
+        <v-checkbox-btn
+          v-for="filter in filters"
+          :key="filter.value"
+          :model-value="filter.selected"
+          :color="checkboxColor(filter.selected)"
+          :disabled="filter.disabled"
+          density="compact"
+          class="text-body-medium"
+          @update:model-value="onToggleFilter(filter)"
         >
-          <div class="text-title-small text-medium-emphasis py-2">
-            Table Filter
-          </div>
-          <v-checkbox-btn
-            v-for="filter in filters"
-            :key="filter.value"
-            :model-value="filter.selected"
-            :color="checkboxColor(filter.selected)"
-            :disabled="filter.disabled"
-            density="compact"
-            class="text-body-medium"
-            @update:model-value="onToggleFilter(filter)"
-          >
-            <template #label>
-              <span
-                class="text-body-small"
-              >
-                {{ filter.text }}
-              </span>
-            </template>
-          </v-checkbox-btn>
-        </v-card-text>
-      </template>
+          <template #label>
+            <span class="text-body-small">
+              {{ filter.text }}
+            </span>
+          </template>
+        </v-checkbox-btn>
+      </v-card-text>
     </v-card>
   </v-menu>
 </template>
 
 <script setup>
 import {
+  computed,
   ref,
   toRefs,
 } from 'vue'
 
 const columnSelectionMenu = ref(false)
+const filterSelectionMenu = ref(false)
 
 // props
 const props = defineProps({
@@ -125,6 +142,8 @@ const props = defineProps({
 })
 
 const { headers, filters, filterTooltip } = toRefs(props)
+
+const hasFilters = computed(() => filters.value?.length > 0)
 
 // emits
 const emit = defineEmits([

--- a/frontend/src/views/GShootList.vue
+++ b/frontend/src/views/GShootList.vue
@@ -560,7 +560,7 @@ export default {
     allFilters () {
       return [
         {
-          text: 'Show only clusters with issues',
+          text: 'Hide healthy clusters',
           value: 'onlyShootsWithIssues',
           selected: this.onlyShootsWithIssues,
           hidden: this.projectScope,
@@ -574,7 +574,7 @@ export default {
           disabled: this.changeFiltersDisabled,
         },
         {
-          text: 'Hide no operator action required issues',
+          text: 'Hide clusters without operator action needed',
           value: 'noOperatorAction',
           selected: this.isFilterActive('noOperatorAction'),
           hidden: this.projectScope || !this.canViewLandscape || this.showAllShoots,
@@ -587,7 +587,7 @@ export default {
           disabled: this.changeFiltersDisabled,
         },
         {
-          text: 'Hide clusters with configured ticket labels',
+          text: 'Hide clusters with ignored ticket labels',
           value: 'hideTicketsWithLabel',
           selected: this.isFilterActive('hideTicketsWithLabel'),
           hidden: this.projectScope || !this.canViewLandscape || !this.gitHubRepoUrl || !this.hideClustersWithLabels.length || this.showAllShoots,


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area usability
/kind cleanup

**What this PR does / why we need it**:

Split the combined table options menu into two separate toolbar buttons: one for column selection, one for filter selection. Clarified filter label wording. Fixed `:key` binding on header checkboxes (`header.key` instead of `header.value`).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```other user
The table column selection and filter selection are now separate toolbar buttons.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated the table column selection menu with a new icon and tooltip text.
  * Improved filter menu behavior so available filters appear more consistently.
  * Refined filter labels in the shoot list for clearer, more user-friendly wording.

* **Bug Fixes**
  * Adjusted checkbox handling in the column selector to make item selection more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->