### PR TITLE
chore(yarn): drop obsolete @vue/test-utils peer extension

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -30,8 +30,6 @@ packageExtensions:
     dependencies:
       "@vue/compiler-dom": "*"
       "@vue/server-renderer": "*"
-    peerDependencies:
-      vue: "*"
   eslint-module-utils@*:
     dependencies:
       eslint-import-resolver-alias: "*"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
Removes the redundant `vue` peer dependency extension for `@vue/test-utils` from `.yarnrc.yml`. `@vue/test-utils@2.4.10` now declares `vue: 3.x` in its own package metadata, so the `packageExtensions` entry was no longer needed and caused Yarn warning `YN0069`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```other dependency
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package configuration for test tooling to use explicit renderer/compiler dependencies, helping keep development and test installs consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->