### PR TITLE
fix: share frontend development certificates

### DIFF
--- a/docs/development/local-setup.md
+++ b/docs/development/local-setup.md
@@ -95,7 +95,7 @@ yarn serve
 
 To start the frontend server, you have two options for handling the server certificate:
 
-1. **Recommended Method**: Run `yarn setup` in the frontend directory to generate a new self-signed CA and TLS server certificate before starting the frontend server for the first time. The CA is automatically added to the keychain on macOS. If you prefer not to add it to the keychain, you can use the `--skip-keychain` flag. For other operating systems, you will need to manually add the generated certificates to the local trust store.
+1. **Recommended Method**: Run `yarn setup` in the frontend directory to generate a new self-signed CA and TLS server certificate before starting the frontend server for the first time. The certificates are stored under `${HOME}/.gardener/dashboard/ssl` and shared by all local Gardener Dashboard repositories. The CA is automatically added to the keychain on macOS. If you prefer not to add it to the keychain, you can use the `--skip-keychain` flag. For other operating systems, you will need to manually add the generated certificates to the local trust store. Set `GARDENER_DASHBOARD_SSL_DIR` to an absolute path to use a different certificate directory.
 
 2. **Alternative Method**: If you prefer not to run `yarn setup`, a temporary self-signed certificate will be generated automatically. This certificate will not be added to the keychain. Note that you will need to click through the insecure warning in your browser to access the dashboard.
 

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -6,6 +6,8 @@
 
 import zlib from 'node:zlib'
 import { createRequire } from 'node:module'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
 import {
   readFileSync,
   existsSync,
@@ -175,8 +177,9 @@ export default defineConfig(({ command, mode }) => {
   }
 
   if (command === 'serve') {
-    const keyPath = resolve('./ssl/key.pem')
-    const certPath = resolve('./ssl/cert.pem')
+    const sslDirectory = process.env.GARDENER_DASHBOARD_SSL_DIR || join(homedir(), '.gardener', 'dashboard', 'ssl')
+    const keyPath = join(sslDirectory, 'key.pem')
+    const certPath = join(sslDirectory, 'cert.pem')
     const https = existsSync(keyPath) && existsSync(certPath)
       ? {
           key: readFileSync(keyPath),
@@ -186,7 +189,7 @@ export default defineConfig(({ command, mode }) => {
 
     if (https === true && mode === 'development') {
       // eslint-disable-next-line no-console
-      console.warn(YELLOW + 'WARNING:' + RESET + ' SSL key and certificate files are missing. We recommend running ' + WHITE_BLACK + 'yarn setup' + RESET + ' to generate certificate files and add the CA to the keychain.')
+      console.warn(YELLOW + 'WARNING:' + RESET + ' SSL key and certificate files are missing from ' + sslDirectory + '. We recommend running ' + WHITE_BLACK + 'yarn setup' + RESET + ' to generate shared certificate files and add the CA to the keychain.')
       config.plugins.push(basicSsl({
         name: 'vite-develpment-server',
         domains: ['localhost', '127.0.0.1'],

--- a/scripts/vite-server-setup.sh
+++ b/scripts/vite-server-setup.sh
@@ -5,14 +5,14 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-# Determine the directory of the script
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Ensure newly generated private keys are not accessible by other users
+umask 077
 
-# Define the SSL directory relative to the script directory
-SSL_DIR="${SCRIPT_DIR}/../frontend/ssl"
+SSL_DIR="${GARDENER_DASHBOARD_SSL_DIR:-${HOME}/.gardener/dashboard/ssl}"
 
 # Create the SSL directory
 mkdir -p "${SSL_DIR}"
+chmod 700 "${SSL_DIR}"
 
 # Create the req.cnf file in the SSL directory
 cat << EOF > "${SSL_DIR}/req.cnf"
@@ -46,6 +46,7 @@ openssl req -x509 -new -nodes -key "${SSL_DIR}/ca-key.pem" -days 3650 -out "${SS
 openssl genrsa -out "${SSL_DIR}/key.pem" 2048
 openssl req -new -key "${SSL_DIR}/key.pem" -out "${SSL_DIR}/csr.pem" -subj "/CN=gardener-dashboard-server" -config "${SSL_DIR}/req.cnf"
 openssl x509 -req -in "${SSL_DIR}/csr.pem" -CA "${SSL_DIR}/ca.pem" -CAkey "${SSL_DIR}/ca-key.pem" -CAcreateserial -out "${SSL_DIR}/cert.pem" -days 3650 -extensions v3_req -extfile "${SSL_DIR}/req.cnf"
+chmod 600 "${SSL_DIR}/ca-key.pem" "${SSL_DIR}/key.pem"
 
 # Parse command line arguments
 SKIP_KEYCHAIN=false


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area quality
  /area usability
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|cost|dev-productivity|documentation|high-availability|logging|monitoring|networking|open-source|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind bug
/label crypto

**What this PR does / why we need it**:
Frontend development certificates are currently stored inside each repository checkout. Each checkout therefore generates a different CA with the same name and replaces the trusted macOS keychain entry, potentially invalidating certificates from other local Dashboard repositories.

This change stores the certificates under `${HOME}/.gardener/dashboard/ssl`, allows overriding the directory with `GARDENER_DASHBOARD_SSL_DIR`, and restricts access to the directory and private keys.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:
Validated with `make verify` and targeted certificate-chain, SAN, permissions, and Vite-loading checks. Developers need to run `yarn setup` once to populate the shared directory.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Frontend development TLS certificates generated by `yarn setup` are now shared across local Dashboard repositories.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded local development setup instructions for generating TLS certificates.
  * Added details about certificate storage, sharing across local repositories, macOS keychain integration, and the option to skip keychain setup.
  * Documented how to customize the certificate directory.

* **Bug Fixes**
  * Improved local HTTPS certificate discovery and setup.
  * Enhanced certificate file protection to help keep private keys secure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->