### PR TITLE
fix(security): harden OIDC callback transaction handling

### DIFF
--- a/backend/__tests__/acceptance/__snapshots__/api.user.spec.js.snap
+++ b/backend/__tests__/acceptance/__snapshots__/api.user.spec.js.snap
@@ -68,6 +68,7 @@ exports[`api > user > should return the kubeconfig data the user 1`] = `
       "groups",
     ],
     "issuerUrl": "https://kubernetes:32001",
+    "usePKCE": true,
   },
   "server": "https://kubernetes.external.foo.bar",
 }

--- a/backend/__tests__/acceptance/auth.spec.js
+++ b/backend/__tests__/acceptance/auth.spec.js
@@ -87,6 +87,7 @@ async function parseCookies (res) {
 
 const ZERO_DATE = new Date(0)
 const OTAC = 'jd93ke'
+const PKCE_CODE_VERIFIER = 'a'.repeat(43)
 
 const {
   discovery,
@@ -112,6 +113,32 @@ describe('auth', function () {
 
   let agent
   let abortController
+
+  function getRequestCookieHeader (res) {
+    return res.headers['set-cookie']
+      .map(value => value.split(';', 1)[0])
+      .join('; ')
+  }
+
+  function expectTransactionCookiesCleared (res) {
+    const cookies = setCookieParser.parse(res, {
+      decodeValues: true,
+      map: true,
+    })
+    expect(cookies['__Host-gStt'].value).toHaveLength(0)
+    expect(cookies['__Host-gStt'].expires).toEqual(ZERO_DATE)
+    expect(cookies['__Host-gCdVrfr'].value).toHaveLength(0)
+    expect(cookies['__Host-gCdVrfr'].expires).toEqual(ZERO_DATE)
+    return cookies
+  }
+
+  async function beginAuthorization () {
+    const res = await agent
+      .get('/auth')
+      .redirects(0)
+      .expect(302)
+    return getRequestCookieHeader(res)
+  }
 
   beforeAll(async () => {
     // The discovery mock must be set before the agent is created,
@@ -139,7 +166,7 @@ describe('auth', function () {
     // but not mockResolvedValue, so this is technically redundant - but explicit).
     discovery.mockResolvedValue(discoveryConfig)
 
-    randomPKCECodeVerifier.mockReturnValueOnce('code-verifier')
+    randomPKCECodeVerifier.mockReturnValueOnce(PKCE_CODE_VERIFIER)
     calculatePKCECodeChallenge.mockReturnValueOnce('code-challenge')
     buildAuthorizationUrl.mockImplementationOnce((config, params) => {
       const url = new URL(oidc.issuer)
@@ -224,6 +251,7 @@ describe('auth', function () {
 
   it('should redirect to home after successful authorization', async function () {
     const bearer = await user.bearer
+    const transactionCookies = await beginAuthorization()
 
     mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewToken())
     mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
@@ -231,11 +259,15 @@ describe('auth', function () {
 
     authorizationCodeGrant.mockImplementationOnce((config, currentUrl, checks) => {
       assert.strictEqual(currentUrl.searchParams.get('code'), OTAC)
+      assert.strictEqual(currentUrl.searchParams.get('state'), 'state')
+      assert.strictEqual(checks.expectedState, 'state')
+      assert.strictEqual(checks.pkceCodeVerifier, PKCE_CODE_VERIFIER)
       return { id_token: bearer }
     })
 
     const res = await agent
-      .get(`/auth/callback?code=${OTAC}`)
+      .get(`/auth/callback?code=${OTAC}&state=state`)
+      .set('cookie', transactionCookies)
       .redirects(0)
       .expect(302)
 
@@ -262,10 +294,12 @@ describe('auth', function () {
     expect(res.headers).toHaveProperty('location', '/')
     expect(mockRequest).toHaveBeenCalledTimes(3)
     expect(authorizationCodeGrant).toHaveBeenCalledTimes(1)
+    expectTransactionCookiesCleared(res)
   })
 
   it('should redirect to login after failed authorization', async function () {
     const bearer = await user.bearer
+    const transactionCookies = await beginAuthorization()
     authorizationCodeGrant.mockImplementationOnce((config, currentUrl, checks) => {
       assert.strictEqual(currentUrl.searchParams.get('code'), OTAC)
       return { id_token: bearer }
@@ -280,12 +314,36 @@ describe('auth', function () {
     }
 
     const res = await agent
-      .get(`/auth/callback?code=${invalidOtac}`)
+      .get(`/auth/callback?code=${invalidOtac}&state=state`)
+      .set('cookie', transactionCookies)
       .redirects(0)
       .expect(302)
 
     expect(res.headers).toHaveProperty('location', `/login#error=${encodeURIComponent(message)}`)
     expect(authorizationCodeGrant).toHaveBeenCalledTimes(1)
+    const cookies = expectTransactionCookiesCleared(res)
+    expect(cookies[COOKIE_HEADER_PAYLOAD]).toBeUndefined()
+    expect(cookies[COOKIE_SIGNATURE]).toBeUndefined()
+    expect(cookies[COOKIE_TOKEN]).toBeUndefined()
+  })
+
+  it('should not overwrite an existing session when the callback has no state transaction', async function () {
+    const res = await agent
+      .get(`/auth/callback?code=${OTAC}&state=state`)
+      .set('cookie', await user.cookie)
+      .redirects(0)
+      .expect(302)
+
+    expect(res.headers).toHaveProperty(
+      'location',
+      `/login#error=${encodeURIComponent('Invalid OIDC state cookie')}`,
+    )
+    expect(authorizationCodeGrant).not.toHaveBeenCalled()
+    expect(mockRequest).not.toHaveBeenCalled()
+    const cookies = expectTransactionCookiesCleared(res)
+    expect(cookies[COOKIE_HEADER_PAYLOAD]).toBeUndefined()
+    expect(cookies[COOKIE_SIGNATURE]).toBeUndefined()
+    expect(cookies[COOKIE_TOKEN]).toBeUndefined()
   })
 
   it('should successfully login with a given token', async function () {

--- a/backend/__tests__/security.spec.js
+++ b/backend/__tests__/security.spec.js
@@ -90,6 +90,7 @@ describe('security', function () {
   describe('openid-client', () => {
     const redirectUrl = new URL('/account', 'https://localhost:8443')
     const sub = 'john.doe@example.org'
+    const codeVerifier = 'a'.repeat(43)
 
     let undici
     let config
@@ -192,9 +193,9 @@ describe('security', function () {
     })
 
     describe('authorizationUrl', () => {
-      it('should return an authorization url with PKCE flow (preferring S256)', async () => {
+      it('should default to PKCE for a confidential client (preferring S256)', async () => {
         const scope = 'oidc email groups profile offline_access'
-        await mockSecurity({ oidc: { scope, usePKCE: true, client_secret: 'client_secret' } })
+        await mockSecurity({ oidc: { scope, client_secret: 'client_secret' } })
         discovery.mockResolvedValue({
           code_challenge_methods_supported: ['S256', 'plain'],
         })
@@ -202,7 +203,7 @@ describe('security', function () {
           'https://issuer.example.org/oauth2/authorize?client_id=my-client-id&...',
         )
         randomState.mockReturnValue('state')
-        randomPKCECodeVerifier.mockReturnValue('code-verifier')
+        randomPKCECodeVerifier.mockReturnValue(codeVerifier)
         calculatePKCECodeChallenge.mockResolvedValue('code-challenge')
 
         const query = {
@@ -232,7 +233,7 @@ describe('security', function () {
         )
         expect(randomState).toHaveBeenCalledTimes(1)
         expect(randomPKCECodeVerifier).toHaveBeenCalledTimes(1)
-        expect(calculatePKCECodeChallenge).toHaveBeenCalledWith('code-verifier')
+        expect(calculatePKCECodeChallenge).toHaveBeenCalledWith(codeVerifier)
         expect(buildAuthorizationUrl).toHaveBeenCalledTimes(1)
         const [openidConfig, params] = buildAuthorizationUrl.mock.calls[0]
         expect(openidConfig).toMatchObject({
@@ -262,7 +263,7 @@ describe('security', function () {
           ],
           [
             '__Host-gCdVrfr',
-            'code-verifier',
+            codeVerifier,
             { httpOnly: true, maxAge: 180000, sameSite: 'Lax', secure: true },
           ],
         ])
@@ -278,7 +279,7 @@ describe('security', function () {
           'https://issuer.example.org/oauth2/authorize?client_id=my-client-id&...',
         )
         randomState.mockReturnValue('state')
-        randomPKCECodeVerifier.mockReturnValue('code-verifier')
+        randomPKCECodeVerifier.mockReturnValue(codeVerifier)
 
         const query = {
           redirectUrl: redirectUrl.toString(),
@@ -293,7 +294,7 @@ describe('security', function () {
         expect(calculatePKCECodeChallenge).not.toHaveBeenCalled() // For "plain" method, no hashed code challenge is required
         const [, params] = buildAuthorizationUrl.mock.calls[0]
         expect(params).toMatchObject({
-          code_challenge: 'code-verifier',
+          code_challenge: codeVerifier,
         })
         expect(authorizationUrl).toBe(
           'https://issuer.example.org/oauth2/authorize?client_id=my-client-id&...',
@@ -311,7 +312,7 @@ describe('security', function () {
           ],
           [
             '__Host-gCdVrfr',
-            'code-verifier',
+            codeVerifier,
             { httpOnly: true, maxAge: 180000, sameSite: 'Lax', secure: true },
           ],
         ])
@@ -325,7 +326,7 @@ describe('security', function () {
         })
         buildAuthorizationUrl.mockReturnValue('should not be called')
         randomState.mockReturnValue('state')
-        randomPKCECodeVerifier.mockReturnValue('code-verifier')
+        randomPKCECodeVerifier.mockReturnValue(codeVerifier)
         calculatePKCECodeChallenge.mockResolvedValue('code-challenge')
 
         const query = {
@@ -485,7 +486,150 @@ describe('security', function () {
     })
 
     describe('authorizationCallback', () => {
-      it('should exchange the code and set cookies', async () => {
+      const validStateCookie = {
+        redirectOrigin: 'https://localhost:8443',
+        redirectPath: '/account',
+        state: 'some-state',
+      }
+      const transactionCookieOptions = {
+        secure: true,
+        path: '/',
+      }
+
+      function createResponse () {
+        return {
+          cookie: vi.fn(),
+          clearCookie: vi.fn(),
+        }
+      }
+
+      function expectTransactionCookiesCleared (res) {
+        expect(res.clearCookie.mock.calls).toEqual([
+          ['__Host-gStt', transactionCookieOptions],
+          ['__Host-gCdVrfr', transactionCookieOptions],
+        ])
+      }
+
+      function expectNoSessionCreated (res) {
+        expect(res.cookie).not.toHaveBeenCalled()
+        expect(authentication.isAuthenticated).not.toHaveBeenCalled()
+        expect(authorization.isAdmin).not.toHaveBeenCalled()
+        expect(authorization.canListShoots).not.toHaveBeenCalled()
+      }
+
+      async function useOpenIdClientStateValidation () {
+        const actualOpenidClient = await vi.importActual('openid-client')
+        const tokenEndpointFetch = vi.fn()
+        const openidConfiguration = new actualOpenidClient.Configuration({
+          issuer: 'https://issuer.example.org',
+          token_endpoint: 'https://issuer.example.org/token',
+        }, config.oidc.client_id, {
+          client_secret: 'client-secret',
+        })
+        openidConfiguration[actualOpenidClient.customFetch] = tokenEndpointFetch
+        discovery.mockResolvedValue(openidConfiguration)
+        authorizationCodeGrant.mockImplementation(actualOpenidClient.authorizationCodeGrant)
+        return tokenEndpointFetch
+      }
+
+      it('rejects a missing state transaction cookie before code exchange', async () => {
+        await mockSecurity()
+        const req = {
+          originalUrl: '/auth/callback?code=some-code&state=some-state',
+          cookies: {},
+        }
+        const res = createResponse()
+
+        await expect(security.authorizationCallback(req, res))
+          .rejects
+          .toThrow('Invalid OIDC state cookie')
+
+        expect(discovery).not.toHaveBeenCalled()
+        expect(authorizationCodeGrant).not.toHaveBeenCalled()
+        expectNoSessionCreated(res)
+        expectTransactionCookiesCleared(res)
+      })
+
+      it.each([
+        ['null', null],
+        ['a scalar string', 'some-state'],
+        ['an empty object', {}],
+        ['an empty state', { ...validStateCookie, state: '' }],
+        ['a whitespace-only state', { ...validStateCookie, state: ' ' }],
+        ['a non-string state', { ...validStateCookie, state: 42 }],
+      ])('rejects a malformed state transaction cookie containing %s', async (description, stateCookie) => {
+        await mockSecurity()
+        const req = {
+          originalUrl: '/auth/callback?code=some-code&state=some-state',
+          cookies: {
+            '__Host-gStt': stateCookie,
+            '__Host-gCdVrfr': codeVerifier,
+          },
+        }
+        const res = createResponse()
+
+        await expect(security.authorizationCallback(req, res))
+          .rejects
+          .toThrow('Invalid OIDC state cookie')
+
+        expect(discovery).not.toHaveBeenCalled()
+        expect(authorizationCodeGrant).not.toHaveBeenCalled()
+        expectNoSessionCreated(res)
+        expectTransactionCookiesCleared(res)
+      })
+
+      it.each([
+        ['missing', '/auth/callback?code=some-code'],
+        ['mismatched', '/auth/callback?code=some-code&state=other-state'],
+      ])('rejects a callback with %s state before a token endpoint request', async (description, originalUrl) => {
+        await mockSecurity()
+        const tokenEndpointFetch = await useOpenIdClientStateValidation()
+        const req = {
+          originalUrl,
+          cookies: {
+            '__Host-gStt': validStateCookie,
+            '__Host-gCdVrfr': codeVerifier,
+          },
+        }
+        const res = createResponse()
+
+        await expect(security.authorizationCallback(req, res)).rejects.toThrow()
+
+        expect(authorizationCodeGrant).toHaveBeenCalledTimes(1)
+        expect(tokenEndpointFetch).not.toHaveBeenCalled()
+        expectNoSessionCreated(res)
+        expectTransactionCookiesCleared(res)
+      })
+
+      it.each([
+        ['missing', undefined],
+        ['empty', ''],
+        ['null', null],
+        ['non-string', 42],
+        ['too short', 'short-verifier'],
+        ['containing invalid characters', `${'a'.repeat(42)}!`],
+      ])('rejects a %s PKCE verifier before code exchange', async (description, pkceCodeVerifier) => {
+        await mockSecurity()
+        const req = {
+          originalUrl: '/auth/callback?code=some-code&state=some-state',
+          cookies: {
+            '__Host-gStt': validStateCookie,
+            '__Host-gCdVrfr': pkceCodeVerifier,
+          },
+        }
+        const res = createResponse()
+
+        await expect(security.authorizationCallback(req, res))
+          .rejects
+          .toThrow('Invalid OIDC PKCE code verifier cookie')
+
+        expect(discovery).not.toHaveBeenCalled()
+        expect(authorizationCodeGrant).not.toHaveBeenCalled()
+        expectNoSessionCreated(res)
+        expectTransactionCookiesCleared(res)
+      })
+
+      it('exchanges a code with matching state and consumes the transaction cookies', async () => {
         await mockSecurity()
         discovery.mockResolvedValue({ code_challenge_methods_supported: ['S256'] })
         authorizationCodeGrant.mockResolvedValue({
@@ -498,132 +642,157 @@ describe('security', function () {
         authorization.canListShoots.mockResolvedValue(false)
 
         const req = {
-          originalUrl: '/auth/callback?code=some-code',
+          originalUrl: '/auth/callback?code=some-code&state=some-state',
           cookies: {
-            '__Host-gStt': {
-              redirectOrigin: 'https://localhost:8443',
-              redirectPath: '/account',
-              state: 'some-state',
-            },
-            '__Host-gCdVrfr': 'pkce-code-verifier',
+            '__Host-gStt': validStateCookie,
+            '__Host-gCdVrfr': codeVerifier,
           },
         }
-        const res = {
-          cookie: vi.fn(),
-          clearCookie: vi.fn(),
-        }
+        const res = createResponse()
 
-        // Act
         const { redirectPath } = await security.authorizationCallback(req, res)
 
-        // Assert
         expect(redirectPath).toBe('/account')
         expect(authorizationCodeGrant).toHaveBeenCalledTimes(1)
         expect(authorizationCodeGrant).toHaveBeenCalledWith(
           expect.any(Object),
-          new URL('/auth/callback?code=some-code', 'https://localhost:8443'),
+          new URL('/auth/callback?code=some-code&state=some-state', 'https://localhost:8443'),
           {
             idTokenExpected: true,
             expectedState: 'some-state',
-            pkceCodeVerifier: 'pkce-code-verifier',
+            pkceCodeVerifier: codeVerifier,
           },
         )
-        // __Host-gStt and __Host-gCdVrfr should be cleared
-        expect(res.clearCookie).toHaveBeenCalledWith('__Host-gStt', { secure: true, path: '/' })
-        expect(res.clearCookie).toHaveBeenCalledWith('__Host-gCdVrfr', { secure: true, path: '/' })
-        // New cookies should be set by setCookies
-        expect(res.cookie).toHaveBeenCalled()
+        expectTransactionCookiesCleared(res)
+        expect(res.cookie).toHaveBeenCalledTimes(3)
+
+        authorizationCodeGrant.mockClear()
+        authentication.isAuthenticated.mockClear()
+        authorization.isAdmin.mockClear()
+        authorization.canListShoots.mockClear()
+        const replayRes = createResponse()
+        await expect(security.authorizationCallback({
+          originalUrl: req.originalUrl,
+          cookies: {},
+        }, replayRes)).rejects.toThrow('Invalid OIDC state cookie')
+        expect(authorizationCodeGrant).not.toHaveBeenCalled()
+        expectNoSessionCreated(replayRes)
+        expectTransactionCookiesCleared(replayRes)
       })
 
-      it('should throw 401 and clear cookies if authorizationCodeGrant fails', async () => {
+      it('does not create a session and consumes transaction cookies when code exchange fails', async () => {
         await mockSecurity()
         discovery.mockResolvedValue({ code_challenge_methods_supported: ['S256'] })
         authorizationCodeGrant.mockRejectedValue(new Error('code exchange failed'))
 
         const req = {
-          originalUrl: '/auth/callback?code=some-code',
+          originalUrl: '/auth/callback?code=some-code&state=some-state',
           cookies: {
-            '__Host-gStt': {
-              redirectOrigin: 'https://localhost:8443',
-              redirectPath: '/account',
-              state: 'another-state',
-            },
-            '__Host-gCdVrfr': 'pkce-code-verifier',
+            '__Host-gStt': validStateCookie,
+            '__Host-gCdVrfr': codeVerifier,
           },
         }
-        const res = {
-          cookie: vi.fn(),
-          clearCookie: vi.fn(),
-        }
+        const res = createResponse()
 
         await expect(security.authorizationCallback(req, res)).rejects.toThrow('code exchange failed')
 
-        expect(res.clearCookie).toHaveBeenCalledWith('__Host-gStt', { secure: true, path: '/' })
-        expect(res.clearCookie).toHaveBeenCalledWith('__Host-gCdVrfr', { secure: true, path: '/' })
-        // No cookies should be set if the exchange fails
-        expect(res.cookie).not.toHaveBeenCalled()
+        expect(authorizationCodeGrant).toHaveBeenCalledTimes(1)
+        expectNoSessionCreated(res)
+        expectTransactionCookiesCleared(res)
+
+        const retryRes = createResponse()
+        await expect(security.authorizationCallback({
+          originalUrl: req.originalUrl,
+          cookies: {},
+        }, retryRes)).rejects.toThrow('Invalid OIDC state cookie')
+        expect(authorizationCodeGrant).toHaveBeenCalledTimes(1)
+        expectNoSessionCreated(retryRes)
+        expectTransactionCookiesCleared(retryRes)
       })
 
-      it('should throw 400 if the redirectPath is from a different (untrusted) origin', async () => {
-        await mockSecurity()
-        discovery.mockResolvedValue({ code_challenge_methods_supported: ['S256'] })
+      it('supports an explicit usePKCE false configuration for a confidential client', async () => {
+        await mockSecurity({
+          oidc: {
+            client_secret: 'client-secret',
+            usePKCE: false,
+          },
+        })
+        discovery.mockResolvedValue({})
+        authorizationCodeGrant.mockResolvedValue({
+          id_token: 'new-id-token',
+        })
         authentication.isAuthenticated.mockResolvedValue({ username: sub, groups: [] })
         authorization.isAdmin.mockResolvedValue(false)
         authorization.canListShoots.mockResolvedValue(false)
 
         const req = {
-          originalUrl: '/auth/callback?code=some-code',
+          originalUrl: '/auth/callback?code=some-code&state=some-state',
+          cookies: {
+            '__Host-gStt': validStateCookie,
+          },
+        }
+        const res = createResponse()
+
+        await expect(security.authorizationCallback(req, res))
+          .resolves
+          .toEqual({ redirectPath: '/account' })
+
+        expect(authorizationCodeGrant).toHaveBeenCalledWith(
+          expect.any(Object),
+          new URL(req.originalUrl, 'https://localhost:8443'),
+          {
+            idTokenExpected: true,
+            expectedState: 'some-state',
+          },
+        )
+        expectTransactionCookiesCleared(res)
+        expect(res.cookie).toHaveBeenCalledTimes(3)
+      })
+
+      it('preserves existing session cookies when a callback is rejected', async () => {
+        await mockSecurity()
+        const req = {
+          originalUrl: '/auth/callback?code=some-code&state=some-state',
+          cookies: {
+            '__Host-gHdrPyl': 'existing-header-and-payload',
+            '__Host-gSgn': 'existing-signature',
+            '__Host-gTkn': 'existing-token',
+          },
+        }
+        const res = createResponse()
+
+        await expect(security.authorizationCallback(req, res))
+          .rejects
+          .toThrow('Invalid OIDC state cookie')
+
+        expect(authorizationCodeGrant).not.toHaveBeenCalled()
+        expectNoSessionCreated(res)
+        expectTransactionCookiesCleared(res)
+      })
+
+      it('rejects an untrusted redirect path before code exchange', async () => {
+        await mockSecurity()
+
+        const req = {
+          originalUrl: '/auth/callback?code=some-code&state=some-state',
           cookies: {
             '__Host-gStt': {
-              redirectOrigin: 'https://localhost:8443',
-              redirectPath: 'https://127.0.0.1/account', // <-- Different origin
-              state: 'some-state',
+              ...validStateCookie,
+              redirectPath: 'https://127.0.0.1/account',
             },
-            '__Host-gCdVrfr': 'pkce-code-verifier',
+            '__Host-gCdVrfr': codeVerifier,
           },
         }
-        const res = {
-          cookie: vi.fn(),
-          clearCookie: vi.fn(),
-        }
-
-        await expect(security.authorizationCallback(req, res)).rejects.toThrow('Invalid redirect path')
-
-        // __Host-gStt and __Host-gCdVrfr should be cleared
-        expect(res.clearCookie).toHaveBeenCalledWith('__Host-gStt', { secure: true, path: '/' })
-        expect(res.clearCookie).toHaveBeenCalledWith('__Host-gCdVrfr', { secure: true, path: '/' })
-        // No new cookies should be set
-        expect(res.cookie).not.toHaveBeenCalled()
-      })
-    })
-
-    describe('authorizationCallback - redirect validation', () => {
-      it('should throw 400 error if redirectPath has a mismatched origin', async () => {
-        await mockSecurity({})
-        const { COOKIE_STATE } = security
-
-        // Simulate a user state cookie that includes a redirectPath pointing to an unexpected domain
-        const req = {
-          cookies: {
-            [COOKIE_STATE]: {
-              redirectOrigin: 'https://localhost:8443',
-              redirectPath: 'https://127.0.0.1/account', // <-- Different origin
-              state: 'test-state',
-            },
-          },
-        }
-
-        const res = {
-          cookie: vi.fn(),
-          clearCookie: vi.fn(),
-        }
+        const res = createResponse()
 
         await expect(security.authorizationCallback(req, res))
           .rejects
           .toThrow('Invalid redirect path')
 
-        expect(res.clearCookie).toHaveBeenCalledWith(COOKIE_STATE, expect.any(Object))
-        expect(res.cookie).not.toHaveBeenCalled()
+        expect(discovery).not.toHaveBeenCalled()
+        expect(authorizationCodeGrant).not.toHaveBeenCalled()
+        expectNoSessionCreated(res)
+        expectTransactionCookiesCleared(res)
       })
     })
 

--- a/backend/lib/routes/user.js
+++ b/backend/lib/routes/user.js
@@ -43,7 +43,7 @@ router.route('/kubeconfig')
       public: {
         clientId = oidc.client_id,
         clientSecret,
-        usePKCE,
+        usePKCE: configuredUsePKCE,
       } = {},
     } = oidc
     const body = {
@@ -58,7 +58,7 @@ router.route('/kubeconfig')
     if (clientSecret) {
       body.oidc.clientSecret = clientSecret
     }
-    if (usePKCE || !clientSecret) {
+    if (configuredUsePKCE !== false || !clientSecret) {
       body.oidc.usePKCE = true
     }
     if (oidc.scope) {

--- a/backend/lib/security/index.js
+++ b/backend/lib/security/index.js
@@ -17,6 +17,7 @@ import {
   head,
   chain,
   pick,
+  isPlainObject,
 } from 'lodash-es'
 import pRetry from 'p-retry'
 import { pTimeout } from '../utils/p-timeout.js'
@@ -60,13 +61,13 @@ const {
   scope,
   client_id: clientId,
   client_secret: clientSecret,
-  usePKCE = !clientSecret,
   sessionLifetime = 86400,
   allowInsecure = false,
   ca,
   rejectUnauthorized = true,
   clockTolerance = 15,
 } = oidc
+const usePKCE = oidc.usePKCE !== false
 const connectOptions = {
   rejectUnauthorized,
 }
@@ -179,6 +180,28 @@ function getCodeChallengeMethod (config) {
     throw createError(500, 'neither code_challenge_method supported by the client is supported by the issuer')
   }
   return 'S256'
+}
+
+// RFC 7636 §4.1: code-verifier = 43*128unreserved
+// https://www.rfc-editor.org/rfc/rfc7636.html#section-4.1
+const PKCE_CODE_VERIFIER_PATTERN = /^[A-Za-z0-9._~-]{43,128}$/
+
+function isNonEmptyString (value) {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+function isValidStateCookie (value) {
+  return isPlainObject(value) &&
+    Object.hasOwn(value, 'redirectPath') &&
+    Object.hasOwn(value, 'redirectOrigin') &&
+    Object.hasOwn(value, 'state') &&
+    isNonEmptyString(value.redirectPath) &&
+    isNonEmptyString(value.redirectOrigin) &&
+    isNonEmptyString(value.state)
+}
+
+function isValidPKCECodeVerifier (value) {
+  return typeof value === 'string' && PKCE_CODE_VERIFIER_PATTERN.test(value)
 }
 
 async function authorizationUrl (req, res) {
@@ -329,13 +352,17 @@ async function authorizationCallback (req, res) {
     secure: true,
     path: '/',
   }
-  let stateObject = {}
-  if (COOKIE_STATE in req.cookies) {
-    stateObject = req.cookies[COOKIE_STATE] // eslint-disable-line security/detect-object-injection -- COOKIE_STATE is a constant
-    res.clearCookie(COOKIE_STATE, options)
+  const stateObject = req.cookies?.[COOKIE_STATE] // eslint-disable-line security/detect-object-injection -- COOKIE_STATE is a constant
+  const codeVerifier = req.cookies?.[COOKIE_CODE_VERIFIER] // eslint-disable-line security/detect-object-injection -- COOKIE_CODE_VERIFIER is a constant
+  res.clearCookie(COOKIE_STATE, options)
+  res.clearCookie(COOKIE_CODE_VERIFIER, options)
+
+  if (!isValidStateCookie(stateObject)) {
+    throw createError(400, 'Invalid OIDC state cookie')
   }
+
   const {
-    redirectPath = '/',
+    redirectPath,
     redirectOrigin,
     state,
   } = stateObject
@@ -344,9 +371,11 @@ async function authorizationCallback (req, res) {
     idTokenExpected: true,
     expectedState: state,
   }
-  if (COOKIE_CODE_VERIFIER in req.cookies) {
-    checks.pkceCodeVerifier = req.cookies[COOKIE_CODE_VERIFIER] // eslint-disable-line security/detect-object-injection -- COOKIE_CODE_VERIFIER is a constant
-    res.clearCookie(COOKIE_CODE_VERIFIER, options)
+  if (usePKCE) {
+    if (!isValidPKCECodeVerifier(codeVerifier)) {
+      throw createError(400, 'Invalid OIDC PKCE code verifier cookie')
+    }
+    checks.pkceCodeVerifier = codeVerifier
   }
 
   const baseUri = head(redirectUris)

--- a/charts/gardener-dashboard/charts/runtime/templates/dashboard/configmap.yaml
+++ b/charts/gardener-dashboard/charts/runtime/templates/dashboard/configmap.yaml
@@ -75,8 +75,8 @@ data:
     {{- if .Values.global.dashboard.oidc }}
     oidc:
       issuer: {{ required ".Values.global.dashboard.oidc.issuerUrl is required" .Values.global.dashboard.oidc.issuerUrl }}
-      {{- if .Values.global.dashboard.oidc.usePKCE }}
-      usePKCE: true
+      {{- if hasKey .Values.global.dashboard.oidc "usePKCE" }}
+      usePKCE: {{ .Values.global.dashboard.oidc.usePKCE }}
       {{- end }}
       {{- if .Values.global.dashboard.oidc.sessionLifetime }}
       sessionLifetime: {{ .Values.global.dashboard.oidc.sessionLifetime }}
@@ -114,7 +114,9 @@ data:
         {{- if .Values.global.dashboard.oidc.public.clientSecret }}
         clientSecret: {{ .Values.global.dashboard.oidc.public.clientSecret }}
         {{- end }}
-        {{- if or .Values.global.dashboard.oidc.public.usePKCE (not .Values.global.dashboard.oidc.public.clientSecret) }}
+        {{- if hasKey .Values.global.dashboard.oidc.public "usePKCE" }}
+        usePKCE: {{ .Values.global.dashboard.oidc.public.usePKCE }}
+        {{- else if not .Values.global.dashboard.oidc.public.clientSecret }}
         usePKCE: true
         {{- end }}
       {{- end }}

--- a/charts/gardener-dashboard/values.yaml
+++ b/charts/gardener-dashboard/values.yaml
@@ -141,7 +141,7 @@ global:
     #   clientSecret: ~
     #   # redirectUris is the list of allowed redirect URIs (the default list is generated based on the ingress hosts)
     #   redirectUris: ~
-    #   # force PKCE usage
+    #   # PKCE is enabled by default; set to false only for compatibility with legacy providers
     #   usePKCE: true
     #   # sessionLifetime is the maximum lifetime of a login session without reauthentication in seconds (defaults to 86400)
     #   sessionLifetime: 86400
@@ -156,7 +156,7 @@ global:
     #     clientId: kube-kubectl
     #     # clientSecret is the public client secret use by kubelogin and all users
     #     clientSecret: ~
-    #     # force PKCE usage (automatically enabled if no clientSecret is given)
+    #     # PKCE is enabled by default and always used if no clientSecret is given; otherwise set false only for compatibility with legacy providers
     #     usePKCE: true
 
     frontendConfig:


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

/area security
/kind bug

**What this PR does / why we need it**:

Hardens OIDC callback transaction handling by validating required transaction data before authorization-code exchange and consuming callback cookies consistently.

PKCE is now enabled by default, including for confidential clients. An explicit `usePKCE: false` compatibility opt-out remains available.

**Which issue(s) this PR fixes**:


**Release note**:
```bugfix operator
Hardened OIDC callback validation and enabled PKCE by default.
```
```breaking operator
OIDC providers that do not support PKCE must explicitly configure `usePKCE: false` under `global.dashboard.oidc` when using the Helm chart.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - PKCE is now enabled by default for OIDC authentication, including confidential clients.
  - Explicitly setting PKCE to `false` remains available for legacy provider compatibility.

- **Bug Fixes**
  - Improved validation and cleanup of OIDC state and PKCE transaction cookies.
  - Prevented invalid callbacks from overwriting existing sessions.
  - Strengthened protection against replayed or malformed authorization responses.

- **Documentation**
  - Updated configuration guidance to clarify default PKCE behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->