### PR TITLE
feat(filter): support field-qualified search terms

### DIFF
--- a/frontend/__tests__/composables/useTableFilter/helper.spec.js
+++ b/frontend/__tests__/composables/useTableFilter/helper.spec.js
@@ -38,6 +38,21 @@ describe('composables/useTableFilter', () => {
       expect(tokens).toEqual(['"test ""quoted"" value"'])
     })
 
+    it('should keep field-qualified bare value as one token', () => {
+      const tokens = tokenizeSearch('seed:aws-ha azure')
+      expect(tokens).toEqual(['seed:aws-ha', 'azure'])
+    })
+
+    it('should keep field-qualified quoted value as one token', () => {
+      const tokens = tokenizeSearch('seed:"two words" azure')
+      expect(tokens).toEqual(['seed:"two words"', 'azure'])
+    })
+
+    it('should keep negated field-qualified quoted value as one token', () => {
+      const tokens = tokenizeSearch('-seed:"two words"')
+      expect(tokens).toEqual(['-seed:"two words"'])
+    })
+
     it('should return empty array for empty string', () => {
       const tokens = tokenizeSearch('')
       expect(tokens).toEqual([])
@@ -47,71 +62,144 @@ describe('composables/useTableFilter', () => {
       const tokens = tokenizeSearch(null)
       expect(tokens).toEqual([])
     })
+
+    it('should preserve whitespace inside quotes', () => {
+      const tokens = tokenizeSearch('"a  b\tc"')
+      expect(tokens).toEqual(['"a  b\tc"'])
+    })
+
+    it('should split on tabs and newlines outside quotes', () => {
+      const tokens = tokenizeSearch('aws\tgcp\nazure')
+      expect(tokens).toEqual(['aws', 'gcp', 'azure'])
+    })
+
+    it('should keep quote-adjacent bare chars as part of the same token', () => {
+      // imperative tokenizer treats `"foo"bar` as one contiguous token
+      const tokens = tokenizeSearch('"foo"bar')
+      expect(tokens).toEqual(['"foo"bar'])
+    })
+
+    it('should consume an unclosed quoted run to end of input', () => {
+      const tokens = tokenizeSearch('aws "unterminated value')
+      expect(tokens).toEqual(['aws', '"unterminated value'])
+    })
+
+    it('should collapse runs of whitespace', () => {
+      const tokens = tokenizeSearch('  aws   gcp  ')
+      expect(tokens).toEqual(['aws', 'gcp'])
+    })
   })
 
   describe('SearchQuery', () => {
     describe('matches', () => {
-      it('should match simple term', () => {
-        const query = new SearchQuery([{ value: 'aws', exact: false, exclude: false }])
-        const values = ['aws-region', 'us-east-1']
-        expect(query.matches(values)).toBe(true)
+      it('should match simple term against any field', () => {
+        const query = new SearchQuery([{ field: null, value: 'aws', exact: false, exclude: false }])
+        expect(query.matches({ name: 'aws-region', region: 'us-east-1' })).toBe(true)
       })
 
-      it('should not match when term is not present', () => {
-        const query = new SearchQuery([{ value: 'azure', exact: false, exclude: false }])
-        const values = ['aws-region', 'us-east-1']
-        expect(query.matches(values)).toBe(false)
+      it('should not match when term is not present in any field', () => {
+        const query = new SearchQuery([{ field: null, value: 'azure', exact: false, exclude: false }])
+        expect(query.matches({ name: 'aws-region', region: 'us-east-1' })).toBe(false)
       })
 
       it('should match exact term', () => {
-        const query = new SearchQuery([{ value: 'aws', exact: true, exclude: false }])
-        const values = ['aws', 'us-east-1']
-        expect(query.matches(values)).toBe(true)
+        const query = new SearchQuery([{ field: null, value: 'aws', exact: true, exclude: false }])
+        expect(query.matches({ name: 'aws', region: 'us-east-1' })).toBe(true)
       })
 
       it('should not match exact term when only substring matches', () => {
-        const query = new SearchQuery([{ value: 'aws', exact: true, exclude: false }])
-        const values = ['aws-region', 'us-east-1']
-        expect(query.matches(values)).toBe(false)
+        const query = new SearchQuery([{ field: null, value: 'aws', exact: true, exclude: false }])
+        expect(query.matches({ name: 'aws-region', region: 'us-east-1' })).toBe(false)
       })
 
       it('should handle exclusion with minus sign', () => {
-        const query = new SearchQuery([{ value: 'azure', exact: false, exclude: true }])
-        const values = ['aws-region', 'us-east-1']
-        expect(query.matches(values)).toBe(true)
+        const query = new SearchQuery([{ field: null, value: 'azure', exact: false, exclude: true }])
+        expect(query.matches({ name: 'aws-region', region: 'us-east-1' })).toBe(true)
       })
 
       it('should not match when excluded term is present', () => {
-        const query = new SearchQuery([{ value: 'azure', exact: false, exclude: true }])
-        const values = ['azure-region', 'west-eu']
-        expect(query.matches(values)).toBe(false)
+        const query = new SearchQuery([{ field: null, value: 'azure', exact: false, exclude: true }])
+        expect(query.matches({ name: 'azure-region', region: 'west-eu' })).toBe(false)
       })
 
       it('should match multiple terms with AND logic', () => {
         const query = new SearchQuery([
-          { value: 'aws', exact: false, exclude: false },
-          { value: 'east', exact: false, exclude: false },
+          { field: null, value: 'aws', exact: false, exclude: false },
+          { field: null, value: 'east', exact: false, exclude: false },
         ])
-        const values = ['aws-region', 'us-east-1']
-        expect(query.matches(values)).toBe(true)
+        expect(query.matches({ name: 'aws-region', region: 'us-east-1' })).toBe(true)
       })
 
       it('should not match when any term is missing (AND logic)', () => {
         const query = new SearchQuery([
-          { value: 'aws', exact: false, exclude: false },
-          { value: 'west', exact: false, exclude: false },
+          { field: null, value: 'aws', exact: false, exclude: false },
+          { field: null, value: 'west', exact: false, exclude: false },
         ])
-        const values = ['aws-region', 'us-east-1']
-        expect(query.matches(values)).toBe(false)
+        expect(query.matches({ name: 'aws-region', region: 'us-east-1' })).toBe(false)
       })
 
       it('should handle combination of inclusion and exclusion', () => {
         const query = new SearchQuery([
-          { value: 'aws', exact: false, exclude: false },
-          { value: 'azure', exact: false, exclude: true },
+          { field: null, value: 'aws', exact: false, exclude: false },
+          { field: null, value: 'azure', exact: false, exclude: true },
         ])
-        const values = ['aws-region', 'us-east-1']
-        expect(query.matches(values)).toBe(true)
+        expect(query.matches({ name: 'aws-region', region: 'us-east-1' })).toBe(true)
+      })
+
+      it('should match qualified term only against its field', () => {
+        const query = new SearchQuery([{ field: 'seed', value: 'aws-ha', exact: false, exclude: false }])
+        expect(query.matches({ name: 'aws-ha-cluster', seed: 'aws-ha' })).toBe(true)
+        expect(query.matches({ name: 'aws-ha-cluster', seed: 'gcp-ha' })).toBe(false)
+      })
+
+      it('should not match qualified term when field value is missing', () => {
+        const query = new SearchQuery([{ field: 'seed', value: 'aws-ha', exact: false, exclude: false }])
+        expect(query.matches({ name: 'aws-ha-cluster' })).toBe(false)
+      })
+
+      it('should treat null field value same as missing', () => {
+        const query = new SearchQuery([{ field: 'seed', value: 'aws-ha', exact: false, exclude: false }])
+        expect(query.matches({ name: 'aws-ha-cluster', seed: null })).toBe(false)
+      })
+
+      it('should match empty value term against null/undefined/empty field', () => {
+        const query = new SearchQuery([{ field: 'seed', value: '', exact: false, exclude: false }])
+        expect(query.matches({ name: 'cluster', seed: null })).toBe(true)
+        expect(query.matches({ name: 'cluster', seed: undefined })).toBe(true)
+        expect(query.matches({ name: 'cluster', seed: '' })).toBe(true)
+        expect(query.matches({ name: 'cluster', seed: 'aws-ha' })).toBe(false)
+      })
+
+      it('should support excluding empty field values', () => {
+        const query = new SearchQuery([{ field: 'seed', value: '', exact: false, exclude: true }])
+        // has a seed → empty not found → exclusion passes
+        expect(query.matches({ name: 'cluster', seed: 'aws-ha' })).toBe(true)
+        // no seed → empty found → exclusion rejects
+        expect(query.matches({ name: 'cluster', seed: null })).toBe(false)
+      })
+
+      it('should treat missing qualified-field value as not-found for exclusion', () => {
+        const query = new SearchQuery([{ field: 'seed', value: 'aws-ha', exact: false, exclude: true }])
+        // missing seed → not found → exclusion passes
+        expect(query.matches({ name: 'cluster' })).toBe(true)
+        expect(query.matches({ name: 'cluster', seed: 'gcp-ha' })).toBe(true)
+        expect(query.matches({ name: 'cluster', seed: 'aws-ha' })).toBe(false)
+      })
+
+      it('should support exact qualified match', () => {
+        const query = new SearchQuery([{ field: 'seed', value: 'aws', exact: true, exclude: false }])
+        expect(query.matches({ seed: 'aws' })).toBe(true)
+        expect(query.matches({ seed: 'aws-ha' })).toBe(false)
+      })
+
+      it('should combine qualified and unqualified terms', () => {
+        const query = new SearchQuery([
+          { field: 'seed', value: 'aws-ha', exact: false, exclude: false },
+          { field: null, value: 'prod', exact: false, exclude: false },
+        ])
+        expect(query.matches({ name: 'prod-cluster', seed: 'aws-ha' })).toBe(true)
+        expect(query.matches({ name: 'dev-cluster', seed: 'aws-ha' })).toBe(false)
+        expect(query.matches({ name: 'prod-cluster', seed: 'gcp-ha' })).toBe(false)
       })
     })
   })
@@ -120,47 +208,47 @@ describe('composables/useTableFilter', () => {
     it('should parse simple search term', () => {
       const query = parseSearch('aws')
       expect(query.terms).toHaveLength(1)
-      expect(query.terms[0]).toEqual({ value: 'aws', exact: false, exclude: false })
+      expect(query.terms[0]).toEqual({ field: null, value: 'aws', exact: false, exclude: false })
     })
 
     it('should parse multiple search terms', () => {
       const query = parseSearch('aws gcp azure')
       expect(query.terms).toHaveLength(3)
-      expect(query.terms[0]).toEqual({ value: 'aws', exact: false, exclude: false })
-      expect(query.terms[1]).toEqual({ value: 'gcp', exact: false, exclude: false })
-      expect(query.terms[2]).toEqual({ value: 'azure', exact: false, exclude: false })
+      expect(query.terms[0]).toEqual({ field: null, value: 'aws', exact: false, exclude: false })
+      expect(query.terms[1]).toEqual({ field: null, value: 'gcp', exact: false, exclude: false })
+      expect(query.terms[2]).toEqual({ field: null, value: 'azure', exact: false, exclude: false })
     })
 
     it('should parse quoted phrase for exact matching', () => {
       const query = parseSearch('"us-east-1"')
       expect(query.terms).toHaveLength(1)
-      expect(query.terms[0]).toEqual({ value: 'us-east-1', exact: true, exclude: false })
+      expect(query.terms[0]).toEqual({ field: null, value: 'us-east-1', exact: true, exclude: false })
     })
 
     it('should parse exclusion with minus sign', () => {
       const query = parseSearch('-azure')
       expect(query.terms).toHaveLength(1)
-      expect(query.terms[0]).toEqual({ value: 'azure', exact: false, exclude: true })
+      expect(query.terms[0]).toEqual({ field: null, value: 'azure', exact: false, exclude: true })
     })
 
     it('should parse quoted exclusion', () => {
       const query = parseSearch('-"my seed"')
       expect(query.terms).toHaveLength(1)
-      expect(query.terms[0]).toEqual({ value: 'my seed', exact: true, exclude: true })
+      expect(query.terms[0]).toEqual({ field: null, value: 'my seed', exact: true, exclude: true })
     })
 
     it('should parse mixed search terms', () => {
       const query = parseSearch('aws -azure "us-east-1"')
       expect(query.terms).toHaveLength(3)
-      expect(query.terms[0]).toEqual({ value: 'aws', exact: false, exclude: false })
-      expect(query.terms[1]).toEqual({ value: 'azure', exact: false, exclude: true })
-      expect(query.terms[2]).toEqual({ value: 'us-east-1', exact: true, exclude: false })
+      expect(query.terms[0]).toEqual({ field: null, value: 'aws', exact: false, exclude: false })
+      expect(query.terms[1]).toEqual({ field: null, value: 'azure', exact: false, exclude: true })
+      expect(query.terms[2]).toEqual({ field: null, value: 'us-east-1', exact: true, exclude: false })
     })
 
     it('should handle escaped quotes within quoted strings', () => {
       const query = parseSearch('"test ""quoted"" value"')
       expect(query.terms).toHaveLength(1)
-      expect(query.terms[0]).toEqual({ value: 'test "quoted" value', exact: true, exclude: false })
+      expect(query.terms[0]).toEqual({ field: null, value: 'test "quoted" value', exact: true, exclude: false })
     })
 
     it('should ignore empty terms', () => {
@@ -173,13 +261,97 @@ describe('composables/useTableFilter', () => {
       expect(query.terms).toHaveLength(0)
     })
 
+    it('should parse field-qualified bare term when field is allowed', () => {
+      const query = parseSearch('seed:aws-ha', ['seed'])
+      expect(query.terms).toHaveLength(1)
+      expect(query.terms[0]).toEqual({ field: 'seed', value: 'aws-ha', exact: false, exclude: false })
+    })
+
+    it('should parse field-qualified quoted term when field is allowed', () => {
+      const query = parseSearch('seed:"two words"', ['seed'])
+      expect(query.terms).toHaveLength(1)
+      expect(query.terms[0]).toEqual({ field: 'seed', value: 'two words', exact: true, exclude: false })
+    })
+
+    it('should parse negated field-qualified term', () => {
+      const query = parseSearch('-seed:aws-ha', ['seed'])
+      expect(query.terms).toHaveLength(1)
+      expect(query.terms[0]).toEqual({ field: 'seed', value: 'aws-ha', exact: false, exclude: true })
+    })
+
+    it('should parse negated field-qualified quoted term', () => {
+      const query = parseSearch('-seed:"two words"', ['seed'])
+      expect(query.terms).toHaveLength(1)
+      expect(query.terms[0]).toEqual({ field: 'seed', value: 'two words', exact: true, exclude: true })
+    })
+
+    it('should treat unknown field qualifier as literal', () => {
+      const query = parseSearch('foo:bar', ['seed'])
+      expect(query.terms).toHaveLength(1)
+      expect(query.terms[0]).toEqual({ field: null, value: 'foo:bar', exact: false, exclude: false })
+    })
+
+    it('should treat negated unknown field qualifier as literal exclusion', () => {
+      const query = parseSearch('-foo:bar', ['seed'])
+      expect(query.terms).toHaveLength(1)
+      expect(query.terms[0]).toEqual({ field: null, value: 'foo:bar', exact: false, exclude: true })
+    })
+
+    it('should treat qualified value with no allowlist as literal', () => {
+      const query = parseSearch('seed:aws-ha')
+      expect(query.terms).toHaveLength(1)
+      expect(query.terms[0]).toEqual({ field: null, value: 'seed:aws-ha', exact: false, exclude: false })
+    })
+
+    it('should mix qualified and unqualified terms', () => {
+      const query = parseSearch('seed:aws-ha -region:eu prod foo:bar', ['seed', 'region'])
+      expect(query.terms).toHaveLength(4)
+      expect(query.terms[0]).toEqual({ field: 'seed', value: 'aws-ha', exact: false, exclude: false })
+      expect(query.terms[1]).toEqual({ field: 'region', value: 'eu', exact: false, exclude: true })
+      expect(query.terms[2]).toEqual({ field: null, value: 'prod', exact: false, exclude: false })
+      expect(query.terms[3]).toEqual({ field: null, value: 'foo:bar', exact: false, exclude: false })
+    })
+
+    it('should accept allowlist as a Set', () => {
+      const query = parseSearch('seed:aws-ha', new Set(['seed']))
+      expect(query.terms[0].field).toBe('seed')
+    })
+
+    it('should accept underscore-prefixed custom field keys', () => {
+      const query = parseSearch('Z_costCenter:42', ['Z_costCenter'])
+      expect(query.terms).toHaveLength(1)
+      expect(query.terms[0]).toEqual({ field: 'Z_costCenter', value: '42', exact: false, exclude: false })
+    })
+
+    it('should parse field-qualified empty quoted value as empty-match term', () => {
+      const query = parseSearch('seed:""', ['seed'])
+      expect(query.terms).toHaveLength(1)
+      expect(query.terms[0]).toEqual({ field: 'seed', value: '', exact: true, exclude: false })
+    })
+
+    it('should parse negated field-qualified empty quoted value', () => {
+      const query = parseSearch('-seed:""', ['seed'])
+      expect(query.terms).toHaveLength(1)
+      expect(query.terms[0]).toEqual({ field: 'seed', value: '', exact: true, exclude: true })
+    })
+
+    it('should drop bare empty field (no quotes)', () => {
+      const query = parseSearch('seed:', ['seed'])
+      expect(query.terms).toHaveLength(1)
+      expect(query.terms[0]).toEqual({ field: 'seed', value: '', exact: false, exclude: false })
+    })
+
     it('should create SearchQuery that matches correctly', () => {
       const query = parseSearch('aws -azure')
-      const values = ['aws-region', 'us-east-1']
-      expect(query.matches(values)).toBe(true)
+      expect(query.matches({ name: 'aws-region', region: 'us-east-1' })).toBe(true)
+      expect(query.matches({ name: 'azure-region', region: 'west-eu' })).toBe(false)
+    })
 
-      const values2 = ['azure-region', 'west-eu']
-      expect(query.matches(values2)).toBe(false)
+    it('should create SearchQuery that field-matches correctly', () => {
+      const query = parseSearch('seed:aws-ha', ['seed'])
+      expect(query.matches({ name: 'aws-ha-cluster', seed: 'aws-ha' })).toBe(true)
+      // substring on name only must NOT satisfy qualified seed term
+      expect(query.matches({ name: 'aws-ha-cluster', seed: 'gcp-ha' })).toBe(false)
     })
   })
 })

--- a/frontend/__tests__/composables/useTableFilter/helper.spec.js
+++ b/frontend/__tests__/composables/useTableFilter/helper.spec.js
@@ -354,4 +354,30 @@ describe('composables/useTableFilter', () => {
       expect(query.matches({ name: 'aws-ha-cluster', seed: 'gcp-ha' })).toBe(false)
     })
   })
+
+  describe('SearchQuery.matches with non-string values', () => {
+    it('should match numeric field values via substring', () => {
+      const query = parseSearch('42')
+      expect(query.matches({ name: 'cluster', workers: 42 })).toBe(true)
+      expect(query.matches({ name: 'cluster', workers: 142 })).toBe(true)
+      expect(query.matches({ name: 'cluster', workers: 5 })).toBe(false)
+    })
+
+    it('should match numeric field values via exact match', () => {
+      const query = parseSearch('"42"')
+      expect(query.matches({ name: 'cluster', workers: 42 })).toBe(true)
+      expect(query.matches({ name: 'cluster', workers: 142 })).toBe(false)
+    })
+
+    it('should match boolean field values', () => {
+      const query = parseSearch('true')
+      expect(query.matches({ name: 'cluster', enabled: true })).toBe(true)
+      expect(query.matches({ name: 'cluster', enabled: false })).toBe(false)
+    })
+
+    it('should not crash on non-string values when no match', () => {
+      const query = parseSearch('xyz')
+      expect(query.matches({ name: 'cluster', count: 99, flag: false })).toBe(false)
+    })
+  })
 })

--- a/frontend/__tests__/composables/useTableFilter/index.spec.js
+++ b/frontend/__tests__/composables/useTableFilter/index.spec.js
@@ -21,7 +21,7 @@ describe('composables/useTableFilter', () => {
         { id: 2, name: 'Bob' },
       ])
       const searchQuery = ref('')
-      const filterFn = (item, query) => item.name.toLowerCase().includes(query.toLowerCase())
+      const filterFn = query => item => item.name.toLowerCase().includes(query.toLowerCase())
 
       const { filteredItems } = useTableFilter({ items, searchQuery, filterFn })
 
@@ -35,7 +35,7 @@ describe('composables/useTableFilter', () => {
         { id: 2, name: 'Bob' },
       ])
       const searchQuery = ref('   ')
-      const filterFn = (item, query) => item.name.toLowerCase().includes(query.toLowerCase())
+      const filterFn = query => item => item.name.toLowerCase().includes(query.toLowerCase())
 
       const { filteredItems } = useTableFilter({ items, searchQuery, filterFn })
 
@@ -49,7 +49,7 @@ describe('composables/useTableFilter', () => {
         { id: 3, name: 'Charlie' },
       ])
       const searchQuery = ref('ali')
-      const filterFn = (item, query) => item.name.toLowerCase().includes(query.toLowerCase())
+      const filterFn = query => item => item.name.toLowerCase().includes(query.toLowerCase())
 
       const { filteredItems } = useTableFilter({ items, searchQuery, filterFn })
 
@@ -63,7 +63,7 @@ describe('composables/useTableFilter', () => {
         { id: 2, name: 'Bob' },
       ])
       const searchQuery = ref('ALICE')
-      const filterFn = (item, query) => item.name.toLowerCase().includes(query.toLowerCase())
+      const filterFn = query => item => item.name.toLowerCase().includes(query.toLowerCase())
 
       const { filteredItems } = useTableFilter({ items, searchQuery, filterFn })
 
@@ -78,7 +78,7 @@ describe('composables/useTableFilter', () => {
         { id: 3, name: 'Charlie' },
       ])
       const searchQuery = ref('ali')
-      const filterFn = (item, query) => item.name.toLowerCase().includes(query.toLowerCase())
+      const filterFn = query => item => item.name.toLowerCase().includes(query.toLowerCase())
 
       const { filteredItems } = useTableFilter({ items, searchQuery, filterFn })
 
@@ -98,7 +98,7 @@ describe('composables/useTableFilter', () => {
         { id: 2, name: 'Bob' },
       ])
       const searchQuery = ref('ali')
-      const filterFn = (item, query) => item.name.toLowerCase().includes(query.toLowerCase())
+      const filterFn = query => item => item.name.toLowerCase().includes(query.toLowerCase())
 
       const { filteredItems } = useTableFilter({ items, searchQuery, filterFn })
 

--- a/frontend/src/components/GTableSearch.vue
+++ b/frontend/src/components/GTableSearch.vue
@@ -5,7 +5,11 @@ SPDX-License-Identifier: Apache-2.0
  -->
 
 <template>
-  <v-tooltip location="top">
+  <v-tooltip
+    location="top"
+    :open-on-focus="false"
+    :open-delay="500"
+  >
     <template #activator="{ props: tooltipProps }">
       <v-text-field
         v-bind="tooltipProps"

--- a/frontend/src/composables/useTableFilter/helper.js
+++ b/frontend/src/composables/useTableFilter/helper.js
@@ -96,7 +96,8 @@ export class SearchQuery {
         if (value == null || value === '') {
           return false
         }
-        return term.exact ? value === term.value : value.includes(term.value)
+        const stringValue = typeof value === 'string' ? value : String(value)
+        return term.exact ? stringValue === term.value : stringValue.includes(term.value)
       }
       const found = values.some(matchesTermValue)
       if ((!found && !term.exclude) || (found && term.exclude)) {

--- a/frontend/src/composables/useTableFilter/helper.js
+++ b/frontend/src/composables/useTableFilter/helper.js
@@ -4,16 +4,80 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import find from 'lodash/find'
-import includes from 'lodash/includes'
+// Identifier-shaped `field:` prefix at the start of a token (after an optional
+// leading `-`). Used to split a token into qualifier and value.
+const fieldPrefixPattern = /^([A-Za-z_][A-Za-z0-9_]*):/
 
-const tokenizePattern = /(-?"([^"]|"")*"|\S+)/g
+const CHAR_QUOTE = 34 // "
+const CHAR_SPACE = 32
+const CHAR_TAB = 9
+const CHAR_LF = 10
+const CHAR_CR = 13
 
+function isTokenSeparator (code) {
+  return code === CHAR_SPACE || code === CHAR_TAB || code === CHAR_LF || code === CHAR_CR
+}
+
+function getTermValues (fields, allValues, field) {
+  if (field === null) {
+    return allValues
+  }
+  if (!Object.hasOwn(fields, field)) {
+    return [undefined]
+  }
+  return [fields[field]] // eslint-disable-line security/detect-object-injection -- key validated by hasOwn above; fields is an app-constructed object literal, field is constrained to allowedFields
+}
+
+// Splits the raw query on whitespace while keeping quoted phrases intact.
+// Qualifiers, exclusions, and quote markers stay in the token for `parseSearch`.
 export function tokenizeSearch (text) {
-  const tokens = typeof text === 'string'
-    ? text.match(tokenizePattern)
-    : null
-  return tokens || []
+  if (typeof text !== 'string' || text.length === 0) {
+    return []
+  }
+
+  const tokens = []
+  const len = text.length
+  let start = -1
+  let inQuotes = false
+  let i = 0
+
+  while (i < len) {
+    const code = text.charCodeAt(i)
+
+    if (code === CHAR_QUOTE) {
+      if (start === -1) {
+        start = i
+      }
+      if (inQuotes && text.charCodeAt(i + 1) === CHAR_QUOTE) {
+        // `""` inside quotes = escaped literal quote; consume both
+        i += 2
+        continue
+      }
+      inQuotes = !inQuotes
+      i++
+      continue
+    }
+
+    if (!inQuotes && isTokenSeparator(code)) {
+      if (start !== -1) {
+        tokens.push(text.slice(start, i))
+        start = -1
+      }
+      i++
+      continue
+    }
+
+    if (start === -1) {
+      start = i
+    }
+    i++
+  }
+
+  if (start !== -1) {
+    tokens.push(text.slice(start, len))
+  }
+
+  return tokens
 }
 
 export class SearchQuery {
@@ -21,9 +85,20 @@ export class SearchQuery {
     this.terms = terms
   }
 
-  matches (values) {
+  matches (fields) {
+    const allValues = Object.values(fields)
     for (const term of this.terms) {
-      const found = !!find(values, value => term.exact ? value === term.value : includes(value, term.value))
+      const values = getTermValues(fields, allValues, term.field)
+      const matchesTermValue = value => {
+        if (term.value === '') {
+          return value == null || value === ''
+        }
+        if (value == null || value === '') {
+          return false
+        }
+        return term.exact ? value === term.value : value.includes(term.value)
+      }
+      const found = values.some(matchesTermValue)
       if ((!found && !term.exclude) || (found && term.exclude)) {
         return false
       }
@@ -32,7 +107,13 @@ export class SearchQuery {
   }
 }
 
-export function parseSearch (text) {
+// Converts tokens into normalized search terms. Only fields listed in
+// `allowedFields` are treated as qualifiers; exclusions and quoted values become
+// flags on each term.
+export function parseSearch (text, allowedFields = []) {
+  const allowed = allowedFields instanceof Set
+    ? allowedFields
+    : new Set(allowedFields)
   const terms = []
   for (let value of tokenizeSearch(text)) {
     let exclude = false
@@ -40,14 +121,29 @@ export function parseSearch (text) {
       exclude = true
       value = value.substring(1)
     }
+
+    let field = null
+    const fieldMatch = fieldPrefixPattern.exec(value)
+    if (fieldMatch) {
+      const [
+        fieldPrefix, // e.g. `seed:`
+        fieldName, // e.g. `seed`
+      ] = fieldMatch
+      if (allowed.has(fieldName)) {
+        field = fieldName
+        value = value.substring(fieldPrefix.length)
+      }
+    }
+
     let exact = false
     const end = value.length - 1
-    if (value[0] === '"' && value[end] === '"') { // eslint-disable-line security/detect-object-injection
+    if (value[0] === '"' && value[end] === '"' && end >= 1) { // eslint-disable-line security/detect-object-injection -- numeric indexing into a string (not object property access); plugin false-positive
       exact = true
       value = value.substring(1, end).replace(/""/g, '"')
     }
-    if (value) {
+    if (value || field !== null) {
       terms.push({
+        field,
         value,
         exact,
         exclude,

--- a/frontend/src/composables/useTableFilter/index.js
+++ b/frontend/src/composables/useTableFilter/index.js
@@ -35,7 +35,8 @@ export function useTableFilter (options = {}) {
       return items.value
     }
 
-    return items.value.filter(item => filterFn(item, query))
+    const predicate = filterFn(query)
+    return items.value.filter(predicate)
   })
 
   return {

--- a/frontend/src/store/shoot/helper.js
+++ b/frontend/src/store/shoot/helper.js
@@ -171,6 +171,10 @@ export function getRawVal (context, item, column) {
       return get(spec, ['kubernetes', 'version'])
     case 'infrastructure':
       return `${get(spec, ['provider', 'type'])} ${get(spec, ['region'])}`
+    case 'provider':
+      return get(spec, ['provider', 'type'])
+    case 'region':
+      return get(spec, ['region'])
     case 'seed':
       return get(item, ['spec', 'seedName'])
     case 'ticketLabels': {
@@ -286,6 +290,19 @@ export function getSortVal (state, context, item, sortBy) {
   }
 }
 
+// Built-in fields addressable with `field:value` in the search.
+const QUALIFIED_SEARCH_FIELDS = Object.freeze([
+  'name',
+  'project',
+  'seed',
+  'purpose',
+  'infrastructure',
+  'provider',
+  'region',
+  'k8sVersion',
+  'createdBy',
+])
+
 export function searchItemsFn (state, context) {
   const {
     shootCustomFieldsComposable,
@@ -299,38 +316,29 @@ export function searchItemsFn (state, context) {
     return filter(shootCustomFields.value, ['searchable', true])
   })
 
-  let searchQuery
-  let searchQueryTerms = []
-  let lastSearch
+  return search => {
+    const searchQuery = parseSearch(search, QUALIFIED_SEARCH_FIELDS)
 
-  return (search, item) => {
-    if (search !== lastSearch) {
-      lastSearch = search
-      searchQuery = parseSearch(search)
-      searchQueryTerms = map(searchQuery.terms, 'value')
-    }
-
-    if (searchQueryTerms.includes('workerless')) {
-      if (getRawVal(context, item, 'workers') === 0) {
-        return true
+    return item => {
+      const fields = {
+        name: getRawVal(context, item, 'name'),
+        provider: getRawVal(context, item, 'provider'),
+        region: getRawVal(context, item, 'region'),
+        seed: getRawVal(context, item, 'seed'),
+        project: getRawVal(context, item, 'project'),
+        createdBy: getRawVal(context, item, 'createdBy'),
+        purpose: getRawVal(context, item, 'purpose'),
+        k8sVersion: getRawVal(context, item, 'k8sVersion'),
+        ticketLabels: getRawVal(context, item, 'ticketLabels'),
+        errorCodes: getRawVal(context, item, 'errorCodes'),
+        controlPlaneHighAvailability: getRawVal(context, item, 'controlPlaneHighAvailability'),
       }
+      Object.assign(fields, Object.fromEntries(
+        searchableCustomFields.value.map(({ key }) => [key, getRawVal(context, item, key)]),
+      ))
+
+      return searchQuery.matches(fields)
     }
-
-    const values = [
-      getRawVal(context, item, 'name'),
-      getRawVal(context, item, 'infrastructure'),
-      getRawVal(context, item, 'seed'),
-      getRawVal(context, item, 'project'),
-      getRawVal(context, item, 'createdBy'),
-      getRawVal(context, item, 'purpose'),
-      getRawVal(context, item, 'k8sVersion'),
-      getRawVal(context, item, 'ticketLabels'),
-      getRawVal(context, item, 'errorCodes'),
-      getRawVal(context, item, 'controlPlaneHighAvailability'),
-      ...map(searchableCustomFields.value, ({ key }) => getRawVal(context, item, key)),
-    ]
-
-    return searchQuery.matches(values)
   }
 }
 

--- a/frontend/src/store/shoot/helper.js
+++ b/frontend/src/store/shoot/helper.js
@@ -296,7 +296,6 @@ const QUALIFIED_SEARCH_FIELDS = Object.freeze([
   'project',
   'seed',
   'purpose',
-  'infrastructure',
   'provider',
   'region',
   'k8sVersion',

--- a/frontend/src/views/GSeedList.vue
+++ b/frontend/src/views/GSeedList.vue
@@ -269,26 +269,40 @@ function getManagedSeedShootName (item) {
   return managedSeedStore.shootNameForSeed(seedName)
 }
 
-function seedFilterFn (item, query) {
-  const conditions = get(item, ['status', 'conditions'], [])
-  const errorCodes = join(errorCodesFromArray(conditions), ' ')
-  const accessRestrictionNames = join(map(get(item, ['spec', 'accessRestrictions'], []), 'name'), ' ')
-  const shootName = getManagedSeedShootName(item) || 'Unmanaged'
+// Built-in fields addressable with `field:value` in the search.
+const QUALIFIED_SEARCH_FIELDS = Object.freeze([
+  'name',
+  'shoot',
+  'provider',
+  'region',
+  'k8sVersion',
+  'gardenerVersion',
+  'visibility',
+])
 
-  const searchableFields = [
-    get(item, ['metadata', 'name']),
-    shootName,
-    get(item, ['spec', 'provider', 'type']),
-    get(item, ['spec', 'provider', 'region']),
-    get(item, ['status', 'kubernetesVersion']),
-    get(item, ['status', 'gardener', 'version']),
-    get(item, ['spec', 'settings', 'scheduling', 'visible']) ? 'visible' : 'hidden',
-    errorCodes,
-    accessRestrictionNames,
-  ]
+function seedFilterFn (query) {
+  const searchQuery = parseSearch(query, QUALIFIED_SEARCH_FIELDS)
 
-  const searchQuery = parseSearch(query)
-  return searchQuery.matches(searchableFields)
+  return item => {
+    const conditions = get(item, ['status', 'conditions'], [])
+    const errorCodes = join(errorCodesFromArray(conditions), ' ')
+    const accessRestrictionNames = join(map(get(item, ['spec', 'accessRestrictions'], []), 'name'), ' ')
+    const shoot = getManagedSeedShootName(item) || 'Unmanaged'
+
+    const fields = {
+      name: get(item, ['metadata', 'name']),
+      shoot,
+      provider: get(item, ['spec', 'provider', 'type']),
+      region: get(item, ['spec', 'provider', 'region']),
+      k8sVersion: get(item, ['status', 'kubernetesVersion']),
+      gardenerVersion: get(item, ['status', 'gardener', 'version']),
+      visibility: get(item, ['spec', 'settings', 'scheduling', 'visible']) ? 'visible' : 'hidden',
+      errorCodes,
+      accessRestrictions: accessRestrictionNames,
+    }
+
+    return searchQuery.matches(fields)
+  }
 }
 
 const { filteredItems: filteredSeeds } = useTableFilter({

--- a/frontend/src/views/GShootList.vue
+++ b/frontend/src/views/GShootList.vue
@@ -647,7 +647,7 @@ export default {
     filteredItems () {
       const query = this.debouncedShootSearch
       return query
-        ? filter(this.items, item => this.searchItems(query, item))
+        ? filter(this.items, this.searchItems(query))
         : [...this.items]
     },
     sortedAndFilteredItems () {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area usability
/kind enhancement

**What this PR does / why we need it**:
Extends the shoot and seed list filters to support field-qualified search terms, e.g. `seed:aws-ha` or `-region:eu`.

Also fixes the search hint tooltip, which was sticking open while the field had focus — now shows on hover only (500 ms delay).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Support field-qualified search terms in shoot and seed list filters (e.g. `seed:aws-ha`, `-region:eu`).
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search now supports field-qualified queries (`field:value` via supported fields), quoted exact phrases, and negation.
  * Empty-value handling is more precise for field-specific and unqualified terms.

* **Bug Fixes**
  * Improved query parsing and matching for whitespace, tabs/newlines, and escaped quotes (including unterminated quotes).
  * Better results when certain fields are missing, null, non-strings, or boolean/numeric values.
  * Table search tooltip is now less intrusive (delayed and not opened on focus).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->