### PR TITLE
enh(frontend): use light background for infra icons

### DIFF
--- a/frontend/src/components/GVendorIcon.vue
+++ b/frontend/src/components/GVendorIcon.vue
@@ -109,10 +109,7 @@ const iconStyle = computed(() => {
 </script>
 
 <style lang="scss" scoped>
-  @use 'vuetify/settings' as vuetify;
-  @use 'sass:map';
-
   .v-theme--dark .icon-background {
-    background-color: map.get(vuetify.$grey, 'darken-2');
+    background-color: #e0e0e0;
   }
 </style>

--- a/frontend/src/components/GVendorIcon.vue
+++ b/frontend/src/components/GVendorIcon.vue
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 <template>
   <v-avatar
     :size="size"
-    rounded="lg"
     tile
     :class="{ 'icon-background': !noBackground }"
   >
@@ -16,7 +15,6 @@ SPDX-License-Identifier: Apache-2.0
       :src="iconSrc"
       :style="iconStyle"
       :alt="`${icon} logo`"
-      class="rounded-0"
     >
     <v-icon
       v-else
@@ -111,5 +109,6 @@ const iconStyle = computed(() => {
 <style lang="scss" scoped>
   .v-theme--dark .icon-background {
     background-color: #e0e0e0;
+    border-radius: 7px !important;
   }
 </style>

--- a/frontend/src/components/GVendorIcon.vue
+++ b/frontend/src/components/GVendorIcon.vue
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 <template>
   <v-avatar
     :size="size"
-    tile
+    rounded="lg"
     :class="{ 'icon-background': !noBackground }"
   >
     <img
@@ -109,6 +109,5 @@ const iconStyle = computed(() => {
 <style lang="scss" scoped>
   .v-theme--dark .icon-background {
     background-color: #e0e0e0;
-    border-radius: 7px !important;
   }
 </style>

--- a/frontend/src/components/NewShoot/GNewShootInfrastructureCard.vue
+++ b/frontend/src/components/NewShoot/GNewShootInfrastructureCard.vue
@@ -21,7 +21,6 @@ SPDX-License-Identifier: Apache-2.0
           :name="providerType"
           vendor-type="infra"
           :size="60"
-          no-background
           :style="getVendorIconStyles(isHovering)"
         />
         <div class="mt-2 text-body-large">


### PR DESCRIPTION


<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area quality
  /area usability
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|cost|dev-productivity|documentation|high-availability|logging|monitoring|networking|open-source|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
Adds a light background color to the infra icons so that they are easily visible in dark mode. This includes both the infra tiles on the tables and the infra tiles on the create cluster screen.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
NONE
```
### Screenshots:
#### Before:
<img width="199" height="318" alt="Screenshot 2026-07-20 at 16 10 40" src="https://github.com/user-attachments/assets/8e630c12-9a3e-4b4e-9b6e-1737ce979919" />

<img width="985" height="191" alt="Screenshot 2026-07-24 at 17 07 30" src="https://github.com/user-attachments/assets/40704617-2c44-4db4-935f-0f277722480b" />


#### After:
<img width="167" height="224" alt="Screenshot 2026-07-24 at 17 06 13" src="https://github.com/user-attachments/assets/533bb522-121e-4a03-bd22-76606832cbce" />

<img width="985" height="191" alt="Screenshot 2026-07-24 at 17 06 45" src="https://github.com/user-attachments/assets/afb1a641-a237-4e33-b979-59debbb17bf4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Style**
  * Improved dark-mode readability of vendor icons by using a fixed light background color.
  * Updated vendor icon rendering by removing the prior tile/rounded styling behavior.
  * Adjusted the infrastructure card to display the vendor icon with default background behavior (no longer overriding it).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->