### PR TITLE
fix(ui): show excluded filter row in donut tooltip even when 0 clusters are hidden

### DIFF
--- a/frontend/__tests__/components/GShootHealthDonut.spec.js
+++ b/frontend/__tests__/components/GShootHealthDonut.spec.js
@@ -253,7 +253,7 @@ describe('components', () => {
         expect(excluded.find('.v-list-item-subtitle-stub').text()).toContain('Progressing Clusters, User Errors & 2 more')
       })
 
-      it('should show excluded row without description when no filter labels provided', () => {
+      it('should not show excluded row when no filter labels provided', () => {
         const wrapper = mountComponent({
           shootCount: 10,
           totalUnhealthyShoots: 5,
@@ -261,9 +261,21 @@ describe('components', () => {
         })
 
         const excluded = findRow(wrapper, 'Excluded')
+        expect(excluded).toBeUndefined()
+      })
+
+      it('should show excluded row with 0 count when filters active but nothing excluded', () => {
+        const wrapper = mountComponent({
+          shootCount: 10,
+          totalUnhealthyShoots: 5,
+          matchingUnhealthyShoots: 5,
+          activeFilterLabels: ['Progressing'],
+        })
+
+        const excluded = findRow(wrapper, 'Excluded')
         expect(excluded).toBeDefined()
-        expect(excluded.find('.v-list-item-title-stub').text()).toBe('3')
-        expect(excluded.find('.v-list-item-subtitle-stub').text()).not.toContain('—')
+        expect(excluded.find('.v-list-item-title-stub').text()).toBe('0')
+        expect(excluded.find('.v-list-item-subtitle-stub').text()).toContain('Progressing')
       })
 
       it('should show healthy legend when there are healthy shoots', () => {

--- a/frontend/src/components/GShootHealthDonut.vue
+++ b/frontend/src/components/GShootHealthDonut.vue
@@ -97,7 +97,7 @@ SPDX-License-Identifier: Apache-2.0
               <v-list-item-subtitle>Unhealthy</v-list-item-subtitle>
               <v-list-item-title>{{ matchingUnhealthy }}</v-list-item-title>
             </v-list-item>
-            <template v-if="hiddenUnhealthy > 0">
+            <template v-if="activeFilterLabels.length > 0">
               <v-list-item :prepend-gap="8">
                 <template #prepend>
                   <v-icon
@@ -172,9 +172,6 @@ const hiddenUnhealthy = computed(() => totalUnhealthy.value - matchingUnhealthy.
 const healthyShoots = computed(() => shootCount.value - totalUnhealthy.value)
 
 const filterDescription = computed(() => {
-  if (hiddenUnhealthy.value === 0) {
-    return undefined
-  }
   const labels = activeFilterLabels.value
   if (!labels.length) {
     return undefined
@@ -253,7 +250,7 @@ const ariaLabel = computed(() => {
     `${shootCount.value} shoots`,
     `${matchingUnhealthy.value} unhealthy shoots`,
   ]
-  if (hiddenUnhealthy.value > 0) {
+  if (activeFilterLabels.value.length > 0) {
     const desc = filterDescription.value
       ? ` (${filterDescription.value})`
       : ''


### PR DESCRIPTION
/area usability
/kind enhancement

**What this PR does / why we need it**:

Show the "Excluded" tooltip row whenever a filter is active, not only when it hides clusters. This makes it visible that the view is filtered regardless of current match count.

**Which issue(s) this PR fixes**:
None

**Release note**:
```other user
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the “Excluded” tooltip row so it now appears when filters are active, even if the excluded count is 0.
  * Updated accessibility text to better reflect when results are excluded by active filters.
  * Refined the filter description shown in the tooltip to display active labels more consistently, including a shortened “and more” summary when needed.

* **Tests**
  * Updated component tests to cover the revised “Excluded” row behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->