### PR TITLE
Trim leading whitespace from project filter input

### DIFF
--- a/frontend/src/components/GMainProjectSelection.vue
+++ b/frontend/src/components/GMainProjectSelection.vue
@@ -288,7 +288,7 @@ const sortedAndFilteredProjectItems = computed(() => {
     }
   })
 
-  const normalizedFilter = toLower(projectFilter.value)
+  const normalizedFilter = toLower(projectFilter.value.trimStart())
 
   const predicate = item => {
     if (!projectFilter.value) {


### PR DESCRIPTION
/area usability
/kind bug

**What this PR does / why we need it**:
Project filter search ignored leading whitespace, causing no results when users accidentally typed a space before the project name. Now trims leading whitespace before normalizing the filter string.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
One-line change in `GMainProjectSelection.vue` — `trimStart()` applied before `toLower()` on the filter value.

**Release note**:

```bugfix user
Project name filter now ignores leading and trailing whitespace, preventing empty search results caused by accidental spaces.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Project searches now ignore leading spaces, providing more accurate filtering results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->