### PR TITLE
[operations-view 4/7] feat(frontend): configure operations view

### DIFF
--- a/frontend/__tests__/composables/useShootItem.spec.js
+++ b/frontend/__tests__/composables/useShootItem.spec.js
@@ -221,10 +221,13 @@ describe('composables', () => {
 
     it('should compute isStaleShoot correctly', () => {
       authzStore._setNamespace('_all')
+      vi.spyOn(authzStore, 'canViewLandscape', 'get').mockReturnValue(true)
       const localStorageStore = useLocalStorageStore()
+      localStorageStore.allProjectsShootDefaultView = 'operations'
       localStorageStore.allProjectsShootFilter = {
-        healthy: true,
         progressing: true,
+        operatorAction: false,
+        allTicketsIgnored: false,
       }
       setShootItem('metadata.labels["shoot.gardener.cloud/status"]', 'progressing')
       expect(reactiveShootItem.isStaleShoot).toBe(true)

--- a/frontend/__tests__/composables/useShootListFilters.spec.js
+++ b/frontend/__tests__/composables/useShootListFilters.spec.js
@@ -13,6 +13,7 @@ import { useAuthnStore } from '@/store/authn'
 import { useAuthzStore } from '@/store/authz'
 import { useConfigStore } from '@/store/config'
 import { useLocalStorageStore } from '@/store/localStorage'
+import { buildSearchTerms } from '@/store/shoot/search'
 
 import { useApi } from '@/composables/useApi'
 import { useShootListFilters } from '@/composables/useShootListFilters'
@@ -53,6 +54,7 @@ describe('composables', () => {
       mockGetSubjectRules = vi.spyOn(api, 'getSubjectRules')
       mockGetSubjectRules.mockResolvedValue(createRulesResponse())
       localStorageStore.allProjectsShootFilter = {}
+      localStorageStore.allProjectsShootDefaultView = null
     })
 
     async function grantLandscapeAccess () {
@@ -66,64 +68,85 @@ describe('composables', () => {
       await authzStore.fetchRules()
     }
 
-    it('should return empty labels when healthy is false', async () => {
+    it('should not return active filter reasons when all clusters is the default', async () => {
       await grantLandscapeAccess()
+      localStorageStore.allProjectsShootDefaultView = 'all'
       localStorageStore.allProjectsShootFilter = {
-        healthy: false,
         progressing: true,
-        noOperatorAction: true,
+        operatorAction: true,
+        allTicketsIgnored: false,
       }
 
-      const { activeFilterLabels } = useShootListFilters()
-      expect(activeFilterLabels.value).toEqual([])
+      const { activeFilterReasons } = useShootListFilters()
+      expect(activeFilterReasons.value).toEqual([])
     })
 
-    it('should return active filter labels for landscape defaults', async () => {
+    it('should preserve Operations View criteria when all clusters is the default', async () => {
+      await grantLandscapeAccess()
+      localStorageStore.allProjectsShootDefaultView = 'all'
+      localStorageStore.allProjectsShootFilter = {
+        progressing: true,
+        operatorAction: true,
+        allTicketsIgnored: true,
+      }
+
+      const {
+        defaultClusterView,
+        operationsViewFilters,
+        shootListFilters,
+      } = useShootListFilters()
+
+      expect(defaultClusterView.value).toBe('all')
+      expect(buildSearchTerms(shootListFilters.value)).toBe('')
+      expect(buildSearchTerms(operationsViewFilters.value)).toBe(
+        'health:unhealthy progressing:false operatorAction:true allTicketsIgnored:false',
+      )
+
+      defaultClusterView.value = 'operations'
+      expect(buildSearchTerms(shootListFilters.value)).toBe(
+        'health:unhealthy progressing:false operatorAction:true allTicketsIgnored:false',
+      )
+    })
+
+    it('should return active filter reasons for landscape defaults', async () => {
       await grantLandscapeAccess()
 
-      const { activeFilterLabels } = useShootListFilters()
-      expect(activeFilterLabels.value).toEqual([
-        'Progressing',
-        'User Errors',
-        'Ignored Ticket Labels',
+      const { activeFilterReasons } = useShootListFilters()
+      expect(activeFilterReasons.value).toEqual([
+        'are progressing',
+        'do not require operator action',
+        'have only ignored tickets',
       ])
     })
 
-    it('should return empty labels without landscape access', () => {
-      const { activeFilterLabels } = useShootListFilters()
-      expect(activeFilterLabels.value).toEqual([])
-    })
-
-    it('should return labels matching locally stored filters', async () => {
+    it('should return reasons matching locally stored filters', async () => {
       await grantLandscapeAccess()
       localStorageStore.allProjectsShootFilter = {
-        healthy: true,
         progressing: true,
-        noOperatorAction: false,
-        ignoredTickets: false,
+        operatorAction: false,
+        allTicketsIgnored: false,
       }
 
-      const { activeFilterLabels } = useShootListFilters()
-      expect(activeFilterLabels.value).toEqual([
-        'Progressing',
+      const { activeFilterReasons } = useShootListFilters()
+      expect(activeFilterReasons.value).toEqual([
+        'are progressing',
       ])
     })
 
-    it('should exclude ignoredTickets when ticket config is missing', async () => {
+    it('should exclude allTicketsIgnored when ticket config is missing', async () => {
       await grantLandscapeAccess()
       configStore.setConfiguration({ ticket: {} })
       localStorageStore.allProjectsShootFilter = {
-        healthy: true,
         progressing: false,
-        noOperatorAction: false,
-        ignoredTickets: true,
+        operatorAction: false,
+        allTicketsIgnored: true,
       }
 
-      const { activeFilterLabels } = useShootListFilters()
-      expect(activeFilterLabels.value).toEqual([])
+      const { activeFilterReasons } = useShootListFilters()
+      expect(activeFilterReasons.value).toEqual([])
     })
 
-    it('should include ignoredTickets when ticket config is present', async () => {
+    it('should include allTicketsIgnored when ticket config is present', async () => {
       await grantLandscapeAccess()
       configStore.setConfiguration({
         ticket: {
@@ -132,16 +155,130 @@ describe('composables', () => {
         },
       })
       localStorageStore.allProjectsShootFilter = {
-        healthy: true,
         progressing: false,
-        noOperatorAction: false,
-        ignoredTickets: true,
+        operatorAction: false,
+        allTicketsIgnored: true,
       }
 
-      const { activeFilterLabels } = useShootListFilters()
+      const { activeFilterReasons } = useShootListFilters()
+      expect(activeFilterReasons.value).toEqual([
+        'have only ignored tickets',
+      ])
+    })
+
+    it('should keep healthy clusters excluded from Operations View criteria', async () => {
+      await grantLandscapeAccess()
+      localStorageStore.allProjectsShootFilter = {
+        healthy: false,
+        progressing: false,
+        operatorAction: false,
+        allTicketsIgnored: false,
+      }
+
+      const { operationsViewFilters } = useShootListFilters()
+
+      expect(operationsViewFilters.value).toEqual({
+        healthy: true,
+        progressing: false,
+        operatorAction: false,
+        allTicketsIgnored: false,
+      })
+    })
+
+    it('should update Operations View criteria through dedicated setters', async () => {
+      await grantLandscapeAccess()
+      localStorageStore.allProjectsShootFilter = {
+        progressing: false,
+        operatorAction: false,
+        allTicketsIgnored: false,
+      }
+
+      const {
+        setHideProgressing,
+        setHideWithoutOperatorAction,
+        setHideAllTicketsIgnored,
+      } = useShootListFilters()
+
+      setHideProgressing(true)
+      setHideWithoutOperatorAction(true)
+      setHideAllTicketsIgnored(true)
+
+      expect(localStorageStore.allProjectsShootFilter).toEqual({
+        progressing: true,
+        operatorAction: true,
+        allTicketsIgnored: true,
+      })
+
+      setHideProgressing(true)
+      expect(localStorageStore.allProjectsShootFilter.progressing).toBe(true)
+    })
+
+    it('should keep existing filter consumers working with the renamed criteria', async () => {
+      await grantLandscapeAccess()
+
+      const {
+        activeFilterLabels,
+        defaultClusterView,
+        healthy,
+        toggleShootListFilter,
+      } = useShootListFilters()
+
       expect(activeFilterLabels.value).toEqual([
+        'Progressing',
+        'User Errors',
         'Ignored Ticket Labels',
       ])
+
+      toggleShootListFilter('operatorAction')
+      expect(localStorageStore.allProjectsShootFilter.operatorAction).toBe(false)
+      expect(activeFilterLabels.value).toEqual([
+        'Progressing',
+        'Ignored Ticket Labels',
+      ])
+
+      toggleShootListFilter('healthy')
+      expect(defaultClusterView.value).toBe('all')
+      expect(healthy.value).toBe(false)
+
+      toggleShootListFilter('healthy')
+      expect(defaultClusterView.value).toBe('operations')
+      expect(healthy.value).toBe(true)
+      expect(localStorageStore.allProjectsShootFilter.operatorAction).toBe(false)
+    })
+
+    it('should default non-landscape users to all clusters', () => {
+      const {
+        defaultClusterView,
+        operationsViewFilters,
+        shootListFilters,
+      } = useShootListFilters()
+
+      expect(defaultClusterView.value).toBe('all')
+      expect(operationsViewFilters.value.healthy).toBe(true)
+      expect(shootListFilters.value.healthy).toBe(false)
+    })
+
+    it('should ignore stored landscape filters for non-landscape users', () => {
+      localStorageStore.allProjectsShootDefaultView = 'operations'
+      localStorageStore.allProjectsShootFilter = {
+        progressing: true,
+        operatorAction: true,
+        allTicketsIgnored: true,
+      }
+
+      const {
+        operationsViewFilters,
+        shootListFilters,
+      } = useShootListFilters()
+
+      const expectedFilters = {
+        healthy: true,
+        progressing: false,
+        operatorAction: false,
+        allTicketsIgnored: false,
+      }
+      expect(operationsViewFilters.value).toEqual(expectedFilters)
+      expect(shootListFilters.value).toEqual(expectedFilters)
     })
   })
 })

--- a/frontend/__tests__/composables/useShootListFilters.spec.js
+++ b/frontend/__tests__/composables/useShootListFilters.spec.js
@@ -51,6 +51,12 @@ describe('composables', () => {
       authzStore = useAuthzStore()
       configStore = useConfigStore()
       localStorageStore = useLocalStorageStore()
+      configStore.setConfiguration({
+        ticket: {
+          gitHubRepoUrl: 'https://github.com/org/repo',
+          hideClustersWithLabels: ['ignore'],
+        },
+      })
       mockGetSubjectRules = vi.spyOn(api, 'getSubjectRules')
       mockGetSubjectRules.mockResolvedValue(createRulesResponse())
       localStorageStore.allProjectsShootFilter = {}
@@ -133,9 +139,12 @@ describe('composables', () => {
       ])
     })
 
-    it('should exclude allTicketsIgnored when ticket config is missing', async () => {
+    it.each([
+      { description: 'missing', configuration: {} },
+      { description: 'incomplete', configuration: { ticket: {} } },
+    ])('should exclude allTicketsIgnored when ticket config is $description', async ({ configuration }) => {
       await grantLandscapeAccess()
-      configStore.setConfiguration({ ticket: {} })
+      configStore.setConfiguration(configuration)
       localStorageStore.allProjectsShootFilter = {
         progressing: false,
         operatorAction: false,

--- a/frontend/__tests__/stores/seedStat.spec.js
+++ b/frontend/__tests__/stores/seedStat.spec.js
@@ -205,15 +205,15 @@ describe('stores', () => {
       expect(getUnhealthyFilterMaskFromShootListFilters({
         healthy: true,
         progressing: true,
-        noOperatorAction: true,
-        ignoredTickets: true,
+        operatorAction: true,
+        allTicketsIgnored: true,
       })).toBe(7)
 
       expect(getUnhealthyFilterMaskFromShootListFilters({
         healthy: false,
         progressing: true,
-        noOperatorAction: true,
-        ignoredTickets: true,
+        operatorAction: true,
+        allTicketsIgnored: true,
       })).toBe(0)
     })
   })

--- a/frontend/__tests__/views/GSettings.spec.js
+++ b/frontend/__tests__/views/GSettings.spec.js
@@ -20,6 +20,23 @@ import { useLocalStorageStore } from '@/store/localStorage'
 
 import GSettings from '@/views/GSettings.vue'
 
+const {
+  replaceRoute,
+  route,
+} = vi.hoisted(() => ({
+  replaceRoute: vi.fn(),
+  route: {
+    hash: '',
+  },
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => route,
+  useRouter: () => ({
+    replace: replaceRoute,
+  }),
+}))
+
 // Disable createSharedComposable so each test gets a fresh composable instance
 vi.mock('@vueuse/core', async importOriginal => {
   const actual = await importOriginal()
@@ -67,6 +84,7 @@ describe('views', () => {
     let wrapper
 
     function mountComponent () {
+      route.hash = window.location.hash
       wrapper = shallowMount(GSettings, {
         attachTo: document.body,
         global: {
@@ -98,6 +116,14 @@ describe('views', () => {
     beforeEach(() => {
       window.localStorage.clear()
       window.history.replaceState({}, '', '/')
+      route.hash = ''
+      replaceRoute.mockReset()
+      replaceRoute.mockImplementation(async ({ hash }) => {
+        route.hash = hash
+        const url = new URL(window.location.href)
+        url.hash = hash
+        window.history.replaceState(window.history.state, '', `${url.pathname}${url.search}${url.hash}`)
+      })
 
       pinia = createPinia()
       setActivePinia(pinia)
@@ -148,6 +174,7 @@ describe('views', () => {
       const operationsViewItem = wrapper.find('.operations-view')
       expect(operationsViewItem.classes()).not.toContain('operations-view--highlighted')
       expect(document.activeElement).not.toBe(operationsViewItem.element)
+      expect(replaceRoute).toHaveBeenCalledWith({ hash: '' })
       expect(window.location.hash).toBe('')
     })
 
@@ -160,6 +187,7 @@ describe('views', () => {
       const defaultClusterViewItem = wrapper.find('.default-view')
       expect(defaultClusterViewItem.classes()).toContain('default-view--highlighted')
       expect(document.activeElement).toBe(defaultClusterViewItem.element)
+      expect(replaceRoute).toHaveBeenCalledWith({ hash: '' })
       expect(window.location.hash).toBe('')
 
       await defaultClusterViewItem.trigger('keydown')
@@ -194,6 +222,12 @@ describe('views', () => {
       await wrapper.find('[aria-label="Configure exclusion criteria"]').trigger('click')
       expect(dialog.props('modelValue')).toBe(true)
 
+      const dialogTitle = wrapper.find('#cluster-operations-dialog-title')
+      expect(dialogTitle.attributes('tabindex')).toBeUndefined()
+      dialog.vm.$emit('afterEnter')
+      await nextTick()
+      expect(document.activeElement).not.toBe(dialogTitle.element)
+
       const okButton = wrapper.find('[aria-label="OK"]')
       expect(okButton.exists()).toBe(true)
 
@@ -216,6 +250,7 @@ describe('views', () => {
 
       const operationsViewItem = wrapper.find('.operations-view')
       expect(operationsViewItem.classes()).toContain('operations-view--highlighted')
+      expect(replaceRoute).toHaveBeenCalledWith({ hash: '' })
       expect(window.location.hash).toBe('')
     })
 

--- a/frontend/__tests__/views/GSettings.spec.js
+++ b/frontend/__tests__/views/GSettings.spec.js
@@ -1,0 +1,298 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import { nextTick } from 'vue'
+import {
+  flushPromises,
+  shallowMount,
+} from '@vue/test-utils'
+import {
+  createPinia,
+  setActivePinia,
+} from 'pinia'
+
+import { useAuthzStore } from '@/store/authz'
+import { useConfigStore } from '@/store/config'
+import { useLocalStorageStore } from '@/store/localStorage'
+
+import GSettings from '@/views/GSettings.vue'
+
+// Disable createSharedComposable so each test gets a fresh composable instance
+vi.mock('@vueuse/core', async importOriginal => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    createSharedComposable: fn => fn,
+  }
+})
+
+const { createVuetifyPlugin } = global.fixtures.helper
+
+const SlotStub = {
+  template: '<div><slot /><slot name="prepend" /><slot name="append" /><slot name="description" /></div>',
+}
+
+const GListItemContentStub = {
+  props: {
+    label: String,
+    description: String,
+  },
+  template: '<div>{{ label }} {{ description }}<slot /><slot name="description" /></div>',
+}
+
+const VDialogStub = {
+  name: 'VDialog',
+  props: {
+    modelValue: Boolean,
+    persistent: Boolean,
+  },
+  emits: [
+    'update:modelValue',
+    'afterEnter',
+    'afterLeave',
+  ],
+  template: '<div data-test="operations-view-dialog"><slot /></div>',
+}
+
+describe('views', () => {
+  describe('g-settings', () => {
+    let authzStore
+    let canViewLandscapeSpy
+    let configStore
+    let localStorageStore
+    let pinia
+    let wrapper
+
+    function mountComponent () {
+      wrapper = shallowMount(GSettings, {
+        attachTo: document.body,
+        global: {
+          plugins: [
+            createVuetifyPlugin(),
+            pinia,
+          ],
+          directives: {
+            tooltip: () => {},
+          },
+          stubs: {
+            GList: SlotStub,
+            GListItem: SlotStub,
+            GListItemContent: GListItemContentStub,
+            GToolbar: SlotStub,
+            VCard: SlotStub,
+            VCardActions: SlotStub,
+            VCardText: SlotStub,
+            VCol: SlotStub,
+            VContainer: SlotStub,
+            VDialog: VDialogStub,
+            VExpandTransition: SlotStub,
+            VRow: SlotStub,
+          },
+        },
+      })
+    }
+
+    beforeEach(() => {
+      window.localStorage.clear()
+      window.history.replaceState({}, '', '/')
+
+      pinia = createPinia()
+      setActivePinia(pinia)
+      authzStore = useAuthzStore()
+      canViewLandscapeSpy = vi.spyOn(authzStore, 'canViewLandscape', 'get').mockReturnValue(false)
+      configStore = useConfigStore()
+      configStore.setConfiguration({})
+      localStorageStore = useLocalStorageStore()
+      localStorageStore.allProjectsShootFilter = {
+        progressing: true,
+        operatorAction: false,
+        allTicketsIgnored: true,
+      }
+      localStorageStore.allProjectsShootDefaultView = 'operations'
+    })
+
+    afterEach(() => {
+      wrapper?.unmount()
+      canViewLandscapeSpy.mockRestore()
+    })
+
+    it('shows Cluster List settings without Operations View configuration controls for regular users', () => {
+      mountComponent()
+
+      const clusterListTitle = wrapper.find('[data-test="cluster-list-settings-title"]')
+      const operationsViewItem = wrapper.find('.operations-view')
+      expect(clusterListTitle.attributes('title')).toBe('Cluster List')
+      expect(operationsViewItem.text()).toContain('Operations View')
+      expect(operationsViewItem.find('[data-test="operations-view-description"]').text()).toBe(
+        'Shows unhealthy clusters that may need attention.',
+      )
+      expect(operationsViewItem.text()).not.toContain('Current settings')
+      expect(operationsViewItem.find('[aria-label="Configure exclusion criteria"]').exists()).toBe(false)
+      expect(wrapper.findComponent(VDialogStub).exists()).toBe(false)
+
+      expect(wrapper.text()).toContain('Default Cluster View')
+      expect(wrapper.text()).toContain('Choose whether the All Projects cluster list opens with all clusters or Operations View')
+      expect(wrapper.text()).not.toContain('determines which unhealthy Shoots are counted for each Seed')
+    })
+
+    it('ignores exclusion-criteria deep links for regular users', async () => {
+      window.history.replaceState({}, '', '/#setting=cluster-operations')
+
+      mountComponent()
+      await flushPromises()
+
+      expect(wrapper.findComponent(VDialogStub).exists()).toBe(false)
+      const operationsViewItem = wrapper.find('.operations-view')
+      expect(operationsViewItem.classes()).not.toContain('operations-view--highlighted')
+      expect(document.activeElement).not.toBe(operationsViewItem.element)
+      expect(window.location.hash).toBe('')
+    })
+
+    it('highlights the deep-linked default cluster view until the user interacts', async () => {
+      window.history.replaceState({}, '', '/#setting=default-cluster-view')
+
+      mountComponent()
+      await flushPromises()
+
+      const defaultClusterViewItem = wrapper.find('.default-view')
+      expect(defaultClusterViewItem.classes()).toContain('default-view--highlighted')
+      expect(document.activeElement).toBe(defaultClusterViewItem.element)
+      expect(window.location.hash).toBe('')
+
+      await defaultClusterViewItem.trigger('keydown')
+
+      expect(defaultClusterViewItem.classes()).not.toContain('default-view--highlighted')
+    })
+
+    it('keeps the default cluster view in the Cluster List card and outside the dialog', () => {
+      canViewLandscapeSpy.mockReturnValue(true)
+      mountComponent()
+
+      const clusterListCard = wrapper.find('.cluster-list-card')
+      const defaultClusterViewItem = clusterListCard.find('.default-view')
+      const dialog = wrapper.find('[data-test="operations-view-dialog"]')
+
+      expect(clusterListCard.find('[data-test="cluster-list-settings-title"]').attributes('title')).toBe('Cluster List')
+      expect(defaultClusterViewItem.text()).toContain('Default Cluster View')
+      expect(defaultClusterViewItem.text()).toContain('Choose whether the All Projects cluster list opens with all clusters or Operations View')
+      expect(defaultClusterViewItem.find('[aria-label="Default cluster view"]').exists()).toBe(true)
+      expect(dialog.text()).not.toContain('Default Cluster View')
+      expect(dialog.text()).not.toContain('Choose whether the All Projects cluster list opens with all clusters or Operations View')
+    })
+
+    it('only closes the persistent Operations View dialog with its OK button', async () => {
+      canViewLandscapeSpy.mockReturnValue(true)
+      mountComponent()
+
+      const dialog = wrapper.findComponent(VDialogStub)
+      expect(dialog.props('persistent')).toBe(true)
+      expect(wrapper.find('[aria-label="Close"]').exists()).toBe(false)
+
+      await wrapper.find('[aria-label="Configure exclusion criteria"]').trigger('click')
+      expect(dialog.props('modelValue')).toBe(true)
+
+      const okButton = wrapper.find('[aria-label="OK"]')
+      expect(okButton.exists()).toBe(true)
+
+      await okButton.trigger('click')
+      expect(dialog.props('modelValue')).toBe(false)
+    })
+
+    it('opens a deep-linked Operations View dialog and highlights its entry after closing for landscape viewers', async () => {
+      canViewLandscapeSpy.mockReturnValue(true)
+      window.history.replaceState({}, '', '/#setting=cluster-operations')
+
+      mountComponent()
+
+      const dialog = wrapper.findComponent(VDialogStub)
+      expect(dialog.props('modelValue')).toBe(true)
+
+      await wrapper.find('[aria-label="OK"]').trigger('click')
+      dialog.vm.$emit('afterLeave')
+      await flushPromises()
+
+      const operationsViewItem = wrapper.find('.operations-view')
+      expect(operationsViewItem.classes()).toContain('operations-view--highlighted')
+      expect(window.location.hash).toBe('')
+    })
+
+    it('places the Operations View description before the exclusion criteria', () => {
+      canViewLandscapeSpy.mockReturnValue(true)
+      mountComponent()
+
+      const dialogText = wrapper.find('[data-test="operations-view-dialog"]').text()
+      expect(dialogText.indexOf('Operations View shows clusters that may need attention')).toBeLessThan(dialogText.indexOf('Exclusion criteria'))
+
+      const exclusionCriteria = wrapper.find('#cluster-operations-exclusion-title').element.parentElement
+      expect(exclusionCriteria.textContent).not.toContain('Operations View shows clusters that may need attention')
+    })
+
+    it('shows the configured criteria inline and lets landscape viewers change them', async () => {
+      canViewLandscapeSpy.mockReturnValue(true)
+      localStorageStore.allProjectsShootDefaultView = 'all'
+      mountComponent()
+
+      const operationsViewItem = wrapper.find('.operations-view')
+      const operationsViewDescription = operationsViewItem.find('[data-test="operations-view-description"]')
+
+      expect(operationsViewDescription.text()).toBe(
+        'Shows unhealthy clusters that may need attention, excluding those that are progressing.',
+      )
+      expect(operationsViewItem.find('[aria-label="Configure exclusion criteria"]').exists()).toBe(true)
+      expect(wrapper.text()).toContain('Exclusion criteria')
+      expect(wrapper.text()).toContain('Operations View shows clusters that may need attention')
+      expect(wrapper.text()).toContain('Choose which clusters to hide')
+      expect(wrapper.text()).toContain('Always excluded')
+      expect(wrapper.text()).toContain('Choose whether the All Projects cluster list opens with all clusters or Operations View')
+      expect(wrapper.text()).toContain('This also determines which unhealthy Shoots are counted for each Seed')
+      expect(wrapper.find('[aria-label="Hide progressing clusters"]').exists()).toBe(true)
+      expect(wrapper.find('[aria-label="Hide clusters without operator action needed"]').exists()).toBe(true)
+      expect(wrapper.find('[aria-label="Hide clusters with only ignored tickets"]').exists()).toBe(false)
+
+      wrapper.findComponent('[aria-label="Hide clusters without operator action needed"]')
+        .vm.$emit('update:modelValue', true)
+      await nextTick()
+
+      expect(operationsViewDescription.text()).toBe(
+        'Shows unhealthy clusters that may need attention, excluding those that are progressing or do not require operator action.',
+      )
+    })
+
+    it('shows the ignored-ticket criterion only when ticket filtering is available', () => {
+      canViewLandscapeSpy.mockReturnValue(true)
+      configStore.setConfiguration({
+        ticket: {
+          gitHubRepoUrl: 'https://github.com/gardener/tickets',
+          hideClustersWithLabels: ['ignored'],
+        },
+      })
+      mountComponent()
+
+      expect(wrapper.find('[data-test="operations-view-description"]').text()).toBe(
+        'Shows unhealthy clusters that may need attention, excluding those that are progressing or have only ignored tickets.',
+      )
+      expect(wrapper.find('[aria-label="Hide clusters with only ignored tickets"]').exists()).toBe(true)
+    })
+
+    it('changes the default without erasing Operations View criteria', async () => {
+      mountComponent()
+
+      const criteria = { ...localStorageStore.allProjectsShootFilter }
+      const defaultViewToggle = wrapper
+        .findAllComponents({ name: 'VBtnToggle' })
+        .find(component => component.attributes('aria-label') === 'Default cluster view')
+
+      expect(defaultViewToggle.props('modelValue')).toBe('operations')
+
+      defaultViewToggle.vm.$emit('update:modelValue', 'all')
+      await nextTick()
+
+      expect(localStorageStore.allProjectsShootDefaultView).toBe('all')
+      expect(localStorageStore.allProjectsShootFilter).toEqual(criteria)
+      expect(defaultViewToggle.props('modelValue')).toBe('all')
+    })
+  })
+})

--- a/frontend/src/composables/useShootListFilters.js
+++ b/frontend/src/composables/useShootListFilters.js
@@ -4,34 +4,50 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { computed } from 'vue'
+import {
+  computed,
+  readonly,
+} from 'vue'
 import { createSharedComposable } from '@vueuse/core'
 
 import { useAuthzStore } from '@/store/authz'
 import { useConfigStore } from '@/store/config'
 import { useLocalStorageStore } from '@/store/localStorage'
+import { resolveShootListFiltersForDonut } from '@/store/shoot/search'
 
 import pick from 'lodash/pick'
 
-const FILTER_LABELS = [
-  { key: 'progressing', label: 'Progressing' },
-  { key: 'noOperatorAction', label: 'User Errors' },
-  { key: 'ignoredTickets', label: 'Ignored Ticket Labels' },
+const OPERATIONS_VIEW_EXCLUSION_CRITERIA = [
+  { key: 'progressing', exclusionReason: 'are progressing', label: 'Progressing' },
+  { key: 'operatorAction', exclusionReason: 'do not require operator action', label: 'User Errors' },
+  { key: 'allTicketsIgnored', exclusionReason: 'have only ignored tickets', label: 'Ignored Ticket Labels' },
 ]
 
 const FILTER_KEYS = [
-  'healthy',
   'progressing',
-  'noOperatorAction',
-  'ignoredTickets',
+  'operatorAction',
+  'allTicketsIgnored',
 ]
+
+const ALL_CLUSTERS_FILTERS = {
+  healthy: false,
+  progressing: false,
+  operatorAction: false,
+  allTicketsIgnored: false,
+}
+
+export function getEnabledOperationsViewExclusionReasons (shootListFilters = {}) {
+  return OPERATIONS_VIEW_EXCLUSION_CRITERIA
+    .filter(({ key }) => shootListFilters[key]) // eslint-disable-line security/detect-object-injection -- key is a fixed set of strings, not user input
+    .map(({ exclusionReason }) => exclusionReason)
+}
 
 function getDefaultAllProjectsShootFilters (canViewLandscape) {
   return {
-    healthy: canViewLandscape,
-    progressing: true,
-    noOperatorAction: canViewLandscape,
-    ignoredTickets: canViewLandscape,
+    healthy: true,
+    progressing: canViewLandscape,
+    operatorAction: canViewLandscape,
+    allTicketsIgnored: canViewLandscape,
   }
 }
 
@@ -44,10 +60,10 @@ export function getUnhealthyFilterMaskFromShootListFilters (shootListFilters = {
   if (shootListFilters.progressing) {
     mask |= 1
   }
-  if (shootListFilters.noOperatorAction) {
+  if (shootListFilters.operatorAction) {
     mask |= 2
   }
-  if (shootListFilters.ignoredTickets) {
+  if (shootListFilters.allTicketsIgnored) {
     mask |= 4
   }
   return mask
@@ -58,16 +74,19 @@ export const useShootListFilters = createSharedComposable(function useShootListF
   const configStore = useConfigStore()
   const localStorageStore = useLocalStorageStore()
 
-  const shootListFilters = computed({
+  const operationsViewFilters = computed({
     get () {
+      const storedFilters = authzStore.canViewLandscape
+        ? pick(localStorageStore.allProjectsShootFilter, FILTER_KEYS)
+        : {} // Prevent saved settings leaking into filters regular users cannot configure
       const filters = {
         ...getDefaultAllProjectsShootFilters(authzStore.canViewLandscape),
-        ...pick(localStorageStore.allProjectsShootFilter, FILTER_KEYS),
+        ...storedFilters,
       }
 
       const { ticket } = configStore
       if (ticket && (!ticket.gitHubRepoUrl || !ticket.hideClustersWithLabels?.length)) {
-        filters.ignoredTickets = false
+        filters.allTicketsIgnored = false
       }
 
       return filters
@@ -77,37 +96,91 @@ export const useShootListFilters = createSharedComposable(function useShootListF
     },
   })
 
-  const healthy = computed(() => {
-    return shootListFilters.value.healthy ?? true
+  const defaultClusterView = computed({
+    get () {
+      return localStorageStore.allProjectsShootDefaultView ?? (
+        authzStore.canViewLandscape ? 'operations' : 'all'
+      )
+    },
+    set (value) {
+      localStorageStore.allProjectsShootDefaultView = value
+    },
   })
 
-  function toggleShootListFilter (key) {
-    shootListFilters.value = {
-      ...shootListFilters.value,
-      [key]: !shootListFilters.value[key], // eslint-disable-line security/detect-object-injection -- key is a fixed set of strings, not user input
+  const shootListFilters = computed({
+    get () {
+      return defaultClusterView.value === 'operations'
+        ? operationsViewFilters.value
+        : ALL_CLUSTERS_FILTERS
+    },
+    set (value) {
+      operationsViewFilters.value = value
+      defaultClusterView.value = value?.healthy ? 'operations' : 'all'
+    },
+  })
+
+  function setOperationsViewFilter (key, value) {
+    operationsViewFilters.value = {
+      ...operationsViewFilters.value,
+      [key]: value,
     }
+  }
+
+  function setHideProgressing (value) {
+    setOperationsViewFilter('progressing', value)
+  }
+
+  function setHideWithoutOperatorAction (value) {
+    setOperationsViewFilter('operatorAction', value)
+  }
+
+  function setHideAllTicketsIgnored (value) {
+    setOperationsViewFilter('allTicketsIgnored', value)
+  }
+
+  const healthy = computed(() => shootListFilters.value.healthy ?? true)
+
+  function toggleShootListFilter (key) {
+    if (key === 'healthy') {
+      defaultClusterView.value = healthy.value ? 'all' : 'operations'
+      return
+    }
+
+    setOperationsViewFilter(key, !operationsViewFilters.value[key]) // eslint-disable-line security/detect-object-injection -- key is a fixed set of strings, not user input
   }
 
   const unhealthyFilterMask = computed(() => {
     return getUnhealthyFilterMaskFromShootListFilters(shootListFilters.value)
   })
 
+  const activeFilterReasons = computed(() => {
+    const effective = resolveShootListFiltersForDonut(shootListFilters.value)
+    return getEnabledOperationsViewExclusionReasons(effective)
+  })
+
+  // Retained until the existing Shoot/Seed list presentations are replaced by
+  // the Operations View controls in their dedicated follow-up tasks.
   const activeFilterLabels = computed(() => {
-    const filters = shootListFilters.value
-    if (!filters.healthy) {
+    if (!healthy.value) {
       return []
     }
 
-    return FILTER_LABELS
-      .filter(({ key }) => filters[key]) // eslint-disable-line security/detect-object-injection -- key is a fixed set of strings, not user input
+    return OPERATIONS_VIEW_EXCLUSION_CRITERIA
+      .filter(({ key }) => shootListFilters.value[key]) // eslint-disable-line security/detect-object-injection -- key is a fixed set of strings, not user input
       .map(({ label }) => label)
   })
 
   return {
     shootListFilters,
+    operationsViewFilters: readonly(operationsViewFilters),
+    defaultClusterView,
     healthy,
     toggleShootListFilter,
+    setHideProgressing,
+    setHideWithoutOperatorAction,
+    setHideAllTicketsIgnored,
     unhealthyFilterMask,
+    activeFilterReasons,
     activeFilterLabels,
   }
 })

--- a/frontend/src/composables/useShootListFilters.js
+++ b/frontend/src/composables/useShootListFilters.js
@@ -85,7 +85,7 @@ export const useShootListFilters = createSharedComposable(function useShootListF
       }
 
       const { ticket } = configStore
-      if (ticket && (!ticket.gitHubRepoUrl || !ticket.hideClustersWithLabels?.length)) {
+      if (!ticket?.gitHubRepoUrl || !ticket.hideClustersWithLabels?.length) {
         filters.allTicketsIgnored = false
       }
 

--- a/frontend/src/router/routes.js
+++ b/frontend/src/router/routes.js
@@ -574,6 +574,7 @@ export function createRoutes () {
       return {
         name: to.name,
         params: to.params,
+        hash: to.hash,
         query: {
           namespace,
           ...to.query,

--- a/frontend/src/store/localStorage.js
+++ b/frontend/src/store/localStorage.js
@@ -211,6 +211,11 @@ export const useLocalStorageStore = defineStore('localStorage', () => {
     writeDefaults: false,
   })
 
+  const allProjectsShootDefaultView = useLocalStorage('project/_all/shoot-list/default-view', null, {
+    serializer: StorageSerializers.enum(['all', 'operations']),
+    writeDefaults: false,
+  })
+
   const seedSelectedColumns = useLocalStorage('seeds/seed-list/selected-columns', {}, {
     serializer: StorageSerializers.json,
     writeDefaults: false,
@@ -273,6 +278,7 @@ export const useLocalStorageStore = defineStore('localStorage', () => {
     seedSelectedColumns,
     seedSortBy,
     allProjectsShootFilter,
+    allProjectsShootDefaultView,
     shootCustomSortBy,
     shootCustomSelectedColumns,
     terminalSplitpaneTreeRef,

--- a/frontend/src/store/shoot/helper.js
+++ b/frontend/src/store/shoot/helper.js
@@ -165,17 +165,17 @@ export function getFilteredUids (state, context) {
   if (isHealthyFilterActive(state, context)) {
     const {
       progressing,
-      noOperatorAction,
-      ignoredTickets,
+      operatorAction,
+      allTicketsIgnored,
     } = context
 
     if (progressing.value) {
       predicates.push(notProgressing)
     }
-    if (noOperatorAction.value) {
+    if (operatorAction.value) {
       predicates.push(requiresOperatorAction)
     }
-    if (ignoredTickets.value) {
+    if (allTicketsIgnored.value) {
       predicates.push(hasTicketsWithoutHideLabel)
     }
   }

--- a/frontend/src/store/shoot/shoot.js
+++ b/frontend/src/store/shoot/shoot.js
@@ -80,8 +80,8 @@ const useShootStore = defineStore('shoot', () => {
   } = useShootListFilters()
 
   const progressing = computed(() => shootListFilters.value.progressing)
-  const noOperatorAction = computed(() => shootListFilters.value.noOperatorAction)
-  const ignoredTickets = computed(() => shootListFilters.value.ignoredTickets)
+  const operatorAction = computed(() => shootListFilters.value.operatorAction)
+  const allTicketsIgnored = computed(() => shootListFilters.value.allTicketsIgnored)
 
   const context = {
     api,
@@ -100,8 +100,8 @@ const useShootStore = defineStore('shoot', () => {
     shootListFilters,
     healthy,
     progressing,
-    noOperatorAction,
-    ignoredTickets,
+    operatorAction,
+    allTicketsIgnored,
   }
 
   const state = reactive({

--- a/frontend/src/views/GSettings.vue
+++ b/frontend/src/views/GSettings.vue
@@ -257,7 +257,6 @@ SPDX-License-Identifier: Apache-2.0
       scrollable
       persistent
       aria-labelledby="cluster-operations-dialog-title"
-      @after-enter="focusClusterOperationsDialogTitle"
       @after-leave="onClusterOperationsDialogClosed"
     >
       <v-card>
@@ -267,8 +266,6 @@ SPDX-License-Identifier: Apache-2.0
         >
           <span
             id="cluster-operations-dialog-title"
-            ref="clusterOperationsDialogTitle"
-            tabindex="-1"
           >
             Operations View
           </span>
@@ -437,10 +434,12 @@ import {
   nextTick,
   onBeforeUnmount,
   ref,
-  toRef,
   watch,
 } from 'vue'
-import { useUrlSearchParams } from '@vueuse/core'
+import {
+  useRoute,
+  useRouter,
+} from 'vue-router'
 
 import { useAuthzStore } from '@/store/authz'
 import { useConfigStore } from '@/store/config'
@@ -457,11 +456,8 @@ const allProjectsDialog = ref(false)
 const showIgnoredTicketLabels = ref(false)
 const defaultClusterViewSettingsItem = ref()
 const clusterOperationsSettingsItem = ref()
-const clusterOperationsDialogTitle = ref()
 const highlightDefaultClusterViewSettings = ref(false)
 const highlightClusterOperationsSettings = ref(false)
-const settingsHashParams = useUrlSearchParams('hash-params')
-const deepLinkedSetting = toRef(settingsHashParams, 'setting')
 let clusterOperationsDeepLinkActive = false
 let clusterOperationsHighlightTimer
 const shootAdminKubeconfig = useShootAdminKubeconfig()
@@ -474,6 +470,12 @@ const {
 
 const authzStore = useAuthzStore()
 const configStore = useConfigStore()
+const route = useRoute()
+const router = useRouter()
+const deepLinkedSetting = computed(() => {
+  const params = new URLSearchParams(route.hash.slice(1))
+  return params.get('setting')
+})
 
 const {
   operationsViewFilters,
@@ -567,8 +569,8 @@ function highlightClusterOperationsEntry () {
   }, 3000)
 }
 
-function focusClusterOperationsDialogTitle () {
-  clusterOperationsDialogTitle.value?.focus({ preventScroll: true })
+async function clearDeepLinkedSetting () {
+  await router.replace({ hash: '' })
 }
 
 async function onClusterOperationsDialogClosed () {
@@ -577,14 +579,14 @@ async function onClusterOperationsDialogClosed () {
   }
 
   clusterOperationsDeepLinkActive = false
-  deepLinkedSetting.value = null
+  await clearDeepLinkedSetting()
   await nextTick()
   highlightClusterOperationsEntry()
 }
 
 watch(deepLinkedSetting, async value => {
   if (value === 'default-cluster-view') {
-    deepLinkedSetting.value = null
+    await clearDeepLinkedSetting()
     await nextTick()
     highlightDefaultClusterViewEntry()
     return
@@ -595,7 +597,7 @@ watch(deepLinkedSetting, async value => {
   }
 
   if (!authzStore.canViewLandscape) {
-    deepLinkedSetting.value = null
+    await clearDeepLinkedSetting()
     return
   }
 

--- a/frontend/src/views/GSettings.vue
+++ b/frontend/src/views/GSettings.vue
@@ -141,8 +141,11 @@ SPDX-License-Identifier: Apache-2.0
         cols="12"
         md="6"
       >
-        <v-card class="mt-4">
-          <g-toolbar title="Advanced" />
+        <v-card class="mt-4 cluster-list-card">
+          <g-toolbar
+            title="Cluster List"
+            data-test="cluster-list-settings-title"
+          />
           <g-list>
             <g-list-item>
               <template #prepend>
@@ -163,22 +166,304 @@ SPDX-License-Identifier: Apache-2.0
                 />
               </template>
             </g-list-item>
+            <v-divider inset />
+            <g-list-item
+              ref="defaultClusterViewSettingsItem"
+              class="default-view"
+              :class="{ 'default-view--highlighted': highlightDefaultClusterViewSettings }"
+              tabindex="-1"
+              @focusout="clearDefaultClusterViewHighlight"
+              @keydown="clearDefaultClusterViewHighlight"
+              @pointerdown="clearDefaultClusterViewHighlight"
+            >
+              <template #prepend>
+                <v-icon color="primary">
+                  mdi-view-dashboard-outline
+                </v-icon>
+              </template>
+              <g-list-item-content label="Default Cluster View">
+                <template #description>
+                  Choose whether the All Projects cluster list opens with all clusters or Operations View.
+                  <template v-if="authzStore.canViewLandscape">
+                    This also determines which unhealthy Shoots are counted for each Seed.
+                  </template>
+                </template>
+              </g-list-item-content>
+              <template #append>
+                <v-btn-toggle
+                  v-model="defaultClusterView"
+                  color="primary"
+                  mandatory="force"
+                  divided
+                  density="compact"
+                  class="default-view-toggle"
+                  aria-label="Default cluster view"
+                >
+                  <v-btn
+                    value="all"
+                    variant="tonal"
+                  >
+                    All clusters
+                  </v-btn>
+                  <v-btn
+                    value="operations"
+                    variant="tonal"
+                  >
+                    Operations View
+                  </v-btn>
+                </v-btn-toggle>
+              </template>
+            </g-list-item>
+            <v-divider inset />
+            <g-list-item
+              ref="clusterOperationsSettingsItem"
+              class="operations-view"
+              :class="{ 'operations-view--highlighted': highlightClusterOperationsSettings }"
+              tabindex="-1"
+            >
+              <template #prepend>
+                <v-icon color="primary">
+                  mdi-filter-outline
+                </v-icon>
+              </template>
+              <g-list-item-content label="Operations View">
+                <template #description>
+                  <div
+                    data-test="operations-view-description"
+                  >
+                    {{ operationsViewDescription }}
+                  </div>
+                </template>
+              </g-list-item-content>
+              <template #append>
+                <v-btn
+                  v-if="authzStore.canViewLandscape"
+                  v-tooltip:top="'Configure exclusion criteria'"
+                  icon="mdi-cog-outline"
+                  variant="text"
+                  aria-label="Configure exclusion criteria"
+                  @click="allProjectsDialog = true"
+                />
+              </template>
+            </g-list-item>
           </g-list>
         </v-card>
       </v-col>
     </v-row>
+    <v-dialog
+      v-if="authzStore.canViewLandscape"
+      v-model="allProjectsDialog"
+      max-width="640"
+      scrollable
+      persistent
+      aria-labelledby="cluster-operations-dialog-title"
+      @after-enter="focusClusterOperationsDialogTitle"
+      @after-leave="onClusterOperationsDialogClosed"
+    >
+      <v-card>
+        <g-toolbar
+          prepend-icon="mdi-filter-cog-outline"
+          size="large"
+        >
+          <span
+            id="cluster-operations-dialog-title"
+            ref="clusterOperationsDialogTitle"
+            tabindex="-1"
+          >
+            Operations View
+          </span>
+        </g-toolbar>
+        <v-card-text class="pa-0">
+          <div class="px-6 pt-5 text-body-medium text-medium-emphasis">
+            Operations View shows clusters that may need attention.
+          </div>
+          <div class="px-6 pt-5">
+            <div
+              id="cluster-operations-exclusion-title"
+              class="text-title-large mb-1"
+            >
+              Exclusion criteria
+            </div>
+            <div
+              v-if="authzStore.canViewLandscape"
+              class="text-body-medium text-medium-emphasis"
+            >
+              Choose which clusters to hide.
+            </div>
+          </div>
+          <g-list class="py-0">
+            <div class="criteria mx-6 my-4">
+              <g-list-item class="criterion px-4 py-3">
+                <g-list-item-content>
+                  <div>Hide healthy clusters</div>
+                  <template #description>
+                    Always excluded.
+                  </template>
+                </g-list-item-content>
+                <template #append>
+                  <span
+                    v-tooltip:top="'Healthy clusters are always hidden in Operations View'"
+                    class="d-inline-flex"
+                  >
+                    <v-switch
+                      :model-value="true"
+                      color="primary"
+                      density="compact"
+                      hide-details
+                      disabled
+                      aria-label="Hide healthy clusters"
+                    />
+                  </span>
+                </template>
+              </g-list-item>
+              <template v-if="authzStore.canViewLandscape">
+                <v-divider />
+                <g-list-item class="criterion px-4 py-3">
+                  <g-list-item-content>
+                    <div>Hide progressing clusters</div>
+                    <template #description>
+                      Clusters with a health issue still within its grace period, or in an expected transient state such as creation, deletion, or a rollout.
+                    </template>
+                  </g-list-item-content>
+                  <template #append>
+                    <v-switch
+                      v-model="hideProgressing"
+                      color="primary"
+                      density="compact"
+                      hide-details
+                      aria-label="Hide progressing clusters"
+                    />
+                  </template>
+                </g-list-item>
+                <v-divider />
+                <g-list-item class="criterion px-4 py-3">
+                  <g-list-item-content>
+                    <div>Hide clusters without operator action needed</div>
+                    <template #description>
+                      <div>
+                        Clusters with user-caused issues, automatically retried infrastructure issues such as rate limits, or this annotation:
+                      </div>
+                      <div class="annotation font-family-monospace mt-1">
+                        dashboard.gardener.cloud/ignore-issues
+                      </div>
+                    </template>
+                  </g-list-item-content>
+                  <template #append>
+                    <v-switch
+                      v-model="hideOperatorAction"
+                      color="primary"
+                      density="compact"
+                      hide-details
+                      aria-label="Hide clusters without operator action needed"
+                    />
+                  </template>
+                </g-list-item>
+                <template v-if="showAllTicketsIgnoredFilter">
+                  <v-divider />
+                  <g-list-item class="criterion px-4 py-3">
+                    <g-list-item-content>
+                      <div>Hide clusters with only ignored tickets</div>
+                      <template #description>
+                        <div>
+                          A ticket is considered ignored if it has any of the labels below. Clusters without tickets remain visible.
+                        </div>
+                        <v-btn
+                          variant="text"
+                          density="compact"
+                          size="small"
+                          color="primary"
+                          class="label-toggle px-0 mt-1"
+                          :append-icon="showIgnoredTicketLabels ? 'mdi-chevron-up' : 'mdi-chevron-down'"
+                          :aria-expanded="showIgnoredTicketLabels"
+                          @click.stop="showIgnoredTicketLabels = !showIgnoredTicketLabels"
+                        >
+                          {{ ignoredTicketLabelToggleText }}
+                        </v-btn>
+                      </template>
+                    </g-list-item-content>
+                    <template #append>
+                      <v-switch
+                        v-model="allTicketsIgnored"
+                        color="primary"
+                        density="compact"
+                        hide-details
+                        aria-label="Hide clusters with only ignored tickets"
+                      />
+                    </template>
+                  </g-list-item>
+                  <v-expand-transition>
+                    <div
+                      v-if="showIgnoredTicketLabels"
+                      class="ticket-labels d-flex flex-wrap ga-1 mx-4 mb-3 pa-2"
+                      aria-label="Configured ignored ticket labels"
+                    >
+                      <v-chip
+                        v-for="label in ignoredTicketLabels"
+                        :key="label"
+                        label
+                        size="small"
+                        variant="tonal"
+                      >
+                        {{ label }}
+                      </v-chip>
+                    </div>
+                  </v-expand-transition>
+                </template>
+              </template>
+            </div>
+          </g-list>
+        </v-card-text>
+        <v-divider />
+        <v-card-actions class="px-6">
+          <v-spacer />
+          <v-btn
+            color="primary"
+            variant="text"
+            aria-label="OK"
+            @click="allProjectsDialog = false"
+          >
+            OK
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
   </v-container>
 </template>
 
 <script setup>
 import { storeToRefs } from 'pinia'
-import { computed } from 'vue'
+import {
+  computed,
+  nextTick,
+  onBeforeUnmount,
+  ref,
+  toRef,
+  watch,
+} from 'vue'
+import { useUrlSearchParams } from '@vueuse/core'
 
+import { useAuthzStore } from '@/store/authz'
+import { useConfigStore } from '@/store/config'
 import { useLocalStorageStore } from '@/store/localStorage'
 
 import { useShootAdminKubeconfig } from '@/composables/useShootAdminKubeconfig'
+import {
+  getEnabledOperationsViewExclusionReasons,
+  useShootListFilters,
+} from '@/composables/useShootListFilters'
 
 const localStorageStore = useLocalStorageStore()
+const allProjectsDialog = ref(false)
+const showIgnoredTicketLabels = ref(false)
+const defaultClusterViewSettingsItem = ref()
+const clusterOperationsSettingsItem = ref()
+const clusterOperationsDialogTitle = ref()
+const highlightDefaultClusterViewSettings = ref(false)
+const highlightClusterOperationsSettings = ref(false)
+const settingsHashParams = useUrlSearchParams('hash-params')
+const deepLinkedSetting = toRef(settingsHashParams, 'setting')
+let clusterOperationsDeepLinkActive = false
+let clusterOperationsHighlightTimer
 const shootAdminKubeconfig = useShootAdminKubeconfig()
 const {
   expirations: shootAdminKubeconfigExpirations,
@@ -186,6 +471,143 @@ const {
   expiration: shootAdminKubeconfigExpiration,
   humanizeExpiration,
 } = shootAdminKubeconfig
+
+const authzStore = useAuthzStore()
+const configStore = useConfigStore()
+
+const {
+  operationsViewFilters,
+  defaultClusterView,
+  setHideProgressing,
+  setHideWithoutOperatorAction,
+  setHideAllTicketsIgnored,
+} = useShootListFilters()
+
+const hideProgressing = computed({
+  get: () => operationsViewFilters.value.progressing ?? false,
+  set: setHideProgressing,
+})
+
+const hideOperatorAction = computed({
+  get: () => operationsViewFilters.value.operatorAction ?? false,
+  set: setHideWithoutOperatorAction,
+})
+
+const allTicketsIgnored = computed({
+  get: () => operationsViewFilters.value.allTicketsIgnored ?? false,
+  set: setHideAllTicketsIgnored,
+})
+
+const ignoredTicketLabels = computed(() => configStore.ticket?.hideClustersWithLabels ?? [])
+
+const ignoredTicketLabelToggleText = computed(() => {
+  const count = ignoredTicketLabels.value.length
+  const action = showIgnoredTicketLabels.value ? 'Hide' : 'Show'
+  return `${action} ${count} ignored ${count === 1 ? 'label' : 'labels'}`
+})
+
+const showAllTicketsIgnoredFilter = computed(() => {
+  return configStore.ticket?.gitHubRepoUrl && ignoredTicketLabels.value.length > 0
+})
+
+const operationsViewFilterReasonFormatter = new Intl.ListFormat('en', {
+  style: 'long',
+  type: 'disjunction',
+})
+
+const operationsViewDescription = computed(() => {
+  const reasons = getEnabledOperationsViewExclusionReasons({
+    ...operationsViewFilters.value,
+    allTicketsIgnored: showAllTicketsIgnoredFilter.value && operationsViewFilters.value.allTicketsIgnored,
+  })
+  const description = 'Shows unhealthy clusters that may need attention'
+  if (!reasons.length) {
+    return `${description}.`
+  }
+
+  return `${description}, excluding those that ${operationsViewFilterReasonFormatter.format(reasons)}.`
+})
+
+function defaultClusterViewSettingsElement () {
+  return defaultClusterViewSettingsItem.value?.$el ?? defaultClusterViewSettingsItem.value
+}
+
+function clusterOperationsSettingsElement () {
+  return clusterOperationsSettingsItem.value?.$el ?? clusterOperationsSettingsItem.value
+}
+
+function clearDefaultClusterViewHighlight () {
+  highlightDefaultClusterViewSettings.value = false
+}
+
+function highlightDefaultClusterViewEntry () {
+  const element = defaultClusterViewSettingsElement()
+  highlightDefaultClusterViewSettings.value = true
+  element?.scrollIntoView?.({
+    behavior: 'smooth',
+    block: 'center',
+  })
+  const focusTarget = element?.querySelector('button') ?? element
+  focusTarget?.focus?.({ preventScroll: true })
+}
+
+function highlightClusterOperationsEntry () {
+  const element = clusterOperationsSettingsElement()
+  highlightClusterOperationsSettings.value = true
+  element?.scrollIntoView?.({
+    behavior: 'smooth',
+    block: 'center',
+  })
+  const focusTarget = element?.querySelector('button') ?? element
+  focusTarget?.focus?.({ preventScroll: true })
+
+  clearTimeout(clusterOperationsHighlightTimer)
+  clusterOperationsHighlightTimer = setTimeout(() => {
+    highlightClusterOperationsSettings.value = false
+  }, 3000)
+}
+
+function focusClusterOperationsDialogTitle () {
+  clusterOperationsDialogTitle.value?.focus({ preventScroll: true })
+}
+
+async function onClusterOperationsDialogClosed () {
+  if (!clusterOperationsDeepLinkActive) {
+    return
+  }
+
+  clusterOperationsDeepLinkActive = false
+  deepLinkedSetting.value = null
+  await nextTick()
+  highlightClusterOperationsEntry()
+}
+
+watch(deepLinkedSetting, async value => {
+  if (value === 'default-cluster-view') {
+    deepLinkedSetting.value = null
+    await nextTick()
+    highlightDefaultClusterViewEntry()
+    return
+  }
+
+  if (value !== 'cluster-operations') {
+    return
+  }
+
+  if (!authzStore.canViewLandscape) {
+    deepLinkedSetting.value = null
+    return
+  }
+
+  clusterOperationsDeepLinkActive = true
+  allProjectsDialog.value = true
+}, {
+  immediate: true,
+})
+
+onBeforeUnmount(() => {
+  clearTimeout(clusterOperationsHighlightTimer)
+})
 
 const logLevels = [
   { value: 'debug', text: 'Verbose', icon: 'mdi-bug', color: 'grey darken-4' },
@@ -211,3 +633,87 @@ const shootAdminKubeconfigExpirationItems = computed(() => {
   })
 })
 </script>
+
+<style lang="scss" scoped>
+.cluster-list-card {
+  container-type: inline-size;
+}
+
+.default-view,
+.operations-view {
+  transition: background-color 0.5s ease;
+}
+
+.default-view--highlighted,
+.operations-view--highlighted {
+  background-color: rgb(var(--v-theme-accent));
+}
+
+:deep(.criterion .g-list-item__prepend) {
+  display: none;
+}
+
+.criteria {
+  overflow: hidden;
+  border: 1px solid rgba(var(--v-border-color), var(--v-border-opacity));
+  border-radius: 8px;
+  background: rgba(var(--v-theme-on-surface), 0.02);
+}
+
+.ticket-labels {
+  max-height: 160px;
+  overflow-y: auto;
+  border-radius: 6px;
+  background: rgba(var(--v-theme-on-surface), 0.04);
+}
+
+.annotation {
+  width: fit-content;
+  max-width: 100%;
+  padding: 2px 6px;
+  overflow-wrap: anywhere;
+  border-radius: 4px;
+  background: rgba(var(--v-theme-on-surface), 0.06);
+}
+
+.label-toggle {
+  letter-spacing: normal;
+  text-transform: none;
+}
+
+@container (max-width: 720px) {
+  .default-view {
+    display: grid !important;
+    grid-template-columns: 40px minmax(0, 1fr);
+    column-gap: 16px;
+  }
+
+  .default-view :deep(.g-list-item__prepend) {
+    grid-column: 1;
+    grid-row: 1;
+    margin-right: 0 !important;
+  }
+
+  .default-view :deep(.g-list-item__content) {
+    grid-column: 2;
+    grid-row: 1;
+  }
+
+  .default-view :deep(.g-list-item__append) {
+    grid-column: 2;
+    grid-row: 2;
+    width: 100%;
+    margin: 12px 0 0 !important;
+  }
+
+  .default-view-toggle {
+    width: 100%;
+    max-width: 420px;
+  }
+
+  .default-view-toggle :deep(.v-btn) {
+    flex: 1 1 0;
+    min-width: 0;
+  }
+}
+</style>

--- a/frontend/src/views/GShootList.vue
+++ b/frontend/src/views/GShootList.vue
@@ -575,8 +575,8 @@ export default {
         },
         {
           text: 'Hide clusters without operator action needed',
-          value: 'noOperatorAction',
-          selected: this.isFilterActive('noOperatorAction'),
+          value: 'operatorAction',
+          selected: this.isFilterActive('operatorAction'),
           hidden: this.projectScope || !this.canViewLandscape || this.showAllShoots,
           helpTooltip: [
             'Hide clusters that do not require action by an operator',
@@ -588,8 +588,8 @@ export default {
         },
         {
           text: 'Hide clusters with ignored ticket labels',
-          value: 'ignoredTickets',
-          selected: this.isFilterActive('ignoredTickets'),
+          value: 'allTicketsIgnored',
+          selected: this.isFilterActive('allTicketsIgnored'),
           hidden: this.projectScope || !this.canViewLandscape || !this.gitHubRepoUrl || !this.hideClustersWithLabels.length || this.showAllShoots,
           helpTooltip: this.ignoredTicketsTooltip,
           disabled: this.changeFiltersDisabled,


### PR DESCRIPTION
/area ops-productivity
/area usability
/kind enhancement

**What this PR does / why we need it**:

Gives Operations View an explicit saved default and a discoverable Settings surface for its exclusion criteria.

- Adds a "Default Cluster View" toggle to the Settings page so users can choose whether the All Projects list opens with all clusters or Operations View.
- Adds an "Operations View" settings card with a dialog to configure exclusion criteria (hide progressing clusters, clusters without operator action, clusters with only ignored tickets).
- Wires the saved filter configuration into the Seed health donut so it counts unhealthy Shoots consistently with the chosen view.

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

Internal filter keys were renamed (`noOperatorAction` → `operatorAction`, `ignoredTickets` → `allTicketsIgnored`). There is no migration or legacy support for the old key names in localStorage.

**Release note**:
```feature operator
The All Projects cluster list can now be configured to open in Operations View by default. Exclusion criteria for Operations View (progressing clusters, clusters not requiring operator action, clusters with only ignored tickets) are configurable from the Settings page.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Operations View configuration to control cluster exclusion criteria and ignored ticket-label behavior.
  * Introduced a persistent “Default Cluster View” (All vs Operations) that drives effective shoot-list filtering.
  * Added deep-link support to open and focus the Operations View settings, with highlighted entry handling.
* **Bug Fixes**
  * Preserved URL hash fragments during namespace-based redirects.
  * Updated shoot-list filtering to use the new operator-action and all-tickets-ignored criteria naming.
* **Tests**
  * Expanded and adjusted filter, settings, and mask coverage for the new criteria behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->