### PR TITLE
fix(sorting): include 'Error' state in status sort order

### DIFF
--- a/frontend/__tests__/composables/useTableSorting.spec.js
+++ b/frontend/__tests__/composables/useTableSorting.spec.js
@@ -126,6 +126,18 @@ describe('composables', () => {
         expect(value).toBe(200)
       })
 
+      it('should treat Error state as error', () => {
+        const value = getLastOperationSortVal({
+          operation: {
+            state: 'Error',
+            progress: 100,
+          },
+          lastErrors: [],
+        })
+
+        expect(value).toBe(0)
+      })
+
       it('should allow overriding user-error detection via callback', () => {
         const value = getLastOperationSortVal({
           operation: {

--- a/frontend/__tests__/stores/shoot.spec.js
+++ b/frontend/__tests__/stores/shoot.spec.js
@@ -118,7 +118,7 @@ describe('stores', () => {
         status: {
           lastOperation: {
             progress: 90,
-            state: 'Succeeded',
+            state: 'Processing',
           },
           conditions: [
             {

--- a/frontend/src/composables/useTableSorting/helper.js
+++ b/frontend/src/composables/useTableSorting/helper.js
@@ -63,7 +63,7 @@ export function getLastOperationSortVal ({
     metadata,
     status,
   })
-  const inProgress = operation.progress !== 100 && operation.state !== 'Failed' && !!operation.progress
+  const inProgress = operation.state === 'Processing'
 
   if (userError) {
     return inProgress

--- a/frontend/src/composables/useTableSorting/helper.js
+++ b/frontend/src/composables/useTableSorting/helper.js
@@ -48,7 +48,7 @@ export function getLastOperationSortVal ({
   status = {},
   isUserErrorFn = ({ lastErrors }) => isUserError(errorCodesFromArray(lastErrors)),
 }) {
-  const isError = operation.state === 'Failed' || lastErrors.length
+  const isError = operation.state === 'Failed' || operation.state === 'Error' || lastErrors.length
   const ignoredFromReconciliation = isReconciliationDeactivated(metadata)
 
   if (ignoredFromReconciliation) {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area quality
/kind bug

**What this PR does / why we need it**:
The `Error` state was missing from the status sort order in `useTableSorting`, causing items with an `Error` state to sort inconsistently.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```bugfix user
Fix status sort order to include the 'Error' state
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table sorting so items in an error state are ranked correctly, including cases with error details or empty error lists.
  * Updated sorting behavior for in-progress items to better reflect processing status.

* **Tests**
  * Added coverage for sorting items marked as error.
  * Adjusted mocked status data in store tests to match the updated sorting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->