### PR TITLE
Add link to the VicotoriaLogs UI

### DIFF
--- a/frontend/src/components/GClusterMetrics.vue
+++ b/frontend/src/components/GClusterMetrics.vue
@@ -47,6 +47,14 @@ SPDX-License-Identifier: Apache-2.0
           :is-shoot-status-hibernated="isShootStatusHibernated"
           content-class="pt-0"
         />
+        <g-link-list-tile
+          v-if="victoriaLogsUrl"
+          app-title="VictoriaLogs"
+          :url="victoriaLogsUrl"
+          :url-text="victoriaLogsUrl"
+          :is-shoot-status-hibernated="isShootStatusHibernated"
+          content-class="pt-0"
+        />
         <v-divider
           v-show="!!username && !!password"
           inset
@@ -83,6 +91,7 @@ import GLinkListTile from '@/components/GLinkListTile'
 import { useShootItem } from '@/composables/useShootItem'
 import { useShootHelper } from '@/composables/useShootHelper'
 import { useShootStatus } from '@/composables/useShootStatus'
+import { useShootAdvertisedAddresses } from '@/composables/useShootAdvertisedAddresses'
 
 import {
   getSeedPlutonoUrl,
@@ -122,6 +131,10 @@ export default {
       shootTechnicalId,
     } = useShootStatus(shootItem)
 
+    const {
+      shootVictoriaLogsUrl,
+    } = useShootAdvertisedAddresses(shootItem)
+
     return {
       shootItem,
       shootInfo,
@@ -131,6 +144,7 @@ export default {
       isOidcObservabilityUrlsEnabled,
       canViewLandscape,
       isTestingCluster,
+      shootVictoriaLogsUrl,
     }
   },
   computed: {
@@ -160,6 +174,19 @@ export default {
       }
 
       return `https://au-${this.prefix}.${this.seedIngressDomain}`
+    },
+    victoriaLogsUrl () {
+      // Prefer the advertised address; fall back to the hardcoded url until
+      // the migration to advertisedAddresses is complete.
+      if (this.shootVictoriaLogsUrl) {
+        return this.shootVictoriaLogsUrl
+      }
+
+      if (this.isOidcObservabilityUrlsEnabled) {
+        return `${this.getOidcDeploymentUrl('victoria-logs')}/select/vmui`
+      }
+
+      return `https://vl-${this.prefix}.${this.seedIngressDomain}/select/vmui`
     },
     seedPlutonoUrl () {
       return getSeedPlutonoUrl(this.seedIngressDomain)

--- a/frontend/src/components/SeedDetails/GSeedMonitoringCard.vue
+++ b/frontend/src/components/SeedDetails/GSeedMonitoringCard.vue
@@ -70,6 +70,13 @@ SPDX-License-Identifier: Apache-2.0
         :url-text="managedSeedShootPrometheusUrl"
         content-class="pt-0"
       />
+      <g-link-list-tile
+        v-if="managedSeedShootVictoriaLogsUrl"
+        app-title="Shoot VictoriaLogs"
+        :url="managedSeedShootVictoriaLogsUrl"
+        :url-text="managedSeedShootVictoriaLogsUrl"
+        content-class="pt-0"
+      />
     </g-list>
   </v-card>
 </template>
@@ -94,6 +101,7 @@ const {
 const {
   managedSeedShootPlutonoUrl,
   managedSeedShootPrometheusUrl,
+  managedSeedShootVictoriaLogsUrl,
 } = useManagedSeedShoot()
 
 const seedPlutonoUrl = computed(() => getSeedPlutonoUrl(seedIngressDomain.value))

--- a/frontend/src/composables/useManagedSeedShootForSeed.js
+++ b/frontend/src/composables/useManagedSeedShootForSeed.js
@@ -45,6 +45,7 @@ export function createManagedSeedShootComposable (seedName) {
   const {
     shootPlutonoUrl: managedSeedShootPlutonoUrl,
     shootPrometheusUrl: managedSeedShootPrometheusUrl,
+    shootVictoriaLogsUrl: managedSeedShootVictoriaLogsUrl,
   } = useShootAdvertisedAddresses(managedSeedShoot)
 
   return {
@@ -53,6 +54,7 @@ export function createManagedSeedShootComposable (seedName) {
     managedSeedShootConditions,
     managedSeedShootPlutonoUrl,
     managedSeedShootPrometheusUrl,
+    managedSeedShootVictoriaLogsUrl,
   }
 }
 

--- a/frontend/src/composables/useShootAdvertisedAddresses.js
+++ b/frontend/src/composables/useShootAdvertisedAddresses.js
@@ -46,13 +46,19 @@ export function useShootAdvertisedAddresses (shootItem) {
     advertisedAddresses: shootPrometheusAdvertisedAddresses,
     url: shootPrometheusUrl,
   } = useAdvertisedAddressesForApplication('prometheus--prometheus')
+  const {
+    advertisedAddresses: shootVictoriaLogsAdvertisedAddresses,
+    url: shootVictoriaLogsUrl,
+  } = useAdvertisedAddressesForApplication('victoria-metrics--victoria-logs')
 
   return {
     shootAdvertisedAddresses,
     shootPlutonoAdvertisedAddresses,
     shootPrometheusAdvertisedAddresses,
+    shootVictoriaLogsAdvertisedAddresses,
     shootPlutonoUrl,
     shootPrometheusUrl,
+    shootVictoriaLogsUrl,
     useAdvertisedAddressesForApplication,
   }
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area quality
  /area usability
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|cost|dev-productivity|documentation|high-availability|logging|monitoring|networking|open-source|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
Adds a new "VictoriaLogs" tile to the shoot cluster metrics card and a "Shoot VictoriaLogs" tile to the seed monitoring card, alongside the existing Plutono and Prometheus links.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added VictoriaLogs link tiles to cluster metrics and seed monitoring views.
  * VictoriaLogs links now use the best available URL automatically, with support for advertised, OIDC-based, or fallback addresses.
  * Improved availability of VictoriaLogs access links for managed seed environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->