### PR TITLE
Fix Vuetify 4 migration leftovers

### DIFF
--- a/frontend/src/components/GBreadcrumb.vue
+++ b/frontend/src/components/GBreadcrumb.vue
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
       />
     </template>
     <template #title="{ item }">
-      <span :class="{ 'text-title-large': !item.to }">
+      <span :class="{ 'text-title-large ml-3': !item.to }">
         {{ item.title || item }}
       </span>
     </template>

--- a/frontend/src/components/GBreadcrumb.vue
+++ b/frontend/src/components/GBreadcrumb.vue
@@ -5,24 +5,26 @@ SPDX-License-Identifier: Apache-2.0
 -->
 
 <template>
-  <v-breadcrumbs
-    :items="breadcrumbItems"
-    active-color="primary"
-    active-class="text-decoration-none"
-    exact
-  >
-    <template #divider>
-      <v-icon
-        icon="mdi-chevron-right"
-        size="large"
-      />
-    </template>
-    <template #title="{ item }">
-      <span :class="{ 'text-title-large ml-3': !item.to }">
-        {{ item.title || item }}
-      </span>
-    </template>
-  </v-breadcrumbs>
+  <div class="ml-3">
+    <v-breadcrumbs
+      :items="breadcrumbItems"
+      active-color="primary"
+      active-class="text-decoration-none"
+      exact
+    >
+      <template #divider>
+        <v-icon
+          icon="mdi-chevron-right"
+          size="large"
+        />
+      </template>
+      <template #title="{ item }">
+        <span :class="{ 'text-title-large': !item.to }">
+          {{ item.title || item }}
+        </span>
+      </template>
+    </v-breadcrumbs>
+  </div>
 </template>
 
 <script setup>

--- a/frontend/src/components/ShootDns/GDnsProviderRow.vue
+++ b/frontend/src/components/ShootDns/GDnsProviderRow.vue
@@ -29,11 +29,11 @@ SPDX-License-Identifier: Apache-2.0
           <template #selection="{ item }">
             <div class="d-flex">
               <g-vendor-icon
-                :name="item.title"
+                :name="item"
                 vendor-type="dns"
                 class="mr-2"
               />
-              {{ item.title }}
+              {{ item }}
             </div>
           </template>
         </v-select>

--- a/frontend/src/components/ShootDns/GManageDns.vue
+++ b/frontend/src/components/ShootDns/GManageDns.vue
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 -->
 
 <template>
-  <v-container class="px-0 mx-0">
+  <div>
     <v-row>
       <v-checkbox
         v-model="customDomainEnabled"
@@ -16,7 +16,7 @@ SPDX-License-Identifier: Apache-2.0
         persistent-hint
         :hint="domainCheckboxHint"
         max-width="50%"
-        class="mb-3 mx-3"
+        class="mb-2"
       />
     </v-row>
     <template v-if="customDomainEnabled">
@@ -60,11 +60,11 @@ SPDX-License-Identifier: Apache-2.0
             <template #selection="{ item }">
               <div class="d-flex">
                 <g-vendor-icon
-                  :name="item.value"
+                  :name="item"
                   vendor-type="dns"
                   class="mr-2"
                 />
-                {{ item.value }}
+                {{ item }}
               </div>
             </template>
           </v-select>
@@ -148,7 +148,7 @@ SPDX-License-Identifier: Apache-2.0
         </v-row>
       </div>
     </template>
-  </v-container>
+  </div>
 </template>
 
 <script>

--- a/frontend/src/components/editable/GEditableAccount.vue
+++ b/frontend/src/components/editable/GEditableAccount.vue
@@ -78,7 +78,7 @@ SPDX-License-Identifier: Apache-2.0
             v-bind="{ ...itemProps, title: undefined }"
           >
             <g-account-avatar
-              :account-name="item.value"
+              :account-name="item"
               :size="24"
             />
           </v-list-item>

--- a/frontend/src/sass/main.scss
+++ b/frontend/src/sass/main.scss
@@ -143,10 +143,6 @@
   text-transform: uppercase;
 }
 
-.v-app-bar .v-toolbar__content {
-  padding-inline: 16px;
-}
-
 ul {
   padding: 0px;
   margin: 0px;

--- a/frontend/src/views/GNewShoot.vue
+++ b/frontend/src/views/GNewShoot.vue
@@ -35,7 +35,7 @@ SPDX-License-Identifier: Apache-2.0
       </v-card>
       <v-card class="mt-4">
         <g-toolbar title="Control Plane High Availability" />
-        <v-card-text class="pt-2">
+        <v-card-text class="py-1">
           <g-manage-control-plane-high-availability />
         </v-card-text>
       </v-card>


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**

/area usability
/kind regression

**What this PR does / why we need it**:

Vuetify 4 exposes the raw list item as `item` in `VSelect` and `VAutocomplete` slots. Several string-based selectors still accessed `item.value` or `item.title`, causing selected DNS provider labels and icons to render empty and owner autocomplete entries to appear as "Unknown".

This change:

- uses the raw provider string in the primary and shoot-dns-service DNS selectors
- uses the raw username in the project-owner autocomplete
- restores breadcrumb, DNS configuration, and control-plane high-availability spacing left over from the Vuetify 4 migration

The changes are limited to rendering and layout. They do not change credential or Secret handling, DNS configuration models, or generated Gardener resources.

**Which issue(s) this PR fixes**:

None.

Validation:

- `make verify`
- changed-file ESLint
- `git diff --check`

**Release note**:

```bugfix user
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the displayed DNS provider type text (and associated icon) in DNS provider selection.
  * Fixed account avatar rendering in account autocomplete selections.
  * Improved breadcrumb layout spacing for non-linked breadcrumb items.

* **Style**
  * Refined spacing/layout in DNS management, including the outer wrapper and cluster domain row spacing.
  * Adjusted vertical padding for the Control Plane High Availability section.
  * Updated app bar toolbar spacing by removing a stylesheet override.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->