### PR TITLE
feat(backend): enable weak ETags for non-API routes

### DIFF
--- a/backend/__tests__/acceptance/caching.spec.js
+++ b/backend/__tests__/acceptance/caching.spec.js
@@ -1,0 +1,126 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+} from 'vitest'
+import {
+  access,
+  mkdir,
+  rmdir,
+  unlink,
+  writeFile,
+} from 'fs/promises'
+import {
+  dirname,
+  join,
+  resolve,
+} from 'path'
+import { fileURLToPath } from 'url'
+import request from '@gardener-dashboard/request'
+
+const { mockRequest } = request
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const PUBLIC_FS_PATH = resolve(__dirname, '../../public')
+const INDEX_FILENAME = join(PUBLIC_FS_PATH, 'index.html')
+
+async function exists (filename) {
+  try {
+    await access(filename)
+    return true
+  } catch {
+    return false
+  }
+}
+
+describe('caching', function () {
+  let agent
+  let createdPublicDir = false
+  let createdIndex = false
+
+  beforeAll(async () => {
+    if (!await exists(PUBLIC_FS_PATH)) {
+      await mkdir(PUBLIC_FS_PATH, { recursive: true })
+      createdPublicDir = true
+    }
+    if (!await exists(INDEX_FILENAME)) {
+      await writeFile(INDEX_FILENAME, '<!doctype html><html><body>Gardener Dashboard</body></html>\n')
+      createdIndex = true
+    }
+
+    agent = await createAgent()
+  })
+
+  afterAll(async () => {
+    agent.close()
+    if (createdIndex) {
+      await unlink(INDEX_FILENAME).catch(() => undefined)
+    }
+    if (createdPublicDir) {
+      await rmdir(PUBLIC_FS_PATH).catch(() => undefined)
+    }
+  })
+
+  beforeEach(() => {
+    mockRequest.mockReset()
+  })
+
+  it('should set etag headers for the SPA fallback', async function () {
+    const res = await agent
+      .get('/login')
+      .set('accept', 'text/html')
+      .expect('content-type', /html/)
+      .expect(200)
+
+    expect(res.headers).toHaveProperty('etag')
+  })
+
+  it('should not set etag headers for api responses', async function () {
+    const res = await agent
+      .get('/api/info')
+      .expect('content-type', /json/)
+      .expect(401)
+
+    expect(res.headers).not.toHaveProperty('etag')
+  })
+
+  it('should not set etag headers for auth responses', async function () {
+    const user = fixtures.auth.createUser({ id: 'john.doe@example.org' })
+
+    mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewToken())
+    mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+    mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+
+    const res = await agent
+      .post('/auth')
+      .send({ token: await user.bearer })
+      .expect('content-type', /json/)
+      .expect(200)
+
+    expect(res.headers).not.toHaveProperty('etag')
+  })
+
+  it('should not set etag headers for webhook error responses', async function () {
+    const body = JSON.stringify({ foo: 1 })
+
+    const res = await agent
+      .post('/webhook')
+      .set('x-github-event', 'unknown_event')
+      .set('x-hub-signature-256', fixtures.github.createHubSignature(body))
+      .type('application/json')
+      .send(body)
+      .expect('content-type', /json/)
+      .expect(422)
+
+    expect(res.headers).not.toHaveProperty('etag')
+  })
+})

--- a/backend/lib/app.js
+++ b/backend/lib/app.js
@@ -70,6 +70,10 @@ if (gitHubRepoUrl) {
 
 // configure app
 const app = express()
+const apiApp = express()
+apiApp.set('etag', false)
+apiApp.use(apiRouter)
+
 app.set('port', port)
 app.set('metricsPort', metricsPort)
 app.set('tls', config.tls)
@@ -78,7 +82,7 @@ app.set('healthCheck', healthCheck)
 app.set('periodSeconds', periodSeconds)
 app.set('hooks', apiHooks)
 app.set('trust proxy', 1)
-app.set('etag', false)
+app.set('etag', 'weak')
 app.set('x-powered-by', false)
 
 app.use(helmet.xDnsPrefetchControl())
@@ -89,7 +93,7 @@ if (process.env.NODE_ENV !== 'development') {
 }
 app.use('/auth', authRouter)
 app.use('/webhook', githubWebhookRouter)
-app.use('/api', apiRouter)
+app.use('/api', apiApp)
 
 app.use(helmet.xXssProtection())
 app.use(helmet.contentSecurityPolicy({

--- a/backend/lib/app.js
+++ b/backend/lib/app.js
@@ -68,12 +68,14 @@ if (gitHubRepoUrl) {
   imgSrc.push(url.origin)
 }
 
-// configure app
 const app = express()
-const apiApp = express()
-apiApp.set('etag', false)
-apiApp.use(apiRouter)
 
+// configure express settings
+app.set('trust proxy', 1)
+app.set('etag', 'weak')
+app.set('x-powered-by', false)
+
+// configure custom app settings used by the server
 app.set('port', port)
 app.set('metricsPort', metricsPort)
 app.set('tls', config.tls)
@@ -81,9 +83,13 @@ app.set('logger', logger)
 app.set('healthCheck', healthCheck)
 app.set('periodSeconds', periodSeconds)
 app.set('hooks', apiHooks)
-app.set('trust proxy', 1)
-app.set('etag', 'weak')
-app.set('x-powered-by', false)
+
+// use a mounted app so /api can opt out of dynamic ETags while the main app keeps them for the SPA fallback
+const apiApp = express()
+apiApp.set('trust proxy', 1)
+apiApp.set('etag', false)
+apiApp.set('x-powered-by', false)
+apiApp.use(apiRouter)
 
 app.use(helmet.xDnsPrefetchControl())
 app.use(helmet.xPermittedCrossDomainPolicies())

--- a/backend/lib/app.js
+++ b/backend/lib/app.js
@@ -85,14 +85,14 @@ app.set('periodSeconds', periodSeconds)
 app.set('hooks', apiHooks)
 
 // use a mounted app so technical routes can opt out of dynamic ETags while the main app keeps them for the SPA fallback
-const technicalApp = express()
-technicalApp.set('trust proxy', 1)
-technicalApp.set('etag', false)
-technicalApp.set('x-powered-by', false)
-technicalApp.use('/auth', authRouter)
-technicalApp.use('/webhook', githubWebhookRouter)
-technicalApp.use('/api', apiRouter)
-technicalApp.use(renderError)
+const apiApp = express()
+apiApp.set('trust proxy', 1)
+apiApp.set('etag', false)
+apiApp.set('x-powered-by', false)
+apiApp.use('/auth', authRouter)
+apiApp.use('/webhook', githubWebhookRouter)
+apiApp.use('/api', apiRouter)
+apiApp.use(renderError)
 
 app.use(helmet.xDnsPrefetchControl())
 app.use(helmet.xPermittedCrossDomainPolicies())
@@ -100,7 +100,7 @@ app.use(helmet.xContentTypeOptions())
 if (process.env.NODE_ENV !== 'development') {
   app.use(helmet.strictTransportSecurity())
 }
-app.use(technicalApp)
+app.use(apiApp)
 
 app.use(helmet.xXssProtection())
 app.use(helmet.contentSecurityPolicy({

--- a/backend/lib/app.js
+++ b/backend/lib/app.js
@@ -84,12 +84,15 @@ app.set('healthCheck', healthCheck)
 app.set('periodSeconds', periodSeconds)
 app.set('hooks', apiHooks)
 
-// use a mounted app so /api can opt out of dynamic ETags while the main app keeps them for the SPA fallback
-const apiApp = express()
-apiApp.set('trust proxy', 1)
-apiApp.set('etag', false)
-apiApp.set('x-powered-by', false)
-apiApp.use(apiRouter)
+// use a mounted app so technical routes can opt out of dynamic ETags while the main app keeps them for the SPA fallback
+const technicalApp = express()
+technicalApp.set('trust proxy', 1)
+technicalApp.set('etag', false)
+technicalApp.set('x-powered-by', false)
+technicalApp.use('/auth', authRouter)
+technicalApp.use('/webhook', githubWebhookRouter)
+technicalApp.use('/api', apiRouter)
+technicalApp.use(renderError)
 
 app.use(helmet.xDnsPrefetchControl())
 app.use(helmet.xPermittedCrossDomainPolicies())
@@ -97,9 +100,7 @@ app.use(helmet.xContentTypeOptions())
 if (process.env.NODE_ENV !== 'development') {
   app.use(helmet.strictTransportSecurity())
 }
-app.use('/auth', authRouter)
-app.use('/webhook', githubWebhookRouter)
-app.use('/api', apiApp)
+app.use(technicalApp)
 
 app.use(helmet.xXssProtection())
 app.use(helmet.contentSecurityPolicy({


### PR DESCRIPTION
**How to categorize this PR?**
/area performance
/kind enhancement

**What this PR does / why we need it**:

Enables weak ETag generation on the main Express app so that static and non-API responses can benefit from conditional request caching (304 Not Modified). API routes are isolated into a dedicated sub-app with ETags explicitly disabled to preserve existing behavior for API consumers.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

A new `apiApp` Express instance is created solely to carry the `etag: false` setting and the API router. The main app switches from `etag: false` to `etag: 'weak'`, enabling conditional responses for everything outside `/api`.

**Release note**:
```bugfix user
The Gardener dashboard now sends ETag headers for SPA fallback responses such as /login. This improves browser cache validation and fixes an issue where rolling back to a previous dashboard version could make browsers reuse stale HTML that referenced assets no longer present on the server, causing 404 errors and failed page loads
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated HTTP caching behavior so SPA fallback responses include an `etag`, while API, auth, and webhook responses omit `etag` to avoid unintended caching.

* **Tests**
  * Added end-to-end acceptance coverage verifying `etag` header behavior across SPA, API, auth, and webhook flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->