### PR TITLE
Move credential details to vendor configuration

### DIFF
--- a/frontend/__tests__/composables/__snapshots__/credential.helper.spec.js.snap
+++ b/frontend/__tests__/composables/__snapshots__/credential.helper.spec.js.snap
@@ -59,7 +59,7 @@ exports[`secretDetails > matches snapshots for all known provider types (includi
   "google-clouddns": [
     {
       "label": "Project",
-      "value": "example-google-project-id",
+      "value": "example-gcp-project-id",
     },
   ],
   "hcloud": [

--- a/frontend/__tests__/composables/__snapshots__/credential.helper.spec.js.snap
+++ b/frontend/__tests__/composables/__snapshots__/credential.helper.spec.js.snap
@@ -1,0 +1,150 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`secretDetails > matches snapshots for all known provider types (including unhandled types) 1`] = `
+{
+  "alicloud": [
+    {
+      "label": "Access Key ID",
+      "value": "example-access-key-id",
+    },
+  ],
+  "alicloud-dns": [
+    {
+      "label": "Access Key ID",
+      "value": "example-access-key-id",
+    },
+  ],
+  "aws": [
+    {
+      "label": "Access Key ID",
+      "value": "example-access-key-id",
+    },
+  ],
+  "aws-route53": [
+    {
+      "label": "Access Key ID",
+      "value": "example-access-key-id",
+    },
+  ],
+  "azure": [
+    {
+      "label": "Subscription ID",
+      "value": "example-subscription-id",
+    },
+  ],
+  "azure-dns": [
+    {
+      "label": "Subscription ID",
+      "value": "example-subscription-id",
+    },
+  ],
+  "azure-private-dns": [
+    {
+      "label": "Subscription ID",
+      "value": "example-subscription-id",
+    },
+  ],
+  "cloudflare-dns": [
+    {
+      "hidden": true,
+      "label": "API Key",
+    },
+  ],
+  "gcp": [
+    {
+      "label": "Project",
+      "value": "example-gcp-project-id",
+    },
+  ],
+  "google-clouddns": [
+    {
+      "label": "Project",
+      "value": "example-google-project-id",
+    },
+  ],
+  "hcloud": [
+    {
+      "hidden": true,
+      "label": "Hetzner Cloud Token",
+    },
+  ],
+  "infoblox-dns": [
+    {
+      "label": "Infoblox Username",
+      "value": "example-infoblox-user",
+    },
+  ],
+  "ironcore": undefined,
+  "local": undefined,
+  "metal": [
+    {
+      "label": "API URL",
+      "value": "https://metal.example.org",
+    },
+  ],
+  "netlify-dns": [
+    {
+      "hidden": true,
+      "label": "API Key",
+    },
+  ],
+  "onMetal": undefined,
+  "openstack": [
+    {
+      "label": "Domain Name",
+      "value": "example-domain",
+    },
+    {
+      "label": "Tenant Name",
+      "value": "example-tenant",
+    },
+  ],
+  "openstack-designate": [
+    {
+      "label": "Domain Name",
+      "value": "example-domain",
+    },
+    {
+      "label": "Tenant Name",
+      "value": "example-tenant",
+    },
+  ],
+  "powerdns": [
+    {
+      "label": "Server",
+      "value": "https://powerdns.example.org",
+    },
+    {
+      "hidden": true,
+      "label": "API Key",
+    },
+  ],
+  "rfc2136": [
+    {
+      "label": "Server",
+      "value": "dns.example.org:53",
+    },
+    {
+      "label": "TSIG Key Name",
+      "value": "key.example.org.",
+    },
+    {
+      "label": "Zone",
+      "value": "example.org.",
+    },
+  ],
+  "stackit": undefined,
+  "vsphere": [
+    {
+      "label": "vSphere Username",
+      "value": "example-vsphere-user",
+    },
+    {
+      "label": "NSX-T Username",
+      "value": "example-nsxt-user",
+    },
+  ],
+}
+`;
+
+exports[`secretDetails > returns undefined for unknown provider types 1`] = `undefined`;

--- a/frontend/__tests__/composables/credential.helper.spec.js
+++ b/frontend/__tests__/composables/credential.helper.spec.js
@@ -1,0 +1,102 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import { Base64 } from 'js-base64'
+
+import { secretDetails } from '@/composables/credential/helper'
+
+import infraProviders from '@/data/vendors/infra'
+import dnsProviders from '@/data/vendors/dns'
+
+function encode (value) {
+  return Base64.encode(value)
+}
+
+function createSecretData () {
+  return {
+    domainName: encode('example-domain'),
+    tenantName: encode('example-tenant'),
+    vsphereUsername: encode('example-vsphere-user'),
+    nsxtUsername: encode('example-nsxt-user'),
+    accessKeyID: encode('example-access-key-id'),
+    subscriptionID: encode('example-subscription-id'),
+    'serviceaccount.json': encode(JSON.stringify({ project_id: 'example-gcp-project-id' })),
+    project: encode('example-google-project-id'),
+    metalAPIURL: encode('https://metal.example.org'),
+    USERNAME: encode('example-infoblox-user'),
+    Server: encode('dns.example.org:53'),
+    TSIGKeyName: encode('key.example.org.'),
+    Zone: encode('example.org.'),
+    server: encode('https://powerdns.example.org'),
+  }
+}
+
+describe('secretDetails', () => {
+  const providerConfigs = [
+    ...infraProviders,
+    ...dnsProviders,
+  ]
+
+  it('matches snapshots for all known provider types (including unhandled types)', () => {
+    const secret = {
+      data: createSecretData(),
+    }
+
+    const detailsByProviderType = Object.fromEntries(
+      providerConfigs.map(providerConfig => {
+        return [providerConfig.name, secretDetails({ secret, providerConfig })]
+      }),
+    )
+
+    expect(detailsByProviderType).toMatchSnapshot()
+  })
+
+  it('returns undefined for unknown provider types', () => {
+    const secret = {
+      data: createSecretData(),
+    }
+
+    expect(secretDetails({ secret, providerConfig: undefined })).toMatchSnapshot()
+  })
+
+  it('does not throw when secret is undefined', () => {
+    const providerConfig = infraProviders.find(({ name }) => name === 'aws')
+
+    expect(secretDetails({ secret: undefined, providerConfig })).toEqual([
+      {
+        label: 'Access Key ID',
+        value: undefined,
+      },
+    ])
+  })
+
+  it('returns undefined for gcp-derived values when serviceaccount.json is invalid', () => {
+    const secret = {
+      data: {
+        ...createSecretData(),
+        project: undefined,
+        'serviceaccount.json': encode('not-json'),
+      },
+    }
+
+    const gcpProviderConfig = infraProviders.find(({ name }) => name === 'gcp')
+    const googleCloudDnsProviderConfig = dnsProviders.find(({ name }) => name === 'google-clouddns')
+
+    expect(secretDetails({ secret, providerConfig: gcpProviderConfig })).toEqual([
+      {
+        label: 'Project',
+        value: undefined,
+      },
+    ])
+
+    expect(secretDetails({ secret, providerConfig: googleCloudDnsProviderConfig })).toEqual([
+      {
+        label: 'Project',
+        value: undefined,
+      },
+    ])
+  })
+})

--- a/frontend/__tests__/composables/credential.helper.spec.js
+++ b/frontend/__tests__/composables/credential.helper.spec.js
@@ -24,7 +24,6 @@ function createSecretData () {
     accessKeyID: encode('example-access-key-id'),
     subscriptionID: encode('example-subscription-id'),
     'serviceaccount.json': encode(JSON.stringify({ project_id: 'example-gcp-project-id' })),
-    project: encode('example-google-project-id'),
     metalAPIURL: encode('https://metal.example.org'),
     USERNAME: encode('example-infoblox-user'),
     Server: encode('dns.example.org:53'),
@@ -32,6 +31,24 @@ function createSecretData () {
     Zone: encode('example.org.'),
     server: encode('https://powerdns.example.org'),
   }
+}
+
+function resolveDetailValue ({ data, valueFrom }) {
+  const details = secretDetails({
+    secret: { data },
+    providerConfig: {
+      secret: {
+        details: [
+          {
+            label: 'Value',
+            valueFrom,
+          },
+        ],
+      },
+    },
+  })
+
+  return details[0].value
 }
 
 describe('secretDetails', () => {
@@ -54,6 +71,86 @@ describe('secretDetails', () => {
     expect(detailsByProviderType).toMatchSnapshot()
   })
 
+  it('uses valueFrom for all visible details in the vendor configuration', () => {
+    for (const providerConfig of providerConfigs) {
+      for (const detail of providerConfig.secret?.details ?? []) {
+        if (detail.hidden) {
+          continue
+        }
+
+        expect(detail).toHaveProperty('valueFrom')
+        expect(detail).not.toHaveProperty('key')
+        expect(detail).not.toHaveProperty('decode')
+      }
+    }
+  })
+
+  it('resolves single and fallback key paths without mutating the source configuration', () => {
+    const literalKeySource = Object.freeze({
+      key: Object.freeze(['literal.key']),
+    })
+    const fallbackKeysSource = Object.freeze({
+      keys: Object.freeze([
+        Object.freeze(['empty']),
+        Object.freeze(['nested', 'fallback']),
+      ]),
+    })
+
+    expect(resolveDetailValue({
+      data: {
+        literal: {
+          key: encode('wrong-value'),
+        },
+        'literal.key': encode('literal-value'),
+      },
+      valueFrom: literalKeySource,
+    })).toBe('literal-value')
+
+    expect(resolveDetailValue({
+      data: {
+        empty: '',
+        nested: {
+          fallback: encode('fallback-value'),
+        },
+      },
+      valueFrom: fallbackKeysSource,
+    })).toBe('fallback-value')
+  })
+
+  it('supports parsing raw values when decoding is disabled', () => {
+    expect(resolveDetailValue({
+      data: {
+        raw: JSON.stringify({
+          nested: {
+            value: 'raw-value',
+          },
+        }),
+      },
+      valueFrom: {
+        key: ['raw'],
+        decode: false,
+        parse: 'json',
+        path: ['nested', 'value'],
+      },
+    })).toBe('raw-value')
+  })
+
+  it.each([
+    ['both key and keys', { key: ['value'], keys: [['value']] }],
+    ['a string key', { key: 'value' }],
+    ['flat fallback keys', { keys: ['value'] }],
+    ['an invalid result path', { key: ['value'], path: 'nested.value' }],
+    ['an unsupported parser', { key: ['value'], parse: 'yaml' }],
+    ['an array', [{ key: ['value'] }]],
+  ])('rejects valueFrom with %s', (description, valueFrom) => {
+    expect(resolveDetailValue({
+      data: {
+        value: encode('value'),
+      },
+      valueFrom,
+    })).toBeUndefined()
+  })
+
   it('returns undefined for unknown provider types', () => {
     const secret = {
       data: createSecretData(),
@@ -73,11 +170,28 @@ describe('secretDetails', () => {
     ])
   })
 
+  it('resolves the Google Cloud DNS project from serviceaccount.json', () => {
+    const secret = {
+      data: {
+        'serviceaccount.json': encode(JSON.stringify({
+          project_id: 'fallback-project-id',
+        })),
+      },
+    }
+    const providerConfig = dnsProviders.find(({ name }) => name === 'google-clouddns')
+
+    expect(secretDetails({ secret, providerConfig })).toEqual([
+      {
+        label: 'Project',
+        value: 'fallback-project-id',
+      },
+    ])
+  })
+
   it('returns undefined for gcp-derived values when serviceaccount.json is invalid', () => {
     const secret = {
       data: {
         ...createSecretData(),
-        project: undefined,
         'serviceaccount.json': encode('not-json'),
       },
     }

--- a/frontend/__tests__/composables/useCloudProviderBinding.spec.js
+++ b/frontend/__tests__/composables/useCloudProviderBinding.spec.js
@@ -145,7 +145,9 @@ describe('useCloudProviderBinding composable', () => {
           details: [
             {
               label: 'Secret',
-              key: 'secret',
+              valueFrom: {
+                key: ['secret'],
+              },
             },
           ],
         },

--- a/frontend/__tests__/composables/useCloudProviderBinding.spec.js
+++ b/frontend/__tests__/composables/useCloudProviderBinding.spec.js
@@ -137,6 +137,35 @@ describe('useCloudProviderBinding composable', () => {
     expect(bindingComposable.credential.value).toMatchSnapshot()
   })
 
+  it('resolves secret details using the infra vendor configuration', () => {
+    const secretBindingRef = findBindingRef('aws-secretbinding')
+    const configStore = {
+      vendorDetails: vi.fn(() => ({
+        secret: {
+          details: [
+            {
+              label: 'Secret',
+              key: 'secret',
+            },
+          ],
+        },
+      })),
+    }
+    const bindingComposable = useCloudProviderBinding(secretBindingRef, { configStore })
+
+    expect(bindingComposable.credentialDetails.value).toEqual([
+      {
+        label: 'Secret',
+        value: 's',
+      },
+    ])
+    expect(configStore.vendorDetails).toHaveBeenCalledTimes(1)
+    expect(configStore.vendorDetails).toHaveBeenCalledWith({
+      type: 'infra',
+      name: 'aws',
+    })
+  })
+
   it('counts shoots referencing infra secretbinding', () => {
     const secretBindingRef = findBindingRef('aws-secretbinding')
     const bindingComposable = useCloudProviderBinding(secretBindingRef)

--- a/frontend/__tests__/composables/useDnsProviderCredential.spec.js
+++ b/frontend/__tests__/composables/useDnsProviderCredential.spec.js
@@ -11,11 +11,11 @@ import {
 import { useShootStore } from '@/store/shoot'
 import { useCredentialStore } from '@/store/credential'
 
-import { useCloudProviderCredential } from '@/composables/credential/useCloudProviderCredential'
+import { useDnsProviderCredential } from '@/composables/credential/useDnsProviderCredential'
 
 import find from 'lodash/find'
 
-describe('useCloudProviderCredential composable', () => {
+describe('useDnsProviderCredential composable', () => {
   let shootStore
   let credentialStore
 
@@ -58,15 +58,44 @@ describe('useCloudProviderCredential composable', () => {
     credentialStore._setCredentials(fixtures.credentials)
   })
 
-  function findbindingCredentialRef (name) {
+  function findDnsCredentialRef (name) {
     const credential = find(credentialStore.dnsCredentialList, c => c.metadata.name === name)
     return ref(credential)
   }
 
   it('counts shoots referencing dns secret', () => {
-    const bindingCredentialRef = findbindingCredentialRef('aws-route53-secret')
-    const composable = useCloudProviderCredential(bindingCredentialRef)
+    const dnsCredentialRef = findDnsCredentialRef('aws-route53-secret')
+    const composable = useDnsProviderCredential(dnsCredentialRef)
     expect(composable.credentialUsageCount.value).toBe(2)
+  })
+
+  it('resolves secret details using the dns vendor configuration', () => {
+    const dnsCredentialRef = findDnsCredentialRef('aws-route53-secret')
+    const configStore = {
+      vendorDetails: vi.fn(() => ({
+        secret: {
+          details: [
+            {
+              label: 'Secret',
+              key: 'secret',
+            },
+          ],
+        },
+      })),
+    }
+    const composable = useDnsProviderCredential(dnsCredentialRef, { configStore })
+
+    expect(composable.credentialDetails.value).toEqual([
+      {
+        label: 'Secret',
+        value: 's',
+      },
+    ])
+    expect(configStore.vendorDetails).toHaveBeenCalledTimes(1)
+    expect(configStore.vendorDetails).toHaveBeenCalledWith({
+      type: 'dns',
+      name: 'aws-route53',
+    })
   })
 
   it('counts shoots referencing legacy dns provider secretName', () => {
@@ -81,8 +110,8 @@ describe('useCloudProviderCredential composable', () => {
       },
     }
 
-    const bindingCredentialRef = findbindingCredentialRef('aws-route53-secret')
-    const composable = useCloudProviderCredential(bindingCredentialRef)
+    const dnsCredentialRef = findDnsCredentialRef('aws-route53-secret')
+    const composable = useDnsProviderCredential(dnsCredentialRef)
     expect(composable.credentialUsageCount.value).toBe(3)
   })
 })

--- a/frontend/__tests__/composables/useDnsProviderCredential.spec.js
+++ b/frontend/__tests__/composables/useDnsProviderCredential.spec.js
@@ -77,7 +77,9 @@ describe('useDnsProviderCredential composable', () => {
           details: [
             {
               label: 'Secret',
-              key: 'secret',
+              valueFrom: {
+                key: ['secret'],
+              },
             },
           ],
         },

--- a/frontend/src/components/Credentials/GBindingName.vue
+++ b/frontend/src/components/Credentials/GBindingName.vue
@@ -34,6 +34,7 @@ SPDX-License-Identifier: Apache-2.0
           :credential="credential"
           :shared="isSharedBinding"
           :provider-type="providerType"
+          vendor-type="infra"
         />
       </v-card>
     </v-tooltip>

--- a/frontend/src/components/Credentials/GBindingRowInfra.vue
+++ b/frontend/src/components/Credentials/GBindingRowInfra.vue
@@ -38,6 +38,7 @@ SPDX-License-Identifier: Apache-2.0
         :credential="item.credential"
         :shared="item.isSharedBinding"
         :provider-type="item.providerType"
+        vendor-type="infra"
       />
     </td>
     <td v-if="selectedHeaders.credentialUsageCount">

--- a/frontend/src/components/Credentials/GCredentialDetailsItemContent.vue
+++ b/frontend/src/components/Credentials/GCredentialDetailsItemContent.vue
@@ -34,6 +34,10 @@ SPDX-License-Identifier: Apache-2.0
 </template>
 
 <script>
+import { mapActions } from 'pinia'
+
+import { useConfigStore } from '@/store/config'
+
 import {
   secretDetails,
   isSecret,
@@ -53,6 +57,9 @@ export default {
     providerType: {
       type: String,
     },
+    vendorType: {
+      type: String,
+    },
     detailsTitle: {
       type: Boolean,
       default: false,
@@ -69,7 +76,23 @@ export default {
           },
         ]
       } else if (isSecret(this.credential)) {
-        const details = secretDetails({ secret: this.credential, providerType: this.providerType })
+        if (!this.vendorType || !this.providerType) {
+          return [
+            {
+              label: this.credential?.kind || 'Unknown',
+              value: 'Details not available',
+              disabledText: true,
+            },
+          ]
+        }
+        const providerConfig = this.vendorDetails({
+          type: this.vendorType,
+          name: this.providerType,
+        })
+        const details = secretDetails({
+          secret: this.credential,
+          providerConfig,
+        })
         if (details) {
           return details
         }
@@ -90,6 +113,9 @@ export default {
         },
       ]
     },
+  },
+  methods: {
+    ...mapActions(useConfigStore, ['vendorDetails']),
   },
 }
 </script>

--- a/frontend/src/components/Credentials/GCredentialName.vue
+++ b/frontend/src/components/Credentials/GCredentialName.vue
@@ -34,6 +34,7 @@ SPDX-License-Identifier: Apache-2.0
           class="ma-1"
           :credential="credential"
           :provider-type="providerType"
+          vendor-type="dns"
         />
       </v-card>
     </v-tooltip>
@@ -56,7 +57,7 @@ import GTextRouterLink from '@/components/GTextRouterLink.vue'
 import GCredentialDetailsItemContent from '@/components/Credentials/GCredentialDetailsItemContent'
 import GCredentialIcon from '@/components/Credentials/GCredentialIcon'
 
-import { useCloudProviderCredential } from '@/composables/credential/useCloudProviderCredential'
+import { useDnsProviderCredential } from '@/composables/credential/useDnsProviderCredential'
 
 const props = defineProps({
   credential: Object,
@@ -74,7 +75,7 @@ const {
   resourceName,
   resourceNamespace,
   resourceUid,
-} = useCloudProviderCredential(credential)
+} = useDnsProviderCredential(credential)
 
 const resourceHash = computed(() => {
   const uid = resourceUid.value

--- a/frontend/src/components/Credentials/GCredentialRowActions.vue
+++ b/frontend/src/components/Credentials/GCredentialRowActions.vue
@@ -41,7 +41,7 @@ import { useAuthzStore } from '@/store/authz'
 
 import GActionButton from '@/components/GActionButton.vue'
 
-import { useCloudProviderCredential } from '@/composables/credential/useCloudProviderCredential'
+import { useDnsProviderCredential } from '@/composables/credential/useDnsProviderCredential'
 
 const props = defineProps({
   credential: Object,
@@ -57,7 +57,7 @@ const {
   hasOwnWorkloadIdentity,
   credentialUsageCount,
   isMarkedForDeletion,
-} = useCloudProviderCredential(credential)
+} = useDnsProviderCredential(credential)
 
 function onUpdate () {
   emit('update', credential.value)

--- a/frontend/src/components/Credentials/GCredentialRowDns.vue
+++ b/frontend/src/components/Credentials/GCredentialRowDns.vue
@@ -29,6 +29,7 @@ SPDX-License-Identifier: Apache-2.0
         :credential="item.credential"
         :shared="item.isSharedBinding"
         :provider-type="item.providerType"
+        vendor-type="dns"
       />
     </td>
     <td v-if="selectedHeaders.credentialUsageCount">

--- a/frontend/src/components/Credentials/GSecretDialog.vue
+++ b/frontend/src/components/Credentials/GSecretDialog.vue
@@ -163,7 +163,7 @@ import { useSecretContext } from '@/composables/credential/useSecretContext'
 import { useSecretBindingContext } from '@/composables/credential/useSecretBindingContext'
 import { useCredentialsBindingContext } from '@/composables/credential/useCredentialsBindingContext'
 import { useCloudProviderBinding } from '@/composables/credential/useCloudProviderBinding'
-import { useCloudProviderCredential } from '@/composables/credential/useCloudProviderCredential'
+import { useDnsProviderCredential } from '@/composables/credential/useDnsProviderCredential'
 
 import {
   messageFromErrors,
@@ -232,7 +232,7 @@ export default {
     if (binding.value) {
       credentialComposable = useCloudProviderBinding(binding)
     } else if (credential.value) {
-      credentialComposable = useCloudProviderCredential(credential)
+      credentialComposable = useDnsProviderCredential(credential)
     }
 
     const {

--- a/frontend/src/components/Credentials/GSecretDialogDelete.vue
+++ b/frontend/src/components/Credentials/GSecretDialogDelete.vue
@@ -83,7 +83,7 @@ import GMessage from '@/components/GMessage'
 import GToolbar from '@/components/GToolbar.vue'
 
 import { useCloudProviderBinding } from '@/composables/credential/useCloudProviderBinding'
-import { useCloudProviderCredential } from '@/composables/credential/useCloudProviderCredential'
+import { useDnsProviderCredential } from '@/composables/credential/useDnsProviderCredential'
 
 import { errorDetailsFromError } from '@/utils/error'
 
@@ -114,7 +114,7 @@ export default {
     if (binding.value) {
       credentialComposable = useCloudProviderBinding(binding)
     } else if (credential.value) {
-      credentialComposable = useCloudProviderCredential(credential)
+      credentialComposable = useDnsProviderCredential(credential)
     }
 
     const {

--- a/frontend/src/components/Credentials/GSelectCredential.vue
+++ b/frontend/src/components/Credentials/GSelectCredential.vue
@@ -91,7 +91,7 @@ import GBindingName from '@/components/Credentials/GBindingName'
 import { useProjectCostObject } from '@/composables/useProjectCostObject'
 import { useCloudProviderEntityList } from '@/composables/credential/useCloudProviderEntityList'
 import { useCloudProviderBinding } from '@/composables/credential/useCloudProviderBinding'
-import { useCloudProviderCredential } from '@/composables/credential/useCloudProviderCredential'
+import { useDnsProviderCredential } from '@/composables/credential/useDnsProviderCredential'
 
 import {
   withParams,
@@ -161,7 +161,7 @@ export default {
     const isDnsProvider = computed(() => dnsProviderTypes.value.includes(providerType.value))
     let composable
     if (isDnsProvider.value) {
-      composable = useCloudProviderCredential(credential)
+      composable = useDnsProviderCredential(credential)
     } else {
       composable = useCloudProviderBinding(credential)
     }

--- a/frontend/src/components/ShootDetails/GShootInfrastructureCard.vue
+++ b/frontend/src/components/ShootDetails/GShootInfrastructureCard.vue
@@ -59,6 +59,7 @@ SPDX-License-Identifier: Apache-2.0
           :credential="credential"
           :shared="isSharedBinding"
           :provider-type="shootCloudProviderBinding.provider.type"
+          vendor-type="infra"
           details-title
         />
       </g-list-item>

--- a/frontend/src/components/ShootDns/GDnsProvider.vue
+++ b/frontend/src/components/ShootDns/GDnsProvider.vue
@@ -58,6 +58,7 @@ SPDX-License-Identifier: Apache-2.0
             class="pb-2"
             :credential="credential"
             :provider-type="type"
+            vendor-type="dns"
             details-title
           />
         </v-list-item>

--- a/frontend/src/composables/credential/helper.js
+++ b/frontend/src/composables/credential/helper.js
@@ -16,6 +16,121 @@ import filter from 'lodash/filter'
 import map from 'lodash/map'
 import omit from 'lodash/omit'
 
+function decodeSecretValue (secretData, key) {
+  const keys = Array.isArray(key) ? key : [key]
+  const selectedKey = keys.find(currentKey => get(secretData, [currentKey]))
+  if (!selectedKey) {
+    return undefined
+  }
+  const value = get(secretData, [selectedKey])
+  if (!value) {
+    return undefined
+  }
+  return decodeBase64(value)
+}
+
+function parseSecretDetailValue (value, parse) {
+  switch (parse) {
+    case 'json':
+      try {
+        return JSON.parse(value)
+      } catch {
+        return undefined
+      }
+    default:
+      return value
+  }
+}
+
+function resolveSecretDetailValueFromSource (secretData, source) {
+  if (!source) {
+    return undefined
+  }
+
+  if (typeof source === 'string') {
+    return decodeSecretValue(secretData, source)
+  }
+
+  const {
+    key,
+    decode = true,
+    parse,
+    path,
+  } = source
+
+  if (!key) {
+    return undefined
+  }
+
+  let value = decode
+    ? decodeSecretValue(secretData, key)
+    : get(secretData, [key])
+
+  if (value === undefined) {
+    return undefined
+  }
+
+  value = parseSecretDetailValue(value, parse)
+
+  if (path) {
+    return get(value, path)
+  }
+
+  return value
+}
+
+function resolveSecretDetailValue (secretData, valueFrom) {
+  const sources = Array.isArray(valueFrom)
+    ? valueFrom
+    : [valueFrom]
+
+  for (const source of sources) {
+    const value = resolveSecretDetailValueFromSource(secretData, source)
+    if (value !== undefined) {
+      return value
+    }
+  }
+
+  return undefined
+}
+
+function resolveSecretDetailsFromVendorConfig ({ secretData, providerConfig }) {
+  const detailDefinitions = get(providerConfig, ['secret', 'details'])
+  if (!Array.isArray(detailDefinitions) || detailDefinitions.length === 0) {
+    return undefined
+  }
+
+  return detailDefinitions.map(detail => {
+    const {
+      label,
+      key,
+      hidden,
+      valueFrom,
+      decode = true,
+    } = detail
+
+    if (hidden) {
+      return { label, hidden: true }
+    }
+
+    if (valueFrom) {
+      return {
+        label,
+        value: resolveSecretDetailValue(secretData, valueFrom),
+      }
+    }
+
+    if (!key) {
+      return { label }
+    }
+
+    return {
+      label,
+      value: decode ? decodeSecretValue(secretData, key) : get(secretData, [key]),
+    }
+  })
+}
+
 // Credentials
 export function isSecret (credential) {
   return credential?.kind === 'Secret'
@@ -213,171 +328,14 @@ export function isInfrastructureBinding ({ binding, infraProviderTypes }) {
 }
 
 // Secret Details
-export function secretDetails ({ secret, providerType }) {
-  const secretData = secret.data || {}
-  const getGCPProjectId = () => {
-    const serviceAccount = get(secretData, ['serviceaccount.json'])
-    return get(JSON.parse(decodeBase64(serviceAccount)), ['project_id'])
-  }
-  try {
-    switch (providerType) {
-      // infra
-      case 'openstack':
-        return [
-          {
-            label: 'Domain Name',
-            value: decodeBase64(secretData.domainName),
-          },
-          {
-            label: 'Tenant Name',
-            value: decodeBase64(secretData.tenantName),
-          },
-        ]
-      case 'vsphere':
-        return [
-          {
-            label: 'vSphere Username',
-            value: decodeBase64(secretData.vsphereUsername),
-          },
-          {
-            label: 'NSX-T Username',
-            value: decodeBase64(secretData.nsxtUsername),
-          },
-        ]
-      case 'aws':
-        return [
-          {
-            label: 'Access Key ID',
-            value: decodeBase64(secretData.accessKeyID),
-          },
-        ]
-      case 'azure':
-        return [
-          {
-            label: 'Subscription ID',
-            value: decodeBase64(secretData.subscriptionID),
-          },
-        ]
-      case 'gcp':
-        return [
-          {
-            label: 'Project',
-            value: getGCPProjectId(),
-          },
-        ]
-      case 'alicloud':
-        return [
-          {
-            label: 'Access Key ID',
-            value: decodeBase64(secretData.accessKeyID),
-          },
-        ]
-      case 'metal':
-        return [
-          {
-            label: 'API URL',
-            value: decodeBase64(secretData.metalAPIURL),
-          },
-        ]
-      case 'hcloud':
-        return [
-          {
-            label: 'Hetzner Cloud Token',
-            hidden: true,
-          },
-        ]
-      case 'openstack-designate':
-        return [
-          {
-            label: 'Domain Name',
-            value: decodeBase64(secretData.domainName),
-          },
-          {
-            label: 'Tenant Name',
-            value: decodeBase64(secretData.tenantName),
-          },
-        ]
-        // dns
-      case 'aws-route53':
-        return [
-          {
-            label: 'Access Key ID',
-            value: decodeBase64(secretData.accessKeyID),
-          },
-        ]
-      case 'azure-dns':
-      case 'azure-private-dns':
-        return [
-          {
-            label: 'Subscription ID',
-            value: decodeBase64(secretData.subscriptionID),
-          },
-        ]
-      case 'google-clouddns':
-        return [
-          {
-            label: 'Project',
-            value: decodeBase64(secretData.project),
-          },
-        ]
-      case 'alicloud-dns':
-        return [
-          {
-            label: 'Access Key ID',
-            value: decodeBase64(secretData.accessKeyID),
-          },
-        ]
-      case 'infoblox-dns':
-        return [
-          {
-            label: 'Infoblox Username',
-            value: decodeBase64(secretData.USERNAME),
-          },
-        ]
-      case 'cloudflare-dns':
-        return [
-          {
-            label: 'API Key',
-            hidden: true,
-          },
-        ]
-      case 'netlify-dns':
-        return [
-          {
-            label: 'API Key',
-            hidden: true,
-          },
-        ]
-      case 'rfc2136':
-        return [
-          {
-            label: 'Server',
-            value: decodeBase64(secretData.Server),
-          },
-          {
-            label: 'TSIG Key Name',
-            value: decodeBase64(secretData.TSIGKeyName),
-          },
-          {
-            label: 'Zone',
-            value: decodeBase64(secretData.Zone),
-          },
-        ]
-      case 'powerdns':
-        return [
-          {
-            label: 'Server',
-            value: decodeBase64(secretData.server),
-          },
-          {
-            label: 'API Key',
-            hidden: true,
-          },
-        ]
-      default:
-        return undefined
-    }
-  } catch (err) {
+export function secretDetails ({ secret, providerConfig }) {
+  const secretData = secret?.data || {}
+  if (!providerConfig) {
     return undefined
   }
+
+  return resolveSecretDetailsFromVendorConfig({
+    secretData,
+    providerConfig,
+  })
 }

--- a/frontend/src/composables/credential/helper.js
+++ b/frontend/src/composables/credential/helper.js
@@ -16,20 +16,48 @@ import filter from 'lodash/filter'
 import map from 'lodash/map'
 import omit from 'lodash/omit'
 
-function decodeSecretValue (secretData, key) {
-  const keys = Array.isArray(key) ? key : [key]
-  const selectedKey = keys.find(currentKey => get(secretData, [currentKey]))
-  if (!selectedKey) {
+function isSecretDetailValuePath (path) {
+  return Array.isArray(path) &&
+    path.length > 0 &&
+    path.every(segment => typeof segment === 'string' || typeof segment === 'number')
+}
+
+function normalizeSecretDetailValuePaths ({ key, keys }) {
+  const hasKey = key !== undefined
+  const hasKeys = keys !== undefined
+
+  if (hasKey === hasKeys) {
     return undefined
   }
-  const value = get(secretData, [selectedKey])
-  if (!value) {
+
+  const paths = hasKey ? [key] : keys
+  if (
+    !Array.isArray(paths) ||
+    paths.length === 0 ||
+    paths.some(path => !isSecretDetailValuePath(path))
+  ) {
     return undefined
   }
-  return decodeBase64(value)
+
+  return paths
+}
+
+function secretDetailValueFromPaths (value, paths) {
+  for (const path of paths) {
+    const selectedValue = get(value, path)
+    if (selectedValue) {
+      return selectedValue
+    }
+  }
+
+  return undefined
 }
 
 function parseSecretDetailValue (value, parse) {
+  if (parse === undefined) {
+    return value
+  }
+
   switch (parse) {
     case 'json':
       try {
@@ -38,60 +66,48 @@ function parseSecretDetailValue (value, parse) {
         return undefined
       }
     default:
-      return value
+      return undefined
   }
 }
 
-function resolveSecretDetailValueFromSource (secretData, source) {
-  if (!source) {
+function resolveSecretDetailValue (secretData, valueFrom) {
+  if (!valueFrom || typeof valueFrom !== 'object' || Array.isArray(valueFrom)) {
     return undefined
-  }
-
-  if (typeof source === 'string') {
-    return decodeSecretValue(secretData, source)
   }
 
   const {
     key,
+    keys,
     decode = true,
     parse,
     path,
-  } = source
+  } = valueFrom
 
-  if (!key) {
+  const paths = normalizeSecretDetailValuePaths({ key, keys })
+  if (!paths) {
     return undefined
   }
 
-  let value = decode
-    ? decodeSecretValue(secretData, key)
-    : get(secretData, [key])
+  let value = secretDetailValueFromPaths(secretData, paths)
 
   if (value === undefined) {
     return undefined
   }
 
+  if (decode) {
+    value = decodeBase64(value)
+  }
+
   value = parseSecretDetailValue(value, parse)
 
-  if (path) {
+  if (path !== undefined) {
+    if (!isSecretDetailValuePath(path)) {
+      return undefined
+    }
     return get(value, path)
   }
 
   return value
-}
-
-function resolveSecretDetailValue (secretData, valueFrom) {
-  const sources = Array.isArray(valueFrom)
-    ? valueFrom
-    : [valueFrom]
-
-  for (const source of sources) {
-    const value = resolveSecretDetailValueFromSource(secretData, source)
-    if (value !== undefined) {
-      return value
-    }
-  }
-
-  return undefined
 }
 
 function resolveSecretDetailsFromVendorConfig ({ secretData, providerConfig }) {
@@ -103,30 +119,21 @@ function resolveSecretDetailsFromVendorConfig ({ secretData, providerConfig }) {
   return detailDefinitions.map(detail => {
     const {
       label,
-      key,
       hidden,
       valueFrom,
-      decode = true,
     } = detail
 
     if (hidden) {
       return { label, hidden: true }
     }
 
-    if (valueFrom) {
-      return {
-        label,
-        value: resolveSecretDetailValue(secretData, valueFrom),
-      }
-    }
-
-    if (!key) {
+    if (!valueFrom) {
       return { label }
     }
 
     return {
       label,
-      value: decode ? decodeSecretValue(secretData, key) : get(secretData, [key]),
+      value: resolveSecretDetailValue(secretData, valueFrom),
     }
   })
 }

--- a/frontend/src/composables/credential/useCloudProviderBinding.js
+++ b/frontend/src/composables/credential/useCloudProviderBinding.js
@@ -13,6 +13,7 @@ import { storeToRefs } from 'pinia'
 import { useShootStore } from '@/store/shoot'
 import { useCloudProfileStore } from '@/store/cloudProfile'
 import { useCredentialStore } from '@/store/credential'
+import { useConfigStore } from '@/store/config'
 
 import { decodeBase64 } from '@/utils'
 
@@ -41,6 +42,7 @@ export const useCloudProviderBinding = (binding, options = {}) => {
     shootStore = useShootStore(),
     cloudProfileStore = useCloudProfileStore(),
     credentialStore = useCredentialStore(),
+    configStore = useConfigStore(),
   } = options
   const { shootList } = storeToRefs(shootStore)
   const { infrastructureBindingList } = storeToRefs(credentialStore)
@@ -86,6 +88,15 @@ export const useCloudProviderBinding = (binding, options = {}) => {
   const providerType = computed(() => {
     return _bindingProviderType(binding.value)
   })
+  const providerConfig = computed(() => {
+    if (!providerType.value) {
+      return undefined
+    }
+    return configStore.vendorDetails({
+      type: 'infra',
+      name: providerType.value,
+    })
+  })
 
   // Credential References
   const bindingCredentialRef = computed(() => {
@@ -118,7 +129,10 @@ export const useCloudProviderBinding = (binding, options = {}) => {
 
   const credentialDetails = computed(() => {
     if (hasSecret.value && credential.value) {
-      return _secretDetails({ secret: credential.value, providerType: providerType.value })
+      return _secretDetails({
+        secret: credential.value,
+        providerConfig: providerConfig.value,
+      })
     }
     return undefined
   })

--- a/frontend/src/composables/credential/useDnsProviderCredential.js
+++ b/frontend/src/composables/credential/useDnsProviderCredential.js
@@ -11,6 +11,7 @@ import {
 import { storeToRefs } from 'pinia'
 
 import { useShootStore } from '@/store/shoot'
+import { useConfigStore } from '@/store/config'
 
 import {
   isSecret as _isSecret,
@@ -20,13 +21,14 @@ import {
 } from './helper'
 
 import some from 'lodash/some'
-export const useCloudProviderCredential = (credential, options = {}) => {
+export const useDnsProviderCredential = (credential, options = {}) => {
   if (!isRef(credential)) {
     throw new TypeError('First argument `credential` must be a ref object')
   }
 
   const {
     shootStore = useShootStore(),
+    configStore = useConfigStore(),
   } = options
   const { shootList } = storeToRefs(shootStore)
 
@@ -38,11 +40,23 @@ export const useCloudProviderCredential = (credential, options = {}) => {
   const credentialName = computed(() => credential.value?.metadata?.name)
   const credentialKind = computed(() => credential.value?.kind)
   const providerType = computed(() => _credentialProviderType(credential.value))
+  const providerConfig = computed(() => {
+    if (!providerType.value) {
+      return undefined
+    }
+    return configStore.vendorDetails({
+      type: 'dns',
+      name: providerType.value,
+    })
+  })
   const resourceUid = computed(() => credential.value?.metadata?.uid)
 
   const credentialDetails = computed(() => {
     if (isSecret.value) {
-      return _secretDetails({ secret: credential.value, providerType: providerType.value })
+      return _secretDetails({
+        secret: credential.value,
+        providerConfig: providerConfig.value,
+      })
     }
     return undefined
   })

--- a/frontend/src/data/vendors/dns/alicloud-dns.js
+++ b/frontend/src/data/vendors/dns/alicloud-dns.js
@@ -1,6 +1,11 @@
+import alicloud from '../infra/alicloud'
+
 export default {
   name: 'alicloud-dns',
   displayName: 'Alicloud DNS',
   weight: 600,
   icon: 'alicloud-dns.png',
+  secret: {
+    details: alicloud.secret.details,
+  },
 }

--- a/frontend/src/data/vendors/dns/aws-route53.js
+++ b/frontend/src/data/vendors/dns/aws-route53.js
@@ -3,4 +3,12 @@ export default {
   displayName: 'Amazon Route53',
   weight: 100,
   icon: 'aws-route53.svg',
+  secret: {
+    details: [
+      {
+        label: 'Access Key ID',
+        key: 'accessKeyID',
+      },
+    ],
+  },
 }

--- a/frontend/src/data/vendors/dns/aws-route53.js
+++ b/frontend/src/data/vendors/dns/aws-route53.js
@@ -7,7 +7,9 @@ export default {
     details: [
       {
         label: 'Access Key ID',
-        key: 'accessKeyID',
+        valueFrom: {
+          key: ['accessKeyID'],
+        },
       },
     ],
   },

--- a/frontend/src/data/vendors/dns/azure-dns.js
+++ b/frontend/src/data/vendors/dns/azure-dns.js
@@ -7,7 +7,12 @@ export default {
     details: [
       {
         label: 'Subscription ID',
-        key: ['subscriptionID', 'subscriptionId'],
+        valueFrom: {
+          keys: [
+            ['subscriptionID'],
+            ['subscriptionId'],
+          ],
+        },
       },
     ],
   },

--- a/frontend/src/data/vendors/dns/azure-dns.js
+++ b/frontend/src/data/vendors/dns/azure-dns.js
@@ -3,4 +3,12 @@ export default {
   displayName: 'Azure DNS',
   weight: 200,
   icon: 'azure-dns.svg',
+  secret: {
+    details: [
+      {
+        label: 'Subscription ID',
+        key: ['subscriptionID', 'subscriptionId'],
+      },
+    ],
+  },
 }

--- a/frontend/src/data/vendors/dns/azure-private-dns.js
+++ b/frontend/src/data/vendors/dns/azure-private-dns.js
@@ -1,6 +1,11 @@
+import azureDns from './azure-dns'
+
 export default {
   name: 'azure-private-dns',
   displayName: 'Azure Private DNS',
   weight: 300,
   icon: 'azure-dns.svg',
+  secret: {
+    details: azureDns.secret.details,
+  },
 }

--- a/frontend/src/data/vendors/dns/cloudflare.js
+++ b/frontend/src/data/vendors/dns/cloudflare.js
@@ -3,4 +3,12 @@ export default {
   displayName: 'Cloudflare DNS',
   weight: 10100,
   icon: 'cloudflare-dns.svg',
+  secret: {
+    details: [
+      {
+        label: 'API Key',
+        hidden: true,
+      },
+    ],
+  },
 }

--- a/frontend/src/data/vendors/dns/google-clouddns.js
+++ b/frontend/src/data/vendors/dns/google-clouddns.js
@@ -7,16 +7,11 @@ export default {
     details: [
       {
         label: 'Project',
-        valueFrom: [
-          {
-            key: 'project',
-          },
-          {
-            key: 'serviceaccount.json',
-            parse: 'json',
-            path: 'project_id',
-          },
-        ],
+        valueFrom: {
+          key: ['serviceaccount.json'],
+          parse: 'json',
+          path: ['project_id'],
+        },
       },
     ],
   },

--- a/frontend/src/data/vendors/dns/google-clouddns.js
+++ b/frontend/src/data/vendors/dns/google-clouddns.js
@@ -3,4 +3,21 @@ export default {
   displayName: 'Google Cloud DNS',
   weight: 400,
   icon: 'google-clouddns.svg',
+  secret: {
+    details: [
+      {
+        label: 'Project',
+        valueFrom: [
+          {
+            key: 'project',
+          },
+          {
+            key: 'serviceaccount.json',
+            parse: 'json',
+            path: 'project_id',
+          },
+        ],
+      },
+    ],
+  },
 }

--- a/frontend/src/data/vendors/dns/infoblox.js
+++ b/frontend/src/data/vendors/dns/infoblox.js
@@ -3,4 +3,12 @@ export default {
   displayName: 'Infoblox',
   weight: 10200,
   icon: 'infoblox-dns.svg',
+  secret: {
+    details: [
+      {
+        label: 'Infoblox Username',
+        key: 'USERNAME',
+      },
+    ],
+  },
 }

--- a/frontend/src/data/vendors/dns/infoblox.js
+++ b/frontend/src/data/vendors/dns/infoblox.js
@@ -7,7 +7,9 @@ export default {
     details: [
       {
         label: 'Infoblox Username',
-        key: 'USERNAME',
+        valueFrom: {
+          key: ['USERNAME'],
+        },
       },
     ],
   },

--- a/frontend/src/data/vendors/dns/netlify.js
+++ b/frontend/src/data/vendors/dns/netlify.js
@@ -3,4 +3,12 @@ export default {
   displayName: 'Netlify DNS',
   weight: 10300,
   icon: 'netlify-dns.svg',
+  secret: {
+    details: [
+      {
+        label: 'API Key',
+        hidden: true,
+      },
+    ],
+  },
 }

--- a/frontend/src/data/vendors/dns/openstack-designate.js
+++ b/frontend/src/data/vendors/dns/openstack-designate.js
@@ -3,4 +3,16 @@ export default {
   displayName: 'OpenStack Designate',
   weight: 500,
   icon: 'openstack.svg',
+  secret: {
+    details: [
+      {
+        label: 'Domain Name',
+        key: 'domainName',
+      },
+      {
+        label: 'Tenant Name',
+        key: 'tenantName',
+      },
+    ],
+  },
 }

--- a/frontend/src/data/vendors/dns/openstack-designate.js
+++ b/frontend/src/data/vendors/dns/openstack-designate.js
@@ -7,11 +7,15 @@ export default {
     details: [
       {
         label: 'Domain Name',
-        key: 'domainName',
+        valueFrom: {
+          key: ['domainName'],
+        },
       },
       {
         label: 'Tenant Name',
-        key: 'tenantName',
+        valueFrom: {
+          key: ['tenantName'],
+        },
       },
     ],
   },

--- a/frontend/src/data/vendors/dns/powerdns.js
+++ b/frontend/src/data/vendors/dns/powerdns.js
@@ -3,4 +3,16 @@ export default {
   displayName: 'PowerDNS',
   weight: 10400,
   icon: 'powerdns.svg',
+  secret: {
+    details: [
+      {
+        label: 'Server',
+        key: 'server',
+      },
+      {
+        label: 'API Key',
+        hidden: true,
+      },
+    ],
+  },
 }

--- a/frontend/src/data/vendors/dns/powerdns.js
+++ b/frontend/src/data/vendors/dns/powerdns.js
@@ -7,7 +7,9 @@ export default {
     details: [
       {
         label: 'Server',
-        key: 'server',
+        valueFrom: {
+          key: ['server'],
+        },
       },
       {
         label: 'API Key',

--- a/frontend/src/data/vendors/dns/rfc2136.js
+++ b/frontend/src/data/vendors/dns/rfc2136.js
@@ -7,15 +7,30 @@ export default {
     details: [
       {
         label: 'Server',
-        key: ['Server', 'server'],
+        valueFrom: {
+          keys: [
+            ['Server'],
+            ['server'],
+          ],
+        },
       },
       {
         label: 'TSIG Key Name',
-        key: ['TSIGKeyName', 'tsigKeyName'],
+        valueFrom: {
+          keys: [
+            ['TSIGKeyName'],
+            ['tsigKeyName'],
+          ],
+        },
       },
       {
         label: 'Zone',
-        key: ['Zone', 'zone'],
+        valueFrom: {
+          keys: [
+            ['Zone'],
+            ['zone'],
+          ],
+        },
       },
     ],
   },

--- a/frontend/src/data/vendors/dns/rfc2136.js
+++ b/frontend/src/data/vendors/dns/rfc2136.js
@@ -3,4 +3,20 @@ export default {
   displayName: 'Dynamic DNS (RFC2136)',
   weight: 10500,
   icon: 'rfc2136.svg',
+  secret: {
+    details: [
+      {
+        label: 'Server',
+        key: ['Server', 'server'],
+      },
+      {
+        label: 'TSIG Key Name',
+        key: ['TSIGKeyName', 'tsigKeyName'],
+      },
+      {
+        label: 'Zone',
+        key: ['Zone', 'zone'],
+      },
+    ],
+  },
 }

--- a/frontend/src/data/vendors/infra/alicloud.js
+++ b/frontend/src/data/vendors/infra/alicloud.js
@@ -3,4 +3,12 @@ export default {
   displayName: 'Alibaba Cloud',
   weight: 500,
   icon: 'alicloud.svg',
+  secret: {
+    details: [
+      {
+        label: 'Access Key ID',
+        key: 'accessKeyID',
+      },
+    ],
+  },
 }

--- a/frontend/src/data/vendors/infra/alicloud.js
+++ b/frontend/src/data/vendors/infra/alicloud.js
@@ -7,7 +7,9 @@ export default {
     details: [
       {
         label: 'Access Key ID',
-        key: 'accessKeyID',
+        valueFrom: {
+          key: ['accessKeyID'],
+        },
       },
     ],
   },

--- a/frontend/src/data/vendors/infra/aws.js
+++ b/frontend/src/data/vendors/infra/aws.js
@@ -3,4 +3,12 @@ export default {
   displayName: 'AWS',
   weight: 100,
   icon: 'aws.svg',
+  secret: {
+    details: [
+      {
+        label: 'Access Key ID',
+        key: 'accessKeyID',
+      },
+    ],
+  },
 }

--- a/frontend/src/data/vendors/infra/aws.js
+++ b/frontend/src/data/vendors/infra/aws.js
@@ -7,7 +7,9 @@ export default {
     details: [
       {
         label: 'Access Key ID',
-        key: 'accessKeyID',
+        valueFrom: {
+          key: ['accessKeyID'],
+        },
       },
     ],
   },

--- a/frontend/src/data/vendors/infra/azure.js
+++ b/frontend/src/data/vendors/infra/azure.js
@@ -7,7 +7,12 @@ export default {
     details: [
       {
         label: 'Subscription ID',
-        key: ['subscriptionID', 'subscriptionId'],
+        valueFrom: {
+          keys: [
+            ['subscriptionID'],
+            ['subscriptionId'],
+          ],
+        },
       },
     ],
   },

--- a/frontend/src/data/vendors/infra/azure.js
+++ b/frontend/src/data/vendors/infra/azure.js
@@ -3,4 +3,12 @@ export default {
   displayName: 'Azure',
   weight: 200,
   icon: 'azure.svg',
+  secret: {
+    details: [
+      {
+        label: 'Subscription ID',
+        key: ['subscriptionID', 'subscriptionId'],
+      },
+    ],
+  },
 }

--- a/frontend/src/data/vendors/infra/gcp.js
+++ b/frontend/src/data/vendors/infra/gcp.js
@@ -8,9 +8,9 @@ export default {
       {
         label: 'Project',
         valueFrom: {
-          key: 'serviceaccount.json',
+          key: ['serviceaccount.json'],
           parse: 'json',
-          path: 'project_id',
+          path: ['project_id'],
         },
       },
     ],

--- a/frontend/src/data/vendors/infra/gcp.js
+++ b/frontend/src/data/vendors/infra/gcp.js
@@ -3,4 +3,16 @@ export default {
   displayName: 'Google Cloud',
   weight: 300,
   icon: 'gcp.svg',
+  secret: {
+    details: [
+      {
+        label: 'Project',
+        valueFrom: {
+          key: 'serviceaccount.json',
+          parse: 'json',
+          path: 'project_id',
+        },
+      },
+    ],
+  },
 }

--- a/frontend/src/data/vendors/infra/hcloud.js
+++ b/frontend/src/data/vendors/infra/hcloud.js
@@ -3,4 +3,12 @@ export default {
   displayName: 'Hetzner Cloud',
   weight: 800,
   icon: 'hcloud.svg',
+  secret: {
+    details: [
+      {
+        label: 'Hetzner Cloud Token',
+        hidden: true,
+      },
+    ],
+  },
 }

--- a/frontend/src/data/vendors/infra/metal.js
+++ b/frontend/src/data/vendors/infra/metal.js
@@ -3,4 +3,12 @@ export default {
   displayName: 'metal-stack',
   weight: 600,
   icon: 'metal.svg',
+  secret: {
+    details: [
+      {
+        label: 'API URL',
+        key: 'metalAPIURL',
+      },
+    ],
+  },
 }

--- a/frontend/src/data/vendors/infra/metal.js
+++ b/frontend/src/data/vendors/infra/metal.js
@@ -7,7 +7,9 @@ export default {
     details: [
       {
         label: 'API URL',
-        key: 'metalAPIURL',
+        valueFrom: {
+          key: ['metalAPIURL'],
+        },
       },
     ],
   },

--- a/frontend/src/data/vendors/infra/openstack.js
+++ b/frontend/src/data/vendors/infra/openstack.js
@@ -3,4 +3,16 @@ export default {
   displayName: 'OpenStack',
   weight: 400,
   icon: 'openstack.svg',
+  secret: {
+    details: [
+      {
+        label: 'Domain Name',
+        key: 'domainName',
+      },
+      {
+        label: 'Tenant Name',
+        key: 'tenantName',
+      },
+    ],
+  },
 }

--- a/frontend/src/data/vendors/infra/openstack.js
+++ b/frontend/src/data/vendors/infra/openstack.js
@@ -7,11 +7,15 @@ export default {
     details: [
       {
         label: 'Domain Name',
-        key: 'domainName',
+        valueFrom: {
+          key: ['domainName'],
+        },
       },
       {
         label: 'Tenant Name',
-        key: 'tenantName',
+        valueFrom: {
+          key: ['tenantName'],
+        },
       },
     ],
   },

--- a/frontend/src/data/vendors/infra/vsphere.js
+++ b/frontend/src/data/vendors/infra/vsphere.js
@@ -7,11 +7,21 @@ export default {
     details: [
       {
         label: 'vSphere Username',
-        key: ['vsphereUsername', 'vSphereUsername'],
+        valueFrom: {
+          keys: [
+            ['vsphereUsername'],
+            ['vSphereUsername'],
+          ],
+        },
       },
       {
         label: 'NSX-T Username',
-        key: ['nsxtUsername', 'NSXTUsername'],
+        valueFrom: {
+          keys: [
+            ['nsxtUsername'],
+            ['NSXTUsername'],
+          ],
+        },
       },
     ],
   },

--- a/frontend/src/data/vendors/infra/vsphere.js
+++ b/frontend/src/data/vendors/infra/vsphere.js
@@ -3,4 +3,16 @@ export default {
   displayName: 'vSphere',
   weight: 700,
   icon: 'vsphere.svg',
+  secret: {
+    details: [
+      {
+        label: 'vSphere Username',
+        key: ['vsphereUsername', 'vSphereUsername'],
+      },
+      {
+        label: 'NSX-T Username',
+        key: ['nsxtUsername', 'NSXTUsername'],
+      },
+    ],
+  },
 }

--- a/frontend/src/views/GCredentials.vue
+++ b/frontend/src/views/GCredentials.vue
@@ -294,7 +294,7 @@ import GToolbar from '@/components/GToolbar'
 import GDataTableFooter from '@/components/GDataTableFooter.vue'
 
 import { useCloudProviderBinding } from '@/composables/credential/useCloudProviderBinding'
-import { useCloudProviderCredential } from '@/composables/credential/useCloudProviderCredential'
+import { useDnsProviderCredential } from '@/composables/credential/useDnsProviderCredential'
 import {
   isSecretBinding,
   isCredentialsBinding,
@@ -554,7 +554,7 @@ export default {
       if (isSecretBinding(resource) || isCredentialsBinding(resource)) {
         composable = useCloudProviderBinding(refResource)
       } else {
-        composable = useCloudProviderCredential(refResource)
+        composable = useDnsProviderCredential(refResource)
       }
       const {
         credentialUsageCount,


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:

This is the third preparatory refactor extracted from #2824 and follows the vendor registry extraction in #3075 and typed vendor lookups in #3082.

Credential detail rendering previously used a provider-name switch in `credential/helper.js`. That kept provider-specific display metadata in application code and required extending the switch for every supported vendor.

This change:

- moves read-only credential-detail definitions into each infrastructure and DNS vendor module under `frontend/src/data/vendors`
- replaces the provider switch with a configuration-driven detail resolver
- supports the existing Azure, vSphere, and RFC2136 Secret-key aliases
- safely resolves GCP project IDs from structured service-account data, including the existing Google Cloud DNS fallback
- looks up vendor configuration through the explicit `infra` or `dns` domain
- renames the DNS-only raw-credential composable to `useDnsProviderCredential`

**Related PRs**:

- Original combined refactor: #2824
- First preparatory refactor: #3075
- Second preparatory refactor: #3082

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

Please review this as the third preparatory refactor in the sequential split of #2824. The `secret.details` configuration is read-only display metadata; it is not used when creating or updating Secrets.

Validation:

- `make verify`
- focused credential-helper, infrastructure-binding, and DNS-credential composable tests
- provider-by-provider snapshot coverage for credential detail output
- GitGuardian pre-commit scan

**Release note**:

```other developer
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added vendor-aware credential details for infrastructure and DNS secrets, including project fields derived from service account content.
  * Improved rendering by passing explicit vendor type into the credential details display.
  * Added support for hidden credential values (e.g., API keys and tokens) in vendor definitions.

* **Bug Fixes**
  * Credential details now safely handle missing/unknown provider data, optional secrets, and malformed or unsupported secret-value mappings.

* **Tests**
  * Expanded Jest coverage for DNS/infra credential resolution, hidden details behavior, and invalid configuration edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->