### PR TITLE
[merged to feature branch only][operations-view 2/7] feat(frontend): add typed shoot search terms

### DIFF
--- a/frontend/__tests__/stores/shoot/search.spec.js
+++ b/frontend/__tests__/stores/shoot/search.spec.js
@@ -1,0 +1,403 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import {
+  createPinia,
+  setActivePinia,
+} from 'pinia'
+
+import { useConfigStore } from '@/store/config'
+import { useProjectStore } from '@/store/project'
+import { useShootStore } from '@/store/shoot'
+import { parseShootSearch } from '@/store/shoot/helper'
+import {
+  SHOOT_ALL_TICKETS_IGNORED_FALSE,
+  SHOOT_ALL_TICKETS_IGNORED_TRUE,
+  SHOOT_HEALTH_UNHEALTHY,
+  SHOOT_OPERATOR_ACTION_TRUE,
+  SHOOT_PROGRESSING_TRUE,
+  buildSearchTerms,
+  hasAllTicketsIgnoredSearchTerm,
+  hasHealthSearchTerm,
+  hasOperatorActionSearchTerm,
+  hasProgressingSearchTerm,
+  resolveShootListFiltersForDonut,
+  resolveShootListFiltersFromSearch,
+} from '@/store/shoot/search'
+import { useTicketStore } from '@/store/ticket'
+
+describe('Shoot search', () => {
+  let configStore
+  let shootStore
+  let ticketStore
+
+  function createShoot ({
+    name,
+    uid,
+    health,
+    annotations,
+    status = {},
+  }) {
+    return {
+      metadata: {
+        name,
+        namespace: 'foo',
+        uid,
+        annotations,
+        labels: {
+          'shoot.gardener.cloud/status': health,
+        },
+      },
+      spec: {
+        provider: {},
+      },
+      status,
+    }
+  }
+
+  function createIssue ({
+    name,
+    number,
+    labels,
+  }) {
+    return {
+      metadata: {
+        name,
+        number,
+        projectName: 'foo',
+        updated_at: '2026-01-01T00:00:00Z',
+      },
+      data: {
+        labels: labels.map((label, index) => ({
+          id: index + 1,
+          name: label,
+        })),
+      },
+    }
+  }
+
+  function matchingNames (search, shoots) {
+    const predicate = shootStore.searchItems(search)
+    return shoots.filter(predicate).map(shoot => shoot.metadata.name)
+  }
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+
+    const projectStore = useProjectStore()
+    projectStore.list = [{
+      metadata: {
+        name: 'foo',
+      },
+      spec: {
+        namespace: 'foo',
+      },
+    }]
+
+    configStore = useConfigStore()
+    ticketStore = useTicketStore()
+    shootStore = useShootStore()
+  })
+
+  it('excludes typed fields from free-text matching', () => {
+    const shoots = [
+      createShoot({ name: 'alpha-shoot', uid: 'healthy', health: 'healthy' }),
+      createShoot({ name: 'beta-shoot', uid: 'unhealthy', health: 'unhealthy' }),
+    ]
+
+    expect(matchingNames('any', shoots)).toEqual([])
+  })
+
+  it('normalizes and matches health terms', () => {
+    const shoots = [
+      createShoot({ name: 'healthy-shoot', uid: 'healthy', health: 'healthy' }),
+      createShoot({ name: 'unhealthy-shoot', uid: 'unhealthy', health: 'unhealthy' }),
+    ]
+    const cases = [
+      {
+        search: 'health:unhealthy',
+        term: { field: 'health', value: 'unhealthy', exact: false, exclude: false },
+        names: ['unhealthy-shoot'],
+      },
+      {
+        search: '-health:healthy',
+        term: { field: 'health', value: 'unhealthy', exact: false, exclude: false },
+        names: ['unhealthy-shoot'],
+      },
+      {
+        search: 'health:any',
+        term: { field: 'health', value: 'any', exact: false, exclude: false },
+        names: ['healthy-shoot', 'unhealthy-shoot'],
+      },
+      {
+        search: 'health:none',
+        term: { field: 'health', value: 'none', exact: false, exclude: false },
+        names: [],
+      },
+      {
+        search: 'health:"healthy"',
+        term: { field: 'health', value: 'healthy', exact: true, exclude: false },
+        names: ['healthy-shoot'],
+      },
+      {
+        search: '-health:unknown',
+        term: { field: 'health', value: 'unknown', exact: false, exclude: true },
+        names: ['healthy-shoot', 'unhealthy-shoot'],
+      },
+    ]
+
+    for (const { search, term, names } of cases) {
+      const query = parseShootSearch(search)
+      expect(query.terms).toEqual([term])
+      expect(matchingNames(search, shoots)).toEqual(names)
+    }
+
+    const query = parseShootSearch('health:unhealthy -health:healthy')
+    expect(query.terms).toEqual([
+      { field: 'health', value: 'unhealthy', exact: false, exclude: false },
+      { field: 'health', value: 'unhealthy', exact: false, exclude: false },
+    ])
+    expect(hasHealthSearchTerm(query, SHOOT_HEALTH_UNHEALTHY)).toBe(true)
+  })
+
+  it('normalizes and matches progressing terms', () => {
+    const shoots = [
+      createShoot({ name: 'progressing-shoot', uid: 'progressing', health: 'progressing' }),
+      createShoot({ name: 'unhealthy-shoot', uid: 'unhealthy', health: 'unhealthy' }),
+    ]
+    const cases = [
+      {
+        search: 'progressing:true',
+        term: { field: 'progressing', value: 'true', exact: false, exclude: false },
+        names: ['progressing-shoot'],
+      },
+      {
+        search: '-progressing:false',
+        term: { field: 'progressing', value: 'true', exact: false, exclude: false },
+        names: ['progressing-shoot'],
+      },
+      {
+        search: 'progressing:false',
+        term: { field: 'progressing', value: 'false', exact: false, exclude: false },
+        names: ['unhealthy-shoot'],
+      },
+      {
+        search: 'progressing:any',
+        term: { field: 'progressing', value: 'any', exact: false, exclude: false },
+        names: ['progressing-shoot', 'unhealthy-shoot'],
+      },
+      {
+        search: 'progressing:none',
+        term: { field: 'progressing', value: 'none', exact: false, exclude: false },
+        names: [],
+      },
+    ]
+
+    for (const { search, term, names } of cases) {
+      const query = parseShootSearch(search)
+      expect(query.terms).toEqual([term])
+      expect(matchingNames(search, shoots)).toEqual(names)
+    }
+
+    expect(hasProgressingSearchTerm(
+      parseShootSearch('-progressing:false'),
+      SHOOT_PROGRESSING_TRUE,
+    )).toBe(true)
+  })
+
+  it('normalizes and matches operator-action terms', () => {
+    const shoots = [
+      createShoot({
+        name: 'operator-action-shoot',
+        uid: 'operator-action',
+        health: 'unhealthy',
+      }),
+      createShoot({
+        name: 'user-error-shoot',
+        uid: 'user-error',
+        health: 'unhealthy',
+        status: {
+          lastErrors: [{
+            codes: ['ERR_CONFIGURATION_PROBLEM'],
+          }],
+        },
+      }),
+    ]
+    const cases = [
+      {
+        search: 'operatorAction:true',
+        term: { field: 'operatorAction', value: 'true', exact: false, exclude: false },
+        names: ['operator-action-shoot'],
+      },
+      {
+        search: '-operatorAction:false',
+        term: { field: 'operatorAction', value: 'true', exact: false, exclude: false },
+        names: ['operator-action-shoot'],
+      },
+      {
+        search: 'operatorAction:false',
+        term: { field: 'operatorAction', value: 'false', exact: false, exclude: false },
+        names: ['user-error-shoot'],
+      },
+      {
+        search: 'operatorAction:any',
+        term: { field: 'operatorAction', value: 'any', exact: false, exclude: false },
+        names: ['operator-action-shoot', 'user-error-shoot'],
+      },
+      {
+        search: 'operatorAction:none',
+        term: { field: 'operatorAction', value: 'none', exact: false, exclude: false },
+        names: [],
+      },
+    ]
+
+    for (const { search, term, names } of cases) {
+      const query = parseShootSearch(search)
+      expect(query.terms).toEqual([term])
+      expect(matchingNames(search, shoots)).toEqual(names)
+    }
+
+    expect(hasOperatorActionSearchTerm(
+      parseShootSearch('-operatorAction:false'),
+      SHOOT_OPERATOR_ACTION_TRUE,
+    )).toBe(true)
+  })
+
+  it('normalizes and matches all-tickets-ignored terms', () => {
+    configStore.setConfiguration({
+      ticket: {
+        gitHubRepoUrl: 'https://github.com/org/repo',
+        hideClustersWithLabels: ['ignore'],
+      },
+    })
+    const shoots = [
+      createShoot({ name: 'ignored-ticket-shoot', uid: 'ignored-ticket', health: 'unhealthy' }),
+      createShoot({ name: 'visible-ticket-shoot', uid: 'visible-ticket', health: 'unhealthy' }),
+    ]
+    ticketStore.receiveIssues([
+      createIssue({
+        name: 'ignored-ticket-shoot',
+        number: 1,
+        labels: ['ignore'],
+      }),
+      createIssue({
+        name: 'visible-ticket-shoot',
+        number: 2,
+        labels: ['needs-attention'],
+      }),
+    ])
+    const cases = [
+      {
+        search: 'allTicketsIgnored:true',
+        term: { field: 'allTicketsIgnored', value: 'true', exact: false, exclude: false },
+        names: ['ignored-ticket-shoot'],
+      },
+      {
+        search: '-allTicketsIgnored:false',
+        term: { field: 'allTicketsIgnored', value: 'true', exact: false, exclude: false },
+        names: ['ignored-ticket-shoot'],
+      },
+      {
+        search: 'allTicketsIgnored:false',
+        term: { field: 'allTicketsIgnored', value: 'false', exact: false, exclude: false },
+        names: ['visible-ticket-shoot'],
+      },
+      {
+        search: 'allTicketsIgnored:any',
+        term: { field: 'allTicketsIgnored', value: 'any', exact: false, exclude: false },
+        names: ['ignored-ticket-shoot', 'visible-ticket-shoot'],
+      },
+      {
+        search: 'allTicketsIgnored:none',
+        term: { field: 'allTicketsIgnored', value: 'none', exact: false, exclude: false },
+        names: [],
+      },
+    ]
+
+    for (const { search, term, names } of cases) {
+      const query = parseShootSearch(search)
+      expect(query.terms).toEqual([term])
+      expect(matchingNames(search, shoots)).toEqual(names)
+    }
+
+    expect(hasAllTicketsIgnoredSearchTerm(
+      parseShootSearch('-allTicketsIgnored:false'),
+      SHOOT_ALL_TICKETS_IGNORED_TRUE,
+    )).toBe(true)
+  })
+
+  it('canonicalizes negated any and none values', () => {
+    expect(parseShootSearch('-health:any').terms).toEqual([
+      { field: 'health', value: 'none', exact: false, exclude: false },
+    ])
+    expect(parseShootSearch('-progressing:none').terms).toEqual([
+      { field: 'progressing', value: 'any', exact: false, exclude: false },
+    ])
+  })
+
+  it('builds the Operations View query from filter values', () => {
+    expect(buildSearchTerms()).toBe('')
+    expect(buildSearchTerms({
+      healthy: false,
+      progressing: true,
+      operatorAction: true,
+      allTicketsIgnored: true,
+    })).toBe('')
+    expect(buildSearchTerms({
+      healthy: true,
+      progressing: true,
+      operatorAction: true,
+      allTicketsIgnored: true,
+    })).toBe(
+      'health:unhealthy progressing:false operatorAction:true allTicketsIgnored:false',
+    )
+  })
+
+  it('resolves filter values from a typed query', () => {
+    const query = parseShootSearch(
+      'health:unhealthy progressing:false operatorAction:true allTicketsIgnored:false',
+    )
+
+    expect(resolveShootListFiltersFromSearch(query)).toEqual({
+      healthy: true,
+      unhealthy: false,
+      progressing: true,
+      operatorAction: true,
+      allTicketsIgnored: true,
+    })
+    expect(hasAllTicketsIgnoredSearchTerm(
+      query,
+      SHOOT_ALL_TICKETS_IGNORED_FALSE,
+    )).toBe(true)
+  })
+
+  it('resolves donut refinements only for an active unhealthy view', () => {
+    expect(resolveShootListFiltersForDonut({
+      healthy: false,
+      progressing: true,
+      operatorAction: true,
+      allTicketsIgnored: true,
+    })).toEqual({
+      healthy: true,
+      unhealthy: false,
+      progressing: false,
+      operatorAction: false,
+      allTicketsIgnored: false,
+    })
+    expect(resolveShootListFiltersForDonut({
+      healthy: true,
+      progressing: true,
+      operatorAction: true,
+      allTicketsIgnored: true,
+    })).toEqual({
+      healthy: true,
+      unhealthy: false,
+      progressing: true,
+      operatorAction: true,
+      allTicketsIgnored: true,
+    })
+  })
+})

--- a/frontend/__tests__/stores/shoot/search.spec.js
+++ b/frontend/__tests__/stores/shoot/search.spec.js
@@ -266,6 +266,23 @@ describe('Shoot search', () => {
     )).toBe(true)
   })
 
+  it('does not match healthy shoots for operatorAction:true', () => {
+    const shoots = [
+      createShoot({
+        name: 'healthy-shoot',
+        uid: 'healthy',
+        health: 'healthy',
+      }),
+      createShoot({
+        name: 'operator-action-shoot',
+        uid: 'operator-action',
+        health: 'unhealthy',
+      }),
+    ]
+
+    expect(matchingNames('operatorAction:true', shoots)).toEqual(['operator-action-shoot'])
+  })
+
   it('normalizes and matches all-tickets-ignored terms', () => {
     configStore.setConfiguration({
       ticket: {

--- a/frontend/src/store/shoot/helper.js
+++ b/frontend/src/store/shoot/helper.js
@@ -132,25 +132,6 @@ export function getFilteredUids (state, context) {
     return !isStatusProgressing(get(item, ['metadata'], {}))
   }
 
-  const noUserError = item => {
-    const ignoreIssues = isTruthyValue(get(item, ['metadata', 'annotations', 'dashboard.gardener.cloud/ignore-issues']))
-    if (ignoreIssues) {
-      return false
-    }
-    const lastErrors = get(item, ['status', 'lastErrors'], [])
-    const allLastErrorCodes = errorCodesFromArray(lastErrors)
-    if (isTemporaryError(allLastErrorCodes)) {
-      return false
-    }
-    const conditions = get(item, ['status', 'conditions'], [])
-    const allConditionCodes = errorCodesFromArray(conditions)
-
-    const constraints = get(item, ['status', 'constraints'], [])
-    const allConstraintCodes = errorCodesFromArray(constraints)
-
-    return !(isUserError(allLastErrorCodes) || isUserError(allConditionCodes) || isUserError(allConstraintCodes))
-  }
-
   const hasTicketsWithoutHideLabel = item => {
     const {
       projectStore,
@@ -189,7 +170,7 @@ export function getFilteredUids (state, context) {
       predicates.push(notProgressing)
     }
     if (noOperatorAction.value) {
-      predicates.push(noUserError)
+      predicates.push(requiresOperatorAction)
     }
     if (ignoredTickets.value) {
       predicates.push(hasTicketsWithoutHideLabel)

--- a/frontend/src/store/shoot/helper.js
+++ b/frontend/src/store/shoot/helper.js
@@ -32,6 +32,19 @@ import {
   errorCodesFromArray,
 } from '@/utils/errorCodes'
 
+import {
+  SHOOT_HEALTH_FIELD,
+  SHOOT_PROGRESSING_FIELD,
+  SHOOT_OPERATOR_ACTION_FIELD,
+  SHOOT_ALL_TICKETS_IGNORED_FIELD,
+  getShootHealth,
+  matchShootHealth,
+  matchShootProgressing,
+  matchShootOperatorAction,
+  matchShootAllTicketsIgnored,
+  normalizeShootSearch,
+} from './search'
+
 import head from 'lodash/head'
 import get from 'lodash/get'
 import map from 'lodash/map'
@@ -61,13 +74,59 @@ export function isHealthyFilterActive (state, context) {
   return authzStore.namespace === '_all' && (healthy.value ?? true)
 }
 
-export function getFilteredUids (state, context) {
+function requiresOperatorAction (item) {
+  const ignoreIssues = isTruthyValue(get(item, ['metadata', 'annotations', 'dashboard.gardener.cloud/ignore-issues']))
+  if (ignoreIssues) {
+    return false
+  }
+  const lastErrors = get(item, ['status', 'lastErrors'], [])
+  const allLastErrorCodes = errorCodesFromArray(lastErrors)
+  if (isTemporaryError(allLastErrorCodes)) {
+    return false
+  }
+  const conditions = get(item, ['status', 'conditions'], [])
+  const allConditionCodes = errorCodesFromArray(conditions)
+
+  const constraints = get(item, ['status', 'constraints'], [])
+  const allConstraintCodes = errorCodesFromArray(constraints)
+
+  return !(isUserError(allLastErrorCodes) || isUserError(allConditionCodes) || isUserError(allConstraintCodes))
+}
+
+function getTicketsForCluster (context, item) {
   const {
     projectStore,
     ticketStore,
-    configStore,
   } = context
 
+  const metadata = get(item, ['metadata'], {})
+  return ticketStore.issues({
+    ...metadata,
+    projectName: projectStore.projectNameByNamespace(metadata),
+  })
+}
+
+function ticketHasHideLabel (ticket, hideClustersWithLabels) {
+  const labelNames = map(get(ticket, ['data', 'labels']), 'name')
+  return some(hideClustersWithLabels, hideClustersWithLabel => includes(labelNames, hideClustersWithLabel))
+}
+
+function areAllTicketsIgnored (context, item) {
+  const { configStore } = context
+
+  const hideClustersWithLabels = get(configStore.ticket, ['hideClustersWithLabels'])
+  if (!hideClustersWithLabels) {
+    return false
+  }
+  const ticketsForCluster = getTicketsForCluster(context, item)
+  if (!ticketsForCluster.length) {
+    return false
+  }
+
+  return !some(ticketsForCluster, ticket => !ticketHasHideLabel(ticket, hideClustersWithLabels))
+}
+
+export function getFilteredUids (state, context) {
   // filter function
   const notProgressing = item => {
     return !isStatusProgressing(get(item, ['metadata'], {}))
@@ -93,6 +152,11 @@ export function getFilteredUids (state, context) {
   }
 
   const hasTicketsWithoutHideLabel = item => {
+    const {
+      projectStore,
+      ticketStore,
+      configStore,
+    } = context
     const hideClustersWithLabels = get(configStore.ticket, ['hideClustersWithLabels'])
     if (!hideClustersWithLabels) {
       return true
@@ -177,6 +241,14 @@ export function getRawVal (context, item, column) {
       return get(spec, ['region'])
     case 'seed':
       return get(item, ['spec', 'seedName'])
+    case SHOOT_HEALTH_FIELD:
+      return getShootHealth(item)
+    case SHOOT_PROGRESSING_FIELD:
+      return isStatusProgressing(metadata)
+    case SHOOT_OPERATOR_ACTION_FIELD:
+      return requiresOperatorAction(item)
+    case SHOOT_ALL_TICKETS_IGNORED_FIELD:
+      return areAllTicketsIgnored(context, item)
     case 'ticketLabels': {
       const labels = ticketStore.labels({
         projectName: projectStore.projectNameByNamespace(metadata),
@@ -300,7 +372,15 @@ const QUALIFIED_SEARCH_FIELDS = Object.freeze([
   'region',
   'k8sVersion',
   'createdBy',
+  SHOOT_HEALTH_FIELD,
+  SHOOT_PROGRESSING_FIELD,
+  SHOOT_OPERATOR_ACTION_FIELD,
+  SHOOT_ALL_TICKETS_IGNORED_FIELD,
 ])
+
+export function parseShootSearch (search) {
+  return normalizeShootSearch(parseSearch(search, QUALIFIED_SEARCH_FIELDS))
+}
 
 export function searchItemsFn (state, context) {
   const {
@@ -316,12 +396,32 @@ export function searchItemsFn (state, context) {
   })
 
   return search => {
-    const searchQuery = parseSearch(search, QUALIFIED_SEARCH_FIELDS)
+    const searchQuery = parseShootSearch(search)
 
     return item => {
       const f = key => ({ get: () => getRawVal(context, item, key) })
       const fields = {
         name: f('name'),
+        [SHOOT_HEALTH_FIELD]: {
+          get: () => getRawVal(context, item, SHOOT_HEALTH_FIELD),
+          match: matchShootHealth,
+          freeText: false,
+        },
+        [SHOOT_PROGRESSING_FIELD]: {
+          get: () => getRawVal(context, item, SHOOT_PROGRESSING_FIELD),
+          match: matchShootProgressing,
+          freeText: false,
+        },
+        [SHOOT_OPERATOR_ACTION_FIELD]: {
+          get: () => getRawVal(context, item, SHOOT_OPERATOR_ACTION_FIELD),
+          match: matchShootOperatorAction,
+          freeText: false,
+        },
+        [SHOOT_ALL_TICKETS_IGNORED_FIELD]: {
+          get: () => getRawVal(context, item, SHOOT_ALL_TICKETS_IGNORED_FIELD),
+          match: matchShootAllTicketsIgnored,
+          freeText: false,
+        },
         provider: f('provider'),
         region: f('region'),
         seed: f('seed'),

--- a/frontend/src/store/shoot/helper.js
+++ b/frontend/src/store/shoot/helper.js
@@ -75,6 +75,9 @@ export function isHealthyFilterActive (state, context) {
 }
 
 function requiresOperatorAction (item) {
+  if (!shootHasIssue(item)) {
+    return false
+  }
   const ignoreIssues = isTruthyValue(get(item, ['metadata', 'annotations', 'dashboard.gardener.cloud/ignore-issues']))
   if (ignoreIssues) {
     return false

--- a/frontend/src/store/shoot/search.js
+++ b/frontend/src/store/shoot/search.js
@@ -1,0 +1,226 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import { SearchQuery } from '@/composables/useTableFilter/helper'
+
+import get from 'lodash/get'
+
+export const SHOOT_HEALTH_FIELD = 'health'
+export const SHOOT_HEALTH_ANY = 'any'
+export const SHOOT_HEALTH_HEALTHY = 'healthy'
+export const SHOOT_HEALTH_UNHEALTHY = 'unhealthy'
+export const SHOOT_HEALTH_NONE = 'none'
+
+export const SHOOT_PROGRESSING_FIELD = 'progressing'
+export const SHOOT_PROGRESSING_ANY = 'any'
+export const SHOOT_PROGRESSING_TRUE = 'true'
+export const SHOOT_PROGRESSING_FALSE = 'false'
+export const SHOOT_PROGRESSING_NONE = 'none'
+
+export const SHOOT_OPERATOR_ACTION_FIELD = 'operatorAction'
+export const SHOOT_OPERATOR_ACTION_ANY = 'any'
+export const SHOOT_OPERATOR_ACTION_TRUE = 'true'
+export const SHOOT_OPERATOR_ACTION_FALSE = 'false'
+export const SHOOT_OPERATOR_ACTION_NONE = 'none'
+
+export const SHOOT_ALL_TICKETS_IGNORED_FIELD = 'allTicketsIgnored'
+export const SHOOT_ALL_TICKETS_IGNORED_ANY = 'any'
+export const SHOOT_ALL_TICKETS_IGNORED_TRUE = 'true'
+export const SHOOT_ALL_TICKETS_IGNORED_FALSE = 'false'
+export const SHOOT_ALL_TICKETS_IGNORED_NONE = 'none'
+
+export const SHOOT_UNHEALTHY_LABEL_SELECTOR = 'shoot.gardener.cloud/status!=healthy'
+
+function createNegationValues (any, positive, negative, none) {
+  return new Map([
+    [any, none],
+    [positive, negative],
+    [negative, positive],
+    [none, any],
+  ])
+}
+
+const NEGATION_VALUE_BY_FIELD = new Map([
+  [SHOOT_HEALTH_FIELD, createNegationValues(
+    SHOOT_HEALTH_ANY,
+    SHOOT_HEALTH_HEALTHY,
+    SHOOT_HEALTH_UNHEALTHY,
+    SHOOT_HEALTH_NONE,
+  )],
+  [SHOOT_PROGRESSING_FIELD, createNegationValues(
+    SHOOT_PROGRESSING_ANY,
+    SHOOT_PROGRESSING_TRUE,
+    SHOOT_PROGRESSING_FALSE,
+    SHOOT_PROGRESSING_NONE,
+  )],
+  [SHOOT_OPERATOR_ACTION_FIELD, createNegationValues(
+    SHOOT_OPERATOR_ACTION_ANY,
+    SHOOT_OPERATOR_ACTION_TRUE,
+    SHOOT_OPERATOR_ACTION_FALSE,
+    SHOOT_OPERATOR_ACTION_NONE,
+  )],
+  [SHOOT_ALL_TICKETS_IGNORED_FIELD, createNegationValues(
+    SHOOT_ALL_TICKETS_IGNORED_ANY,
+    SHOOT_ALL_TICKETS_IGNORED_TRUE,
+    SHOOT_ALL_TICKETS_IGNORED_FALSE,
+    SHOOT_ALL_TICKETS_IGNORED_NONE,
+  )],
+])
+
+function canonicalNegationValue (term) {
+  return NEGATION_VALUE_BY_FIELD.get(term.field)?.get(term.value)
+}
+
+function normalizeNegatedTerm (term) {
+  if (!term.exclude) {
+    return term
+  }
+
+  const canonicalValue = canonicalNegationValue(term)
+  if (canonicalValue === undefined) {
+    return term
+  }
+
+  return {
+    ...term,
+    value: canonicalValue,
+    exclude: false,
+  }
+}
+
+export function normalizeShootSearch (query) {
+  const terms = (query?.terms ?? []).map(normalizeNegatedTerm)
+  return new SearchQuery(terms)
+}
+
+export function hasSearchTerm (query, field, value) {
+  return query?.terms?.some(
+    term => term.field === field && term.value === value,
+  ) ?? false
+}
+
+export const hasHealthSearchTerm = (query, value) => hasSearchTerm(query, SHOOT_HEALTH_FIELD, value)
+export const hasProgressingSearchTerm = (query, value) => hasSearchTerm(query, SHOOT_PROGRESSING_FIELD, value)
+export const hasOperatorActionSearchTerm = (query, value) => hasSearchTerm(query, SHOOT_OPERATOR_ACTION_FIELD, value)
+export const hasAllTicketsIgnoredSearchTerm = (query, value) => hasSearchTerm(query, SHOOT_ALL_TICKETS_IGNORED_FIELD, value)
+
+// Each shoot-list filter flag, when active, excludes rows with one specific
+// value for its field. The search activates the filter exactly when that value
+// survives no same-field term — mirroring SearchQuery.matches: a term admits
+// the value iff matchShootField (negated when the term is excluded).
+export function isHiddenBySearch (query, field, excludedCaseValue) {
+  const terms = query?.terms?.filter(term => term.field === field) ?? []
+  if (!terms.length) {
+    return undefined
+  }
+  return !terms.every(term => {
+    const matched = matchShootField(field, term, excludedCaseValue)
+    return term.exclude ? !matched : matched
+  })
+}
+
+// The second arg is the row-value the filter EXCLUDES when active (note the
+// operatorAction filter excludes `false`, not `true`).
+export const isHealthyHiddenBySearch = query => isHiddenBySearch(query, SHOOT_HEALTH_FIELD, SHOOT_HEALTH_HEALTHY)
+export const isUnhealthyHiddenBySearch = query => isHiddenBySearch(query, SHOOT_HEALTH_FIELD, SHOOT_HEALTH_UNHEALTHY)
+export const isProgressingHiddenBySearch = query => isHiddenBySearch(query, SHOOT_PROGRESSING_FIELD, true)
+export const isOperatorActionHiddenBySearch = query => isHiddenBySearch(query, SHOOT_OPERATOR_ACTION_FIELD, false)
+export const areAllTicketsIgnoredHiddenBySearch = query => isHiddenBySearch(query, SHOOT_ALL_TICKETS_IGNORED_FIELD, true)
+
+export function resolveShootListFiltersFromSearch (shootSearchQuery) {
+  return {
+    healthy: isHealthyHiddenBySearch(shootSearchQuery) ?? false,
+    unhealthy: isUnhealthyHiddenBySearch(shootSearchQuery) ?? false,
+    progressing: isProgressingHiddenBySearch(shootSearchQuery) ?? false,
+    operatorAction: isOperatorActionHiddenBySearch(shootSearchQuery) ?? false,
+    allTicketsIgnored: areAllTicketsIgnoredHiddenBySearch(shootSearchQuery) ?? false,
+  }
+}
+
+// The donut always links to the unhealthy subset. Its refinements are only
+// effective while the parent "hide healthy" preference is enabled, though the
+// persisted sub-filter values remain untouched.
+export function resolveShootListFiltersForDonut (shootListFilters) {
+  const refineUnhealthy = shootListFilters.healthy ?? false
+
+  return {
+    healthy: true,
+    unhealthy: false,
+    progressing: refineUnhealthy && (shootListFilters.progressing ?? false),
+    operatorAction: refineUnhealthy && (shootListFilters.operatorAction ?? false),
+    allTicketsIgnored: refineUnhealthy && (shootListFilters.allTicketsIgnored ?? false),
+  }
+}
+
+// Per-field: which term.value maps to which concrete row value.
+// A term matches a row iff the row's value is in the term value's match-set.
+// `any` matches everything, `none` matches nothing.
+const MATCH_SET_BY_FIELD = new Map([
+  [SHOOT_HEALTH_FIELD, new Map([
+    [SHOOT_HEALTH_HEALTHY, new Set([SHOOT_HEALTH_HEALTHY])],
+    [SHOOT_HEALTH_UNHEALTHY, new Set([SHOOT_HEALTH_UNHEALTHY])],
+  ])],
+  [SHOOT_PROGRESSING_FIELD, new Map([
+    [SHOOT_PROGRESSING_TRUE, new Set([true])],
+    [SHOOT_PROGRESSING_FALSE, new Set([false])],
+  ])],
+  [SHOOT_OPERATOR_ACTION_FIELD, new Map([
+    [SHOOT_OPERATOR_ACTION_TRUE, new Set([true])],
+    [SHOOT_OPERATOR_ACTION_FALSE, new Set([false])],
+  ])],
+  [SHOOT_ALL_TICKETS_IGNORED_FIELD, new Map([
+    [SHOOT_ALL_TICKETS_IGNORED_TRUE, new Set([true])],
+    [SHOOT_ALL_TICKETS_IGNORED_FALSE, new Set([false])],
+  ])],
+])
+
+const ANY_VALUE_BY_FIELD = new Map([
+  [SHOOT_HEALTH_FIELD, SHOOT_HEALTH_ANY],
+  [SHOOT_PROGRESSING_FIELD, SHOOT_PROGRESSING_ANY],
+  [SHOOT_OPERATOR_ACTION_FIELD, SHOOT_OPERATOR_ACTION_ANY],
+  [SHOOT_ALL_TICKETS_IGNORED_FIELD, SHOOT_ALL_TICKETS_IGNORED_ANY],
+])
+
+export function matchShootField (field, term, value) {
+  if (term.value === ANY_VALUE_BY_FIELD.get(field)) {
+    return true
+  }
+  const matchSet = MATCH_SET_BY_FIELD.get(field)?.get(term.value)
+  return matchSet ? matchSet.has(value) : false
+}
+
+export const matchShootHealth = (term, value) => matchShootField(SHOOT_HEALTH_FIELD, term, value)
+export const matchShootProgressing = (term, value) => matchShootField(SHOOT_PROGRESSING_FIELD, term, value)
+export const matchShootOperatorAction = (term, value) => matchShootField(SHOOT_OPERATOR_ACTION_FIELD, term, value)
+export const matchShootAllTicketsIgnored = (term, value) => matchShootField(SHOOT_ALL_TICKETS_IGNORED_FIELD, term, value)
+
+export function buildSearchTerms (filters = {}) {
+  // The remaining filters refine the unhealthy subset and are therefore only
+  // effective while healthy shoots are hidden.
+  if (!filters.healthy) {
+    return ''
+  }
+
+  const terms = []
+  terms.push(`${SHOOT_HEALTH_FIELD}:${SHOOT_HEALTH_UNHEALTHY}`)
+  if (filters.progressing) {
+    terms.push(`${SHOOT_PROGRESSING_FIELD}:${SHOOT_PROGRESSING_FALSE}`)
+  }
+  if (filters.operatorAction) {
+    terms.push(`${SHOOT_OPERATOR_ACTION_FIELD}:${SHOOT_OPERATOR_ACTION_TRUE}`)
+  }
+  if (filters.allTicketsIgnored) {
+    terms.push(`${SHOOT_ALL_TICKETS_IGNORED_FIELD}:${SHOOT_ALL_TICKETS_IGNORED_FALSE}`)
+  }
+  return terms.join(' ')
+}
+
+export function getShootHealth (object) {
+  const status = get(object, ['metadata', 'labels', 'shoot.gardener.cloud/status'], SHOOT_HEALTH_HEALTHY)
+  return status === SHOOT_HEALTH_HEALTHY
+    ? SHOOT_HEALTH_HEALTHY
+    : SHOOT_HEALTH_UNHEALTHY
+}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area quality
/area usability
/kind enhancement

**What this PR does / why we need it**:

Introduces the typed Shoot-search vocabulary and its pure matching rules for health and operational criteria. Isolating these semantics—and their tests—from the subscription store keeps the query language independently reviewable and prevents lifecycle behavior from being hidden in parser tests.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

This is stacked on `enh/typed-table-search-fields` which adds generic typed-field support to the table filter infrastructure. This PR only adds the Shoot-specific search vocabulary on top.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced shoot search with filters for health, progressing status, operator action, and tickets where all issues are ignored.
  - Added support for `any` and `none` values, negated searches, and more consistent query handling.
  - Improved filtering and donut refinements to accurately reflect search criteria.
  - Expanded matching to distinguish structured filter fields from free-text searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->