### PR TITLE
refactor(dashboard): redesign and unify detail tooltips

### DIFF
--- a/frontend/__tests__/components/GDetailTooltip.spec.js
+++ b/frontend/__tests__/components/GDetailTooltip.spec.js
@@ -41,6 +41,13 @@ describe('components', () => {
       expect(wrapper.find('.detail-tooltip-footer').exists()).toBe(false)
     })
 
+    it('should omit the body container when no body content is provided', () => {
+      const wrapper = mountComponent()
+
+      expect(wrapper.find('.detail-tooltip-heading').text()).toBe('Details')
+      expect(wrapper.find('.detail-tooltip-body').exists()).toBe(false)
+    })
+
     it('should render optional activator and footer slots', () => {
       const wrapper = mountComponent({}, {
         activator: '<button class="activator">Open</button>',

--- a/frontend/__tests__/components/GDetailTooltip.spec.js
+++ b/frontend/__tests__/components/GDetailTooltip.spec.js
@@ -1,0 +1,72 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import { shallowMount } from '@vue/test-utils'
+
+import GDetailTooltip from '@/components/GDetailTooltip.vue'
+
+describe('components', () => {
+  describe('g-detail-tooltip', () => {
+    function mountComponent (props = {}, slots = {}) {
+      return shallowMount(GDetailTooltip, {
+        props: {
+          title: 'Details',
+          ...props,
+        },
+        slots,
+        global: {
+          stubs: {
+            'v-tooltip': {
+              props: ['activator'],
+              template: '<div class="tooltip" :data-activator="activator"><slot name="activator" :props="{}" /><slot /></div>',
+            },
+            'v-card': {
+              template: '<div><slot /></div>',
+            },
+          },
+        },
+      })
+    }
+
+    it('should render a title and body content', () => {
+      const wrapper = mountComponent({}, {
+        default: '<span class="body-content">Body</span>',
+      })
+
+      expect(wrapper.find('.detail-tooltip-heading').text()).toBe('Details')
+      expect(wrapper.find('.body-content').text()).toBe('Body')
+      expect(wrapper.find('.detail-tooltip-footer').exists()).toBe(false)
+    })
+
+    it('should render optional activator and footer slots', () => {
+      const wrapper = mountComponent({}, {
+        activator: '<button class="activator">Open</button>',
+        footer: '<span class="footer-content">Explanation</span>',
+      })
+
+      expect(wrapper.find('.activator').exists()).toBe(true)
+      expect(wrapper.find('.footer-content').text()).toBe('Explanation')
+    })
+
+    it('should accept positive card widths only', () => {
+      const validator = GDetailTooltip.props.width.validator
+
+      expect(validator(320)).toBe(true)
+      expect(validator(0)).toBe(false)
+      expect(validator(-1)).toBe(false)
+    })
+
+    it('should enable hover activation by default', () => {
+      expect(GDetailTooltip.props.openOnHover.default).toBe(true)
+    })
+
+    it('should support using the parent element as activator', () => {
+      const wrapper = mountComponent({ activator: 'parent' })
+
+      expect(wrapper.find('.tooltip').attributes('data-activator')).toBe('parent')
+    })
+  })
+})

--- a/frontend/__tests__/components/GProjectTooltip.spec.js
+++ b/frontend/__tests__/components/GProjectTooltip.spec.js
@@ -1,0 +1,112 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import { shallowMount } from '@vue/test-utils'
+import { createPinia } from 'pinia'
+import { h } from 'vue'
+
+import GProjectTooltip from '@/components/GProjectTooltip.vue'
+
+describe('components', () => {
+  describe('g-project-tooltip', () => {
+    const project = {
+      metadata: {
+        name: 'example-project',
+        creationTimestamp: '2026-07-01T12:00:00Z',
+        annotations: {
+          'dashboard.gardener.cloud/project-title': 'Example title',
+        },
+      },
+      spec: {
+        createdBy: { name: 'creator@example.com' },
+        description: 'Example description',
+        owner: { name: 'owner@example.com' },
+        purpose: 'evaluation',
+      },
+    }
+
+    function mountComponent (props = {}, slots = {}) {
+      return shallowMount(GProjectTooltip, {
+        props: {
+          project,
+          ...props,
+        },
+        slots: {
+          default: '<span class="activator-content">Example project</span>',
+          ...slots,
+        },
+        global: {
+          plugins: [createPinia()],
+          stubs: {
+            GDetailTooltip: {
+              props: ['activator'],
+              template: '<div class="detail-tooltip" :data-activator="activator"><slot name="activator" :props="{ \'data-tooltip-activator\': \'true\' }" /><slot /><slot name="footer" /></div>',
+            },
+            GAccountAvatar: {
+              props: ['accountName'],
+              template: '<span class="account-avatar">{{ accountName }}</span>',
+            },
+            GTimeString: {
+              template: '<span class="time-string" />',
+            },
+          },
+        },
+      })
+    }
+
+    it('should render project details and creation metadata', () => {
+      const wrapper = mountComponent()
+
+      expect(wrapper.find('.activator-content').text()).toBe('Example project')
+      expect(wrapper.find('.project-tooltip-activator').attributes('data-tooltip-activator')).toBe('true')
+      expect(wrapper.find('.project-tooltip-activator').attributes('tabindex')).toBe('0')
+      expect(wrapper.find('.detail-tooltip').attributes('data-activator')).toBeUndefined()
+      expect(wrapper.find('.project-details').text()).toContain('Nameexample-project')
+      expect(wrapper.find('.project-details').text()).toContain('TitleExample title')
+      expect(wrapper.find('.project-details').text()).toContain('DescriptionExample description')
+      expect(wrapper.find('.project-details').text()).toContain('Ownerowner@example.com')
+      expect(wrapper.find('.project-details').text()).toContain('Purposeevaluation')
+      expect(wrapper.find('.project-metadata').text()).toContain('Created bycreator@example.com')
+      expect(wrapper.find('.time-string').exists()).toBe(true)
+    })
+
+    it('should omit optional project details when empty', () => {
+      const wrapper = mountComponent({
+        project: {
+          metadata: {
+            name: 'minimal-project',
+            creationTimestamp: '2026-07-01T12:00:00Z',
+          },
+          spec: {},
+        },
+      })
+
+      expect(wrapper.find('.project-details').text()).toContain('Nameminimal-project')
+      expect(wrapper.find('.project-details').text()).not.toContain('Title')
+      expect(wrapper.find('.project-details').text()).not.toContain('Description')
+      expect(wrapper.find('.project-details').text()).not.toContain('Purpose')
+    })
+
+    it('should allow the activator to be controlled by the consumer', () => {
+      const wrapper = mountComponent({}, {
+        activator: ({ props }) => h('button', {
+          ...props,
+          class: 'external-activator',
+        }, 'Example project'),
+      })
+
+      expect(wrapper.find('.external-activator').attributes('data-tooltip-activator')).toBe('true')
+      expect(wrapper.find('.detail-tooltip').attributes('data-activator')).toBeUndefined()
+    })
+
+    it('should forward an explicit activator', () => {
+      const wrapper = mountComponent({ activator: '#project-row' })
+
+      expect(wrapper.find('.detail-tooltip').attributes('data-activator')).toBe('#project-row')
+      expect(wrapper.find('.activator-content').exists()).toBe(false)
+    })
+  })
+})

--- a/frontend/__tests__/components/GSeedCapacityIndicator.spec.js
+++ b/frontend/__tests__/components/GSeedCapacityIndicator.spec.js
@@ -58,14 +58,20 @@ describe('components', () => {
       )
     })
 
-    it('should never report negative remaining capacity', () => {
+    it('should report overcommitment while capping the progress bars', () => {
       const wrapper = mountComponent({
         shootCount: 12,
         allocatableShoots: 10,
       })
 
-      expect(wrapper.find('.capacity-summary').text()).toContain('100% used')
+      expect(wrapper.find('.capacity-summary').text()).toContain('120% used')
       expect(wrapper.find('.capacity-summary').text()).toContain('0 remaining')
+      expect(wrapper.find('.activator').attributes('aria-label')).toContain('(120%)')
+      const progressBars = wrapper.findAll('v-progress-linear-stub')
+      expect(progressBars).toHaveLength(2)
+      for (const progressBar of progressBars) {
+        expect(progressBar.attributes('modelvalue')).toBe('100')
+      }
     })
   })
 })

--- a/frontend/__tests__/components/GSeedCapacityIndicator.spec.js
+++ b/frontend/__tests__/components/GSeedCapacityIndicator.spec.js
@@ -1,0 +1,71 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import { shallowMount } from '@vue/test-utils'
+
+import GSeedCapacityIndicator from '@/components/Seeds/GSeedCapacityIndicator.vue'
+
+const { createVuetifyPlugin } = global.fixtures.helper
+
+describe('components', () => {
+  describe('g-seed-capacity-indicator', () => {
+    const vuetifyPlugin = createVuetifyPlugin()
+
+    function mountComponent (props = {}) {
+      return shallowMount(GSeedCapacityIndicator, {
+        props,
+        global: {
+          plugins: [vuetifyPlugin],
+          stubs: {
+            GDetailTooltip: {
+              template: '<div><slot /><div v-if="$slots.footer" class="detail-tooltip-footer"><slot name="footer" /></div></div>',
+            },
+            RouterLink: {
+              props: ['to'],
+              template: '<a class="router-link-stub"><slot /></a>',
+            },
+            'v-icon': true,
+            'v-progress-linear': true,
+          },
+        },
+      })
+    }
+
+    it('should present capacity as compact, aligned metrics', () => {
+      const wrapper = mountComponent({
+        shootCount: 26,
+        allocatableShoots: 250,
+      })
+
+      const rows = wrapper.findAll('.metric-row')
+      expect(rows).toHaveLength(2)
+      expect(rows[0].text()).toContain('Assigned shoots26')
+      expect(rows[1].text()).toContain('Allocatable shoots250')
+      expect(wrapper.find('.capacity-summary').text()).toContain('10% used')
+      expect(wrapper.find('.capacity-summary').text()).toContain('224 remaining')
+    })
+
+    it('should explain when allocatable capacity is unknown', () => {
+      const wrapper = mountComponent({ shootCount: 26 })
+
+      expect(wrapper.findAll('.metric-row')[1].text()).toContain('Unknown')
+      expect(wrapper.find('.capacity-summary').exists()).toBe(false)
+      expect(wrapper.find('.detail-tooltip-footer').text()).toBe(
+        'This seed does not report its allocatable shoot capacity.',
+      )
+    })
+
+    it('should never report negative remaining capacity', () => {
+      const wrapper = mountComponent({
+        shootCount: 12,
+        allocatableShoots: 10,
+      })
+
+      expect(wrapper.find('.capacity-summary').text()).toContain('100% used')
+      expect(wrapper.find('.capacity-summary').text()).toContain('0 remaining')
+    })
+  })
+})

--- a/frontend/__tests__/components/GShootHealthDonut.spec.js
+++ b/frontend/__tests__/components/GShootHealthDonut.spec.js
@@ -8,40 +8,33 @@ import { shallowMount } from '@vue/test-utils'
 
 import GShootHealthDonut from '@/components/GShootHealthDonut.vue'
 
+const { createVuetifyPlugin } = global.fixtures.helper
+
 describe('components', () => {
   describe('g-shoot-health-donut', () => {
+    const vuetifyPlugin = createVuetifyPlugin()
+
     function mountComponent (props = {}) {
       return shallowMount(GShootHealthDonut, {
         props,
         global: {
+          plugins: [vuetifyPlugin],
           stubs: {
-            'v-tooltip': {
-              template: '<div><slot name="activator" :props="{}" /><slot /></div>',
+            GDetailTooltip: {
+              template: '<div><slot /><slot name="footer" /></div>',
             },
             'v-card': {
               template: '<div><slot /></div>',
             },
             'v-icon': true,
-            'v-list': {
-              template: '<div class="v-list-stub"><slot /></div>',
-            },
-            'v-list-item': {
-              template: '<div class="v-list-item-stub"><slot name="prepend" /><slot /></div>',
-            },
-            'v-list-item-title': {
-              template: '<span class="v-list-item-title-stub"><slot /></span>',
-            },
-            'v-list-item-subtitle': {
-              template: '<span class="v-list-item-subtitle-stub"><slot /></span>',
-            },
           },
         },
       })
     }
 
     function findRow (wrapper, label) {
-      return wrapper.findAll('.v-list-item-stub').find(item => {
-        return item.find('.v-list-item-subtitle-stub').text().startsWith(label)
+      return wrapper.findAll('.health-row').find(item => {
+        return item.find('span').text() === label
       })
     }
 
@@ -49,15 +42,15 @@ describe('components', () => {
       it('should show a dash when shootCount is 0', () => {
         const wrapper = mountComponent({ shootCount: 0 })
 
-        expect(wrapper.find('.empty').exists()).toBe(true)
-        expect(wrapper.find('.empty').text()).toBe('-')
+        expect(wrapper.find('.text-medium-emphasis').exists()).toBe(true)
+        expect(wrapper.find('.text-medium-emphasis').text()).toBe('-')
         expect(wrapper.find('svg').exists()).toBe(false)
       })
 
       it('should show a dash when shootCount is not provided', () => {
         const wrapper = mountComponent()
 
-        expect(wrapper.find('.empty').exists()).toBe(true)
+        expect(wrapper.find('.text-medium-emphasis').exists()).toBe(true)
       })
     })
 
@@ -217,9 +210,9 @@ describe('components', () => {
 
         const unhealthy = findRow(wrapper, 'Unhealthy')
         expect(unhealthy).toBeDefined()
-        expect(unhealthy.find('.v-list-item-title-stub').text()).toBe('5')
+        expect(unhealthy.find('strong').text()).toBe('5')
 
-        const excluded = findRow(wrapper, 'Excluded')
+        const excluded = findRow(wrapper, 'Unhealthy filtered out')
         expect(excluded).toBeUndefined()
       })
 
@@ -231,13 +224,13 @@ describe('components', () => {
           activeFilterLabels: ['User Errors', 'Progressing'],
         })
 
-        const unhealthy = findRow(wrapper, 'Unhealthy')
-        expect(unhealthy.find('.v-list-item-title-stub').text()).toBe('2')
+        const unhealthy = findRow(wrapper, 'Unhealthy shown')
+        expect(unhealthy.find('strong').text()).toBe('2')
 
-        const excluded = findRow(wrapper, 'Excluded')
+        const excluded = findRow(wrapper, 'Unhealthy filtered out')
         expect(excluded).toBeDefined()
-        expect(excluded.find('.v-list-item-title-stub').text()).toBe('3')
-        expect(excluded.find('.v-list-item-subtitle-stub').text()).toContain('User Errors, Progressing')
+        expect(excluded.find('strong').text()).toBe('3')
+        expect(wrapper.find('.filter-summary').text()).toContain('User Errors, Progressing')
       })
 
       it('should truncate filter labels after 2 with "& N more"', () => {
@@ -248,9 +241,9 @@ describe('components', () => {
           activeFilterLabels: ['Progressing', 'User Errors', 'Deactivated Reconciliation', 'Ignored Ticket Labels'],
         })
 
-        const excluded = findRow(wrapper, 'Excluded')
-        expect(excluded.find('.v-list-item-title-stub').text()).toBe('6')
-        expect(excluded.find('.v-list-item-subtitle-stub').text()).toContain('Progressing, User Errors & 2 more')
+        const excluded = findRow(wrapper, 'Unhealthy filtered out')
+        expect(excluded.find('strong').text()).toBe('6')
+        expect(wrapper.find('.filter-summary').text()).toContain('Progressing, User Errors & 2 more')
       })
 
       it('should not show excluded row when no filter labels provided', () => {
@@ -260,7 +253,7 @@ describe('components', () => {
           matchingUnhealthyShoots: 2,
         })
 
-        const excluded = findRow(wrapper, 'Excluded')
+        const excluded = findRow(wrapper, 'Unhealthy filtered out')
         expect(excluded).toBeUndefined()
       })
 
@@ -272,10 +265,10 @@ describe('components', () => {
           activeFilterLabels: ['Progressing'],
         })
 
-        const excluded = findRow(wrapper, 'Excluded')
+        const excluded = findRow(wrapper, 'Unhealthy filtered out')
         expect(excluded).toBeDefined()
-        expect(excluded.find('.v-list-item-title-stub').text()).toBe('0')
-        expect(excluded.find('.v-list-item-subtitle-stub').text()).toContain('Progressing')
+        expect(excluded.find('strong').text()).toBe('0')
+        expect(wrapper.find('.filter-summary').text()).toContain('Progressing')
       })
 
       it('should show healthy legend when there are healthy shoots', () => {
@@ -287,7 +280,7 @@ describe('components', () => {
 
         const healthy = findRow(wrapper, 'Healthy')
         expect(healthy).toBeDefined()
-        expect(healthy.find('.v-list-item-title-stub').text()).toBe('7')
+        expect(healthy.find('strong').text()).toBe('7')
       })
     })
 
@@ -304,8 +297,8 @@ describe('components', () => {
 
         expect(label).toContain('Shoot health distribution')
         expect(label).toContain('10 shoots')
-        expect(label).toContain('1 unhealthy shoots')
-        expect(label).toContain('2 excluded by filter (User Errors)')
+        expect(label).toContain('1 unhealthy shoot')
+        expect(label).toContain('2 unhealthy shoots excluded by Cluster Operations filters (User Errors)')
         expect(label).toContain('7 healthy shoots')
       })
     })

--- a/frontend/__tests__/components/GShootHealthDonut.spec.js
+++ b/frontend/__tests__/components/GShootHealthDonut.spec.js
@@ -295,11 +295,13 @@ describe('components', () => {
 
         const label = wrapper.attributes('aria-label')
 
-        expect(label).toContain('Shoot health distribution')
-        expect(label).toContain('10 shoots')
-        expect(label).toContain('1 unhealthy shoot')
-        expect(label).toContain('2 unhealthy shoots excluded by Cluster Operations filters (User Errors)')
-        expect(label).toContain('7 healthy shoots')
+        expect(label).toBe([
+          'Shoot health distribution',
+          '10 shoots',
+          '1 unhealthy shoot',
+          '2 unhealthy shoots excluded by Cluster Operations filters (User Errors)',
+          '7 healthy shoots.',
+        ].join(', '))
       })
     })
 

--- a/frontend/__tests__/components/GStatusTag.spec.js
+++ b/frontend/__tests__/components/GStatusTag.spec.js
@@ -34,7 +34,7 @@ describe('components', () => {
     let authzStore
     let mockGetSubjectRules
 
-    function mountStatusTag (condition) {
+    function mountStatusTag (condition, props = {}) {
       return mount(GStatusTag, {
         global: {
           plugins: [
@@ -44,6 +44,7 @@ describe('components', () => {
         },
         props: {
           condition,
+          ...props,
         },
       })
     }
@@ -82,6 +83,18 @@ describe('components', () => {
       expect(vm.color).toBe('primary')
       expect(vm.visible).toBe(true)
       expect(vm.chipAriaLabel).toBe('foo-bar: Healthy')
+    })
+
+    it('should qualify a stale condition in the accessible label', () => {
+      const wrapper = mountStatusTag({
+        shortName: 'foo',
+        name: 'foo-bar',
+        status: 'True',
+      }, {
+        staleShoot: true,
+      })
+
+      expect(wrapper.vm.chipAriaLabel).toBe('foo-bar: Last status: Healthy')
     })
 
     it('should render condition with user error', () => {

--- a/frontend/__tests__/components/GStatusTag.spec.js
+++ b/frontend/__tests__/components/GStatusTag.spec.js
@@ -81,6 +81,7 @@ describe('components', () => {
       expect(vm.isError || vm.isUnknown || vm.isProgressing).toBe(false)
       expect(vm.color).toBe('primary')
       expect(vm.visible).toBe(true)
+      expect(vm.chipAriaLabel).toBe('foo-bar: Healthy')
     })
 
     it('should render condition with user error', () => {

--- a/frontend/__tests__/components/GStatusTagTooltip.spec.js
+++ b/frontend/__tests__/components/GStatusTagTooltip.spec.js
@@ -25,8 +25,8 @@ describe('components', () => {
           plugins: [vuetifyPlugin],
           stubs: {
             GDetailTooltip: {
-              props: ['activator'],
-              template: '<div :data-activator="activator"><div class="body"><slot /></div><div class="footer"><slot name="footer" /></div></div>',
+              props: ['activator', 'title'],
+              template: '<div :data-activator="activator"><div class="heading">{{ title }}</div><div v-if="$slots.default" class="body"><slot /></div><div v-if="$slots.footer" class="footer"><slot name="footer" /></div></div>',
             },
             'v-icon': true,
           },
@@ -47,7 +47,15 @@ describe('components', () => {
       })
 
       expect(wrapper.find('.status-description').text()).toBe('The API server is available.')
-      expect(wrapper.find('.footer').text()).toBe('')
+      expect(wrapper.find('.footer').exists()).toBe(false)
+    })
+
+    it('should render only the full condition name when no details are configured', () => {
+      const wrapper = mountComponent()
+
+      expect(wrapper.find('.heading').text()).toBe('API Server')
+      expect(wrapper.find('.body').exists()).toBe(false)
+      expect(wrapper.find('.footer').exists()).toBe(false)
     })
 
     it('should render user error summaries', () => {

--- a/frontend/__tests__/components/GStatusTagTooltip.spec.js
+++ b/frontend/__tests__/components/GStatusTagTooltip.spec.js
@@ -1,0 +1,65 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import { shallowMount } from '@vue/test-utils'
+
+import GStatusTagTooltip from '@/components/GStatusTagTooltip.vue'
+
+const { createVuetifyPlugin } = global.fixtures.helper
+
+describe('components', () => {
+  describe('g-status-tag-tooltip', () => {
+    const vuetifyPlugin = createVuetifyPlugin()
+
+    function mountComponent (props = {}, slots = {}) {
+      return shallowMount(GStatusTagTooltip, {
+        props: {
+          title: 'API Server',
+          ...props,
+        },
+        slots,
+        global: {
+          plugins: [vuetifyPlugin],
+          stubs: {
+            GDetailTooltip: {
+              props: ['activator'],
+              template: '<div :data-activator="activator"><div class="body"><slot /></div><div class="footer"><slot name="footer" /></div></div>',
+            },
+            'v-icon': true,
+          },
+        },
+      })
+    }
+
+    it('should forward a parent activator prop without wrapping', () => {
+      const wrapper = mountComponent({ activator: 'parent' })
+
+      expect(wrapper.find('[data-activator="parent"]').exists()).toBe(true)
+      expect(wrapper.find('.activator').exists()).toBe(false)
+    })
+
+    it('should render a description in the body when there are no user errors', () => {
+      const wrapper = mountComponent({
+        description: 'The API server is available.',
+      })
+
+      expect(wrapper.find('.status-description').text()).toBe('The API server is available.')
+      expect(wrapper.find('.footer').text()).toBe('')
+    })
+
+    it('should render user error summaries', () => {
+      const wrapper = mountComponent({
+        description: 'The API server is available.',
+        userErrors: [{ shortDescription: 'Configuration problem' }],
+      })
+
+      expect(wrapper.find('.user-error-row').text()).toContain('Configuration problem')
+      expect(wrapper.find('.user-error-row v-icon-stub').attributes('icon')).toBe('mdi-account-alert-outline')
+      expect(wrapper.find('.status-description').exists()).toBe(false)
+      expect(wrapper.find('.footer').text()).toBe('The API server is available.')
+    })
+  })
+})

--- a/frontend/src/components/Credentials/GCredentialRowDns.vue
+++ b/frontend/src/components/Credentials/GCredentialRowDns.vue
@@ -18,6 +18,7 @@ SPDX-License-Identifier: Apache-2.0
     <td v-if="selectedHeaders.dnsProvider">
       <g-vendor
         extended
+        tooltip-title="DNS"
         :provider-type="item.providerType"
       />
     </td>

--- a/frontend/src/components/GDetailTooltip.vue
+++ b/frontend/src/components/GDetailTooltip.vue
@@ -1,0 +1,104 @@
+<!--
+SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+<template>
+  <v-tooltip
+    :activator="activator"
+    :location="location"
+    :open-delay="openDelay"
+    :open-on-hover="openOnHover"
+    :disabled="disabled"
+    content-class="pa-0"
+    :content-props="{ style: { background: 'transparent' } }"
+  >
+    <template
+      v-if="$slots.activator"
+      #activator="{ props: activatorProps }"
+    >
+      <slot
+        name="activator"
+        :props="activatorProps"
+      />
+    </template>
+    <v-card
+      class="detail-tooltip-card"
+      :style="{ '--g-detail-tooltip-width': width + 'px' }"
+      elevation="12"
+    >
+      <div class="detail-tooltip-heading">
+        {{ title }}
+      </div>
+      <div class="detail-tooltip-body">
+        <slot />
+      </div>
+      <div
+        v-if="$slots.footer"
+        class="detail-tooltip-footer text-medium-emphasis"
+      >
+        <slot name="footer" />
+      </div>
+    </v-card>
+  </v-tooltip>
+</template>
+
+<script setup>
+defineProps({
+  title: {
+    type: String,
+    required: true,
+  },
+  activator: {
+    type: [String, Object],
+  },
+  location: {
+    type: String,
+    default: 'top',
+  },
+  openDelay: {
+    type: Number,
+    default: 200,
+  },
+  openOnHover: {
+    type: Boolean,
+    default: true,
+  },
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+  width: {
+    type: Number,
+    default: 280,
+    validator: value => value > 0,
+  },
+})
+</script>
+
+<style lang="scss" scoped>
+  .detail-tooltip-card {
+    width: min(var(--g-detail-tooltip-width), calc(100vw - 24px));
+  }
+
+  .detail-tooltip-heading {
+    font-size: 0.875rem;
+    font-weight: 600;
+    padding: 12px 16px 4px;
+  }
+
+  .detail-tooltip-body {
+    display: grid;
+    gap: 10px;
+    padding: 8px 16px 14px;
+  }
+
+  .detail-tooltip-footer {
+    border-top: 1px solid rgba(var(--v-theme-on-surface), 0.12);
+    font-size: 0.75rem;
+    line-height: 1.4;
+    margin: 0 16px;
+    padding: 10px 0 14px;
+  }
+</style>

--- a/frontend/src/components/GDetailTooltip.vue
+++ b/frontend/src/components/GDetailTooltip.vue
@@ -31,7 +31,10 @@ SPDX-License-Identifier: Apache-2.0
       <div class="detail-tooltip-heading">
         {{ title }}
       </div>
-      <div class="detail-tooltip-body">
+      <div
+        v-if="$slots.default"
+        class="detail-tooltip-body"
+      >
         <slot />
       </div>
       <div

--- a/frontend/src/components/GProjectTooltip.vue
+++ b/frontend/src/components/GProjectTooltip.vue
@@ -5,84 +5,111 @@ SPDX-License-Identifier: Apache-2.0
 -->
 
 <template>
-  <!-- we make the tooltip background transparent so that it does not conflict with the cards background -->
-  <v-tooltip
+  <g-detail-tooltip
+    :activator="$slots.activator ? undefined : activator"
     location="right"
     :open-delay="openDelay"
     :open-on-hover="openOnHover"
-    :max-width="300"
-    content-class="pa-0"
-    :content-props="{ style: { background: 'transparent' } }"
+    title="Project details"
+    :width="360"
   >
-    <template #activator="{ props: activatorProps }">
-      <div v-bind="activatorProps">
+    <template
+      v-if="$slots.activator || !activator"
+      #activator="{ props: activatorProps }"
+    >
+      <slot
+        v-if="$slots.activator"
+        name="activator"
+        :props="activatorProps"
+      />
+      <div
+        v-else
+        class="project-tooltip-activator"
+        tabindex="0"
+        v-bind="activatorProps"
+      >
         <slot />
       </div>
     </template>
-    <v-card elevation="12">
-      <v-list>
-        <v-list-item>
-          <v-list-item-subtitle>Project Name</v-list-item-subtitle>
-          <v-list-item-title>{{ projectName }}</v-list-item-title>
-        </v-list-item>
-        <v-list-item v-if="projectTitle">
-          <v-list-item-subtitle>Project Title</v-list-item-subtitle>
-          <v-list-item-title>{{ projectTitle }}</v-list-item-title>
-        </v-list-item>
-        <v-list-item v-if="projectDescription">
-          <v-list-item-subtitle>Description</v-list-item-subtitle>
-          <v-list-item-title>{{ projectDescription }}</v-list-item-title>
-        </v-list-item>
-        <v-list-item>
-          <v-list-item-subtitle>Owner</v-list-item-subtitle>
-          <v-list-item-title>
-            <g-account-avatar
-              :account-name="projectOwner"
-            />
-          </v-list-item-title>
-        </v-list-item>
-      </v-list>
-      <v-list-item>
-        <v-list-item-subtitle>Created By</v-list-item-subtitle>
-        <v-list-item-title>
+    <dl class="project-details">
+      <div class="project-detail-row">
+        <dt>Name</dt>
+        <dd>{{ projectName }}</dd>
+      </div>
+      <div
+        v-if="projectTitle"
+        class="project-detail-row"
+      >
+        <dt>Title</dt>
+        <dd>{{ projectTitle }}</dd>
+      </div>
+      <div
+        v-if="projectDescription"
+        class="project-detail-row"
+      >
+        <dt>Description</dt>
+        <dd>{{ projectDescription }}</dd>
+      </div>
+      <div class="project-detail-row">
+        <dt>Owner</dt>
+        <dd>
           <g-account-avatar
-            :account-name="projectCreatedBy"
+            :account-name="projectOwner"
           />
-        </v-list-item-title>
-      </v-list-item>
-      <v-list-item>
-        <v-list-item-subtitle>Created At</v-list-item-subtitle>
-        <v-list-item-title>
-          <g-time-string
-            :date-time="projectCreationTimestamp"
-            :point-in-time="-1"
-          />
-        </v-list-item-title>
-      </v-list-item>
-      <v-list-item v-if="projectPurpose">
-        <v-list-item-subtitle>Purpose</v-list-item-subtitle>
-        <v-list-item-title>{{ projectPurpose }}</v-list-item-title>
-      </v-list-item>
-    </v-card>
-  </v-tooltip>
+        </dd>
+      </div>
+      <div
+        v-if="projectPurpose"
+        class="project-detail-row"
+      >
+        <dt>Purpose</dt>
+        <dd>{{ projectPurpose }}</dd>
+      </div>
+    </dl>
+    <template #footer>
+      <dl class="project-metadata">
+        <div class="project-metadata-row">
+          <dt>Created by</dt>
+          <dd>
+            <g-account-avatar
+              :account-name="projectCreatedBy"
+              :size="20"
+            />
+          </dd>
+        </div>
+        <div class="project-metadata-row">
+          <dt>Created</dt>
+          <dd>
+            <g-time-string
+              :date-time="projectCreationTimestamp"
+              :point-in-time="-1"
+            />
+          </dd>
+        </div>
+      </dl>
+    </template>
+  </g-detail-tooltip>
 </template>
 
 <script setup>
 import { toRefs } from 'vue'
 
-import GTimeString from '@/components/GTimeString.vue'
 import GAccountAvatar from '@/components/GAccountAvatar.vue'
+import GDetailTooltip from '@/components/GDetailTooltip.vue'
+import GTimeString from '@/components/GTimeString.vue'
 
 import { useProjectMetadata } from '@/composables/useProjectMetadata'
 import { useProvideProjectItem } from '@/composables/useProjectItem.js'
 
 const props = defineProps({
   project: { type: Object, required: true },
+  activator: { type: [String, Object] },
   openDelay: { type: Number, default: 200 },
   openOnHover: { type: Boolean, default: true },
 })
 const {
   project,
+  activator,
   openDelay,
   openOnHover,
 } = toRefs(props)
@@ -98,3 +125,33 @@ const {
   projectPurpose,
 } = useProvideProjectItem(project)
 </script>
+
+<style lang="scss" scoped>
+  .project-details,
+  .project-metadata {
+    display: grid;
+    gap: 10px;
+    margin: 0;
+  }
+
+  .project-detail-row,
+  .project-metadata-row {
+    display: grid;
+    gap: 16px;
+    grid-template-columns: 88px minmax(0, 1fr);
+
+    dt {
+      color: rgba(var(--v-theme-on-surface), var(--v-medium-emphasis-opacity));
+    }
+
+    dd {
+      margin: 0;
+      min-width: 0;
+      overflow-wrap: anywhere;
+    }
+  }
+
+  .project-metadata-row {
+    align-items: center;
+  }
+</style>

--- a/frontend/src/components/GSeedStatusTag.vue
+++ b/frontend/src/components/GSeedStatusTag.vue
@@ -113,7 +113,10 @@ export default {
       return this.condition.shortName || ''
     },
     chipAriaLabel () {
-      return `${this.condition.name}: ${this.chipStatus}`
+      const status = this.staleShoot
+        ? `Last status: ${this.chipStatus}`
+        : this.chipStatus
+      return `${this.condition.name}: ${status}`
     },
     chipStatus () {
       if (this.isError) {

--- a/frontend/src/components/GSeedStatusTag.vue
+++ b/frontend/src/components/GSeedStatusTag.vue
@@ -17,12 +17,14 @@ SPDX-License-Identifier: Apache-2.0
         <span v-else>{{ condition.name }} - </span>
         <span class="font-family-monospace font-weight-bold">{{ seedName }}</span>
       </template>
-      <template #activator="{ props }">
+      <template #activator="{ props: popoverActivatorProps }">
         <v-chip
-          v-bind="props"
+          v-bind="popoverActivatorProps"
           :class="{ 'cursor-pointer': condition.message }"
           :variant="!isError ? 'tonal' : 'flat'"
           :text-color="textColor"
+          :aria-label="chipAriaLabel"
+          tabindex="0"
           size="small"
           :color="color"
           class="status-tag"
@@ -34,24 +36,12 @@ SPDX-License-Identifier: Apache-2.0
             class="chip-icon"
           />
           {{ chipText }}
-          <v-tooltip
+          <g-status-tag-tooltip
             activator="parent"
-            location="top"
-            max-width="400px"
-            :open-delay="750"
+            :description="chipTooltip.description"
             :disabled="internalValue"
-          >
-            <div class="font-weight-bold">
-              {{ chipTooltip.title }}
-            </div>
-            <div>Status: {{ chipTooltip.status }}</div>
-            <template v-if="chipTooltip.description">
-              <v-divider color="white" />
-              <div>
-                {{ chipTooltip.description }}
-              </div>
-            </template>
-          </v-tooltip>
+            :title="chipTooltip.title"
+          />
         </v-chip>
       </template>
       <g-shoot-message-details
@@ -70,6 +60,7 @@ import { mapState } from 'pinia'
 import { useAuthzStore } from '@/store/authz'
 
 import GShootMessageDetails from '@/components/GShootMessageDetails.vue'
+import GStatusTagTooltip from '@/components/GStatusTagTooltip.vue'
 
 import map from 'lodash/map'
 import get from 'lodash/get'
@@ -78,6 +69,7 @@ import isEmpty from 'lodash/isEmpty'
 export default {
   components: {
     GShootMessageDetails,
+    GStatusTagTooltip,
   },
   inject: [
     'activePopoverKey',
@@ -119,6 +111,9 @@ export default {
     },
     chipText () {
       return this.condition.shortName || ''
+    },
+    chipAriaLabel () {
+      return `${this.condition.name}: ${this.chipStatus}`
     },
     chipStatus () {
       if (this.isError) {

--- a/frontend/src/components/GShootHealthDonut.vue
+++ b/frontend/src/components/GShootHealthDonut.vue
@@ -251,8 +251,8 @@ const ariaLabel = computed(() => {
   }
   const parts = [
     'Shoot health distribution',
-    `${shootCount.value} shoots`,
-    `${matchingUnhealthy.value} unhealthy shoots`,
+    formatShootCount(shootCount.value),
+    formatShootCount(matchingUnhealthy.value, 'unhealthy'),
   ]
   if (activeFilterLabels.value.length > 0) {
     const desc = filterDescription.value

--- a/frontend/src/components/GShootHealthDonut.vue
+++ b/frontend/src/components/GShootHealthDonut.vue
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 
 <template>
   <div
-    class="d-inline-flex align-center justify-center"
+    class="activator d-inline-flex align-center justify-center"
     :style="{ minWidth: `${donut.size}px`, minHeight: `${donut.size}px` }"
     tabindex="0"
     role="img"
@@ -14,7 +14,7 @@ SPDX-License-Identifier: Apache-2.0
   >
     <span
       v-if="shootCount === 0"
-      class="empty text-medium-emphasis"
+      class="text-medium-emphasis"
       aria-hidden="true"
     >-</span>
     <svg
@@ -60,73 +60,63 @@ SPDX-License-Identifier: Apache-2.0
         aria-hidden="true"
       >{{ centerText }}</text>
     </svg>
-    <v-tooltip
+    <g-detail-tooltip
       activator="parent"
-      location="top"
-      :open-delay="200"
-      content-class="pa-0"
-      :content-props="{ style: { background: 'transparent' } }"
+      title="Shoot health"
     >
-      <v-card
-        class="tooltip-card"
-        elevation="12"
+      <div
+        v-if="shootCount === 0"
+        class="d-flex align-center text-medium-emphasis"
       >
-        <v-list
-          class="tooltip-list"
-          density="compact"
+        <v-icon
+          class="mr-2"
+          icon="mdi-information-outline"
+          size="small"
+        />
+        <span>No shoots assigned</span>
+      </div>
+      <template v-else>
+        <div class="health-row">
+          <v-icon
+            :color="errorColor"
+            icon="mdi-alert-circle-outline"
+            size="small"
+          />
+          <span>{{ hasActiveFilters ? 'Unhealthy shown' : 'Unhealthy' }}</span>
+          <strong>{{ matchingUnhealthy }}</strong>
+        </div>
+        <div
+          v-if="hasActiveFilters"
+          class="health-row"
         >
-          <template v-if="shootCount === 0">
-            <v-list-item :prepend-gap="8">
-              <template #prepend>
-                <v-icon
-                  icon="mdi-information-outline"
-                  class="text-medium-emphasis"
-                />
-              </template>
-              <v-list-item-title>No shoots assigned</v-list-item-title>
-            </v-list-item>
-          </template>
-          <template v-else>
-            <v-list-item :prepend-gap="8">
-              <template #prepend>
-                <v-icon
-                  color="error"
-                  icon="mdi-alert-circle-outline"
-                />
-              </template>
-              <v-list-item-subtitle>Unhealthy</v-list-item-subtitle>
-              <v-list-item-title>{{ matchingUnhealthy }}</v-list-item-title>
-            </v-list-item>
-            <template v-if="activeFilterLabels.length > 0">
-              <v-list-item :prepend-gap="8">
-                <template #prepend>
-                  <v-icon
-                    icon="mdi-filter-outline"
-                    class="text-error-lighten-3"
-                  />
-                </template>
-                <v-list-item-subtitle>
-                  Excluded<template v-if="filterDescription">
-                    — {{ filterDescription }}
-                  </template>
-                </v-list-item-subtitle>
-                <v-list-item-title>{{ hiddenUnhealthy }}</v-list-item-title>
-              </v-list-item>
-            </template>
-            <v-list-item :prepend-gap="8">
-              <template #prepend>
-                <v-icon
-                  color="success"
-                  icon="mdi-check-circle-outline"
-                />
-              </template>
-              <v-list-item-subtitle>Healthy</v-list-item-subtitle>
-              <v-list-item-title>{{ healthyShoots }}</v-list-item-title>
-            </v-list-item>
-          </template>
-        </v-list>
-      </v-card>
-    </v-tooltip>
+          <v-icon
+            :color="warningColor"
+            icon="mdi-filter-minus-outline"
+            size="small"
+          />
+          <span>Unhealthy filtered out</span>
+          <strong>{{ hiddenUnhealthy }}</strong>
+        </div>
+        <div class="health-row">
+          <v-icon
+            color="success"
+            icon="mdi-check-circle-outline"
+            size="small"
+          />
+          <span>Healthy</span>
+          <strong>{{ healthyShoots }}</strong>
+        </div>
+      </template>
+      <template
+        v-if="hasActiveFilters"
+        #footer
+      >
+        <div class="filter-summary">
+          <span>Cluster Operations excludes</span>
+          <span>{{ filterDescription }}</span>
+        </div>
+      </template>
+    </g-detail-tooltip>
   </div>
 </template>
 
@@ -135,6 +125,9 @@ import {
   computed,
   toRefs,
 } from 'vue'
+import { useTheme } from 'vuetify'
+
+import GDetailTooltip from '@/components/GDetailTooltip.vue'
 
 import { useDonutChart } from '@/composables/useDonutChart'
 
@@ -170,6 +163,12 @@ const {
 
 const hiddenUnhealthy = computed(() => totalUnhealthy.value - matchingUnhealthy.value)
 const healthyShoots = computed(() => shootCount.value - totalUnhealthy.value)
+const hasActiveFilters = computed(() => activeFilterLabels.value.length > 0)
+
+const theme = useTheme()
+const isDark = computed(() => theme.current.value.dark)
+const errorColor = computed(() => isDark.value ? 'error-lighten-2' : 'error')
+const warningColor = computed(() => isDark.value ? 'warning-lighten-2' : 'warning')
 
 const filterDescription = computed(() => {
   const labels = activeFilterLabels.value
@@ -241,6 +240,11 @@ const centerTextSizeClass = computed(() => {
 
 // --- accessibility ---
 
+function formatShootCount (count, qualifier) {
+  const noun = count === 1 ? 'shoot' : 'shoots'
+  return [count, qualifier, noun].filter(value => value !== undefined).join(' ')
+}
+
 const ariaLabel = computed(() => {
   if (shootCount.value === 0) {
     return 'No shoots assigned to this seed.'
@@ -254,22 +258,34 @@ const ariaLabel = computed(() => {
     const desc = filterDescription.value
       ? ` (${filterDescription.value})`
       : ''
-    parts.push(`${hiddenUnhealthy.value} excluded by filter${desc}`)
+    parts.push(`${formatShootCount(hiddenUnhealthy.value, 'unhealthy')} excluded by Cluster Operations filters${desc}`)
   }
-  parts.push(`${healthyShoots.value} healthy shoots`)
+  parts.push(formatShootCount(healthyShoots.value, 'healthy'))
   return parts.join(', ') + '.'
 })
 </script>
 
 <style lang="scss" scoped>
-  .empty {
-    font-size: 0.875rem;
+  .activator {
+    color: inherit;
+    text-decoration: none;
   }
 
-  .tooltip-card,
-  .tooltip-list {
-    background-color: rgb(var(--v-theme-surface));
-    color: rgb(var(--v-theme-on-surface));
+  .health-row {
+    align-items: center;
+    display: grid;
+    gap: 10px;
+    grid-template-columns: 20px minmax(0, 1fr) auto;
+
+    strong {
+      font-variant-numeric: tabular-nums;
+      font-weight: 500;
+    }
+  }
+
+  .filter-summary {
+    display: grid;
+    gap: 2px;
   }
 
   .center-text {
@@ -288,7 +304,8 @@ const ariaLabel = computed(() => {
     }
 
     &.error {
-      fill: rgb(var(--v-theme-error));
+      fill: rgba(var(--v-theme-on-surface), 0.92);
+      font-weight: 500;
     }
   }
 

--- a/frontend/src/components/GStatusTag.vue
+++ b/frontend/src/components/GStatusTag.vue
@@ -13,12 +13,14 @@ SPDX-License-Identifier: Apache-2.0
       :toolbar-title="popperTitle"
       :toolbar-color="color"
     >
-      <template #activator="{ props }">
+      <template #activator="{ props: popoverActivatorProps }">
         <v-chip
-          v-bind="props"
+          v-bind="popoverActivatorProps"
           :class="{ 'cursor-pointer': condition.message }"
           :variant="!isError ? 'tonal' : 'flat'"
           :text-color="textColor"
+          :aria-label="chipAriaLabel"
+          tabindex="0"
           size="small"
           :color="color"
           class="status-tag"
@@ -30,37 +32,13 @@ SPDX-License-Identifier: Apache-2.0
             class="chip-icon"
           />
           {{ chipText }}
-          <v-tooltip
+          <g-status-tag-tooltip
             activator="parent"
-            location="top"
-            max-width="400px"
-            :open-delay="750"
+            :description="chipTooltip.description"
             :disabled="internalValue"
-          >
-            <div class="font-weight-bold">
-              {{ chipTooltip.title }}
-            </div>
-            <div>Status: {{ chipTooltip.status }}</div>
-            <div
-              v-for="({ shortDescription }) in chipTooltip.userErrorCodeObjects"
-              :key="shortDescription"
-            >
-              <v-icon
-                class="mr-1"
-                color="white"
-                size="small"
-              >
-                mdi-account-alert
-              </v-icon>
-              <span class="font-weight-bold text--lighten-2">{{ shortDescription }}</span>
-            </div>
-            <template v-if="chipTooltip.description">
-              <v-divider color="white" />
-              <div>
-                {{ chipTooltip.description }}
-              </div>
-            </template>
-          </v-tooltip>
+            :title="chipTooltip.title"
+            :user-errors="chipTooltip.userErrorCodeObjects"
+          />
         </v-chip>
       </template>
       <g-shoot-message-details
@@ -80,6 +58,7 @@ import { mapState } from 'pinia'
 import { useAuthzStore } from '@/store/authz'
 
 import GShootMessageDetails from '@/components/GShootMessageDetails.vue'
+import GStatusTagTooltip from '@/components/GStatusTagTooltip.vue'
 
 import {
   isUserError,
@@ -93,6 +72,7 @@ import filter from 'lodash/filter'
 export default {
   components: {
     GShootMessageDetails,
+    GStatusTagTooltip,
   },
   inject: [
     'activePopoverKey',
@@ -141,6 +121,9 @@ export default {
     },
     chipText () {
       return this.condition.shortName || ''
+    },
+    chipAriaLabel () {
+      return `${this.condition.name}: ${this.chipStatus}`
     },
     chipStatus () {
       if (this.isError) {

--- a/frontend/src/components/GStatusTag.vue
+++ b/frontend/src/components/GStatusTag.vue
@@ -123,7 +123,10 @@ export default {
       return this.condition.shortName || ''
     },
     chipAriaLabel () {
-      return `${this.condition.name}: ${this.chipStatus}`
+      const status = this.staleShoot
+        ? `Last status: ${this.chipStatus}`
+        : this.chipStatus
+      return `${this.condition.name}: ${status}`
     },
     chipStatus () {
       if (this.isError) {

--- a/frontend/src/components/GStatusTagTooltip.vue
+++ b/frontend/src/components/GStatusTagTooltip.vue
@@ -1,0 +1,89 @@
+<!--
+SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+<template>
+  <g-detail-tooltip
+    :activator="activator"
+    :disabled="disabled"
+    :open-delay="750"
+    :title="title"
+    :width="320"
+  >
+    <template v-if="userErrors.length">
+      <div
+        v-for="({ shortDescription }) in userErrors"
+        :key="shortDescription"
+        class="user-error-row"
+      >
+        <v-icon
+          :color="errorColor"
+          icon="mdi-account-alert-outline"
+          size="small"
+        />
+        <span>{{ shortDescription }}</span>
+      </div>
+    </template>
+    <div
+      v-else-if="description"
+      class="status-description text-medium-emphasis"
+    >
+      {{ description }}
+    </div>
+    <template
+      v-if="description && userErrors.length"
+      #footer
+    >
+      {{ description }}
+    </template>
+  </g-detail-tooltip>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { useTheme } from 'vuetify'
+
+import GDetailTooltip from '@/components/GDetailTooltip.vue'
+
+defineProps({
+  title: {
+    type: String,
+    required: true,
+  },
+  description: {
+    type: String,
+  },
+  activator: {
+    type: [String, Object],
+    default: 'parent',
+  },
+  userErrors: {
+    type: Array,
+    default: () => [],
+  },
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+})
+
+const theme = useTheme()
+const isDark = computed(() => theme.current.value.dark)
+const errorColor = computed(() => isDark.value ? 'error-lighten-2' : 'error')
+</script>
+
+<style lang="scss" scoped>
+  .status-description {
+    font-size: 0.75rem;
+    line-height: 1.4;
+  }
+
+  .user-error-row {
+    align-items: start;
+    display: grid;
+    gap: 10px;
+    grid-template-columns: 20px minmax(0, 1fr);
+  }
+</style>

--- a/frontend/src/components/GStatusTagTooltip.vue
+++ b/frontend/src/components/GStatusTagTooltip.vue
@@ -12,26 +12,31 @@ SPDX-License-Identifier: Apache-2.0
     :title="title"
     :width="320"
   >
-    <template v-if="userErrors.length">
+    <template
+      v-if="userErrors.length || description"
+      #default
+    >
+      <template v-if="userErrors.length">
+        <div
+          v-for="({ shortDescription }) in userErrors"
+          :key="shortDescription"
+          class="user-error-row"
+        >
+          <v-icon
+            :color="errorColor"
+            icon="mdi-account-alert-outline"
+            size="small"
+          />
+          <span>{{ shortDescription }}</span>
+        </div>
+      </template>
       <div
-        v-for="({ shortDescription }) in userErrors"
-        :key="shortDescription"
-        class="user-error-row"
+        v-else
+        class="status-description text-medium-emphasis"
       >
-        <v-icon
-          :color="errorColor"
-          icon="mdi-account-alert-outline"
-          size="small"
-        />
-        <span>{{ shortDescription }}</span>
+        {{ description }}
       </div>
     </template>
-    <div
-      v-else-if="description"
-      class="status-description text-medium-emphasis"
-    >
-      {{ description }}
-    </div>
     <template
       v-if="description && userErrors.length"
       #footer

--- a/frontend/src/components/GVendor.vue
+++ b/frontend/src/components/GVendor.vue
@@ -8,9 +8,9 @@ SPDX-License-Identifier: Apache-2.0
   <span v-if="title">{{ titleText }}</span>
   <div
     v-else
-    class="d-flex align-center infrastructure-activator"
+    class="d-flex align-center vendor-activator"
     tabindex="0"
-    :aria-label="infrastructureAriaLabel"
+    :aria-label="vendorAriaLabel"
   >
     <g-vendor-icon
       :name="providerType"
@@ -23,7 +23,7 @@ SPDX-License-Identifier: Apache-2.0
     </span>
     <g-detail-tooltip
       activator="parent"
-      title="Infrastructure"
+      :title="tooltipTitle"
     >
       <dl class="tooltip-details">
         <div class="tooltip-row">
@@ -94,6 +94,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    tooltipTitle: {
+      type: String,
+      default: 'Infrastructure',
+    },
     extended: {
       type: Boolean,
       default: false,
@@ -158,7 +162,7 @@ export default {
     vendorName () {
       return this.vendorDisplayName(this.providerType)
     },
-    infrastructureAriaLabel () {
+    vendorAriaLabel () {
       const details = [`Provider ${this.vendorName}`]
       if (this.shootCloudProfileRef) {
         details.push(`cloud profile ${this.cloudProfileRefDisplayValue}`)
@@ -169,7 +173,7 @@ export default {
       if (this.zones.length) {
         details.push(`${this.zoneTitle.toLowerCase()} ${this.zoneText}`)
       }
-      return `Infrastructure: ${details.join(', ')}`
+      return `${this.tooltipTitle}: ${details.join(', ')}`
     },
   },
   methods: {
@@ -179,7 +183,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .infrastructure-activator {
+  .vendor-activator {
     width: fit-content;
   }
 

--- a/frontend/src/components/GVendor.vue
+++ b/frontend/src/components/GVendor.vue
@@ -6,58 +6,60 @@ SPDX-License-Identifier: Apache-2.0
 
 <template>
   <span v-if="title">{{ titleText }}</span>
-  <!-- we make the tooltip background transparent so that it does not conflict with the cards background -->
-  <v-tooltip
+  <div
     v-else
-    location="top"
-    :open-delay="200"
-    content-class="pa-0"
-    :content-props="{ style: { background: 'transparent' } }"
+    class="d-flex align-center infrastructure-activator"
+    tabindex="0"
+    :aria-label="infrastructureAriaLabel"
   >
-    <template #activator="{ props }">
-      <div
-        class="d-flex align-center"
-        tabindex="0"
-        v-bind="props"
-      >
-        <g-vendor-icon
-          :name="providerType"
-        />
-        <span
-          v-if="description"
-          class="ml-2"
-        >
-          {{ description }}
-        </span>
-      </div>
-    </template>
-    <v-card elevation="12">
-      <v-list>
-        <v-list-item>
-          <v-list-item-subtitle>Provider</v-list-item-subtitle>
-          <v-list-item-title class="d-flex">
+    <g-vendor-icon
+      :name="providerType"
+    />
+    <span
+      v-if="description"
+      class="ml-2"
+    >
+      {{ description }}
+    </span>
+    <g-detail-tooltip
+      activator="parent"
+      title="Infrastructure"
+    >
+      <dl class="tooltip-details">
+        <div class="tooltip-row">
+          <dt>Provider</dt>
+          <dd class="d-flex align-center">
             <g-vendor-icon
               :name="providerType"
               class="mr-2"
             />
             {{ vendorName }}
-          </v-list-item-title>
-        </v-list-item>
-        <v-list-item v-if="shootCloudProfileRef">
-          <v-list-item-subtitle>Cloud Profile</v-list-item-subtitle>
-          <v-list-item-title>{{ cloudProfileRefDisplayValue }}</v-list-item-title>
-        </v-list-item>
-        <v-list-item v-if="region">
-          <v-list-item-subtitle>Region</v-list-item-subtitle>
-          <v-list-item-title>{{ region }}</v-list-item-title>
-        </v-list-item>
-        <v-list-item v-if="zones.length">
-          <v-list-item-subtitle>{{ zoneTitle }}</v-list-item-subtitle>
-          <v-list-item-title>{{ zoneText }}</v-list-item-title>
-        </v-list-item>
-      </v-list>
-    </v-card>
-  </v-tooltip>
+          </dd>
+        </div>
+        <div
+          v-if="shootCloudProfileRef"
+          class="tooltip-row"
+        >
+          <dt>Cloud profile</dt>
+          <dd>{{ cloudProfileRefDisplayValue }}</dd>
+        </div>
+        <div
+          v-if="region"
+          class="tooltip-row"
+        >
+          <dt>Region</dt>
+          <dd>{{ region }}</dd>
+        </div>
+        <div
+          v-if="zones.length"
+          class="tooltip-row"
+        >
+          <dt>{{ zoneTitle }}</dt>
+          <dd>{{ zoneText }}</dd>
+        </div>
+      </dl>
+    </g-detail-tooltip>
+  </div>
 </template>
 
 <script>
@@ -66,6 +68,7 @@ import { mapActions } from 'pinia'
 import { useConfigStore } from '@/store/config'
 
 import GVendorIcon from '@/components/GVendorIcon'
+import GDetailTooltip from '@/components/GDetailTooltip.vue'
 
 import { useShootItem } from '@/composables/useShootItem'
 
@@ -73,6 +76,7 @@ import join from 'lodash/join'
 
 export default {
   components: {
+    GDetailTooltip,
     GVendorIcon,
   },
   props: {
@@ -154,9 +158,50 @@ export default {
     vendorName () {
       return this.vendorDisplayName(this.providerType)
     },
+    infrastructureAriaLabel () {
+      const details = [`Provider ${this.vendorName}`]
+      if (this.shootCloudProfileRef) {
+        details.push(`cloud profile ${this.cloudProfileRefDisplayValue}`)
+      }
+      if (this.region) {
+        details.push(`region ${this.region}`)
+      }
+      if (this.zones.length) {
+        details.push(`${this.zoneTitle.toLowerCase()} ${this.zoneText}`)
+      }
+      return `Infrastructure: ${details.join(', ')}`
+    },
   },
   methods: {
     ...mapActions(useConfigStore, ['vendorDisplayName']),
   },
 }
 </script>
+
+<style lang="scss" scoped>
+  .infrastructure-activator {
+    width: fit-content;
+  }
+
+  .tooltip-details {
+    display: grid;
+    gap: 10px;
+    margin: 0;
+  }
+
+  .tooltip-row {
+    display: grid;
+    gap: 16px;
+    grid-template-columns: minmax(88px, auto) minmax(0, 1fr);
+
+    dt {
+      color: rgba(var(--v-theme-on-surface), var(--v-medium-emphasis-opacity));
+    }
+
+    dd {
+      font-variant-numeric: tabular-nums;
+      margin: 0;
+      overflow-wrap: anywhere;
+    }
+  }
+</style>

--- a/frontend/src/components/Seeds/GSeedCapacityIndicator.vue
+++ b/frontend/src/components/Seeds/GSeedCapacityIndicator.vue
@@ -15,7 +15,7 @@ SPDX-License-Identifier: Apache-2.0
       <v-progress-linear
         v-if="hasCapacityProgress"
         class="progress"
-        :model-value="capacityUsagePercent"
+        :model-value="capacityProgressPercent"
         color="primary"
         :height="8"
         rounded
@@ -48,7 +48,7 @@ SPDX-License-Identifier: Apache-2.0
       </div>
       <template v-if="hasCapacityProgress">
         <v-progress-linear
-          :model-value="capacityUsagePercent"
+          :model-value="capacityProgressPercent"
           color="primary"
           :height="6"
           rounded
@@ -101,7 +101,11 @@ const capacityUsagePercent = computed(() => {
     return 0
   }
 
-  return Math.min(props.shootCount / props.allocatableShoots * 100, 100)
+  return props.shootCount / props.allocatableShoots * 100
+})
+
+const capacityProgressPercent = computed(() => {
+  return Math.min(capacityUsagePercent.value, 100)
 })
 
 const capacityText = computed(() => {

--- a/frontend/src/components/Seeds/GSeedCapacityIndicator.vue
+++ b/frontend/src/components/Seeds/GSeedCapacityIndicator.vue
@@ -21,64 +21,58 @@ SPDX-License-Identifier: Apache-2.0
         rounded
       />
     </div>
-    <v-tooltip
+    <g-detail-tooltip
       activator="parent"
-      location="top"
-      :open-delay="200"
-      content-class="pa-0"
-      :content-props="{ style: { background: 'transparent' } }"
+      title="Seed capacity"
     >
-      <v-card
-        class="tooltip-card"
-        elevation="12"
+      <div class="metric-row">
+        <v-icon
+          :color="primaryColor"
+          icon="mdi-vector-link"
+          size="small"
+        />
+        <span>Assigned shoots</span>
+        <strong>{{ props.shootCount }}</strong>
+      </div>
+      <div class="metric-row">
+        <v-icon
+          :color="hasKnownCapacity ? primaryColor : undefined"
+          :class="{ 'text-medium-emphasis': !hasKnownCapacity }"
+          :icon="hasKnownCapacity ? 'mdi-chart-box-outline' : 'mdi-information-outline'"
+          size="small"
+        />
+        <span>Allocatable shoots</span>
+        <strong :class="{ 'text-medium-emphasis': !hasKnownCapacity }">
+          {{ hasKnownCapacity ? props.allocatableShoots : 'Unknown' }}
+        </strong>
+      </div>
+      <template v-if="hasCapacityProgress">
+        <v-progress-linear
+          :model-value="capacityUsagePercent"
+          color="primary"
+          :height="6"
+          rounded
+        />
+        <div class="capacity-summary text-medium-emphasis">
+          <span>{{ capacityUsageLabel }} used</span>
+          <span>{{ remainingCapacity }} remaining</span>
+        </div>
+      </template>
+      <template
+        v-if="!hasKnownCapacity"
+        #footer
       >
-        <v-list
-          class="tooltip-list"
-          density="compact"
-        >
-          <v-list-item :prepend-gap="8">
-            <template #prepend>
-              <v-icon
-                color="primary"
-                icon="mdi-vector-link"
-              />
-            </template>
-            <v-list-item-subtitle>Assigned</v-list-item-subtitle>
-            <v-list-item-title>{{ props.shootCount }}</v-list-item-title>
-          </v-list-item>
-          <v-list-item :prepend-gap="8">
-            <template #prepend>
-              <v-icon
-                color="primary"
-                :icon="hasKnownCapacity ? 'mdi-chart-box-outline' : 'mdi-information-outline'"
-              />
-            </template>
-            <v-list-item-subtitle>
-              <template v-if="hasKnownCapacity">
-                Allocatable — Total allocatable shoots for this seed
-              </template>
-              <template v-else>
-                Allocatable — This seed does not report allocatable shoot capacity
-              </template>
-            </v-list-item-subtitle>
-            <v-list-item-title>
-              <template v-if="hasKnownCapacity">
-                {{ props.allocatableShoots }}
-              </template>
-              <span
-                v-else
-                class="text-medium-emphasis"
-              >Unknown</span>
-            </v-list-item-title>
-          </v-list-item>
-        </v-list>
-      </v-card>
-    </v-tooltip>
+        This seed does not report its allocatable shoot capacity.
+      </template>
+    </g-detail-tooltip>
   </div>
 </template>
 
 <script setup>
 import { computed } from 'vue'
+import { useTheme } from 'vuetify'
+
+import GDetailTooltip from '@/components/GDetailTooltip.vue'
 
 const props = defineProps({
   allocatableShoots: {
@@ -93,6 +87,10 @@ const props = defineProps({
 const hasKnownCapacity = computed(() => {
   return Number.isFinite(props.allocatableShoots)
 })
+
+const theme = useTheme()
+const isDark = computed(() => theme.current.value.dark)
+const primaryColor = computed(() => isDark.value ? 'primary-lighten-2' : 'primary')
 
 const hasCapacityProgress = computed(() => {
   return hasKnownCapacity.value && props.allocatableShoots > 0
@@ -114,6 +112,17 @@ const capacityText = computed(() => {
   return `${props.shootCount} / ${props.allocatableShoots}`
 })
 
+const capacityUsageLabel = computed(() => {
+  return `${Math.round(capacityUsagePercent.value)}%`
+})
+
+const remainingCapacity = computed(() => {
+  if (!hasKnownCapacity.value) {
+    return undefined
+  }
+  return Math.max(props.allocatableShoots - props.shootCount, 0)
+})
+
 const ariaLabel = computed(() => {
   if (!hasKnownCapacity.value) {
     return `Seed capacity: ${props.shootCount} assigned shoots, allocatable capacity unknown`
@@ -125,7 +134,9 @@ const ariaLabel = computed(() => {
 
 <style lang="scss" scoped>
   .activator {
+    color: inherit;
     display: inline-grid;
+    text-decoration: none;
   }
 
   .capacity-indicator {
@@ -134,10 +145,22 @@ const ariaLabel = computed(() => {
     min-width: 88px;
   }
 
-  .tooltip-card,
-  .tooltip-list {
-    background-color: rgb(var(--v-theme-surface));
-    color: rgb(var(--v-theme-on-surface));
+  .metric-row {
+    align-items: center;
+    display: grid;
+    gap: 10px;
+    grid-template-columns: 20px minmax(0, 1fr) auto;
+
+    strong {
+      font-variant-numeric: tabular-nums;
+      font-weight: 500;
+    }
+  }
+
+  .capacity-summary {
+    display: flex;
+    font-size: 0.75rem;
+    justify-content: space-between;
   }
 
   .text {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area usability
/kind cleanup

**What this PR does / why we need it**:
Introduces two shared tooltip components (`GDetailTooltip`, `GStatusTagTooltip`) to eliminate duplicated tooltip markup and establish a consistent visual design across all affected tooltips.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```other user
Redesigned tooltips: project details, infrastructure details, shoot health, and status tags now use a unified layout.
```
```other operator
Redesigned tooltips: shoot health donut, seed capacity indicators, and seed condition status now use a unified layout.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable detail-tooltip component with consistent title/body/footer support and configurable sizing/behavior.
  * Migrated project, vendor, seed capacity, shoot health, and status tag tooltips to the new component with improved layouts and contextual messaging.
  * Enhanced tooltip/activator accessibility via improved activator handling, ARIA labels, and keyboard focus support.
  * Updated DNS credential provider column to display the “DNS” tooltip title.

* **Tests**
  * Added comprehensive unit tests covering slot rendering, conditional sections, activator wiring/prop forwarding, and tooltip validation/accessibility behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->