### PR TITLE
fix: scope Vuetify 4 padding overrides to specific components

### DIFF
--- a/frontend/src/components/GTerminalTarget.vue
+++ b/frontend/src/components/GTerminalTarget.vue
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Apache-2.0
   <v-radio-group
     v-model="selectedTarget"
     label="Terminal Target"
-    class="mt-6"
+    class="mt-6 px-4"
     :hint="hint"
     persistent-hint
   >

--- a/frontend/src/sass/main.scss
+++ b/frontend/src/sass/main.scss
@@ -143,8 +143,7 @@
   text-transform: uppercase;
 }
 
-.v-toolbar__content,
-.v-toolbar__extension {
+.v-app-bar .v-toolbar__content {
   padding-inline: 16px;
 }
 

--- a/frontend/src/sass/main.scss
+++ b/frontend/src/sass/main.scss
@@ -148,10 +148,6 @@
   padding-inline: 16px;
 }
 
-.v-input__details {
-  padding-inline: 16px;
-}
-
 ul {
   padding: 0px;
   margin: 0px;


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area quality
  /area usability
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|cost|dev-productivity|documentation|high-availability|logging|monitoring|networking|open-source|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area usability
/kind cleanup

**What this PR does / why we need it**:
In PR #3056 the paddings were changed globally, but this caused some elements to have too much padding. This change scopes the padding changes to just the elements that got broken in the Vuetify 4 upgrade. 


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved horizontal spacing for terminal target selection controls.
  - Refined application bar padding to prevent unintended styling of other toolbar elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->