### PR TITLE
Add ironcore-metal infra provider

### DIFF
--- a/frontend/__tests__/composables/__snapshots__/credential.helper.spec.js.snap
+++ b/frontend/__tests__/composables/__snapshots__/credential.helper.spec.js.snap
@@ -75,6 +75,7 @@ exports[`secretDetails > matches snapshots for all known provider types (includi
     },
   ],
   "ironcore": undefined,
+  "ironcore-metal": undefined,
   "local": undefined,
   "metal": [
     {

--- a/frontend/src/data/vendors/infra/index.js
+++ b/frontend/src/data/vendors/infra/index.js
@@ -8,6 +8,7 @@ import vsphere from './vsphere'
 import hcloud from './hcloud'
 import onmetal from './onmetal'
 import ironcore from './ironcore'
+import ironcoreMetal from './ironcore-metal'
 import stackit from './stackit'
 import local from './local'
 
@@ -22,6 +23,7 @@ export default [
   hcloud,
   onmetal,
   ironcore,
+  ironcoreMetal,
   stackit,
   local,
 ]

--- a/frontend/src/data/vendors/infra/ironcore-metal.js
+++ b/frontend/src/data/vendors/infra/ironcore-metal.js
@@ -1,0 +1,6 @@
+export default {
+  name: 'ironcore-metal',
+  displayName: 'IronCore Metal',
+  weight: 900,
+  icon: 'ironcore.svg',
+}


### PR DESCRIPTION
**How to categorize this PR?**
/kind enhancement

- Add `ironcore-metal` as an additional infrastructure provider

**Background***

The IronCore project has next to the IaaS layer (provider name: `ironcore`) also an `ironcore-metal` provider. This one is ment to manage bare metal Gardener Shoot clusters. This provider type has it's own extension provider: https://github.com/ironcore-dev/gardener-extension-provider-ironcore-metal

**Release note**:
```feature operator
Add support for IronCore Metal as infrastructure provider
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **IronCore Metal** as an available infrastructure vendor.
  * **IronCore Metal** now appears in vendor listings with its display name, icon, and ranking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->