### PR TITLE
Use typed vendor lookups

### DIFF
--- a/frontend/__tests__/stores/config.spec.js
+++ b/frontend/__tests__/stores/config.spec.js
@@ -1,0 +1,67 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import {
+  createPinia,
+  setActivePinia,
+} from 'pinia'
+
+import { useConfigStore } from '@/store/config'
+
+describe('stores', () => {
+  describe('config', () => {
+    let configStore
+
+    beforeEach(() => {
+      setActivePinia(createPinia())
+      configStore = useConfigStore()
+      configStore.setConfiguration({
+        branding: {
+          infraVendors: [{
+            name: 'shared-provider',
+            displayName: 'Infrastructure Provider',
+          }],
+          dnsVendors: [{
+            name: 'shared-provider',
+            displayName: 'DNS Provider',
+          }],
+        },
+      })
+    })
+
+    it('looks up vendors by type and name', () => {
+      expect(configStore.vendorDetails({
+        type: 'infra',
+        name: 'shared-provider',
+      })).toMatchObject({
+        type: 'infra',
+        name: 'shared-provider',
+        displayName: 'Infrastructure Provider',
+      })
+
+      expect(configStore.vendorDetails({
+        type: 'dns',
+        name: 'shared-provider',
+      })).toMatchObject({
+        type: 'dns',
+        name: 'shared-provider',
+        displayName: 'DNS Provider',
+      })
+    })
+
+    it('looks up display names by type and name', () => {
+      expect(configStore.vendorDisplayName({
+        type: 'infra',
+        name: 'shared-provider',
+      })).toBe('Infrastructure Provider')
+
+      expect(configStore.vendorDisplayName({
+        type: 'dns',
+        name: 'shared-provider',
+      })).toBe('DNS Provider')
+    })
+  })
+})

--- a/frontend/src/components/Credentials/GBindingRowInfra.vue
+++ b/frontend/src/components/Credentials/GBindingRowInfra.vue
@@ -29,6 +29,7 @@ SPDX-License-Identifier: Apache-2.0
       <g-vendor
         extended
         :provider-type="item.providerType"
+        vendor-type="infra"
       />
     </td>
     <td v-if="selectedHeaders.details">

--- a/frontend/src/components/Credentials/GCredentialRowDns.vue
+++ b/frontend/src/components/Credentials/GCredentialRowDns.vue
@@ -20,6 +20,7 @@ SPDX-License-Identifier: Apache-2.0
         extended
         tooltip-title="DNS"
         :provider-type="item.providerType"
+        vendor-type="dns"
       />
     </td>
     <td v-if="selectedHeaders.details">

--- a/frontend/src/components/Credentials/GSecretDialog.vue
+++ b/frontend/src/components/Credentials/GSecretDialog.vue
@@ -206,6 +206,10 @@ export default {
       type: String,
       required: true,
     },
+    vendorType: {
+      type: String,
+      required: true,
+    },
     binding: {
       type: Object,
     },
@@ -360,7 +364,10 @@ export default {
       }
     },
     displayName () {
-      return this.vendorDisplayName(this.providerType)
+      return this.vendorDisplayName({
+        type: this.vendorType,
+        name: this.providerType,
+      })
     },
     name: {
       get () {

--- a/frontend/src/components/Credentials/GSecretDialogGeneric.vue
+++ b/frontend/src/components/Credentials/GSecretDialogGeneric.vue
@@ -10,6 +10,7 @@ SPDX-License-Identifier: Apache-2.0
     :secret-validations="v$"
     :binding="binding"
     :provider-type="providerType"
+    :vendor-type="vendorType"
   >
     <template #secret-slot>
       <div>
@@ -77,6 +78,10 @@ export default {
     providerType: {
       type: String,
     },
+    vendorType: {
+      type: String,
+      required: true,
+    },
   },
   emits: [
     'update:modelValue',
@@ -140,7 +145,10 @@ export default {
       return !this.secret
     },
     vendorName () {
-      return this.vendorDisplayName(this.providerType)
+      return this.vendorDisplayName({
+        type: this.vendorType,
+        name: this.providerType,
+      })
     },
   },
   watch: {

--- a/frontend/src/components/Credentials/GSecretDialogWrapper.vue
+++ b/frontend/src/components/Credentials/GSecretDialogWrapper.vue
@@ -9,7 +9,7 @@ SPDX-License-Identifier: Apache-2.0
     :is="resolvedComponent"
     v-if="visibleDialog"
     v-model="visibleDialogState"
-    v-bind="{ credential: selectedDnsCredential, binding: selectedInfraBinding, providerType: visibleDialog }"
+    v-bind="{ credential: selectedDnsCredential, binding: selectedInfraBinding, providerType: visibleDialog, vendorType: visibleDialogVendorType }"
   />
 </template>
 
@@ -38,6 +38,7 @@ export default {
     selectedDnsCredential: { type: Object, required: false },
     selectedInfraBinding: { type: Object, required: false },
     visibleDialog: { type: String, required: false },
+    visibleDialogVendorType: { type: String, required: false },
   },
   emits: ['dialog-closed'],
   data () {

--- a/frontend/src/components/Credentials/GSelectCredential.vue
+++ b/frontend/src/components/Credentials/GSelectCredential.vue
@@ -64,6 +64,7 @@ SPDX-License-Identifier: Apache-2.0
     </v-select>
     <g-secret-dialog-wrapper
       :visible-dialog="visibleSecretDialog"
+      :visible-dialog-vendor-type="isDnsProvider ? 'dns' : 'infra'"
       @dialog-closed="onSecretDialogClosed"
     />
   </div>

--- a/frontend/src/components/GSeedListRow.vue
+++ b/frontend/src/components/GSeedListRow.vue
@@ -21,6 +21,7 @@ SPDX-License-Identifier: Apache-2.0
       <template v-else-if="header.key === 'infrastructure'">
         <g-vendor
           :provider-type="seedProviderType"
+          vendor-type="infra"
           :region="seedProviderRegion"
           :zones="seedProviderZones"
         />

--- a/frontend/src/components/GShootListRow.vue
+++ b/frontend/src/components/GShootListRow.vue
@@ -48,6 +48,7 @@ SPDX-License-Identifier: Apache-2.0
       <template v-if="cell.header.key === 'infrastructure'">
         <g-vendor
           :provider-type="shootProviderType"
+          vendor-type="infra"
           :region="shootRegion"
           :zones="shootZones"
         />

--- a/frontend/src/components/GVendor.vue
+++ b/frontend/src/components/GVendor.vue
@@ -35,7 +35,7 @@ SPDX-License-Identifier: Apache-2.0
               :vendor-type="vendorType"
               class="mr-2"
             />
-            {{ vendorName }}
+            {{ displayName }}
           </dd>
         </div>
         <div
@@ -88,6 +88,7 @@ export default {
     },
     providerType: {
       type: String,
+      required: true,
     },
     vendorType: {
       type: String,
@@ -129,8 +130,8 @@ export default {
     },
     description () {
       const description = []
-      if (this.extended && this.providerType) {
-        description.push(this.vendorName)
+      if (this.extended) {
+        description.push(this.displayName)
       }
       if (this.region) {
         description.push(this.region)
@@ -143,7 +144,7 @@ export default {
     },
     titleText () {
       const titles = []
-      if (this.extended && this.providerType) {
+      if (this.extended) {
         titles.push('Provider')
       }
       if (this.region) {
@@ -165,17 +166,14 @@ export default {
 
       return this.shootCloudProfileRef.name
     },
-    vendorName () {
-      if (!this.providerType) {
-        return undefined
-      }
+    displayName () {
       return this.vendorDisplayName({
         type: this.vendorType,
         name: this.providerType,
       })
     },
     vendorAriaLabel () {
-      const details = [`Provider ${this.vendorName}`]
+      const details = [`Provider ${this.displayName}`]
       if (this.shootCloudProfileRef) {
         details.push(`cloud profile ${this.cloudProfileRefDisplayValue}`)
       }

--- a/frontend/src/components/GVendor.vue
+++ b/frontend/src/components/GVendor.vue
@@ -14,6 +14,7 @@ SPDX-License-Identifier: Apache-2.0
   >
     <g-vendor-icon
       :name="providerType"
+      :vendor-type="vendorType"
     />
     <span
       v-if="description"
@@ -31,6 +32,7 @@ SPDX-License-Identifier: Apache-2.0
           <dd class="d-flex align-center">
             <g-vendor-icon
               :name="providerType"
+              :vendor-type="vendorType"
               class="mr-2"
             />
             {{ vendorName }}
@@ -86,6 +88,10 @@ export default {
     },
     providerType: {
       type: String,
+    },
+    vendorType: {
+      type: String,
+      required: true,
     },
     region: {
       type: String,
@@ -160,7 +166,13 @@ export default {
       return this.shootCloudProfileRef.name
     },
     vendorName () {
-      return this.vendorDisplayName(this.providerType)
+      if (!this.providerType) {
+        return undefined
+      }
+      return this.vendorDisplayName({
+        type: this.vendorType,
+        name: this.providerType,
+      })
     },
     vendorAriaLabel () {
       const details = [`Provider ${this.vendorName}`]

--- a/frontend/src/components/GVendorIcon.vue
+++ b/frontend/src/components/GVendorIcon.vue
@@ -42,6 +42,9 @@ const props = defineProps({
     type: String,
     default: '',
   },
+  vendorType: {
+    type: String,
+  },
   icon: {
     type: String,
     default: '',
@@ -64,7 +67,13 @@ const iconName = computed(() => {
   if (props.icon) {
     return props.icon
   }
-  const vendor = configStore.vendorDetails(props.name)
+  if (!props.vendorType || !props.name) {
+    return undefined
+  }
+  const vendor = configStore.vendorDetails({
+    type: props.vendorType,
+    name: props.name,
+  })
   return vendor?.icon
 })
 

--- a/frontend/src/components/NewShoot/GNewShootInfrastructureCard.vue
+++ b/frontend/src/components/NewShoot/GNewShootInfrastructureCard.vue
@@ -19,6 +19,7 @@ SPDX-License-Identifier: Apache-2.0
       <div class="d-flex flex-column justify-center align-center">
         <g-vendor-icon
           :name="providerType"
+          vendor-type="infra"
           :size="60"
           no-background
           :style="getVendorIconStyles(isHovering)"
@@ -64,7 +65,10 @@ export default {
       return this.modelValue ? 'outlined' : 'elevated'
     },
     vendorName () {
-      return this.vendorDisplayName(this.providerType)
+      return this.vendorDisplayName({
+        type: 'infra',
+        name: this.providerType,
+      })
     },
   },
   methods: {

--- a/frontend/src/components/SeedDetails/GSeedInfrastructureCard.vue
+++ b/frontend/src/components/SeedDetails/GSeedInfrastructureCard.vue
@@ -20,6 +20,7 @@ SPDX-License-Identifier: Apache-2.0
               title
               extended
               :provider-type="seedProviderType"
+              vendor-type="infra"
               :region="seedProviderRegion"
               :zones="seedProviderZones"
             />
@@ -28,6 +29,7 @@ SPDX-License-Identifier: Apache-2.0
             <g-vendor
               extended
               :provider-type="seedProviderType"
+              vendor-type="infra"
               :region="seedProviderRegion"
               :zones="seedProviderZones"
             />

--- a/frontend/src/components/ShootDetails/GShootInfrastructureCard.vue
+++ b/frontend/src/components/ShootDetails/GShootInfrastructureCard.vue
@@ -20,6 +20,7 @@ SPDX-License-Identifier: Apache-2.0
               title
               extended
               :provider-type="shootProviderType"
+              vendor-type="infra"
               :region="shootRegion"
               :zones="shootZones"
             />
@@ -28,6 +29,7 @@ SPDX-License-Identifier: Apache-2.0
             <g-vendor
               extended
               :provider-type="shootProviderType"
+              vendor-type="infra"
               :region="shootRegion"
               :zones="shootZones"
             />

--- a/frontend/src/components/ShootDns/GDnsProvider.vue
+++ b/frontend/src/components/ShootDns/GDnsProvider.vue
@@ -20,6 +20,7 @@ SPDX-License-Identifier: Apache-2.0
       >
         <g-vendor-icon
           :name="type"
+          vendor-type="dns"
           :size="14"
         />
         <g-credential-name

--- a/frontend/src/components/ShootDns/GDnsProviderRow.vue
+++ b/frontend/src/components/ShootDns/GDnsProviderRow.vue
@@ -19,7 +19,10 @@ SPDX-License-Identifier: Apache-2.0
           <template #item="{ props }">
             <v-list-item v-bind="props">
               <template #prepend>
-                <g-vendor-icon :name="props.value" />
+                <g-vendor-icon
+                  :name="props.value"
+                  vendor-type="dns"
+                />
               </template>
             </v-list-item>
           </template>
@@ -27,6 +30,7 @@ SPDX-License-Identifier: Apache-2.0
             <div class="d-flex">
               <g-vendor-icon
                 :name="item.title"
+                vendor-type="dns"
                 class="mr-2"
               />
               {{ item.title }}

--- a/frontend/src/components/ShootDns/GManageDns.vue
+++ b/frontend/src/components/ShootDns/GManageDns.vue
@@ -50,7 +50,10 @@ SPDX-License-Identifier: Apache-2.0
             <template #item="{ props }">
               <v-list-item v-bind="props">
                 <template #prepend>
-                  <g-vendor-icon :name="props.value" />
+                  <g-vendor-icon
+                    :name="props.value"
+                    vendor-type="dns"
+                  />
                 </template>
               </v-list-item>
             </template>
@@ -58,6 +61,7 @@ SPDX-License-Identifier: Apache-2.0
               <div class="d-flex">
                 <g-vendor-icon
                   :name="item.value"
+                  vendor-type="dns"
                   class="mr-2"
                 />
                 {{ item.value }}

--- a/frontend/src/composables/useCloudProfile/useMachineImages.js
+++ b/frontend/src/composables/useCloudProfile/useMachineImages.js
@@ -60,7 +60,10 @@ export function useMachineImages (cloudProfile) {
    */
   function flattenAndSortMachineImages (machineImages) {
     const machineImagesWithVendors = map(machineImages, machineImage => {
-      const vendor = configStore.vendorDetails(machineImage.name)
+      const vendor = configStore.vendorDetails({
+        type: 'machineImage',
+        name: machineImage.name,
+      })
       return {
         ...machineImage,
         vendor,

--- a/frontend/src/store/cloudProfile/index.js
+++ b/frontend/src/store/cloudProfile/index.js
@@ -52,7 +52,12 @@ export const useCloudProfileStore = defineStore('cloudProfile', () => {
   })
 
   const sortedInfraProviderTypeList = computed(() => {
-    const infraProviderVendors = map(infraProviderTypesList.value, configStore.vendorDetails)
+    const infraProviderVendors = map(infraProviderTypesList.value, name => {
+      return configStore.vendorDetails({
+        type: 'infra',
+        name,
+      })
+    })
     const sortedVisibleInfraVendors = sortBy(infraProviderVendors, 'weight')
     return map(sortedVisibleInfraVendors, 'name')
   })

--- a/frontend/src/store/config.js
+++ b/frontend/src/store/config.js
@@ -29,7 +29,6 @@ import camelCase from 'lodash/camelCase'
 import find from 'lodash/find'
 import uniq from 'lodash/uniq'
 import sortBy from 'lodash/sortBy'
-import head from 'lodash/head'
 
 const logger = useLogger()
 
@@ -483,35 +482,23 @@ export const useConfigStore = defineStore('config', () => {
     return detailsMap
   })
 
-  function vendorDetails (name) {
-    const matches = []
-    for (const t of vendorTypes.value) {
-      const vendor = vendorDetailsMap.value.get(vendorKey(t, name))
-      if (vendor) {
-        matches.push(vendor)
-      }
+  function vendorDetails ({ type, name }) {
+    const vendor = vendorDetailsMap.value.get(vendorKey(type, name))
+    if (vendor) {
+      return vendor
     }
 
-    if (matches.length === 1) {
-      return head(matches)
-    }
-
-    if (matches.length === 0) {
-      logger.warn(`VendorDetails: No vendor found for name='${name}'`)
-    }
-
-    if (matches.length > 1) {
-      logger.warn(`VendorDetails: Multiple vendors found for name='${name}'`)
-    }
+    logger.warn(`VendorDetails: No vendor found for type='${type}' name='${name}'`)
 
     return {
+      type,
       name,
       weight: Number.MAX_SAFE_INTEGER,
     }
   }
 
-  function vendorDisplayName (name) {
-    return get(vendorDetails(name), ['displayName'], name)
+  function vendorDisplayName ({ type, name }) {
+    return get(vendorDetails({ type, name }), ['displayName'], name)
   }
 
   const dnsProviderTypesList = computed(() => {
@@ -522,7 +509,7 @@ export const useConfigStore = defineStore('config', () => {
   })
 
   const sortedDnsProviderTypeList = computed(() => {
-    const dnsProviderVendors = map(dnsProviderTypesList.value, vendorDetails)
+    const dnsProviderVendors = map(dnsProviderTypesList.value, name => vendorDetails({ type: 'dns', name }))
     const sortedVisibleDnsVendors = sortBy(dnsProviderVendors, 'weight')
     return map(sortedVisibleDnsVendors, 'name')
   })
@@ -574,7 +561,6 @@ export const useConfigStore = defineStore('config', () => {
     setConfiguration,
     conditionForType,
     vendorDetails,
-    // vendor: vendorDetails,
     vendorDisplayName,
     $reset,
   }

--- a/frontend/src/store/config.js
+++ b/frontend/src/store/config.js
@@ -444,8 +444,6 @@ export const useConfigStore = defineStore('config', () => {
     machineImage: knownMachineImageVendors,
   }
 
-  const vendorKey = (type, name) => `${type}::${name}`
-
   const vendorTypes = computed(() => {
     return new Set([
       ...Object.keys(knownVendors),
@@ -457,6 +455,7 @@ export const useConfigStore = defineStore('config', () => {
     const detailsMap = new Map()
 
     for (const type of vendorTypes.value) {
+      const detailsByName = new Map()
       const knownArr = get(knownVendors, [type], [])
       const confArr = get(configVendors.value, [type], [])
 
@@ -469,7 +468,7 @@ export const useConfigStore = defineStore('config', () => {
         const knownVendor = find(knownArr, ['name', name])
         const configuredVendor = find(confArr, ['name', name])
 
-        detailsMap.set(vendorKey(type, name), {
+        detailsByName.set(name, {
           type,
           name,
           weight: Number.MAX_SAFE_INTEGER,
@@ -477,13 +476,15 @@ export const useConfigStore = defineStore('config', () => {
           ...configuredVendor,
         })
       }
+
+      detailsMap.set(type, detailsByName)
     }
 
     return detailsMap
   })
 
   function vendorDetails ({ type, name }) {
-    const vendor = vendorDetailsMap.value.get(vendorKey(type, name))
+    const vendor = vendorDetailsMap.value.get(type)?.get(name)
     if (vendor) {
       return vendor
     }

--- a/frontend/src/views/GCredentials.vue
+++ b/frontend/src/views/GCredentials.vue
@@ -63,11 +63,12 @@ SPDX-License-Identifier: Apache-2.0
                 <template #prepend>
                   <g-vendor-icon
                     :name="infrastructure"
+                    vendor-type="infra"
                     :size="24"
                   />
                 </template>
                 <v-list-item-title>
-                  {{ vendorDisplayName(infrastructure) }}
+                  {{ vendorDisplayName({ type: 'infra', name: infrastructure }) }}
                 </v-list-item-title>
               </v-list-item>
             </v-list>
@@ -189,11 +190,12 @@ SPDX-License-Identifier: Apache-2.0
                 <template #prepend>
                   <g-vendor-icon
                     :name="dnsProvider"
+                    vendor-type="dns"
                     :size="24"
                   />
                 </template>
                 <v-list-item-title>
-                  {{ vendorDisplayName(dnsProvider) }}
+                  {{ vendorDisplayName({ type: 'dns', name: dnsProvider }) }}
                 </v-list-item-title>
               </v-list-item>
             </v-list>
@@ -251,6 +253,7 @@ SPDX-License-Identifier: Apache-2.0
 
     <g-secret-dialog-wrapper
       :visible-dialog="visibleCredentialDialog"
+      :visible-dialog-vendor-type="visibleCredentialVendorType"
       :selected-dns-credential="selectedDnsCredential"
       :selected-infra-binding="selectedInfraBinding"
       @dialog-closed="onDialogClosed"
@@ -382,6 +385,7 @@ export default {
       dnsCredentialFilter: '',
       createDnsCredentialMenu: false,
       visibleCredentialDialog: undefined,
+      visibleCredentialVendorType: undefined,
     }
   },
   computed: {
@@ -579,38 +583,45 @@ export default {
       this.selectedInfraBinding = undefined
       this.selectedDnsCredential = undefined
       this.visibleCredentialDialog = providerType
+      this.visibleCredentialVendorType = 'infra'
     },
     onAddDnsCredential (providerType) {
       this.selectedInfraBinding = undefined
       this.selectedDnsCredential = undefined
       this.visibleCredentialDialog = providerType
+      this.visibleCredentialVendorType = 'dns'
     },
     onUpdateInfraBinding (binding) {
       const providerType = bindingProviderType(binding)
       this.selectedInfraBinding = binding
       this.selectedDnsCredential = undefined
       this.visibleCredentialDialog = providerType
+      this.visibleCredentialVendorType = 'infra'
     },
     onDeleteInfraBinding (binding) {
       this.selectedInfraBinding = binding
       this.selectedDnsCredential = undefined
       this.visibleCredentialDialog = 'delete'
+      this.visibleCredentialVendorType = 'infra'
     },
     onMigrateSecretBinding (binding) {
       this.selectedInfraBinding = binding
       this.selectedDnsCredential = undefined
       this.visibleCredentialDialog = 'migrate-secret-binding'
+      this.visibleCredentialVendorType = 'infra'
     },
     onUpdateDnsCredential (credential) {
       const providerType = credentialProviderType(credential)
       this.selectedDnsCredential = credential
       this.selectedInfraBinding = undefined
       this.visibleCredentialDialog = providerType
+      this.visibleCredentialVendorType = 'dns'
     },
     onDeleteDnsCredential (credential) {
       this.selectedDnsCredential = credential
       this.selectedInfraBinding = undefined
       this.visibleCredentialDialog = 'delete'
+      this.visibleCredentialVendorType = 'dns'
     },
     setSelectedInfraHeader (header) {
       this.infraCredentialSelectedColumns[header.key] = !header.selected
@@ -633,6 +644,7 @@ export default {
     onDialogClosed () {
       // This forces re-rendering of credential dialogs when re-opened so we don't need to reset them manually
       this.visibleCredentialDialog = undefined
+      this.visibleCredentialVendorType = undefined
     },
     sortItems (items, sortByArr, secondSortCriteria) {
       const sortByObj = head(sortByArr)


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:

This is the second preparatory refactor extracted from #2824 and follows the vendor registry extraction in #3075.

Vendor lookup previously accepted only a vendor name and searched across infrastructure, DNS, and machine-image vendors. This became ambiguous when multiple vendor domains used the same name and made it impossible for callers to state which registry they intended to query.

This change:

- requires vendor lookups to provide both the vendor domain (`infra`, `dns`, or `machineImage`) and name
- propagates the vendor domain through vendor icons, display names, credential dialog routing, cloud-profile sorting, and machine-image decoration
- adds regression coverage proving that infrastructure and DNS vendors with the same name resolve independently

**Related PRs**:

- Original combined refactor: #2824
- First preparatory refactor: #3075

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

Please review this as the second preparatory refactor in the sequential split of #2824. The API change is intentionally mechanical: every lookup site now supplies its known vendor domain.

Validation:

- `make verify`
- focused config-store, cloud-profile, and machine-image tests

**Release note**:

```other developer
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved vendor identification by consistently using vendor type for infrastructure and DNS across lists, tooltips, popovers, and selection UIs.
  - Corrected vendor display names in credential dialogs and related screens.
  - Fixed vendor icon resolution when the required vendor details aren’t available.

- **Tests**
  - Added unit test coverage for vendor details and display-name lookups for both infrastructure and DNS providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->