### PR TITLE
fix(GMainProjectSelection): re-sync selected project when store entry changes

### DIFF
--- a/frontend/__tests__/components/GMainProjectSelection.spec.js
+++ b/frontend/__tests__/components/GMainProjectSelection.spec.js
@@ -1,0 +1,67 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import { nextTick } from 'vue'
+import { shallowMount } from '@vue/test-utils'
+import { createPinia } from 'pinia'
+
+import { useAuthzStore } from '@/store/authz'
+import { useProjectStore } from '@/store/project'
+
+import GMainProjectSelection from '@/components/GMainProjectSelection.vue'
+
+const { createVuetifyPlugin } = global.fixtures.helper
+
+describe('components', () => {
+  describe('g-main-project-selection', () => {
+    it('should update the selected project when its store entry is replaced', async () => {
+      const pinia = createPinia()
+      const projectStore = useProjectStore(pinia)
+      const authzStore = useAuthzStore(pinia)
+
+      const project = {
+        metadata: {
+          name: 'foo',
+          uid: 'foo-uid',
+        },
+        spec: {
+          namespace: 'garden-foo',
+          description: 'Old description',
+        },
+        status: {
+          phase: 'Ready',
+        },
+      }
+      projectStore.list = [project]
+      authzStore._setNamespace(project.spec.namespace)
+
+      const wrapper = shallowMount(GMainProjectSelection, {
+        props: {
+          modelValue: project,
+        },
+        global: {
+          plugins: [
+            createVuetifyPlugin(),
+            pinia,
+          ],
+        },
+      })
+
+      const updatedProject = {
+        ...project,
+        spec: {
+          ...project.spec,
+          description: 'New description',
+        },
+      }
+      projectStore.list.splice(0, 1, updatedProject)
+      await nextTick()
+
+      const updates = wrapper.emitted('update:modelValue')
+      expect(updates.at(-1)).toEqual([projectStore.list[0]])
+    })
+  })
+})

--- a/frontend/src/components/GMainNavigation.vue
+++ b/frontend/src/components/GMainNavigation.vue
@@ -30,7 +30,6 @@ SPDX-License-Identifier: Apache-2.0
     </template>
 
     <v-list
-      ref="refMainMenu"
       variant="flat"
       class="main-menu"
     >
@@ -155,7 +154,6 @@ const currentRoute = useRoute()
 const { mdAndDown } = useDisplay()
 
 const projectDialog = ref(false)
-const refMainMenu = ref(null)
 
 const namespace = toRef(projectStore, 'namespace')
 const projectList = toRef(projectStore, 'projectList')

--- a/frontend/src/components/GMainProjectSelection.vue
+++ b/frontend/src/components/GMainProjectSelection.vue
@@ -248,6 +248,16 @@ const canCreateProject = toRef(authzStore, 'canCreateProject')
 
 const selectedProject = defineModel({ type: Object })
 
+const currentProject = computed(() => {
+  if (isAllProjectsNamespace(namespace.value)) {
+    return allProjectsItem
+  }
+  return find(projectList.value, [
+    'spec.namespace',
+    namespace.value,
+  ])
+})
+
 const projectMenuIcon = computed(() => {
   return projectMenu.value ? 'mdi-chevron-up' : 'mdi-chevron-down'
 })
@@ -348,7 +358,7 @@ function onProjectClick (event, project) {
 function selectProject (project) {
   projectMenu.value = false
 
-  if (project !== selectedProject.value) {
+  if (project?.spec.namespace !== selectedProject.value?.spec.namespace) {
     selectedProject.value = project
     emit('projectSelect', project)
   }
@@ -399,7 +409,11 @@ function isSelectedProject (project) {
 }
 
 function isAllProjectsItem (project) {
-  return project?.spec.namespace === allProjectsItem.spec.namespace
+  return isAllProjectsNamespace(project?.spec.namespace)
+}
+
+function isAllProjectsNamespace (namespace) {
+  return namespace === allProjectsItem.spec.namespace
 }
 
 watch(projectMenu, value => {
@@ -415,16 +429,9 @@ watch(projectMenu, value => {
 })
 
 watch(
-  namespace,
-  () => {
-    if (namespace.value === allProjectsItem.spec.namespace) {
-      selectedProject.value = allProjectsItem
-    } else {
-      selectedProject.value = find(projectList.value, [
-        'spec.namespace',
-        namespace.value,
-      ])
-    }
+  currentProject,
+  project => {
+    selectedProject.value = project
   },
   { immediate: true },
 )


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area usability
/kind bug

**What this PR does / why we need it**:
Re-syncs the selected project in `GMainProjectSelection` when the corresponding store entry changes, preventing stale project state after store updates.

**How to reproduce**:

1. In one browser tab, open the project selection, select Project A, and filter the project list to Project A.
2. In a second tab, open Project A under Administration and update its description.
3. Return to the first tab and hover over both the selected project and the matching entry in the filtered list.
4. Observe that the selected project tooltip still shows the previous description, while the filtered list tooltip shows the updated description.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```bugfix user
Fixed stale selected project in the navigation after store entry changes.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project selection synchronization when project details are replaced or updated.
  * Ensured the selected project remains accurate for both individual projects and the “All Projects” option.
  * Improved change detection to prevent unnecessary selection updates.

* **Tests**
  * Added coverage verifying that project selection updates when the project store changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->