### PR TITLE
chore(eslint): regenerate Yarn PnP SDK via yarn dlx @yarnpkg/sdks vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,7 +36,8 @@
     "**/.yarn/sdks/**": true,
     "**/.yarn/unplugged/**": true,
     "**/.yarn/versions/**": true,
-    "**/dist": true
+    "**/dist": true,
+    "**/.yarn": true
   },
   "eslint.nodePath": ".yarn/sdks",
   "files.exclude": {

--- a/.yarn/sdks/eslint/bin/eslint.js
+++ b/.yarn/sdks/eslint/bin/eslint.js
@@ -1,20 +1,32 @@
 #!/usr/bin/env node
 
 const {existsSync} = require(`fs`);
-const {createRequire} = require(`module`);
+const {createRequire, register} = require(`module`);
 const {resolve} = require(`path`);
+const {pathToFileURL} = require(`url`);
 
 const relPnpApiPath = "../../../../.pnp.cjs";
 
 const absPnpApiPath = resolve(__dirname, relPnpApiPath);
+const absUserWrapperPath = resolve(__dirname, `./sdk.user.cjs`);
 const absRequire = createRequire(absPnpApiPath);
+
+const absPnpLoaderPath = resolve(absPnpApiPath, `../.pnp.loader.mjs`);
+const isPnpLoaderEnabled = existsSync(absPnpLoaderPath);
 
 if (existsSync(absPnpApiPath)) {
   if (!process.versions.pnp) {
     // Setup the environment to be able to require eslint/bin/eslint.js
     require(absPnpApiPath).setup();
+    if (isPnpLoaderEnabled && register) {
+      register(pathToFileURL(absPnpLoaderPath));
+    }
   }
 }
 
+const wrapWithUserWrapper = existsSync(absUserWrapperPath)
+  ? exports => absRequire(absUserWrapperPath)(exports)
+  : exports => exports;
+
 // Defer to the real eslint/bin/eslint.js your application uses
-module.exports = absRequire(`eslint/bin/eslint.js`);
+module.exports = wrapWithUserWrapper(absRequire(`eslint/bin/eslint.js`));

--- a/.yarn/sdks/eslint/lib/config-api.js
+++ b/.yarn/sdks/eslint/lib/config-api.js
@@ -16,7 +16,7 @@ const isPnpLoaderEnabled = existsSync(absPnpLoaderPath);
 
 if (existsSync(absPnpApiPath)) {
   if (!process.versions.pnp) {
-    // Setup the environment to be able to require eslint
+    // Setup the environment to be able to require eslint/config
     require(absPnpApiPath).setup();
     if (isPnpLoaderEnabled && register) {
       register(pathToFileURL(absPnpLoaderPath));
@@ -28,5 +28,5 @@ const wrapWithUserWrapper = existsSync(absUserWrapperPath)
   ? exports => absRequire(absUserWrapperPath)(exports)
   : exports => exports;
 
-// Defer to the real eslint your application uses
-module.exports = wrapWithUserWrapper(absRequire(`eslint`));
+// Defer to the real eslint/config your application uses
+module.exports = wrapWithUserWrapper(absRequire(`eslint/config`));

--- a/.yarn/sdks/eslint/lib/types/config-api.d.ts
+++ b/.yarn/sdks/eslint/lib/types/config-api.d.ts
@@ -5,7 +5,7 @@ const {createRequire, register} = require(`module`);
 const {resolve} = require(`path`);
 const {pathToFileURL} = require(`url`);
 
-const relPnpApiPath = "../../../../.pnp.cjs";
+const relPnpApiPath = "../../../../../.pnp.cjs";
 
 const absPnpApiPath = resolve(__dirname, relPnpApiPath);
 const absUserWrapperPath = resolve(__dirname, `./sdk.user.cjs`);
@@ -16,7 +16,7 @@ const isPnpLoaderEnabled = existsSync(absPnpLoaderPath);
 
 if (existsSync(absPnpApiPath)) {
   if (!process.versions.pnp) {
-    // Setup the environment to be able to require eslint
+    // Setup the environment to be able to require eslint/config
     require(absPnpApiPath).setup();
     if (isPnpLoaderEnabled && register) {
       register(pathToFileURL(absPnpLoaderPath));
@@ -28,5 +28,5 @@ const wrapWithUserWrapper = existsSync(absUserWrapperPath)
   ? exports => absRequire(absUserWrapperPath)(exports)
   : exports => exports;
 
-// Defer to the real eslint your application uses
-module.exports = wrapWithUserWrapper(absRequire(`eslint`));
+// Defer to the real eslint/config your application uses
+module.exports = wrapWithUserWrapper(absRequire(`eslint/config`));

--- a/.yarn/sdks/eslint/lib/types/index.d.ts
+++ b/.yarn/sdks/eslint/lib/types/index.d.ts
@@ -5,7 +5,7 @@ const {createRequire, register} = require(`module`);
 const {resolve} = require(`path`);
 const {pathToFileURL} = require(`url`);
 
-const relPnpApiPath = "../../../../.pnp.cjs";
+const relPnpApiPath = "../../../../../.pnp.cjs";
 
 const absPnpApiPath = resolve(__dirname, relPnpApiPath);
 const absUserWrapperPath = resolve(__dirname, `./sdk.user.cjs`);

--- a/.yarn/sdks/eslint/lib/types/rules.d.ts
+++ b/.yarn/sdks/eslint/lib/types/rules.d.ts
@@ -5,7 +5,7 @@ const {createRequire, register} = require(`module`);
 const {resolve} = require(`path`);
 const {pathToFileURL} = require(`url`);
 
-const relPnpApiPath = "../../../../.pnp.cjs";
+const relPnpApiPath = "../../../../../.pnp.cjs";
 
 const absPnpApiPath = resolve(__dirname, relPnpApiPath);
 const absUserWrapperPath = resolve(__dirname, `./sdk.user.cjs`);
@@ -16,7 +16,7 @@ const isPnpLoaderEnabled = existsSync(absPnpLoaderPath);
 
 if (existsSync(absPnpApiPath)) {
   if (!process.versions.pnp) {
-    // Setup the environment to be able to require eslint
+    // Setup the environment to be able to require eslint/rules
     require(absPnpApiPath).setup();
     if (isPnpLoaderEnabled && register) {
       register(pathToFileURL(absPnpLoaderPath));
@@ -28,5 +28,5 @@ const wrapWithUserWrapper = existsSync(absUserWrapperPath)
   ? exports => absRequire(absUserWrapperPath)(exports)
   : exports => exports;
 
-// Defer to the real eslint your application uses
-module.exports = wrapWithUserWrapper(absRequire(`eslint`));
+// Defer to the real eslint/rules your application uses
+module.exports = wrapWithUserWrapper(absRequire(`eslint/rules`));

--- a/.yarn/sdks/eslint/lib/types/universal.d.ts
+++ b/.yarn/sdks/eslint/lib/types/universal.d.ts
@@ -5,7 +5,7 @@ const {createRequire, register} = require(`module`);
 const {resolve} = require(`path`);
 const {pathToFileURL} = require(`url`);
 
-const relPnpApiPath = "../../../../.pnp.cjs";
+const relPnpApiPath = "../../../../../.pnp.cjs";
 
 const absPnpApiPath = resolve(__dirname, relPnpApiPath);
 const absUserWrapperPath = resolve(__dirname, `./sdk.user.cjs`);
@@ -16,7 +16,7 @@ const isPnpLoaderEnabled = existsSync(absPnpLoaderPath);
 
 if (existsSync(absPnpApiPath)) {
   if (!process.versions.pnp) {
-    // Setup the environment to be able to require eslint
+    // Setup the environment to be able to require eslint/universal
     require(absPnpApiPath).setup();
     if (isPnpLoaderEnabled && register) {
       register(pathToFileURL(absPnpLoaderPath));
@@ -28,5 +28,5 @@ const wrapWithUserWrapper = existsSync(absUserWrapperPath)
   ? exports => absRequire(absUserWrapperPath)(exports)
   : exports => exports;
 
-// Defer to the real eslint your application uses
-module.exports = wrapWithUserWrapper(absRequire(`eslint`));
+// Defer to the real eslint/universal your application uses
+module.exports = wrapWithUserWrapper(absRequire(`eslint/universal`));

--- a/.yarn/sdks/eslint/lib/types/use-at-your-own-risk.d.ts
+++ b/.yarn/sdks/eslint/lib/types/use-at-your-own-risk.d.ts
@@ -5,7 +5,7 @@ const {createRequire, register} = require(`module`);
 const {resolve} = require(`path`);
 const {pathToFileURL} = require(`url`);
 
-const relPnpApiPath = "../../../../.pnp.cjs";
+const relPnpApiPath = "../../../../../.pnp.cjs";
 
 const absPnpApiPath = resolve(__dirname, relPnpApiPath);
 const absUserWrapperPath = resolve(__dirname, `./sdk.user.cjs`);
@@ -16,7 +16,7 @@ const isPnpLoaderEnabled = existsSync(absPnpLoaderPath);
 
 if (existsSync(absPnpApiPath)) {
   if (!process.versions.pnp) {
-    // Setup the environment to be able to require eslint
+    // Setup the environment to be able to require eslint/use-at-your-own-risk
     require(absPnpApiPath).setup();
     if (isPnpLoaderEnabled && register) {
       register(pathToFileURL(absPnpLoaderPath));
@@ -28,5 +28,5 @@ const wrapWithUserWrapper = existsSync(absUserWrapperPath)
   ? exports => absRequire(absUserWrapperPath)(exports)
   : exports => exports;
 
-// Defer to the real eslint your application uses
-module.exports = wrapWithUserWrapper(absRequire(`eslint`));
+// Defer to the real eslint/use-at-your-own-risk your application uses
+module.exports = wrapWithUserWrapper(absRequire(`eslint/use-at-your-own-risk`));

--- a/.yarn/sdks/eslint/lib/universal.js
+++ b/.yarn/sdks/eslint/lib/universal.js
@@ -16,7 +16,7 @@ const isPnpLoaderEnabled = existsSync(absPnpLoaderPath);
 
 if (existsSync(absPnpApiPath)) {
   if (!process.versions.pnp) {
-    // Setup the environment to be able to require eslint
+    // Setup the environment to be able to require eslint/universal
     require(absPnpApiPath).setup();
     if (isPnpLoaderEnabled && register) {
       register(pathToFileURL(absPnpLoaderPath));
@@ -28,5 +28,5 @@ const wrapWithUserWrapper = existsSync(absUserWrapperPath)
   ? exports => absRequire(absUserWrapperPath)(exports)
   : exports => exports;
 
-// Defer to the real eslint your application uses
-module.exports = wrapWithUserWrapper(absRequire(`eslint`));
+// Defer to the real eslint/universal your application uses
+module.exports = wrapWithUserWrapper(absRequire(`eslint/universal`));

--- a/.yarn/sdks/eslint/lib/unsupported-api.js
+++ b/.yarn/sdks/eslint/lib/unsupported-api.js
@@ -1,20 +1,32 @@
 #!/usr/bin/env node
 
 const {existsSync} = require(`fs`);
-const {createRequire} = require(`module`);
+const {createRequire, register} = require(`module`);
 const {resolve} = require(`path`);
+const {pathToFileURL} = require(`url`);
 
 const relPnpApiPath = "../../../../.pnp.cjs";
 
 const absPnpApiPath = resolve(__dirname, relPnpApiPath);
+const absUserWrapperPath = resolve(__dirname, `./sdk.user.cjs`);
 const absRequire = createRequire(absPnpApiPath);
+
+const absPnpLoaderPath = resolve(absPnpApiPath, `../.pnp.loader.mjs`);
+const isPnpLoaderEnabled = existsSync(absPnpLoaderPath);
 
 if (existsSync(absPnpApiPath)) {
   if (!process.versions.pnp) {
     // Setup the environment to be able to require eslint/use-at-your-own-risk
     require(absPnpApiPath).setup();
+    if (isPnpLoaderEnabled && register) {
+      register(pathToFileURL(absPnpLoaderPath));
+    }
   }
 }
 
+const wrapWithUserWrapper = existsSync(absUserWrapperPath)
+  ? exports => absRequire(absUserWrapperPath)(exports)
+  : exports => exports;
+
 // Defer to the real eslint/use-at-your-own-risk your application uses
-module.exports = absRequire(`eslint/use-at-your-own-risk`);
+module.exports = wrapWithUserWrapper(absRequire(`eslint/use-at-your-own-risk`));

--- a/.yarn/sdks/eslint/package.json
+++ b/.yarn/sdks/eslint/package.json
@@ -1,14 +1,31 @@
 {
   "name": "eslint",
-  "version": "8.50.0-sdk",
+  "version": "9.39.4-sdk",
   "main": "./lib/api.js",
   "type": "commonjs",
   "bin": {
     "eslint": "./bin/eslint.js"
   },
   "exports": {
+    ".": {
+      "types": "./lib/types/index.d.ts",
+      "default": "./lib/api.js"
+    },
+    "./config": {
+      "types": "./lib/types/config-api.d.ts",
+      "default": "./lib/config-api.js"
+    },
     "./package.json": "./package.json",
-    ".": "./lib/api.js",
-    "./use-at-your-own-risk": "./lib/unsupported-api.js"
+    "./use-at-your-own-risk": {
+      "types": "./lib/types/use-at-your-own-risk.d.ts",
+      "default": "./lib/unsupported-api.js"
+    },
+    "./rules": {
+      "types": "./lib/types/rules.d.ts"
+    },
+    "./universal": {
+      "types": "./lib/types/universal.d.ts",
+      "default": "./lib/universal.js"
+    }
   }
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:

Regenerates the Yarn PnP ESLint SDK shims (`.yarn/sdks/eslint/`) to match ESLint 9.

The SDK was pinned to ESLint 8.50.0 while the project uses ESLint 9. Without the PnP ESM loader hook registered in the SDK entry points, Node's bare ESM resolver failed to resolve packages (e.g. `locate-path`) from within Yarn zip archives, breaking the VS Code ESLint extension.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Generated by `yarn dlx @yarnpkg/sdks vscode` — no manual edits.

**Release note**:
```other developer
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated search exclusions to hide Yarn-generated files from workspace search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->