### PR TITLE
fix(frontend): harden shoot creation defaults

### DIFF
--- a/frontend/__tests__/components/GNewShootInfrastructureDetails.spec.js
+++ b/frontend/__tests__/components/GNewShootInfrastructureDetails.spec.js
@@ -1,0 +1,215 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import {
+  nextTick,
+  ref,
+} from 'vue'
+import { shallowMount } from '@vue/test-utils'
+
+import GNewShootInfrastructureDetails from '@/components/NewShoot/GNewShootInfrastructureDetails.vue'
+
+function refList () {
+  return ref([])
+}
+
+describe('components', () => {
+  describe('g-new-shoot-infrastructure-details', () => {
+    let wrapper
+    let shootContext
+
+    function createShootContext () {
+      return {
+        providerType: ref('aws'),
+        cloudProfileRef: ref({ name: 'profile', kind: 'CloudProfile' }),
+        infrastructureBinding: ref(),
+        region: ref('region-1'),
+        networkingType: ref('cilium'),
+        providerControlPlaneConfigLoadBalancerProviderName: ref(),
+        providerControlPlaneConfigLoadBalancerClassNames: refList(),
+        providerInfrastructureConfigFloatingPoolName: ref(),
+        providerInfrastructureConfigPartitionID: ref(),
+        providerInfrastructureConfigProjectID: ref(),
+        providerInfrastructureConfigFirewallImage: ref(),
+        providerInfrastructureConfigFirewallSize: ref(),
+        providerInfrastructureConfigFirewallNetworks: refList(),
+        cloudProfiles: refList(),
+        infrastructureBindings: refList(),
+        regionsWithSeed: ref(['region-1']),
+        regionsWithoutSeed: refList(),
+        showAllRegions: ref(true),
+        networkingTypes: ref(['calico', 'cilium']),
+        allLoadBalancerProviderNames: ref(['f5']),
+        allLoadBalancerClassNames: refList(),
+        partitionIDs: refList(),
+        firewallImages: refList(),
+        firewallSizes: refList(),
+        allFirewallNetworks: refList(),
+        allFloatingPoolNames: refList(),
+        workerless: ref(false),
+      }
+    }
+
+    function mountComponent () {
+      shootContext = createShootContext()
+      wrapper = shallowMount(GNewShootInfrastructureDetails, {
+        global: {
+          provide: {
+            'shoot-context': shootContext,
+          },
+          stubs: {
+            VContainer: {
+              template: '<div><slot /></div>',
+            },
+            VRow: {
+              template: '<div><slot /></div>',
+            },
+            VCol: {
+              template: '<div><slot /></div>',
+            },
+            VSelect: {
+              props: ['label'],
+              template: '<div class="v-select" :data-label="label" />',
+            },
+            VTextField: {
+              props: ['label'],
+              emits: ['blur'],
+              template: '<button class="v-text-field" :data-label="label" @click="$emit(\'blur\')" />',
+            },
+            GSelectCloudProfile: {
+              template: '<div data-test="cloud-profile" />',
+            },
+            GSelectCredential: {
+              template: '<div data-test="credential" />',
+            },
+            GWildcardSelect: {
+              template: '<div data-test="floating-pool" />',
+            },
+          },
+        },
+      })
+    }
+
+    function selectByLabel (label) {
+      return wrapper.find(`.v-select[data-label="${label}"]`)
+    }
+
+    beforeEach(() => {
+      mountComponent()
+    })
+
+    afterEach(() => {
+      wrapper.unmount()
+    })
+
+    it('should always require region and require networking only for shoots with workers', async () => {
+      shootContext.region.value = ''
+      shootContext.networkingType.value = ''
+      await wrapper.vm.v$.$validate()
+
+      expect(wrapper.vm.v$.region.required.$invalid).toBe(true)
+      expect(wrapper.vm.v$.networkingType.required.$invalid).toBe(true)
+      expect(wrapper.find('[data-test="credential"]').exists()).toBe(true)
+      expect(selectByLabel('Networking Type').exists()).toBe(true)
+
+      shootContext.workerless.value = true
+      await nextTick()
+      await wrapper.vm.v$.$validate()
+
+      expect(wrapper.vm.v$.region.required.$invalid).toBe(true)
+      expect(wrapper.vm.v$.networkingType.required.$invalid).toBe(false)
+      expect(wrapper.find('[data-test="credential"]').exists()).toBe(false)
+      expect(selectByLabel('Networking Type').exists()).toBe(false)
+    })
+
+    it('should require and show only OpenStack-specific infrastructure fields', async () => {
+      shootContext.providerType.value = 'openstack'
+      await nextTick()
+      await wrapper.vm.v$.$validate()
+
+      expect(wrapper.vm.v$.loadBalancerProviderName.required.$invalid).toBe(true)
+      expect(wrapper.vm.v$.loadBalancerProviderName.required.$params.fieldName).toBe('Load Balancer Provider')
+      expect(wrapper.vm.v$.projectID.required.$invalid).toBe(false)
+      expect(wrapper.find('[data-test="floating-pool"]').exists()).toBe(true)
+      expect(selectByLabel('Load Balancer Provider').exists()).toBe(true)
+
+      shootContext.providerControlPlaneConfigLoadBalancerProviderName.value = 'f5'
+      await nextTick()
+      await wrapper.vm.v$.$validate()
+      expect(wrapper.vm.v$.loadBalancerProviderName.required.$invalid).toBe(false)
+
+      shootContext.workerless.value = true
+      await nextTick()
+      await wrapper.vm.v$.$validate()
+      expect(wrapper.vm.v$.loadBalancerProviderName.required.$invalid).toBe(false)
+      expect(wrapper.find('[data-test="floating-pool"]').exists()).toBe(false)
+      expect(selectByLabel('Load Balancer Provider').exists()).toBe(false)
+    })
+
+    it('should require every Metal-specific infrastructure field', async () => {
+      shootContext.providerType.value = 'metal'
+      await nextTick()
+      await wrapper.vm.v$.$validate()
+
+      for (const field of ['projectID', 'partitionID', 'firewallImage', 'firewallSize', 'firewallNetworks']) {
+        expect(wrapper.vm.v$[field].required.$invalid).toBe(true)
+      }
+
+      expect(wrapper.find('.v-text-field[data-label="Project ID"]').exists()).toBe(true)
+      expect(selectByLabel('Partition ID').exists()).toBe(true)
+      expect(selectByLabel('Firewall Image').exists()).toBe(true)
+      expect(selectByLabel('Firewall Size').exists()).toBe(true)
+      expect(selectByLabel('Firewall Networks').exists()).toBe(true)
+
+      shootContext.providerInfrastructureConfigProjectID.value = 'project-1'
+      shootContext.providerInfrastructureConfigPartitionID.value = 'partition-1'
+      shootContext.providerInfrastructureConfigFirewallImage.value = 'image-1'
+      shootContext.providerInfrastructureConfigFirewallSize.value = 'size-1'
+      shootContext.providerInfrastructureConfigFirewallNetworks.value = ['internet']
+      await nextTick()
+      await wrapper.vm.v$.$validate()
+
+      for (const field of ['projectID', 'partitionID', 'firewallImage', 'firewallSize', 'firewallNetworks']) {
+        expect(wrapper.vm.v$[field].required.$invalid).toBe(false)
+      }
+    })
+
+    it('should touch the Firewall Size validation when its field is blurred', async () => {
+      shootContext.providerType.value = 'metal'
+      await nextTick()
+
+      expect(wrapper.vm.v$.firewallSize.$dirty).toBe(false)
+      await wrapper.find('.v-select[data-label="Firewall Size"]').trigger('blur')
+      expect(wrapper.vm.v$.firewallSize.$dirty).toBe(true)
+    })
+
+    it('should require the default vSphere load balancer class when available', async () => {
+      shootContext.allLoadBalancerClassNames.value = ['default', 'other']
+      shootContext.providerType.value = 'vsphere'
+      await nextTick()
+      await wrapper.vm.v$.$validate()
+
+      expect(wrapper.vm.v$.loadBalancerClassNames.required.$invalid).toBe(true)
+      expect(wrapper.vm.v$.loadBalancerClassNames.includesKey.$invalid).toBe(true)
+      expect(selectByLabel('Load Balancer Classes').exists()).toBe(true)
+
+      shootContext.providerControlPlaneConfigLoadBalancerClassNames.value = ['other']
+      await nextTick()
+      await wrapper.vm.v$.$validate()
+      expect(wrapper.vm.v$.loadBalancerClassNames.required.$invalid).toBe(false)
+      expect(wrapper.vm.v$.loadBalancerClassNames.includesKey.$invalid).toBe(true)
+
+      shootContext.providerControlPlaneConfigLoadBalancerClassNames.value = ['default']
+      await nextTick()
+      await wrapper.vm.v$.$validate()
+      expect(wrapper.vm.v$.loadBalancerClassNames.includesKey.$invalid).toBe(false)
+
+      shootContext.workerless.value = true
+      await nextTick()
+      expect(selectByLabel('Load Balancer Classes').exists()).toBe(false)
+    })
+  })
+})

--- a/frontend/__tests__/components/GNewShootInfrastructureDetails.spec.js
+++ b/frontend/__tests__/components/GNewShootInfrastructureDetails.spec.js
@@ -207,8 +207,13 @@ describe('components', () => {
       await wrapper.vm.v$.$validate()
       expect(wrapper.vm.v$.loadBalancerClassNames.includesKey.$invalid).toBe(false)
 
+      shootContext.providerControlPlaneConfigLoadBalancerClassNames.value = []
       shootContext.workerless.value = true
       await nextTick()
+      await wrapper.vm.v$.$validate()
+      expect(wrapper.vm.v$.loadBalancerClassNames.required.$invalid).toBe(false)
+      expect(wrapper.vm.v$.loadBalancerClassNames.includesKey.$invalid).toBe(false)
+      expect(wrapper.vm.v$.$invalid).toBe(false)
       expect(selectByLabel('Load Balancer Classes').exists()).toBe(false)
     })
   })

--- a/frontend/__tests__/components/GWildcardSelect.spec.js
+++ b/frontend/__tests__/components/GWildcardSelect.spec.js
@@ -90,20 +90,24 @@ describe('components', () => {
       expect(wildcardVariablePartSuffix).toBe('')
     })
 
-    it('Should select initial custom wildcard value', () => {
+    it('should select initial custom wildcard value', () => {
       const wrapper = mountWildcardSelect('*')
-      const { wildcardSelectedValue, wildcardVariablePartSuffix } = wrapper.vm
+      const { wildcardSelectedValue, wildcardVariablePartPrefix, wildcardVariablePartSuffix } = wrapper.vm
       expect(wildcardSelectedValue.value).toBe('')
       expect(wildcardSelectedValue.customWildcard).toBe(true)
+      expect(wildcardVariablePartPrefix).toBe('')
       expect(wildcardVariablePartSuffix).toBe('')
     })
 
-    it('Should select custom wildcard', () => {
+    it('should preserve a concrete value selected through the catch-all wildcard', () => {
       const wrapper = mountWildcardSelect('RandomValue')
-      const { wildcardSelectedValue, wildcardVariablePartSuffix } = wrapper.vm
+      const { wildcardSelectedValue, wildcardVariablePartPrefix, wildcardVariablePartSuffix } = wrapper.vm
       expect(wildcardSelectedValue.value).toBe('')
       expect(wildcardSelectedValue.customWildcard).toBe(true)
-      expect(wildcardVariablePartSuffix).toBe('RandomValue')
+      expect(wildcardVariablePartPrefix).toBe('RandomValue')
+      expect(wildcardVariablePartSuffix).toBe('')
+      expect(wrapper.vm.internalValue).toBe('RandomValue')
+      expect(wrapper.emitted('update:modelValue').at(-1)).toEqual(['RandomValue'])
     })
   })
 })

--- a/frontend/__tests__/composables/useShootContext.spec.js
+++ b/frontend/__tests__/composables/useShootContext.spec.js
@@ -213,6 +213,31 @@ describe('composables', () => {
       expect(shootContextStore.shootManifest.spec.controlPlane).toBeUndefined()
     })
 
+    it('should restore a default worker when disabling workerless mode', () => {
+      setShootDefaults({
+        workerlessCluster: true,
+      })
+
+      shootContextStore.createShootManifest({
+        providerType: 'aws',
+      })
+
+      expect(shootContextStore.workerless).toBe(true)
+      expect(shootContextStore.shootManifest.spec.provider.workers).toBeUndefined()
+      expect(shootContextStore.shootManifest.spec.networking).toBeUndefined()
+
+      shootContextStore.workerless = false
+      expect(shootContextStore.providerWorkers).toHaveLength(1)
+      const workerName = shootContextStore.providerWorkers[0].name
+
+      shootContextStore.workerless = true
+      expect(shootContextStore.shootManifest.spec.provider.workers).toBeUndefined()
+
+      shootContextStore.workerless = false
+      expect(shootContextStore.providerWorkers).toHaveLength(1)
+      expect(shootContextStore.providerWorkers[0].name).toBe(workerName)
+    })
+
     it('should honor an explicit workerless option over the configured default', () => {
       setShootDefaults({
         workerlessCluster: true,
@@ -283,6 +308,76 @@ describe('composables', () => {
 
       expect(shootManifest.spec.provider.infrastructureConfig.floatingPoolName).toBe('FloatingIP-external')
       expect(shootManifest.spec.provider.controlPlaneConfig.loadBalancerProvider).toBe('f5')
+    })
+
+    it('should infer workerless mode when an existing manifest is loaded', () => {
+      shootContextStore.setShootManifest({
+        metadata: {
+          name: 'workerless-shoot',
+          creationTimestamp: '2024-03-01T12:00:00Z',
+        },
+        spec: {
+          provider: {
+            type: 'aws',
+          },
+        },
+      })
+      expect(shootContextStore.workerless).toBe(true)
+
+      shootContextStore.setShootManifest({
+        metadata: {
+          name: 'shoot-with-workers',
+          creationTimestamp: '2024-03-01T12:00:00Z',
+        },
+        spec: {
+          provider: {
+            type: 'aws',
+            workers: [{
+              name: 'worker-a',
+              minimum: 1,
+              maximum: 2,
+            }],
+          },
+        },
+      })
+      expect(shootContextStore.workerless).toBe(false)
+    })
+
+    it('should preserve explicit workerless mode when a new manifest is loaded', () => {
+      shootContextStore.createShootManifest({
+        providerType: 'aws',
+        workerless: false,
+      })
+
+      shootContextStore.setShootManifest({
+        metadata: {
+          name: 'new-shoot',
+        },
+        spec: {
+          provider: {
+            type: 'aws',
+          },
+        },
+      })
+      expect(shootContextStore.workerless).toBe(false)
+
+      shootContextStore.workerless = true
+      shootContextStore.setShootManifest({
+        metadata: {
+          name: 'new-workerless-shoot',
+        },
+        spec: {
+          provider: {
+            type: 'aws',
+            workers: [{
+              name: 'worker-a',
+              minimum: 1,
+              maximum: 2,
+            }],
+          },
+        },
+      })
+      expect(shootContextStore.workerless).toBe(true)
     })
 
     it('should change the infrastructure kind', async () => {

--- a/frontend/__tests__/stores/config.spec.js
+++ b/frontend/__tests__/stores/config.spec.js
@@ -132,5 +132,15 @@ describe('stores', () => {
       expect(configStore.defaultHibernationSchedule).toEqual({ evaluation: [{ start: 'legacy' }] })
       expect(configStore.defaultNodesCIDR).toBe('10.0.0.0/16')
     })
+
+    it('falls back to safe maintenance hours for an empty configuration', () => {
+      configStore.setConfiguration({
+        shootDefaults: {
+          maintenanceHours: [],
+        },
+      })
+
+      expect(configStore.defaultMaintenanceHours).toEqual(['22', '23', '00', '01', '02', '03', '04', '05'])
+    })
   })
 })

--- a/frontend/__tests__/stores/config.spec.js
+++ b/frontend/__tests__/stores/config.spec.js
@@ -133,14 +133,30 @@ describe('stores', () => {
       expect(configStore.defaultNodesCIDR).toBe('10.0.0.0/16')
     })
 
-    it('falls back to safe maintenance hours for an empty configuration', () => {
+    it.each([
+      { maintenanceHours: [] },
+      { maintenanceHours: ['24'] },
+      { maintenanceHours: ['1'] },
+      { maintenanceHours: [12] },
+      { maintenanceHours: ['12.5'] },
+    ])('falls back to safe maintenance hours for an invalid configuration: $maintenanceHours', ({ maintenanceHours }) => {
       configStore.setConfiguration({
         shootDefaults: {
-          maintenanceHours: [],
+          maintenanceHours,
         },
       })
 
       expect(configStore.defaultMaintenanceHours).toEqual(['22', '23', '00', '01', '02', '03', '04', '05'])
+    })
+
+    it('accepts configured maintenance hours from 00 through 23', () => {
+      configStore.setConfiguration({
+        shootDefaults: {
+          maintenanceHours: ['00', '12', '23'],
+        },
+      })
+
+      expect(configStore.defaultMaintenanceHours).toEqual(['00', '12', '23'])
     })
   })
 })

--- a/frontend/__tests__/utils/index.spec.js
+++ b/frontend/__tests__/utils/index.spec.js
@@ -385,6 +385,10 @@ describe('utils', () => {
     })
   })
   describe('randomMaintenanceBegin', () => {
+    it('should use the safe default hours for an explicitly empty list', () => {
+      expect(['22:00', '23:00', '00:00', '01:00', '02:00', '03:00', '04:00', '05:00']).toContain(randomMaintenanceBegin([]))
+    })
+
     it('should select and format a configured hour', () => {
       expect(randomMaintenanceBegin(['12'])).toBe('12:00')
     })

--- a/frontend/__tests__/utils/index.spec.js
+++ b/frontend/__tests__/utils/index.spec.js
@@ -385,8 +385,14 @@ describe('utils', () => {
     })
   })
   describe('randomMaintenanceBegin', () => {
-    it('should use the safe default hours for an explicitly empty list', () => {
-      expect(['22:00', '23:00', '00:00', '01:00', '02:00', '03:00', '04:00', '05:00']).toContain(randomMaintenanceBegin([]))
+    it.each([
+      { hours: [] },
+      { hours: ['24'] },
+      { hours: ['1'] },
+      { hours: [12] },
+      { hours: ['12.5'] },
+    ])('should use the safe default hours for an invalid explicit list: $hours', ({ hours }) => {
+      expect(['22:00', '23:00', '00:00', '01:00', '02:00', '03:00', '04:00', '05:00']).toContain(randomMaintenanceBegin(hours))
     })
 
     it('should select and format a configured hour', () => {

--- a/frontend/src/components/GWildcardSelect.vue
+++ b/frontend/src/components/GWildcardSelect.vue
@@ -160,13 +160,14 @@ export default {
       this.wildcardSelectedValue = bestMatch
       const value = trim(newValue, '*')
       const index = value.indexOf(bestMatch.value)
-      if (bestMatch.startsWithWildcard) {
+      if (bestMatch.customWildcard) {
+        this.wildcardVariablePartPrefix = value
+      } else if (bestMatch.startsWithWildcard) {
         this.wildcardVariablePartPrefix = value.substring(0, index)
       } else {
         this.wildcardVariablePartPrefix = ''
       }
-      if (bestMatch.endsWithWildcard || bestMatch.customWildcard) {
-        const value = trim(newValue, '*')
+      if (bestMatch.endsWithWildcard) {
         this.wildcardVariablePartSuffix = value.substring(index + bestMatch.value.length)
       } else {
         this.wildcardVariablePartSuffix = ''

--- a/frontend/src/components/NewShoot/GNewShootInfrastructureDetails.vue
+++ b/frontend/src/components/NewShoot/GNewShootInfrastructureDetails.vue
@@ -65,7 +65,7 @@ SPDX-License-Identifier: Apache-2.0
           @blur="v$.networkingType.$touch()"
         />
       </v-col>
-      <template v-if="providerType === 'openstack'">
+      <template v-if="!workerless && providerType === 'openstack'">
         <v-col cols="3">
           <g-wildcard-select
             v-model="floatingPoolName"
@@ -87,7 +87,7 @@ SPDX-License-Identifier: Apache-2.0
           />
         </v-col>
       </template>
-      <template v-else-if="providerType === 'metal'">
+      <template v-else-if="!workerless && providerType === 'metal'">
         <v-col cols="3">
           <v-text-field
             v-model="v$.projectID.$model"
@@ -136,7 +136,7 @@ SPDX-License-Identifier: Apache-2.0
             :items="firewallSizes"
             :error-messages="getErrorMessages(v$.firewallSize)"
             variant="underlined"
-            @blur="v$.firewallImage.$touch()"
+            @blur="v$.firewallSize.$touch()"
           />
         </v-col>
         <v-col cols="3">
@@ -155,7 +155,7 @@ SPDX-License-Identifier: Apache-2.0
           />
         </v-col>
       </template>
-      <template v-else-if="providerType === 'vsphere'">
+      <template v-else-if="!workerless && providerType === 'vsphere'">
         <v-col cols="3">
           <v-select
             v-model="v$.loadBalancerClassNames.$model"
@@ -270,16 +270,16 @@ export default {
   },
   validations () {
     const requiresInfrastructure = providerType => {
-      return requiredIf(() => this.providerType === providerType)
+      return requiredIf(() => !this.workerless && this.providerType === providerType)
     }
     return {
       region: withFieldName('Region', {
         required,
       }),
       networkingType: withFieldName('Networking Type', {
-        required: requiredIf(!this.workerless),
+        required: requiredIf(() => !this.workerless),
       }),
-      loadBalancerProviderName: withFieldName('Cluster Name', {
+      loadBalancerProviderName: withFieldName('Load Balancer Provider', {
         required: requiresInfrastructure('openstack'),
       }),
       loadBalancerClassNames: withFieldName('Load Balancer Class Names', {

--- a/frontend/src/components/NewShoot/GNewShootInfrastructureDetails.vue
+++ b/frontend/src/components/NewShoot/GNewShootInfrastructureDetails.vue
@@ -177,6 +177,7 @@ SPDX-License-Identifier: Apache-2.0
 
 <script>
 import {
+  or,
   required,
   requiredIf,
 } from '@vuelidate/validators'
@@ -269,8 +270,9 @@ export default {
     }
   },
   validations () {
+    const infrastructureRequired = providerType => !this.workerless && this.providerType === providerType
     const requiresInfrastructure = providerType => {
-      return requiredIf(() => !this.workerless && this.providerType === providerType)
+      return requiredIf(() => infrastructureRequired(providerType))
     }
     return {
       region: withFieldName('Region', {
@@ -284,7 +286,10 @@ export default {
       }),
       loadBalancerClassNames: withFieldName('Load Balancer Class Names', {
         required: requiresInfrastructure('vsphere'),
-        includesKey: withMessage('Load Balancer Class \'default\' must be selected', includesIfAvailable('default', 'allLoadBalancerClassNames')),
+        includesKey: withMessage('Load Balancer Class \'default\' must be selected', or(
+          () => !infrastructureRequired('vsphere'),
+          includesIfAvailable('default', 'allLoadBalancerClassNames'),
+        )),
       }),
       partitionID: withFieldName('Partition ID', {
         required: requiresInfrastructure('metal'),

--- a/frontend/src/composables/useShootContext.js
+++ b/frontend/src/composables/useShootContext.js
@@ -370,7 +370,7 @@ export function createShootContextComposable (options = {}) {
 
   /* provider */
   const providerState = reactive({
-    workerless: configStore.defaultWorkerlessCluster,
+    workerless: false,
   })
 
   const providerType = computed({
@@ -570,6 +570,9 @@ export function createShootContextComposable (options = {}) {
       applySpecTemplate(cloudProfileRef.value)
       resetCloudProfileDependendValues()
     }
+    if (isEmpty(providerWorkers.value)) {
+      resetProviderWorkers()
+    }
   }, {
     flush: 'sync',
   })
@@ -767,6 +770,9 @@ export function createShootContextComposable (options = {}) {
       appStore.timezone,
       configStore.defaultMaintenanceWindowSizeMinutes,
     )
+    if (!timeWindow) {
+      return
+    }
     maintenanceTimeWindowBegin.value = timeWindow.begin
     maintenanceTimeWindowEnd.value = timeWindow.end
   }

--- a/frontend/src/store/config.js
+++ b/frontend/src/store/config.js
@@ -339,7 +339,10 @@ export const useConfigStore = defineStore('config', () => {
   })
 
   const defaultMaintenanceHours = computed(() => {
-    return shootDefaults.value.maintenanceHours ?? ['22', '23', '00', '01', '02', '03', '04', '05']
+    const maintenanceHours = shootDefaults.value.maintenanceHours
+    return Array.isArray(maintenanceHours) && maintenanceHours.length
+      ? maintenanceHours
+      : ['22', '23', '00', '01', '02', '03', '04', '05']
   })
 
   const defaultMaintenanceWindowSizeMinutes = computed(() => {

--- a/frontend/src/store/config.js
+++ b/frontend/src/store/config.js
@@ -17,6 +17,7 @@ import { useBrowserLocation } from '@vueuse/core'
 import { useApi } from '@/composables/useApi'
 import { useLogger } from '@/composables/useLogger'
 
+import { isValidMaintenanceHours } from '@/utils'
 import { hash } from '@/utils/crypto'
 import knownInfraVendors from '@/data/vendors/infra'
 import knownDNSVendors from '@/data/vendors/dns'
@@ -340,7 +341,7 @@ export const useConfigStore = defineStore('config', () => {
 
   const defaultMaintenanceHours = computed(() => {
     const maintenanceHours = shootDefaults.value.maintenanceHours
-    return Array.isArray(maintenanceHours) && maintenanceHours.length
+    return isValidMaintenanceHours(maintenanceHours)
       ? maintenanceHours
       : ['22', '23', '00', '01', '02', '03', '04', '05']
   })

--- a/frontend/src/store/gardenerExtension.js
+++ b/frontend/src/store/gardenerExtension.js
@@ -25,6 +25,7 @@ import get from 'lodash/get'
 import some from 'lodash/some'
 import find from 'lodash/find'
 import sortBy from 'lodash/sortBy'
+import uniq from 'lodash/uniq'
 
 export const useGardenerExtensionStore = defineStore('gardenerExtension', () => {
   const api = useApi()
@@ -81,7 +82,7 @@ export const useGardenerExtensionStore = defineStore('gardenerExtension', () => 
   })
 
   const sortedNetworkingTypes = computed(() => {
-    const types = sortBy(networkingTypes.value)
+    const types = sortBy(uniq(networkingTypes.value))
 
     if (types.includes(configStore.defaultNetworkingType)) {
       const filtered = types.filter(type => type !== configStore.defaultNetworkingType)

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -522,7 +522,7 @@ const defaultMaintenanceHours = ['22', '23', '00', '01', '02', '03', '04', '05']
 
 export function randomMaintenanceBegin (hours = defaultMaintenanceHours) {
   // randomize maintenance time window
-  const randomHour = sample(hours)
+  const randomHour = sample(isEmpty(hours) ? defaultMaintenanceHours : hours)
   return `${randomHour}:00`
 }
 

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -519,10 +519,17 @@ export function transformHtml (html, transformToExternalLinks = true) {
 }
 
 const defaultMaintenanceHours = ['22', '23', '00', '01', '02', '03', '04', '05']
+const maintenanceHourRegex = /^(?:[01]\d|2[0-3])$/
+
+export function isValidMaintenanceHours (hours) {
+  return Array.isArray(hours) &&
+    hours.length > 0 &&
+    hours.every(hour => typeof hour === 'string' && maintenanceHourRegex.test(hour))
+}
 
 export function randomMaintenanceBegin (hours = defaultMaintenanceHours) {
   // randomize maintenance time window
-  const randomHour = sample(isEmpty(hours) ? defaultMaintenanceHours : hours)
+  const randomHour = sample(isValidMaintenanceHours(hours) ? hours : defaultMaintenanceHours)
   return `${randomHour}:00`
 }
 


### PR DESCRIPTION
Follow-up to #2476 containing the fixes intentionally separated from the shoot-default configuration work.

## What changed

- Preserve concrete values selected through the catch-all wildcard.
- Safely handle explicitly empty maintenance-hour configurations and invalid maintenance windows.
- Correct workerless initialization, worker restoration, field visibility, and validation behavior while preserving explicit state for new Shoots.
- Deduplicate the sorted networking-type choices.
- Correct the OpenStack load balancer provider validation field name.
- Touch Firewall Size validation when the Firewall Size field loses focus instead of touching Firewall Image.
- Add focused regression coverage for these repairs.

## Why

These repairs were intentionally separated from the configuration and default-application logic in #2476 so regressions can be isolated cleanly.

## Validation

- `make verify` passed.
- Full frontend suite: 73 files, 707 tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Workerless mode now hides infrastructure-specific options and makes their required validation conditional.
  - Loaded shoot manifests correctly infer workerless mode, and re-enabling workers restores default worker state when needed.
- **Bug Fixes**
  - Custom wildcard behavior now preserves the correct prefix/suffix handling.
  - Maintenance-hour inputs are validated; invalid settings fall back to safe defaults, including random maintenance begin generation.
  - Duplicate networking types are removed from selection lists.
  - Maintenance scheduling avoids invalid empty time ranges; firewall validation correctly updates after blur.
- **Tests**
  - Added/updated unit tests covering workerless mode, wildcard behavior, maintenance-hour validation, and component validation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->