### PR TITLE
feat: configurable endpoints and scoped secret file loading

### DIFF
--- a/backend/__tests__/config.spec.js
+++ b/backend/__tests__/config.spec.js
@@ -144,6 +144,8 @@ describe('config', function () {
         const env = Object.assign({
           NODE_ENV: 'production',
           PORT: '3456',
+          BIND_HOST: '127.0.0.1',
+          METRICS_BIND_HOST: '127.0.0.2',
           LOG_LEVEL: 'error',
           OIDC_CLIENT_ID: 'client_id',
           OIDC_CLIENT_SECRET: 'client_secret',
@@ -157,6 +159,8 @@ describe('config', function () {
 
         // local env
         expect(config.port).toBe(3456)
+        expect(config.host).toBe('127.0.0.1')
+        expect(config.metricsHost).toBe('127.0.0.2')
         expect(config.logLevel).toBe('error')
         expect(config.oidc.client_id).toBe('client_id')
         expect(config.oidc.client_secret).toBe('client_secret')
@@ -166,6 +170,37 @@ describe('config', function () {
         expect(config.apiServerUrl).toBe('apiServerUrl')
         expect(config.sessionSecret).toBe('secret')
         expect(config.websocketAllowedOrigins).toEqual(['https://foo.example.org', 'https://bar.example.org'])
+      })
+
+      it('should use the configured host for metrics when metricsHost is absent', function () {
+        const env = {
+          ...environmentVariables,
+          BIND_HOST: '127.0.0.1',
+        }
+
+        const config = gardener.loadConfig(undefined, { env })
+
+        expect(config.host).toBe('127.0.0.1')
+        expect(config.metricsHost).toBe('127.0.0.1')
+      })
+
+      it('should preserve an explicitly configured metricsHost', function () {
+        const filename = '/etc/gardener/config.yaml'
+        gardener.readConfig.mockReturnValueOnce({
+          apiServerUrl: 'apiServerUrl',
+          sessionSecret: 'secret',
+          websocketAllowedOrigins: ['*'],
+          host: '127.0.0.1',
+          metricsHost: '127.0.0.2',
+        })
+        const env = {
+          BIND_HOST: '127.0.0.3',
+        }
+
+        const config = gardener.loadConfig(filename, { env })
+
+        expect(config.host).toBe('127.0.0.3')
+        expect(config.metricsHost).toBe('127.0.0.2')
       })
 
       it('should throw empty apiServerUrl', function () {

--- a/backend/__tests__/config.spec.js
+++ b/backend/__tests__/config.spec.js
@@ -112,7 +112,7 @@ describe('config', function () {
         expect(config.logLevel).toBe('warn')
       })
 
-      it('should return the config with values read from the filesystem', function () {
+      it('should use OIDC and GitHub file fallbacks when the providers are configured', function () {
         const env = {}
         const fileMap = {
           '/etc/gardener-dashboard/secrets/oidc/client_id': 'client_id_from_file',
@@ -138,6 +138,47 @@ describe('config', function () {
         expect(config.gitHub.authentication.installationId).toBe(67890)
         expect(config.websocketAllowedOrigins).toEqual(['*'])
         expect(config.logLevel).toBe('info')
+        for (const filePath of Object.keys(fileMap)) {
+          expect(readFileSyncSpy).toHaveBeenCalledWith(filePath, 'utf8')
+        }
+      })
+
+      it('should not read OIDC or GitHub file fallbacks when the providers are not configured', function () {
+        readFileSyncSpy.mockReturnValue('ambient-secret')
+        const env = {
+          ...environmentVariables,
+          SESSION_SECRET_PREVIOUS: 'previous-secret',
+        }
+
+        const config = gardener.loadConfig(undefined, { env })
+
+        expect(readFileSyncSpy).not.toHaveBeenCalled()
+        expect(config).not.toHaveProperty('oidc')
+        expect(config).not.toHaveProperty('gitHub')
+      })
+
+      it('should keep session secret file fallbacks independent of provider configuration', function () {
+        const fileMap = {
+          '/etc/gardener-dashboard/secrets/session/sessionSecret': 'current-secret',
+          '/etc/gardener-dashboard/secrets/session/sessionSecretPrevious': 'previous-secret',
+        }
+        readFileSyncSpy.mockImplementation(filePath => {
+          if (filePath in fileMap) {
+            return fileMap[filePath]
+          }
+          throw new Error(filePath + ': not found')
+        })
+        const env = {
+          API_SERVER_URL: 'apiServerUrl',
+          WEBSOCKET_ALLOWED_ORIGINS: '*',
+        }
+
+        const config = gardener.loadConfig(undefined, { env })
+
+        expect(config.sessionSecrets).toEqual(['current-secret', 'previous-secret'])
+        expect(readFileSyncSpy.mock.calls).toEqual(
+          Object.keys(fileMap).map(filePath => [filePath, 'utf8']),
+        )
       })
 
       it('should return the config overridden by environment variables', function () {
@@ -241,6 +282,7 @@ describe('config', function () {
           NODE_ENV: 'production',
           API_SERVER_URL: 'apiServerUrl',
           SESSION_SECRET: 'secret',
+          SESSION_SECRET_PREVIOUS: 'previous-secret',
           WEBSOCKET_ALLOWED_ORIGINS: '*',
           OIDC_CLIENT_ID: 'client_id',
         })

--- a/backend/__tests__/server.spec.js
+++ b/backend/__tests__/server.spec.js
@@ -19,14 +19,16 @@ import terminus from '@godaddy/terminus'
 import metricsApp from '@gardener-dashboard/monitor'
 import createServer from '../lib/server.js'
 
-function createApplication (port, metricsPort, { tls } = {}) {
+function createApplication (port, metricsPort, { tls, host, metricsHost } = {}) {
   const app = (req, res) => {
     res.writeHead(200, { 'Content-Type': 'text/plain' })
     res.end('ok', 'utf8')
   }
   const map = new Map()
   map.set('port', port)
+  map.set('host', host)
   map.set('metricsPort', metricsPort)
+  map.set('metricsHost', metricsHost)
   map.set('tls', tls)
   map.set('periodSeconds', 1)
   map.set('healthCheck', vi.fn())
@@ -57,7 +59,7 @@ describe('server', () => {
   const port = 1234
   const metricsPort = 5678
   const mockServer = {
-    listen: vi.fn((_, callback) => setImmediate(callback)),
+    listen: vi.fn((...args) => setImmediate(args.at(-1))),
   }
   const mockTerminus = {}
   let app
@@ -81,6 +83,7 @@ describe('server', () => {
 
   beforeEach(() => {
     setTimeoutSpy.mockClear()
+    mockServer.listen.mockClear()
     mockCreateServer = vi.spyOn(http, 'createServer').mockReturnValue(mockServer)
     mockCreateTerminus = vi.spyOn(terminus, 'createTerminus').mockReturnValue(mockTerminus)
     app = createApplication(port, metricsPort)
@@ -129,6 +132,21 @@ describe('server', () => {
     ])
   })
 
+  it('should bind both listeners to configured hosts', async () => {
+    const app = createApplication(port, metricsPort, {
+      host: '127.0.0.1',
+      metricsHost: '127.0.0.2',
+    })
+    const server = createServer(app, metricsApp)
+
+    await server.run()
+
+    expect(mockServer.listen.mock.calls).toEqual([
+      [metricsPort, '127.0.0.2', expect.any(Function)],
+      [port, '127.0.0.1', expect.any(Function)],
+    ])
+  })
+
   it('should initialize terminus', async () => {
     expect(terminus.createTerminus).toHaveBeenCalledTimes(1)
     expect(terminus.createTerminus.mock.calls[0]).toHaveLength(2)
@@ -171,7 +189,7 @@ describe('server (https)', () => {
     key: 'mock-key-content',
   }
   const mockServer = {
-    listen: vi.fn((_, callback) => setImmediate(callback)),
+    listen: vi.fn((...args) => setImmediate(args.at(-1))),
   }
   let app
   let logger
@@ -192,6 +210,7 @@ describe('server (https)', () => {
 
   beforeEach(() => {
     setTimeoutSpy.mockClear()
+    mockServer.listen.mockClear()
     mockHttpCreateServer = vi.spyOn(http, 'createServer').mockReturnValue(mockServer)
     mockHttpsCreateServer = vi.spyOn(https, 'createServer').mockReturnValue(mockServer)
     app = createApplication(port, metricsPort, { tls })

--- a/backend/lib/app.js
+++ b/backend/lib/app.js
@@ -30,7 +30,7 @@ import { router as authRouter } from './auth.js'
 import { router as githubWebhookRouter } from './github/webhook/index.js'
 import { healthCheck } from './healthz/index.js'
 
-const { port, metricsPort } = config
+const { port, host, metricsPort, metricsHost } = config
 const periodSeconds = config.readinessProbe?.periodSeconds || 10
 
 // protect against Prototype Pollution vulnerabilities
@@ -77,7 +77,9 @@ app.set('x-powered-by', false)
 
 // configure custom app settings used by the server
 app.set('port', port)
+app.set('host', host)
 app.set('metricsPort', metricsPort)
+app.set('metricsHost', metricsHost)
 app.set('tls', config.tls)
 app.set('logger', logger)
 app.set('healthCheck', healthCheck)

--- a/backend/lib/config/gardener.js
+++ b/backend/lib/config/gardener.js
@@ -110,10 +110,21 @@ const configMappings = [
     configPath: 'port',
     type: 'Integer',
   },
+  // Also used for metrics unless metricsHost is configured separately. If omitted,
+  // Node.js binds to :: when IPv6 is available, otherwise 0.0.0.0.
+  {
+    environmentVariableName: 'BIND_HOST',
+    configPath: 'host',
+  },
   {
     environmentVariableName: 'METRICS_PORT',
     configPath: 'metricsPort',
     type: 'Integer',
+  },
+  // If omitted, inherits host. If both are omitted, Node.js uses its default bind behavior.
+  {
+    environmentVariableName: 'METRICS_BIND_HOST',
+    configPath: 'metricsHost',
   },
   {
     environmentVariableName: 'WEBSOCKET_ALLOWED_ORIGINS',
@@ -191,6 +202,9 @@ export default {
       } catch (err) { /* ignore */ }
     }
     this.assignConfigFromEnvironmentAndFileSystem(config, env)
+    if (!_.has(config, ['metricsHost']) && _.has(config, ['host'])) {
+      config.metricsHost = config.host
+    }
     const requiredConfigurationProperties = [
       'sessionSecret',
       'apiServerUrl',

--- a/backend/lib/config/gardener.js
+++ b/backend/lib/config/gardener.js
@@ -16,6 +16,7 @@ configMappings defines mappings between config values, their sources (environmen
 and destinations in the config object. Properties:
 - environmentVariableName: The environment variable to read the value from.
 - filePath: (Optional) File path to read the value from if environment variable is not set.
+- fileFallbackWhen: (Optional) Predicate that controls whether the file fallback applies. Defaults to allowing the fallback.
 - configPath: The path in the config object to set the value.
 - type: (Optional) 'Boolean', 'Integer', or 'String' (default). Value is converted to this type.
 
@@ -52,48 +53,57 @@ const configMappings = [
   {
     environmentVariableName: 'OIDC_CLIENT_ID',
     filePath: '/etc/gardener-dashboard/secrets/oidc/client_id',
+    fileFallbackWhen: config => Boolean(config.oidc?.issuer),
     configPath: 'oidc.client_id',
   },
   {
     environmentVariableName: 'OIDC_CLIENT_SECRET',
     filePath: '/etc/gardener-dashboard/secrets/oidc/client_secret',
+    fileFallbackWhen: config => Boolean(config.oidc?.issuer),
     configPath: 'oidc.client_secret',
   },
   {
     environmentVariableName: 'GITHUB_AUTHENTICATION_APP_ID',
     filePath: '/etc/gardener-dashboard/secrets/github/authentication.appId',
+    fileFallbackWhen: config => Boolean(config.gitHub),
     configPath: 'gitHub.authentication.appId',
     type: 'Integer',
   },
   {
     environmentVariableName: 'GITHUB_AUTHENTICATION_CLIENT_ID',
     filePath: '/etc/gardener-dashboard/secrets/github/authentication.clientId',
+    fileFallbackWhen: config => Boolean(config.gitHub),
     configPath: 'gitHub.authentication.clientId',
   },
   {
     environmentVariableName: 'GITHUB_AUTHENTICATION_CLIENT_SECRET',
     filePath: '/etc/gardener-dashboard/secrets/github/authentication.clientSecret',
+    fileFallbackWhen: config => Boolean(config.gitHub),
     configPath: 'gitHub.authentication.clientSecret',
   },
   {
     environmentVariableName: 'GITHUB_AUTHENTICATION_INSTALLATION_ID',
     filePath: '/etc/gardener-dashboard/secrets/github/authentication.installationId',
+    fileFallbackWhen: config => Boolean(config.gitHub),
     configPath: 'gitHub.authentication.installationId',
     type: 'Integer',
   },
   {
     environmentVariableName: 'GITHUB_AUTHENTICATION_PRIVATE_KEY',
     filePath: '/etc/gardener-dashboard/secrets/github/authentication.privateKey',
+    fileFallbackWhen: config => Boolean(config.gitHub),
     configPath: 'gitHub.authentication.privateKey',
   },
   {
     environmentVariableName: 'GITHUB_AUTHENTICATION_TOKEN',
     filePath: '/etc/gardener-dashboard/secrets/github/authentication.token',
+    fileFallbackWhen: config => Boolean(config.gitHub),
     configPath: 'gitHub.authentication.token',
   },
   {
     environmentVariableName: 'GITHUB_WEBHOOK_SECRET',
     filePath: '/etc/gardener-dashboard/secrets/github/webhookSecret',
+    fileFallbackWhen: config => Boolean(config.gitHub),
     configPath: 'gitHub.webhookSecret',
   },
   {
@@ -154,26 +164,39 @@ function parseConfigValue (value, type) {
   }
 }
 
+function assignConfigValue (config, { configPath, type = 'String' }, rawValue) {
+  const value = parseConfigValue(rawValue, type)
+  if (value !== undefined) {
+    _.set(config, configPath, value)
+  }
+}
+
 export default {
   assignConfigFromEnvironmentAndFileSystem (config, env) {
+    // Apply all environment values first so file fallback eligibility is independent of mapping order.
+    for (const configMapping of configMappings) {
+      const { environmentVariableName } = configMapping
+      const rawValue = env[environmentVariableName] // eslint-disable-line security/detect-object-injection
+      assignConfigValue(config, configMapping, rawValue)
+    }
+
     for (const configMapping of configMappings) {
       const {
         environmentVariableName,
-        configPath,
         filePath,
-        type = 'String',
+        fileFallbackWhen = () => true,
       } = configMapping
-      let rawValue = env[environmentVariableName] // eslint-disable-line security/detect-object-injection
-      if (!rawValue && filePath) {
-        try {
-          rawValue = fs.readFileSync(filePath, 'utf8') // eslint-disable-line security/detect-non-literal-fs-filename
-        } catch (err) { /* ignore error */ }
+      const environmentValue = env[environmentVariableName] // eslint-disable-line security/detect-object-injection
+      if (!filePath || environmentValue || !fileFallbackWhen(config)) {
+        continue
       }
-      const value = parseConfigValue(rawValue, type)
-
-      if (value !== undefined) {
-        _.set(config, configPath, value)
+      let rawValue
+      try {
+        rawValue = fs.readFileSync(filePath, 'utf8') // eslint-disable-line security/detect-non-literal-fs-filename
+      } catch (err) {
+        continue
       }
+      assignConfigValue(config, configMapping, rawValue)
     }
   },
   getDefaults ({ env } = process) {

--- a/backend/lib/server.js
+++ b/backend/lib/server.js
@@ -19,7 +19,9 @@ function toMilliseconds (seconds) {
 
 function createServer (app, metricsApp) {
   const port = app.get('port')
+  const host = app.get('host')
   const metricsPort = app.get('metricsPort')
+  const metricsHost = app.get('metricsHost')
   const tls = app.get('tls')
   const periodSeconds = app.get('periodSeconds')
   const healthCheckFunc = app.get('healthCheck')
@@ -68,7 +70,7 @@ function createServer (app, metricsApp) {
 
   return {
     async run () {
-      await new Promise(resolve => metricsServer.listen(metricsPort, resolve))
+      await new Promise(resolve => metricsServer.listen(metricsPort, metricsHost, resolve))
       logger.info('Metrics server listening on port %d', metricsPort)
 
       const begin = Date.now()
@@ -80,7 +82,7 @@ function createServer (app, metricsApp) {
       } catch (err) {
         logger.warn('Before listen hook timed out: %s', err.message)
       }
-      await new Promise(resolve => server.listen(port, resolve))
+      await new Promise(resolve => server.listen(port, host, resolve))
       logger.info('%s server listening on port %d', isHttps ? 'HTTPS' : 'HTTP', port)
     },
   }

--- a/docs/development/local-setup.md
+++ b/docs/development/local-setup.md
@@ -57,6 +57,7 @@ Place the Gardener Dashboard configuration under `${HOME}/.gardener/config.yaml`
 A local configuration example could look like follows:
 
 ```yaml
+host: 127.0.0.1
 port: 3030
 logLevel: debug
 logFormat: text

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -17,7 +17,10 @@ import {
   URL,
 } from 'node:url'
 
-import { defineConfig } from 'vite'
+import {
+  defineConfig,
+  loadEnv,
+} from 'vite'
 import vue from '@vitejs/plugin-vue'
 import basicSsl from '@vitejs/plugin-basic-ssl'
 import vuetify, { transformAssetUrls } from 'vite-plugin-vuetify'
@@ -25,8 +28,6 @@ import Unfonts from 'unplugin-fonts/vite'
 import compression from 'vite-plugin-compression'
 import { visualizer } from 'rollup-plugin-visualizer'
 import { mdiMeta } from './vite/g-mdi-meta.js'
-
-const proxyTarget = 'http://localhost:3030'
 
 const KiB = 1024
 
@@ -177,6 +178,8 @@ export default defineConfig(({ command, mode }) => {
   }
 
   if (command === 'serve') {
+    const env = loadEnv(mode, process.cwd())
+    const proxyTarget = env.VITE_PROXY_TARGET || 'http://localhost:3030'
     const sslDirectory = process.env.GARDENER_DASHBOARD_SSL_DIR || join(homedir(), '.gardener', 'dashboard', 'ssl')
     const keyPath = join(sslDirectory, 'key.pem')
     const certPath = join(sslDirectory, 'cert.pem')


### PR DESCRIPTION
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

- Adds `BIND_HOST` and `METRICS_BIND_HOST` environment variables to allow configuring listener addresses for the backend and metrics servers, supporting isolated dev/test setups.
- Scopes OIDC and GitHub secret file fallbacks to only run when the corresponding provider is actually configured, preventing spurious file reads in unconfigured environments.
- Makes the Vite dev server proxy target configurable via `VITE_PROXY_TARGET`, defaulting to the existing `http://localhost:3030`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```feature developer
To restrict local Dashboard services to the loopback interface, developers should add `host: 127.0.0.1` to `${HOME}/.gardener/config.yaml`.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added configurable `host` and `metricsHost` support for application and metrics server binding.
  - Made the frontend dev `/api` and `/auth` proxy target configurable via environment variable (defaults unchanged).

- **Bug Fixes**
  - Improved secret loading so OIDC/GitHub file fallbacks apply only when those providers are configured; session secret fallbacks remain applied consistently.
  - `metricsHost` now defaults to `host` when not explicitly set.

- **Tests**
  - Expanded coverage for host/metricsHost handling and conditional secret fallback behavior.

- **Documentation**
  - Updated the local setup example to include `host`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->