### PR TITLE
[operations-view 1/7] refactor(frontend): support typed table search fields

### DIFF
--- a/frontend/__tests__/composables/useTableFilter/helper.spec.js
+++ b/frontend/__tests__/composables/useTableFilter/helper.spec.js
@@ -165,6 +165,11 @@ describe('composables/useTableFilter', () => {
         expect(query.matches(fieldSpecs({ name: 'aws-ha-cluster' }))).toBe(false)
       })
 
+      it('should treat inherited qualified fields as missing', () => {
+        const query = parseSearch('constructor:value', ['constructor'])
+        expect(query.matches(fieldSpecs({ name: 'shoot' }))).toBe(false)
+      })
+
       it('should treat null field value same as missing', () => {
         const query = new SearchQuery([{ field: 'seed', value: 'aws-ha', exact: false, exclude: false }])
         expect(query.matches(fieldSpecs({ name: 'aws-ha-cluster', seed: null }))).toBe(false)

--- a/frontend/__tests__/composables/useTableFilter/helper.spec.js
+++ b/frontend/__tests__/composables/useTableFilter/helper.spec.js
@@ -454,5 +454,12 @@ describe('composables/useTableFilter', () => {
       const query = parseSearch('xyz')
       expect(query.matches(fieldSpecs({ name: 'cluster', count: '99', flag: 'false' }))).toBe(false)
     })
+
+    it('should coerce raw primitive field values before matching', () => {
+      expect(parseSearch('42').matches(fieldSpecs({ workers: 142 }))).toBe(true)
+      expect(parseSearch('"42"').matches(fieldSpecs({ workers: 42 }))).toBe(true)
+      expect(parseSearch('true').matches(fieldSpecs({ enabled: true }))).toBe(true)
+      expect(parseSearch('xyz').matches(fieldSpecs({ count: 99, flag: false }))).toBe(false)
+    })
   })
 })

--- a/frontend/__tests__/composables/useTableFilter/helper.spec.js
+++ b/frontend/__tests__/composables/useTableFilter/helper.spec.js
@@ -8,6 +8,7 @@ import {
   describe,
   it,
   expect,
+  vi,
 } from 'vitest'
 
 import {
@@ -15,6 +16,13 @@ import {
   tokenizeSearch,
   SearchQuery,
 } from '@/composables/useTableFilter/helper'
+
+function fieldSpecs (fields) {
+  return Object.fromEntries(Object.entries(fields).map(([key, value]) => [
+    key,
+    { get: () => value },
+  ]))
+}
 
 describe('composables/useTableFilter', () => {
   describe('tokenizeSearch', () => {
@@ -94,32 +102,32 @@ describe('composables/useTableFilter', () => {
     describe('matches', () => {
       it('should match simple term against any field', () => {
         const query = new SearchQuery([{ field: null, value: 'aws', exact: false, exclude: false }])
-        expect(query.matches({ name: 'aws-region', region: 'us-east-1' })).toBe(true)
+        expect(query.matches(fieldSpecs({ name: 'aws-region', region: 'us-east-1' }))).toBe(true)
       })
 
       it('should not match when term is not present in any field', () => {
         const query = new SearchQuery([{ field: null, value: 'azure', exact: false, exclude: false }])
-        expect(query.matches({ name: 'aws-region', region: 'us-east-1' })).toBe(false)
+        expect(query.matches(fieldSpecs({ name: 'aws-region', region: 'us-east-1' }))).toBe(false)
       })
 
       it('should match exact term', () => {
         const query = new SearchQuery([{ field: null, value: 'aws', exact: true, exclude: false }])
-        expect(query.matches({ name: 'aws', region: 'us-east-1' })).toBe(true)
+        expect(query.matches(fieldSpecs({ name: 'aws', region: 'us-east-1' }))).toBe(true)
       })
 
       it('should not match exact term when only substring matches', () => {
         const query = new SearchQuery([{ field: null, value: 'aws', exact: true, exclude: false }])
-        expect(query.matches({ name: 'aws-region', region: 'us-east-1' })).toBe(false)
+        expect(query.matches(fieldSpecs({ name: 'aws-region', region: 'us-east-1' }))).toBe(false)
       })
 
       it('should handle exclusion with minus sign', () => {
         const query = new SearchQuery([{ field: null, value: 'azure', exact: false, exclude: true }])
-        expect(query.matches({ name: 'aws-region', region: 'us-east-1' })).toBe(true)
+        expect(query.matches(fieldSpecs({ name: 'aws-region', region: 'us-east-1' }))).toBe(true)
       })
 
       it('should not match when excluded term is present', () => {
         const query = new SearchQuery([{ field: null, value: 'azure', exact: false, exclude: true }])
-        expect(query.matches({ name: 'azure-region', region: 'west-eu' })).toBe(false)
+        expect(query.matches(fieldSpecs({ name: 'azure-region', region: 'west-eu' }))).toBe(false)
       })
 
       it('should match multiple terms with AND logic', () => {
@@ -127,7 +135,7 @@ describe('composables/useTableFilter', () => {
           { field: null, value: 'aws', exact: false, exclude: false },
           { field: null, value: 'east', exact: false, exclude: false },
         ])
-        expect(query.matches({ name: 'aws-region', region: 'us-east-1' })).toBe(true)
+        expect(query.matches(fieldSpecs({ name: 'aws-region', region: 'us-east-1' }))).toBe(true)
       })
 
       it('should not match when any term is missing (AND logic)', () => {
@@ -135,7 +143,7 @@ describe('composables/useTableFilter', () => {
           { field: null, value: 'aws', exact: false, exclude: false },
           { field: null, value: 'west', exact: false, exclude: false },
         ])
-        expect(query.matches({ name: 'aws-region', region: 'us-east-1' })).toBe(false)
+        expect(query.matches(fieldSpecs({ name: 'aws-region', region: 'us-east-1' }))).toBe(false)
       })
 
       it('should handle combination of inclusion and exclusion', () => {
@@ -143,53 +151,53 @@ describe('composables/useTableFilter', () => {
           { field: null, value: 'aws', exact: false, exclude: false },
           { field: null, value: 'azure', exact: false, exclude: true },
         ])
-        expect(query.matches({ name: 'aws-region', region: 'us-east-1' })).toBe(true)
+        expect(query.matches(fieldSpecs({ name: 'aws-region', region: 'us-east-1' }))).toBe(true)
       })
 
       it('should match qualified term only against its field', () => {
         const query = new SearchQuery([{ field: 'seed', value: 'aws-ha', exact: false, exclude: false }])
-        expect(query.matches({ name: 'aws-ha-cluster', seed: 'aws-ha' })).toBe(true)
-        expect(query.matches({ name: 'aws-ha-cluster', seed: 'gcp-ha' })).toBe(false)
+        expect(query.matches(fieldSpecs({ name: 'aws-ha-cluster', seed: 'aws-ha' }))).toBe(true)
+        expect(query.matches(fieldSpecs({ name: 'aws-ha-cluster', seed: 'gcp-ha' }))).toBe(false)
       })
 
       it('should not match qualified term when field value is missing', () => {
         const query = new SearchQuery([{ field: 'seed', value: 'aws-ha', exact: false, exclude: false }])
-        expect(query.matches({ name: 'aws-ha-cluster' })).toBe(false)
+        expect(query.matches(fieldSpecs({ name: 'aws-ha-cluster' }))).toBe(false)
       })
 
       it('should treat null field value same as missing', () => {
         const query = new SearchQuery([{ field: 'seed', value: 'aws-ha', exact: false, exclude: false }])
-        expect(query.matches({ name: 'aws-ha-cluster', seed: null })).toBe(false)
+        expect(query.matches(fieldSpecs({ name: 'aws-ha-cluster', seed: null }))).toBe(false)
       })
 
       it('should match empty value term against null/undefined/empty field', () => {
         const query = new SearchQuery([{ field: 'seed', value: '', exact: false, exclude: false }])
-        expect(query.matches({ name: 'cluster', seed: null })).toBe(true)
-        expect(query.matches({ name: 'cluster', seed: undefined })).toBe(true)
-        expect(query.matches({ name: 'cluster', seed: '' })).toBe(true)
-        expect(query.matches({ name: 'cluster', seed: 'aws-ha' })).toBe(false)
+        expect(query.matches(fieldSpecs({ name: 'cluster', seed: null }))).toBe(true)
+        expect(query.matches(fieldSpecs({ name: 'cluster', seed: undefined }))).toBe(true)
+        expect(query.matches(fieldSpecs({ name: 'cluster', seed: '' }))).toBe(true)
+        expect(query.matches(fieldSpecs({ name: 'cluster', seed: 'aws-ha' }))).toBe(false)
       })
 
       it('should support excluding empty field values', () => {
         const query = new SearchQuery([{ field: 'seed', value: '', exact: false, exclude: true }])
         // has a seed → empty not found → exclusion passes
-        expect(query.matches({ name: 'cluster', seed: 'aws-ha' })).toBe(true)
+        expect(query.matches(fieldSpecs({ name: 'cluster', seed: 'aws-ha' }))).toBe(true)
         // no seed → empty found → exclusion rejects
-        expect(query.matches({ name: 'cluster', seed: null })).toBe(false)
+        expect(query.matches(fieldSpecs({ name: 'cluster', seed: null }))).toBe(false)
       })
 
       it('should treat missing qualified-field value as not-found for exclusion', () => {
         const query = new SearchQuery([{ field: 'seed', value: 'aws-ha', exact: false, exclude: true }])
         // missing seed → not found → exclusion passes
-        expect(query.matches({ name: 'cluster' })).toBe(true)
-        expect(query.matches({ name: 'cluster', seed: 'gcp-ha' })).toBe(true)
-        expect(query.matches({ name: 'cluster', seed: 'aws-ha' })).toBe(false)
+        expect(query.matches(fieldSpecs({ name: 'cluster' }))).toBe(true)
+        expect(query.matches(fieldSpecs({ name: 'cluster', seed: 'gcp-ha' }))).toBe(true)
+        expect(query.matches(fieldSpecs({ name: 'cluster', seed: 'aws-ha' }))).toBe(false)
       })
 
       it('should support exact qualified match', () => {
         const query = new SearchQuery([{ field: 'seed', value: 'aws', exact: true, exclude: false }])
-        expect(query.matches({ seed: 'aws' })).toBe(true)
-        expect(query.matches({ seed: 'aws-ha' })).toBe(false)
+        expect(query.matches(fieldSpecs({ seed: 'aws' }))).toBe(true)
+        expect(query.matches(fieldSpecs({ seed: 'aws-ha' }))).toBe(false)
       })
 
       it('should combine qualified and unqualified terms', () => {
@@ -197,9 +205,76 @@ describe('composables/useTableFilter', () => {
           { field: 'seed', value: 'aws-ha', exact: false, exclude: false },
           { field: null, value: 'prod', exact: false, exclude: false },
         ])
-        expect(query.matches({ name: 'prod-cluster', seed: 'aws-ha' })).toBe(true)
-        expect(query.matches({ name: 'dev-cluster', seed: 'aws-ha' })).toBe(false)
-        expect(query.matches({ name: 'prod-cluster', seed: 'gcp-ha' })).toBe(false)
+        expect(query.matches(fieldSpecs({ name: 'prod-cluster', seed: 'aws-ha' }))).toBe(true)
+        expect(query.matches(fieldSpecs({ name: 'dev-cluster', seed: 'aws-ha' }))).toBe(false)
+        expect(query.matches(fieldSpecs({ name: 'prod-cluster', seed: 'gcp-ha' }))).toBe(false)
+      })
+
+      it('should support custom field matchers while keeping exclusion outside the matcher', () => {
+        const matchHealth = (term, value) => term.value === 'any' || term.value === value
+        const query = new SearchQuery([{ field: 'health', value: 'any', exact: false, exclude: false }])
+        const excludedQuery = new SearchQuery([{ field: 'health', value: 'any', exact: false, exclude: true }])
+        const fields = {
+          health: { get: () => 'healthy', match: matchHealth },
+        }
+
+        expect(query.matches(fields)).toBe(true)
+        expect(excludedQuery.matches(fields)).toBe(false)
+      })
+
+      it('should only call the getter for a referenced qualified field', () => {
+        const query = new SearchQuery([{ field: 'seed', value: 'aws-ha', exact: false, exclude: false }])
+        const getName = vi.fn(() => 'aws-ha-cluster')
+        const getSeed = vi.fn(() => 'aws-ha')
+
+        expect(query.matches({
+          name: { get: getName },
+          seed: { get: getSeed },
+        })).toBe(true)
+
+        expect(getSeed).toHaveBeenCalledTimes(1)
+        expect(getName).not.toHaveBeenCalled()
+      })
+
+      it('should exclude freeText false fields from unqualified matching', () => {
+        const query = new SearchQuery([{ field: null, value: 'any', exact: false, exclude: false }])
+        const getHealth = vi.fn(() => 'healthy')
+        const matchHealth = vi.fn(() => true)
+
+        expect(query.matches({
+          name: { get: () => 'shoot' },
+          health: {
+            get: getHealth,
+            match: matchHealth,
+            freeText: false,
+          },
+        })).toBe(false)
+
+        expect(getHealth).not.toHaveBeenCalled()
+        expect(matchHealth).not.toHaveBeenCalled()
+      })
+
+      it('should still match unqualified terms against default free-text fields', () => {
+        const query = new SearchQuery([{ field: null, value: 'aws', exact: false, exclude: false }])
+
+        expect(query.matches(fieldSpecs({
+          name: 'aws-region',
+          region: 'us-east-1',
+        }))).toBe(true)
+      })
+
+      it('should call a field getter once per matching term without memoization', () => {
+        const query = new SearchQuery([
+          { field: 'seed', value: 'aws', exact: false, exclude: false },
+          { field: 'seed', value: 'ha', exact: false, exclude: false },
+        ])
+        const getSeed = vi.fn(() => 'aws-ha')
+
+        expect(query.matches({
+          seed: { get: getSeed },
+        })).toBe(true)
+
+        expect(getSeed).toHaveBeenCalledTimes(2)
       })
     })
   })
@@ -343,41 +418,41 @@ describe('composables/useTableFilter', () => {
 
     it('should create SearchQuery that matches correctly', () => {
       const query = parseSearch('aws -azure')
-      expect(query.matches({ name: 'aws-region', region: 'us-east-1' })).toBe(true)
-      expect(query.matches({ name: 'azure-region', region: 'west-eu' })).toBe(false)
+      expect(query.matches(fieldSpecs({ name: 'aws-region', region: 'us-east-1' }))).toBe(true)
+      expect(query.matches(fieldSpecs({ name: 'azure-region', region: 'west-eu' }))).toBe(false)
     })
 
     it('should create SearchQuery that field-matches correctly', () => {
       const query = parseSearch('seed:aws-ha', ['seed'])
-      expect(query.matches({ name: 'aws-ha-cluster', seed: 'aws-ha' })).toBe(true)
+      expect(query.matches(fieldSpecs({ name: 'aws-ha-cluster', seed: 'aws-ha' }))).toBe(true)
       // substring on name only must NOT satisfy qualified seed term
-      expect(query.matches({ name: 'aws-ha-cluster', seed: 'gcp-ha' })).toBe(false)
+      expect(query.matches(fieldSpecs({ name: 'aws-ha-cluster', seed: 'gcp-ha' }))).toBe(false)
     })
   })
 
-  describe('SearchQuery.matches with non-string values', () => {
-    it('should match numeric field values via substring', () => {
+  describe('SearchQuery.matches with stringified field values', () => {
+    it('should match numeric-like string field values via substring', () => {
       const query = parseSearch('42')
-      expect(query.matches({ name: 'cluster', workers: 42 })).toBe(true)
-      expect(query.matches({ name: 'cluster', workers: 142 })).toBe(true)
-      expect(query.matches({ name: 'cluster', workers: 5 })).toBe(false)
+      expect(query.matches(fieldSpecs({ name: 'cluster', workers: '42' }))).toBe(true)
+      expect(query.matches(fieldSpecs({ name: 'cluster', workers: '142' }))).toBe(true)
+      expect(query.matches(fieldSpecs({ name: 'cluster', workers: '5' }))).toBe(false)
     })
 
-    it('should match numeric field values via exact match', () => {
+    it('should match numeric-like string field values via exact match', () => {
       const query = parseSearch('"42"')
-      expect(query.matches({ name: 'cluster', workers: 42 })).toBe(true)
-      expect(query.matches({ name: 'cluster', workers: 142 })).toBe(false)
+      expect(query.matches(fieldSpecs({ name: 'cluster', workers: '42' }))).toBe(true)
+      expect(query.matches(fieldSpecs({ name: 'cluster', workers: '142' }))).toBe(false)
     })
 
-    it('should match boolean field values', () => {
+    it('should match boolean-like string field values', () => {
       const query = parseSearch('true')
-      expect(query.matches({ name: 'cluster', enabled: true })).toBe(true)
-      expect(query.matches({ name: 'cluster', enabled: false })).toBe(false)
+      expect(query.matches(fieldSpecs({ name: 'cluster', enabled: 'true' }))).toBe(true)
+      expect(query.matches(fieldSpecs({ name: 'cluster', enabled: 'false' }))).toBe(false)
     })
 
-    it('should not crash on non-string values when no match', () => {
+    it('should not match when no field contains the term', () => {
       const query = parseSearch('xyz')
-      expect(query.matches({ name: 'cluster', count: 99, flag: false })).toBe(false)
+      expect(query.matches(fieldSpecs({ name: 'cluster', count: '99', flag: 'false' }))).toBe(false)
     })
   })
 })

--- a/frontend/src/composables/useTableFilter/helper.js
+++ b/frontend/src/composables/useTableFilter/helper.js
@@ -18,14 +18,14 @@ function isTokenSeparator (code) {
   return code === CHAR_SPACE || code === CHAR_TAB || code === CHAR_LF || code === CHAR_CR
 }
 
-function getTermValues (fields, allValues, field) {
-  if (field === null) {
-    return allValues
+export function defaultFieldMatch (term, value) {
+  if (term.value === '') {
+    return value == null || value === ''
   }
-  if (!Object.hasOwn(fields, field)) {
-    return [undefined]
+  if (value == null || value === '') {
+    return false
   }
-  return [fields[field]] // eslint-disable-line security/detect-object-injection -- key validated by hasOwn above; fields is an app-constructed object literal, field is constrained to allowedFields
+  return term.exact ? value === term.value : value.includes(term.value)
 }
 
 // Splits the raw query on whitespace while keeping quoted phrases intact.
@@ -86,20 +86,17 @@ export class SearchQuery {
   }
 
   matches (fields) {
-    const allValues = Object.values(fields)
     for (const term of this.terms) {
-      const values = getTermValues(fields, allValues, term.field)
-      const matchesTermValue = value => {
-        if (term.value === '') {
-          return value == null || value === ''
-        }
-        if (value == null || value === '') {
-          return false
-        }
-        const stringValue = typeof value === 'string' ? value : String(value)
-        return term.exact ? stringValue === term.value : stringValue.includes(term.value)
+      let found
+      if (term.field !== null) {
+        const spec = fields[term.field]
+        const match = spec?.match ?? defaultFieldMatch
+        found = match(term, spec ? spec.get() : undefined)
+      } else {
+        found = Object.values(fields)
+          .filter(spec => spec.freeText !== false)
+          .some(spec => (spec.match ?? defaultFieldMatch)(term, spec.get()))
       }
-      const found = values.some(matchesTermValue)
       if ((!found && !term.exclude) || (found && term.exclude)) {
         return false
       }

--- a/frontend/src/composables/useTableFilter/helper.js
+++ b/frontend/src/composables/useTableFilter/helper.js
@@ -25,7 +25,8 @@ export function defaultFieldMatch (term, value) {
   if (value == null || value === '') {
     return false
   }
-  return term.exact ? value === term.value : value.includes(term.value)
+  const stringValue = typeof value === 'string' ? value : String(value)
+  return term.exact ? stringValue === term.value : stringValue.includes(term.value)
 }
 
 // Splits the raw query on whitespace while keeping quoted phrases intact.

--- a/frontend/src/composables/useTableFilter/helper.js
+++ b/frontend/src/composables/useTableFilter/helper.js
@@ -90,7 +90,9 @@ export class SearchQuery {
     for (const term of this.terms) {
       let found
       if (term.field !== null) {
-        const spec = fields[term.field]
+        const spec = Object.hasOwn(fields, term.field)
+          ? fields[term.field]
+          : undefined
         const match = spec?.match ?? defaultFieldMatch
         found = match(term, spec ? spec.get() : undefined)
       } else {

--- a/frontend/src/store/shoot/helper.js
+++ b/frontend/src/store/shoot/helper.js
@@ -319,21 +319,22 @@ export function searchItemsFn (state, context) {
     const searchQuery = parseSearch(search, QUALIFIED_SEARCH_FIELDS)
 
     return item => {
+      const f = key => ({ get: () => getRawVal(context, item, key) })
       const fields = {
-        name: getRawVal(context, item, 'name'),
-        provider: getRawVal(context, item, 'provider'),
-        region: getRawVal(context, item, 'region'),
-        seed: getRawVal(context, item, 'seed'),
-        project: getRawVal(context, item, 'project'),
-        createdBy: getRawVal(context, item, 'createdBy'),
-        purpose: getRawVal(context, item, 'purpose'),
-        k8sVersion: getRawVal(context, item, 'k8sVersion'),
-        ticketLabels: getRawVal(context, item, 'ticketLabels'),
-        errorCodes: getRawVal(context, item, 'errorCodes'),
-        controlPlaneHighAvailability: getRawVal(context, item, 'controlPlaneHighAvailability'),
+        name: f('name'),
+        provider: f('provider'),
+        region: f('region'),
+        seed: f('seed'),
+        project: f('project'),
+        createdBy: f('createdBy'),
+        purpose: f('purpose'),
+        k8sVersion: f('k8sVersion'),
+        ticketLabels: f('ticketLabels'),
+        errorCodes: f('errorCodes'),
+        controlPlaneHighAvailability: f('controlPlaneHighAvailability'),
       }
       Object.assign(fields, Object.fromEntries(
-        searchableCustomFields.value.map(({ key }) => [key, getRawVal(context, item, key)]),
+        searchableCustomFields.value.map(({ key }) => [key, f(key)]),
       ))
 
       return searchQuery.matches(fields)

--- a/frontend/src/views/GSeedList.vue
+++ b/frontend/src/views/GSeedList.vue
@@ -284,21 +284,18 @@ function seedFilterFn (query) {
   const searchQuery = parseSearch(query, QUALIFIED_SEARCH_FIELDS)
 
   return item => {
-    const conditions = get(item, ['status', 'conditions'], [])
-    const errorCodes = join(errorCodesFromArray(conditions), ' ')
-    const accessRestrictionNames = join(map(get(item, ['spec', 'accessRestrictions'], []), 'name'), ' ')
-    const shoot = getManagedSeedShootName(item) || 'Unmanaged'
+    const f = getter => ({ get: getter })
 
     const fields = {
-      name: get(item, ['metadata', 'name']),
-      shoot,
-      provider: get(item, ['spec', 'provider', 'type']),
-      region: get(item, ['spec', 'provider', 'region']),
-      k8sVersion: get(item, ['status', 'kubernetesVersion']),
-      gardenerVersion: get(item, ['status', 'gardener', 'version']),
-      visibility: get(item, ['spec', 'settings', 'scheduling', 'visible']) ? 'visible' : 'hidden',
-      errorCodes,
-      accessRestrictions: accessRestrictionNames,
+      name: f(() => get(item, ['metadata', 'name'])),
+      shoot: f(() => getManagedSeedShootName(item) || 'Unmanaged'),
+      provider: f(() => get(item, ['spec', 'provider', 'type'])),
+      region: f(() => get(item, ['spec', 'provider', 'region'])),
+      k8sVersion: f(() => get(item, ['status', 'kubernetesVersion'])),
+      gardenerVersion: f(() => get(item, ['status', 'gardener', 'version'])),
+      visibility: f(() => get(item, ['spec', 'settings', 'scheduling', 'visible']) ? 'visible' : 'hidden'),
+      errorCodes: f(() => join(errorCodesFromArray(get(item, ['status', 'conditions'], [])), ' ')),
+      accessRestrictions: f(() => join(map(get(item, ['spec', 'accessRestrictions'], []), 'name'), ' ')),
     }
 
     return searchQuery.matches(fields)


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area quality
/kind enhancement

**What this PR does / why we need it**:
Makes table-search field definitions lazy and extensible. Previously every field was eagerly evaluated; now each field exposes a `match` function called only when a search term is active. This removes unnecessary computation and opens the door for domain-specific matching strategies (e.g. typed Shoot-search terms) without touching call sites.

Existing Seed and Shoot search behaviour is unchanged.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This is a prerequisite refactor — no user-visible behaviour change is intended. The API surface of `useTableFilter/helper` changes (match functions replace pre-computed strings), but all consumers are updated in this commit.

**Release note**:
```other developer
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table and seed search matching for numeric, boolean-like, and other non-string values.
  * Corrected exact and partial matching, including null and empty values.
  * Ensured custom matching, qualified fields, and free-text exclusions work consistently.
  * Improved search efficiency by evaluating values only when needed.
* **Tests**
  * Expanded coverage for custom matching, qualified searches, empty values, and stringified value matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->