### PR TITLE
[operations-view 6/7] feat(frontend): add operations view controls

### DIFF
--- a/frontend/__tests__/components/GShootListToolbar.spec.js
+++ b/frontend/__tests__/components/GShootListToolbar.spec.js
@@ -92,6 +92,15 @@ describe('components', () => {
       expect(wrapper.vm.operationsView.state).toBe('active')
     })
 
+    it.each([
+      { description: 'negated-equivalent', modelValue: '-health:healthy', state: 'active' },
+      { description: 'zero-term', modelValue: ' \t\n ', state: 'all' },
+    ])('classifies a $description search', ({ modelValue, state }) => {
+      const wrapper = mountToolbar({ modelValue })
+
+      expect(wrapper.vm.operationsView.state).toBe(state)
+    })
+
     it('uses the toolbar text variant for the create action', () => {
       const wrapper = mountToolbar({
         canCreateShoots: true,

--- a/frontend/__tests__/components/GShootListToolbar.spec.js
+++ b/frontend/__tests__/components/GShootListToolbar.spec.js
@@ -1,0 +1,134 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import { shallowMount } from '@vue/test-utils'
+import {
+  createPinia,
+  setActivePinia,
+} from 'pinia'
+
+import GShootListToolbar from '@/components/GShootListToolbar.vue'
+import GTableColumnSelection from '@/components/GTableColumnSelection.vue'
+import GTableSearch from '@/components/GTableSearch.vue'
+
+const { createVuetifyPlugin } = global.fixtures.helper
+
+// Disable createSharedComposable so each test gets a fresh composable instance
+vi.mock('@vueuse/core', async importOriginal => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    createSharedComposable: fn => fn,
+  }
+})
+
+const VModelStub = {
+  name: 'VSwitch',
+  props: {
+    modelValue: Boolean,
+  },
+  emits: ['update:modelValue'],
+  template: '<div><slot name="label" /></div>',
+}
+
+describe('components', () => {
+  describe('g-shoot-list-toolbar', () => {
+    function mountToolbar (props = {}) {
+      const pinia = createPinia()
+      setActivePinia(pinia)
+
+      return shallowMount(GShootListToolbar, {
+        props: {
+          modelValue: 'health:unhealthy',
+          namespace: '_all',
+          issueSinceColumnVisible: true,
+          selectableHeaders: [{ key: 'name' }],
+          ...props,
+        },
+        global: {
+          plugins: [
+            createVuetifyPlugin(),
+            pinia,
+          ],
+          directives: {
+            tooltip: () => {},
+          },
+          stubs: {
+            VBadge: {
+              template: '<div><slot /></div>',
+            },
+            VMenu: {
+              template: '<div><slot name="activator" :props="{}" /><slot /></div>',
+            },
+            VSheet: {
+              template: '<div><slot /></div>',
+            },
+            VSwitch: VModelStub,
+            VTooltip: {
+              template: '<div><slot name="activator" :props="{}" /><slot /></div>',
+            },
+          },
+        },
+      })
+    }
+
+    beforeEach(() => {
+      window.localStorage.clear()
+    })
+
+    it('owns its layout and uses the public fluid search API', () => {
+      const wrapper = mountToolbar()
+      const search = wrapper.findComponent(GTableSearch)
+      const columnSelection = wrapper.findComponent(GTableColumnSelection)
+
+      expect(wrapper.find('.toolbar').exists()).toBe(true)
+      expect(search.props('fluid')).toBe(true)
+      expect(columnSelection.props('activatorColor')).toBe('toolbar-title')
+      expect(columnSelection.props('activatorVariant')).toBe('text')
+      expect(wrapper.find('.focus-label').text()).toBe('Focus')
+      expect(wrapper.vm.operationsView.state).toBe('active')
+    })
+
+    it('uses the toolbar text variant for the create action', () => {
+      const wrapper = mountToolbar({
+        canCreateShoots: true,
+        namespace: 'garden',
+        projectScope: true,
+      })
+      const createButton = wrapper.findComponent({ name: 'VBtn' })
+
+      expect(createButton.props('color')).toBe('toolbar-title')
+      expect(createButton.props('variant')).toBe('text')
+      expect(createButton.props('to')).toEqual({
+        name: 'NewShoot',
+        params: { namespace: 'garden' },
+      })
+    })
+
+    it('forwards search, focus, and table actions through its public events', async () => {
+      const wrapper = mountToolbar({
+        modelValue: 'provider:aws',
+      })
+
+      wrapper.findComponent(GTableSearch).vm.$emit('update:modelValue', 'seed:local')
+      wrapper.vm.showAllClusters()
+      wrapper.vm.applyOperationsView()
+      wrapper.findComponent(VModelStub).vm.$emit('update:modelValue', true)
+      wrapper.findComponent(GTableColumnSelection).vm.$emit('setSelectedHeader', { key: 'name' })
+      wrapper.findComponent(GTableColumnSelection).vm.$emit('reset')
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.emitted('update:modelValue')).toEqual([['seed:local']])
+      expect(wrapper.emitted('setSearch')).toEqual([
+        [''],
+        ['health:unhealthy'],
+      ])
+      expect(wrapper.emitted('update:focusMode')).toEqual([[true]])
+      expect(wrapper.emitted('setSelectedHeader')).toEqual([[{ key: 'name' }]])
+      expect(wrapper.emitted('reset')).toEqual([[]])
+    })
+  })
+})

--- a/frontend/__tests__/components/GTableSearch.spec.js
+++ b/frontend/__tests__/components/GTableSearch.spec.js
@@ -50,8 +50,12 @@ describe('components', () => {
       expect(wrapper.classes()).toContain('fluid')
 
       field.vm.$emit('update:modelValue', 'provider:aws')
+      await field.trigger('keyup.esc')
       await wrapper.vm.$nextTick()
-      expect(wrapper.emitted('update:modelValue')).toEqual([['provider:aws']])
+      expect(wrapper.emitted('update:modelValue')).toEqual([
+        ['provider:aws'],
+        [''],
+      ])
     })
   })
 })

--- a/frontend/__tests__/components/GTableSearch.spec.js
+++ b/frontend/__tests__/components/GTableSearch.spec.js
@@ -1,0 +1,57 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import { shallowMount } from '@vue/test-utils'
+
+import GTableSearch from '@/components/GTableSearch.vue'
+
+const VTextFieldStub = {
+  name: 'VTextField',
+  inheritAttrs: false,
+  props: {
+    modelValue: String,
+  },
+  emits: ['update:modelValue'],
+  template: '<input v-bind="$attrs" :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)">',
+}
+
+describe('components', () => {
+  describe('g-table-search', () => {
+    function mountSearch (props = {}) {
+      return shallowMount(GTableSearch, {
+        props,
+        global: {
+          stubs: {
+            VTextField: VTextFieldStub,
+            VTooltip: {
+              template: '<div><slot name="activator" :props="{}" /><slot /></div>',
+            },
+          },
+        },
+      })
+    }
+
+    it('uses the established constrained layout by default', () => {
+      const wrapper = mountSearch()
+
+      expect(wrapper.classes()).toContain('g-table-search-field')
+      expect(wrapper.classes()).not.toContain('fluid')
+    })
+
+    it('exposes fluid layout without changing search events', async () => {
+      const wrapper = mountSearch({
+        fluid: true,
+      })
+      const field = wrapper.findComponent(VTextFieldStub)
+
+      expect(wrapper.classes()).toContain('fluid')
+
+      field.vm.$emit('update:modelValue', 'provider:aws')
+      await wrapper.vm.$nextTick()
+      expect(wrapper.emitted('update:modelValue')).toEqual([['provider:aws']])
+    })
+  })
+})

--- a/frontend/__tests__/composables/useShootListFilters.spec.js
+++ b/frontend/__tests__/composables/useShootListFilters.spec.js
@@ -222,15 +222,10 @@ describe('composables', () => {
       expect(localStorageStore.allProjectsShootFilter.progressing).toBe(true)
     })
 
-    it('should keep existing filter consumers working with the renamed criteria', async () => {
+    it('should keep the existing Seed filter label consumer working', async () => {
       await grantLandscapeAccess()
 
-      const {
-        activeFilterLabels,
-        defaultClusterView,
-        healthy,
-        toggleShootListFilter,
-      } = useShootListFilters()
+      const { activeFilterLabels } = useShootListFilters()
 
       expect(activeFilterLabels.value).toEqual([
         'Progressing',
@@ -238,21 +233,15 @@ describe('composables', () => {
         'Ignored Ticket Labels',
       ])
 
-      toggleShootListFilter('operatorAction')
-      expect(localStorageStore.allProjectsShootFilter.operatorAction).toBe(false)
+      localStorageStore.allProjectsShootFilter = {
+        progressing: true,
+        operatorAction: false,
+        allTicketsIgnored: true,
+      }
       expect(activeFilterLabels.value).toEqual([
         'Progressing',
         'Ignored Ticket Labels',
       ])
-
-      toggleShootListFilter('healthy')
-      expect(defaultClusterView.value).toBe('all')
-      expect(healthy.value).toBe(false)
-
-      toggleShootListFilter('healthy')
-      expect(defaultClusterView.value).toBe('operations')
-      expect(healthy.value).toBe(true)
-      expect(localStorageStore.allProjectsShootFilter.operatorAction).toBe(false)
     })
 
     it('should default non-landscape users to all clusters', () => {

--- a/frontend/__tests__/stores/shoot.spec.js
+++ b/frontend/__tests__/stores/shoot.spec.js
@@ -559,6 +559,8 @@ describe('stores', () => {
           namespace: '_all',
           search: 'provider:aws',
         })
+        shootStore.setFocusMode(true)
+        const frozenUids = [...shootStore.state.froozenUids]
 
         vi.clearAllMocks()
 
@@ -574,13 +576,16 @@ describe('stores', () => {
         expect(mockEmitUnsubscribe).not.toHaveBeenCalled()
         expect(mockEmitSubscribe).not.toHaveBeenCalled()
         expect(mockGetShoots).not.toHaveBeenCalled()
+        expect(shootStore.focusMode).toBe(true)
+        expect(shootStore.state.froozenUids).toEqual(frozenUids)
       })
 
-      it('should coalesce equal ShootList targets while a replacement is closing', async () => {
+      it('should exit focus mode when coalescing equal ShootList targets during replacement', async () => {
         await shootStore.activateShootList({
           namespace: '_all',
           search: 'provider:aws',
         })
+        shootStore.setFocusMode(true)
 
         vi.clearAllMocks()
 
@@ -593,6 +598,8 @@ describe('stores', () => {
           namespace: '_all',
           search: 'health:unhealthy provider:aws',
         })
+        expect(shootStore.focusMode).toBe(false)
+        shootStore.setFocusMode(true)
         const secondActivation = shootStore.activateShootList({
           namespace: '_all',
           search: 'health:unhealthy provider:gcp',
@@ -600,6 +607,8 @@ describe('stores', () => {
 
         expect(mockEmitUnsubscribe).toHaveBeenCalledTimes(1)
         expect(Object.keys(shootStore.state.shoots)).toHaveLength(shootList.length)
+        expect(shootStore.focusMode).toBe(false)
+        expect(shootStore.state.froozenUids).toEqual([])
 
         finishClose()
         await Promise.all([firstActivation, secondActivation])

--- a/frontend/__tests__/views/GShootList.spec.js
+++ b/frontend/__tests__/views/GShootList.spec.js
@@ -1,0 +1,560 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import { nextTick } from 'vue'
+import {
+  flushPromises,
+  shallowMount,
+} from '@vue/test-utils'
+import {
+  createPinia,
+  setActivePinia,
+} from 'pinia'
+import {
+  createMemoryHistory,
+  createRouter,
+} from 'vue-router'
+
+import { useAuthzStore } from '@/store/authz'
+import { useConfigStore } from '@/store/config'
+import { useLocalStorageStore } from '@/store/localStorage'
+import { useShootStore } from '@/store/shoot'
+
+import GShootList from '@/views/GShootList.vue'
+
+import GShootListToolbar from '@/components/GShootListToolbar.vue'
+
+import { useShootListFilters } from '@/composables/useShootListFilters'
+
+import {
+  getShootListContext,
+  normalizeShootListRoute,
+} from '@/router/shootList'
+
+// Disable createSharedComposable so each test gets a fresh composable instance
+vi.mock('@vueuse/core', async importOriginal => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    createSharedComposable: fn => fn,
+  }
+})
+
+vi.mock('@/components/GDataTableFooter.vue', () => ({
+  default: { template: '<div />' },
+}))
+
+vi.mock('@/components/GShootListActions.vue', () => ({
+  default: { template: '<div />' },
+}))
+
+vi.mock('@/components/GShootListProgress.vue', () => ({
+  default: { template: '<div />' },
+}))
+
+vi.mock('@/components/GShootListRow.vue', () => ({
+  default: { template: '<div />' },
+}))
+
+vi.mock('@/components/GTableColumnSelection.vue', () => ({
+  default: { template: '<div />' },
+}))
+
+vi.mock('@/components/GTableSearch.vue', () => ({
+  default: { template: '<div />' },
+}))
+
+vi.mock('@/composables/useProjectShootCustomFields', async () => {
+  const { ref } = await import('vue')
+  return {
+    useProjectShootCustomFields: () => ({
+      shootCustomFields: ref([]),
+    }),
+  }
+})
+
+vi.mock('@/composables/useProjectShootCustomFields/helper', () => ({
+  isCustomField: () => false,
+}))
+
+vi.mock('@/composables/useShootAction', () => ({
+  useProvideShootAction: () => {},
+}))
+
+const DEFAULT_SEARCH = 'health:unhealthy progressing:false operatorAction:true allTicketsIgnored:false'
+const { createVuetifyPlugin } = global.fixtures.helper
+
+const VBtnStub = {
+  inheritAttrs: false,
+  emits: ['click'],
+  template: '<button v-bind="$attrs" @click="$emit(\'click\')"><slot /></button>',
+}
+
+const VMenuStub = {
+  name: 'VMenu',
+  props: {
+    modelValue: Boolean,
+    activatorProps: Object,
+    contentProps: Object,
+  },
+  emits: ['update:modelValue'],
+  template: '<div><slot name="activator" :props="{}" /><slot /></div>',
+}
+
+describe('views', () => {
+  describe('g-shoot-list', () => {
+    let authzStore
+    let canViewLandscapeSpy
+    let localStorageStore
+    let pinia
+    let router
+    let shootStore
+    let wrapper
+    let initialQuery
+
+    function setConfiguredFilters (filters = {}) {
+      localStorageStore.allProjectsShootFilter = {
+        healthy: true,
+        progressing: true,
+        operatorAction: true,
+        allTicketsIgnored: true,
+        ...filters,
+      }
+    }
+
+    async function mountComponent () {
+      const target = {
+        name: 'ShootList',
+        params: {
+          namespace: authzStore.namespace,
+        },
+        query: initialQuery,
+      }
+      const route = router.resolve(target)
+      const { shootListFilters } = useShootListFilters()
+      const normalizedTarget = normalizeShootListRoute(route, shootListFilters.value)
+      await router.replace(normalizedTarget ?? target)
+
+      wrapper = shallowMount(GShootList, {
+        global: {
+          plugins: [
+            createVuetifyPlugin(),
+            pinia,
+            router,
+          ],
+          directives: {
+            tooltip: () => {},
+          },
+          stubs: {
+            GShootListToolbar: false,
+            VBtn: VBtnStub,
+            VCard: {
+              template: '<div><slot /></div>',
+            },
+            VChip: {
+              template: '<span><slot /></span>',
+            },
+            VContainer: {
+              template: '<div><slot /></div>',
+            },
+            VSheet: {
+              template: '<div><slot /></div>',
+            },
+            VTooltip: {
+              template: '<div><slot name="activator" :props="{}" /><slot /></div>',
+            },
+            VMenu: VMenuStub,
+            VList: {
+              template: '<div><slot /></div>',
+            },
+            VListSubheader: {
+              template: '<div><slot /></div>',
+            },
+            VListItem: {
+              inheritAttrs: false,
+              props: {
+                to: Object,
+              },
+              emits: ['click'],
+              template: '<div v-bind="$attrs" @click="$emit(\'click\')"><slot /><slot name="prepend" /><slot name="append" /></div>',
+            },
+            VListItemTitle: {
+              template: '<span><slot /></span>',
+            },
+            VListItemSubtitle: {
+              template: '<span><slot /></span>',
+            },
+            VDivider: {
+              template: '<hr />',
+            },
+            VIcon: {
+              template: '<i />',
+            },
+          },
+        },
+      })
+      return wrapper
+    }
+
+    function getOperationsView () {
+      return wrapper.findComponent(GShootListToolbar).vm.operationsView
+    }
+
+    function getRouteSearch () {
+      return router.resolve(router.options.history.location).query.q
+    }
+
+    function getCommittedRouteSearch () {
+      return router.currentRoute.value.query.q
+    }
+
+    async function settleSearchUpdate () {
+      await nextTick()
+      await flushPromises()
+      await nextTick()
+    }
+
+    beforeEach(() => {
+      vi.useFakeTimers()
+      window.localStorage.clear()
+
+      pinia = createPinia()
+      setActivePinia(pinia)
+      authzStore = useAuthzStore()
+      canViewLandscapeSpy = vi.spyOn(authzStore, 'canViewLandscape', 'get').mockReturnValue(true)
+      useConfigStore().setConfiguration({
+        ticket: {
+          gitHubRepoUrl: 'https://github.com/org/repo',
+          hideClustersWithLabels: ['ignore'],
+        },
+      })
+      localStorageStore = useLocalStorageStore()
+      shootStore = useShootStore()
+      vi.spyOn(shootStore, 'subscribeShoots').mockResolvedValue()
+      authzStore._setNamespace('_all')
+      setConfiguredFilters()
+      localStorageStore.allProjectsShootDefaultView = 'operations'
+      initialQuery = {}
+
+      router = createRouter({
+        history: createMemoryHistory(),
+        routes: [{
+          name: 'ShootList',
+          path: '/namespace/:namespace/shoots',
+          component: {},
+        }],
+      })
+      router.afterEach(to => {
+        if (to.name === 'ShootList') {
+          shootStore.activateShootList(getShootListContext(to))
+        }
+      })
+    })
+
+    afterEach(() => {
+      wrapper?.unmount()
+      canViewLandscapeSpy.mockRestore()
+      vi.useRealTimers()
+    })
+
+    it('applies the configured default when q is absent', async () => {
+      await mountComponent()
+
+      expect(wrapper.vm.shootSearch).toBe(DEFAULT_SEARCH)
+      expect(wrapper.vm.debouncedShootSearch).toBe(DEFAULT_SEARCH)
+      expect(getRouteSearch()).toBe(DEFAULT_SEARCH)
+      expect(shootStore.shootSearchQuery.terms).toHaveLength(4)
+      expect(getOperationsView().state).toBe('active')
+      const activator = wrapper.find('[data-test="operations-view-activator"]')
+      expect(activator.text()).toContain('Operations View')
+      expect(activator.attributes('aria-label')).toBe('Operations View is active')
+      expect(activator.attributes('variant')).toBe('tonal')
+      expect(getOperationsView().activatorIcon).toBe('mdi-filter-check-outline')
+      expect(wrapper.find('[data-test="operations-view-status"]').text()).toBe('Active')
+      const menu = wrapper.findComponent(VMenuStub)
+      expect(menu.props('activatorProps')).toEqual({ 'aria-haspopup': 'dialog' })
+      expect(menu.props('contentProps')).toEqual({
+        role: 'dialog',
+        'aria-labelledby': 'operations-view-menu-title',
+        'aria-describedby': 'operations-view-menu-description operations-view-menu-status',
+      })
+      expect(wrapper.find('[data-test="operations-view-menu-list"]').attributes('tabindex')).toBe('-1')
+      expect(wrapper.find('[data-test="operations-view-show-all"]').exists()).toBe(true)
+      const showAllItem = wrapper.find('[data-test="operations-view-show-all"]')
+      expect(showAllItem.attributes('role')).toBe('button')
+      expect(showAllItem.attributes('tabindex')).toBe('0')
+      expect(showAllItem.text()).toContain('Clears every term in the current search.')
+      expect(wrapper.find('[data-test="operations-view-apply"]').exists()).toBe(false)
+      expect(wrapper.text()).toContain('Shows unhealthy clusters that may need attention')
+
+      const defaultClusterViewItem = wrapper.findComponent('[data-test="operations-view-default-cluster-view"]')
+      expect(defaultClusterViewItem.text()).toContain('Default cluster view')
+      expect(defaultClusterViewItem.text()).toContain('Operations View')
+      expect(wrapper.find('[data-test="operations-view-default-cluster-view-value"]').text()).toBe('Operations View')
+      expect(defaultClusterViewItem.attributes('tabindex')).toBe('0')
+      expect(defaultClusterViewItem.props('to')).toEqual({
+        name: 'Settings',
+        query: { namespace: '_all' },
+        hash: '#setting=default-cluster-view',
+      })
+
+      const exclusionCriteriaItem = wrapper.findComponent('[data-test="operations-view-exclusion-criteria"]')
+      expect(exclusionCriteriaItem.text()).toContain('Edit exclusion criteria…')
+      expect(exclusionCriteriaItem.attributes('tabindex')).toBe('0')
+      expect(exclusionCriteriaItem.props('to')).toEqual({
+        name: 'Settings',
+        query: { namespace: '_all' },
+        hash: '#setting=cluster-operations',
+      })
+      expect(wrapper.text()).toContain('Settings')
+    })
+
+    it('keeps an explicit non-empty query independent of local defaults', async () => {
+      initialQuery = {
+        q: 'provider:aws',
+      }
+      await mountComponent()
+
+      setConfiguredFilters({
+        progressing: false,
+        operatorAction: false,
+        allTicketsIgnored: false,
+      })
+      await nextTick()
+
+      expect(wrapper.vm.shootSearch).toBe('provider:aws')
+      expect(getRouteSearch()).toBe('provider:aws')
+      expect(shootStore.shootSearchQuery.terms).toEqual([{
+        field: 'provider',
+        value: 'aws',
+        exact: false,
+        exclude: false,
+      }])
+      expect(getOperationsView().state).toBe('custom')
+      expect(wrapper.find('[data-test="operations-view-activator"]').attributes('aria-label')).toBe('Operations View — custom search')
+      expect(wrapper.find('[data-test="operations-view-activator"]').attributes('variant')).toBe('text')
+      expect(getOperationsView().activatorIcon).toBe('mdi-filter-cog-outline')
+      expect(wrapper.find('[data-test="operations-view-status"]').text()).toBe('Custom search')
+      expect(wrapper.find('[data-test="operations-view-show-all"]').exists()).toBe(true)
+      expect(wrapper.find('[data-test="operations-view-apply"]').exists()).toBe(true)
+      expect(wrapper.find('[data-test="operations-view-apply"]').attributes('role')).toBe('button')
+      expect(wrapper.find('[data-test="operations-view-apply"]').attributes('tabindex')).toBe('0')
+      expect(wrapper.find('[data-test="operations-view-apply"]').text()).toContain('Replaces every term in the current search with the Operations View criteria.')
+      expect(wrapper.find('[data-test="operations-view-default-cluster-view"]').exists()).toBe(true)
+      expect(wrapper.find('[data-test="operations-view-default-cluster-view-value"]').text()).toBe('Operations View')
+      expect(wrapper.find('[data-test="operations-view-exclusion-criteria"]').exists()).toBe(true)
+    })
+
+    it('applies the all-clusters default without changing Operations View criteria', async () => {
+      localStorageStore.allProjectsShootDefaultView = 'all'
+      await mountComponent()
+
+      expect(wrapper.vm.shootSearch).toBe('')
+      expect(wrapper.vm.debouncedShootSearch).toBe('')
+      expect(getRouteSearch()).toBe('')
+      expect(shootStore.shootSearchQuery.terms).toEqual([])
+      expect(getOperationsView().state).toBe('all')
+      expect(wrapper.find('[data-test="operations-view-activator"]').attributes('aria-label')).toBe('Operations View — showing all clusters')
+      expect(wrapper.find('[data-test="operations-view-activator"]').attributes('variant')).toBe('text')
+      expect(getOperationsView().activatorIcon).toBe('mdi-filter-off-outline')
+      expect(wrapper.find('[data-test="operations-view-status"]').text()).toBe('All clusters')
+      expect(wrapper.find('[data-test="operations-view-show-all"]').exists()).toBe(false)
+      expect(wrapper.find('[data-test="operations-view-apply"]').exists()).toBe(true)
+      expect(wrapper.find('[data-test="operations-view-default-cluster-view"]').exists()).toBe(true)
+      expect(wrapper.find('[data-test="operations-view-default-cluster-view-value"]').text()).toBe('All clusters')
+      expect(wrapper.find('[data-test="operations-view-exclusion-criteria"]').exists()).toBe(true)
+      expect(wrapper.find('[data-test="operations-view-apply"]').text()).toContain('Apply Operations View')
+      expect(wrapper.find('[data-test="operations-view-apply"]').text()).toContain('Uses the Operations View criteria to show clusters that may need attention.')
+    })
+
+    it('uses the shared Operations View terminology for regular users', async () => {
+      canViewLandscapeSpy.mockReturnValue(false)
+      setConfiguredFilters({
+        progressing: false,
+        operatorAction: false,
+        allTicketsIgnored: false,
+      })
+      initialQuery = {
+        q: 'provider:aws',
+      }
+      await mountComponent()
+
+      expect(wrapper.text()).toContain('Shows unhealthy clusters that may need attention')
+      expect(wrapper.text()).not.toContain('configured in Settings')
+
+      const defaultClusterViewItem = wrapper.find('[data-test="operations-view-default-cluster-view"]')
+      expect(defaultClusterViewItem.text()).toContain('Default cluster view')
+      expect(defaultClusterViewItem.text()).toContain('Operations View')
+
+      expect(wrapper.find('[data-test="operations-view-exclusion-criteria"]').exists()).toBe(false)
+      expect(wrapper.text()).not.toContain('About Operations View')
+      expect(wrapper.find('[data-test="operations-view-apply"]').text()).toContain('Apply Operations View')
+      expect(wrapper.find('[data-test="operations-view-apply"]').text()).toContain('Replaces every term in the current search with the Operations View criteria.')
+
+      await wrapper.find('[data-test="operations-view-apply"]').trigger('click')
+      await settleSearchUpdate()
+
+      expect(wrapper.vm.shootSearch).toBe('health:unhealthy')
+      expect(getRouteSearch()).toBe('health:unhealthy')
+      expect(getOperationsView().state).toBe('active')
+    })
+
+    it('keeps an explicitly empty query without reapplying the local default', async () => {
+      initialQuery = {
+        q: '',
+      }
+      await mountComponent()
+
+      expect(wrapper.vm.shootSearch).toBe('')
+      expect(getRouteSearch()).toBe('')
+      expect(shootStore.shootSearchQuery.terms).toEqual([])
+      expect(getOperationsView().state).toBe('all')
+    })
+
+    it('shows all clusters by clearing the complete current search', async () => {
+      await mountComponent()
+      const configuredFilters = { ...localStorageStore.allProjectsShootFilter }
+
+      await wrapper.find('[data-test="operations-view-show-all"]').trigger('click')
+      await settleSearchUpdate()
+
+      expect(wrapper.vm.shootSearch).toBe('')
+      expect(wrapper.vm.debouncedShootSearch).toBe('')
+      expect(getRouteSearch()).toBe('')
+      expect(getCommittedRouteSearch()).toBe(DEFAULT_SEARCH)
+      expect(shootStore.shootSearchQuery.terms).toEqual([])
+      expect(getOperationsView().state).toBe('all')
+      expect(localStorageStore.allProjectsShootDefaultView).toBe('operations')
+      expect(localStorageStore.allProjectsShootFilter).toEqual(configuredFilters)
+    })
+
+    it('applies the latest Operations View criteria to the complete query', async () => {
+      initialQuery = {
+        q: 'provider:aws',
+      }
+      await mountComponent()
+
+      setConfiguredFilters({
+        progressing: false,
+        operatorAction: false,
+        allTicketsIgnored: false,
+      })
+      await nextTick()
+
+      await wrapper.find('[data-test="operations-view-apply"]').trigger('click')
+      await settleSearchUpdate()
+
+      expect(wrapper.vm.shootSearch).toBe('health:unhealthy')
+      expect(wrapper.vm.debouncedShootSearch).toBe('health:unhealthy')
+      expect(getRouteSearch()).toBe('health:unhealthy')
+      expect(shootStore.shootSearchQuery.terms).toEqual([{
+        field: 'health',
+        value: 'unhealthy',
+        exact: false,
+        exclude: false,
+      }])
+      expect(getOperationsView().state).toBe('active')
+    })
+
+    it('applies Operations View independently of the saved default', async () => {
+      initialQuery = {
+        q: 'provider:aws',
+      }
+      localStorageStore.allProjectsShootDefaultView = 'all'
+      await mountComponent()
+
+      await wrapper.find('[data-test="operations-view-apply"]').trigger('click')
+      await settleSearchUpdate()
+
+      expect(wrapper.vm.shootSearch).toBe(DEFAULT_SEARCH)
+      expect(wrapper.vm.debouncedShootSearch).toBe(DEFAULT_SEARCH)
+      expect(getRouteSearch()).toBe(DEFAULT_SEARCH)
+      expect(shootStore.shootSearchQuery.terms).toHaveLength(4)
+      expect(getOperationsView().state).toBe('active')
+      expect(localStorageStore.allProjectsShootDefaultView).toBe('all')
+    })
+
+    it('recognizes a reordered Operations expression as active', async () => {
+      initialQuery = {
+        q: 'progressing:false health:unhealthy operatorAction:true allTicketsIgnored:false',
+      }
+      await mountComponent()
+
+      expect(getOperationsView().state).toBe('active')
+      expect(wrapper.find('[data-test="operations-view-status"]').text()).toBe('Active')
+      expect(wrapper.find('[data-test="operations-view-show-all"]').exists()).toBe(true)
+      expect(wrapper.find('[data-test="operations-view-apply"]').exists()).toBe(false)
+    })
+
+    it('recognizes Operations View with additional filters and offers apply', async () => {
+      initialQuery = {
+        q: 'seed:"infra1-seed" progressing:false health:unhealthy operatorAction:true allTicketsIgnored:false',
+      }
+      await mountComponent()
+
+      expect(getOperationsView().state).toBe('refined')
+      expect(wrapper.find('[data-test="operations-view-activator"]').attributes('aria-label')).toBe('Operations View with additional filters')
+      expect(wrapper.find('[data-test="operations-view-activator"]').attributes('variant')).toBe('tonal')
+      expect(getOperationsView().activatorIcon).toBe('mdi-filter-plus-outline')
+      expect(wrapper.find('[data-test="operations-view-status"]').text()).toBe('Additional filters')
+      expect(wrapper.find('[data-test="operations-view-show-all"]').exists()).toBe(true)
+      expect(wrapper.find('[data-test="operations-view-apply"]').exists()).toBe(true)
+      expect(wrapper.find('[data-test="operations-view-apply"]').text()).toContain('Reset to Operations View')
+      expect(wrapper.find('[data-test="operations-view-apply"]').text()).toContain('Removes every additional term from the current search.')
+
+      await wrapper.find('[data-test="operations-view-apply"]').trigger('click')
+      await settleSearchUpdate()
+
+      expect(wrapper.vm.shootSearch).toBe(DEFAULT_SEARCH)
+      expect(getOperationsView().state).toBe('active')
+    })
+
+    it('reports the current search as refined when Operations View criteria are relaxed', async () => {
+      await mountComponent()
+
+      setConfiguredFilters({
+        progressing: false,
+        operatorAction: false,
+        allTicketsIgnored: false,
+      })
+      await nextTick()
+
+      expect(wrapper.vm.shootSearch).toBe(DEFAULT_SEARCH)
+      expect(getRouteSearch()).toBe(DEFAULT_SEARCH)
+      expect(getOperationsView().state).toBe('refined')
+      expect(wrapper.find('[data-test="operations-view-apply"]').exists()).toBe(true)
+    })
+
+    it('reports the current search as custom when required Operations View criteria are missing', async () => {
+      setConfiguredFilters({
+        progressing: false,
+        operatorAction: false,
+        allTicketsIgnored: false,
+      })
+      await mountComponent()
+
+      setConfiguredFilters()
+      await nextTick()
+
+      expect(wrapper.vm.shootSearch).toBe('health:unhealthy')
+      expect(getRouteSearch()).toBe('health:unhealthy')
+      expect(getOperationsView().state).toBe('custom')
+      expect(wrapper.find('[data-test="operations-view-apply"]').exists()).toBe(true)
+    })
+
+    it('does not show the Operations View menu for a project-scoped list', async () => {
+      authzStore._setNamespace('garden-local')
+      initialQuery = {
+        q: '',
+      }
+      await mountComponent()
+
+      expect(wrapper.find('[data-test="operations-view-activator"]').exists()).toBe(false)
+      expect(wrapper.find('[data-test="operations-view-default-cluster-view"]').exists()).toBe(false)
+      expect(wrapper.find('[data-test="operations-view-exclusion-criteria"]').exists()).toBe(false)
+    })
+  })
+})

--- a/frontend/__tests__/views/GShootList.spec.js
+++ b/frontend/__tests__/views/GShootList.spec.js
@@ -383,14 +383,12 @@ describe('views', () => {
       await mountComponent()
 
       expect(wrapper.text()).toContain('Shows unhealthy clusters that may need attention')
-      expect(wrapper.text()).not.toContain('configured in Settings')
 
       const defaultClusterViewItem = wrapper.find('[data-test="operations-view-default-cluster-view"]')
       expect(defaultClusterViewItem.text()).toContain('Default cluster view')
       expect(defaultClusterViewItem.text()).toContain('Operations View')
 
       expect(wrapper.find('[data-test="operations-view-exclusion-criteria"]').exists()).toBe(false)
-      expect(wrapper.text()).not.toContain('About Operations View')
       expect(wrapper.find('[data-test="operations-view-apply"]').text()).toContain('Apply Operations View')
       expect(wrapper.find('[data-test="operations-view-apply"]').text()).toContain('Replaces every term in the current search with the Operations View criteria.')
 

--- a/frontend/src/components/GShootListToolbar.vue
+++ b/frontend/src/components/GShootListToolbar.vue
@@ -1,0 +1,595 @@
+<!--
+SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+<template>
+  <v-sheet
+    class="toolbar text-toolbar-title"
+    color="toolbar-background"
+  >
+    <div class="heading">
+      <v-icon
+        class="heading-icon"
+        icon="mdi-hexagon-multiple"
+      />
+      <div class="heading-title text-title-large">
+        Kubernetes Clusters
+      </div>
+    </div>
+    <div class="controls">
+      <div class="search-context">
+        <div
+          class="search"
+          :class="{ 'search--expanded': modelValue }"
+        >
+          <g-table-search
+            :model-value="modelValue"
+            :examples="['my-shoot', 'John Doe']"
+            :exclude-examples="['myproject', 'Jane Doe']"
+            fluid
+            @update:model-value="$emit('update:modelValue', $event)"
+          />
+        </div>
+        <v-menu
+          v-if="!projectScope"
+          v-model="operationsViewMenuOpen"
+          :activator-props="{ 'aria-haspopup': 'dialog' }"
+          :content-props="{
+            role: 'dialog',
+            'aria-labelledby': 'operations-view-menu-title',
+            'aria-describedby': 'operations-view-menu-description operations-view-menu-status',
+          }"
+          location="bottom end"
+        >
+          <template #activator="{ props: activatorProps }">
+            <v-btn
+              v-tooltip:bottom="operationsView.tooltip"
+              v-bind="activatorProps"
+              class="operations-view"
+              :variant="operationsView.isApplied ? 'tonal' : 'text'"
+              color="toolbar-title"
+              :aria-label="operationsView.tooltip"
+              data-test="operations-view-activator"
+            >
+              <v-icon :icon="operationsView.activatorIcon" />
+              <span class="operations-view-label mx-2">
+                Operations View
+              </span>
+              <v-icon
+                class="operations-view-chevron"
+                :icon="operationsViewMenuOpen ? 'mdi-menu-up' : 'mdi-menu-down'"
+                size="small"
+              />
+            </v-btn>
+          </template>
+          <v-card class="operations-view-menu">
+            <div class="pa-4">
+              <div class="operations-view-heading d-flex align-center justify-space-between mb-1">
+                <div
+                  id="operations-view-menu-title"
+                  class="text-title-medium"
+                >
+                  Operations View
+                </div>
+                <v-chip
+                  id="operations-view-menu-status"
+                  :color="operationsView.statusColor"
+                  :prepend-icon="operationsView.statusIcon"
+                  data-test="operations-view-status"
+                  label
+                  size="small"
+                  variant="tonal"
+                >
+                  {{ operationsView.statusLabel }}
+                </v-chip>
+              </div>
+              <div
+                id="operations-view-menu-description"
+                class="text-body-medium text-medium-emphasis"
+              >
+                Shows unhealthy clusters that may need attention.
+              </div>
+            </div>
+            <v-divider />
+            <v-list
+              data-test="operations-view-menu-list"
+              density="compact"
+              tabindex="-1"
+            >
+              <v-list-item
+                v-if="operationsView.state !== 'all'"
+                data-test="operations-view-show-all"
+                role="button"
+                tabindex="0"
+                @click="showAllClusters"
+              >
+                <template #prepend>
+                  <v-icon icon="mdi-filter-off-outline" />
+                </template>
+                <v-list-item-title class="text-wrap">
+                  Show all clusters
+                </v-list-item-title>
+                <v-list-item-subtitle class="operations-view-description text-wrap">
+                  Clears every term in the current search.
+                </v-list-item-subtitle>
+              </v-list-item>
+              <v-list-item
+                v-if="operationsView.state !== 'active'"
+                data-test="operations-view-apply"
+                role="button"
+                tabindex="0"
+                @click="applyOperationsView"
+              >
+                <template #prepend>
+                  <v-icon icon="mdi-filter-outline" />
+                </template>
+                <v-list-item-title class="text-wrap">
+                  {{ operationsView.applyActionLabel }}
+                </v-list-item-title>
+                <v-list-item-subtitle class="operations-view-description text-wrap">
+                  {{ operationsView.applyActionDescription }}
+                </v-list-item-subtitle>
+              </v-list-item>
+              <v-divider />
+              <v-list-subheader>
+                Settings
+              </v-list-subheader>
+              <v-list-item
+                :to="{ name: 'Settings', query: { namespace }, hash: '#setting=default-cluster-view' }"
+                data-test="operations-view-default-cluster-view"
+                tabindex="0"
+              >
+                <template #prepend>
+                  <v-icon icon="mdi-view-dashboard-outline" />
+                </template>
+                <v-list-item-title class="text-wrap">
+                  Default cluster view
+                </v-list-item-title>
+                <template #append>
+                  <span
+                    class="text-body-small text-medium-emphasis mr-1"
+                    data-test="operations-view-default-cluster-view-value"
+                  >
+                    {{ defaultClusterViewLabel }}
+                  </span>
+                  <v-icon
+                    color="medium-emphasis"
+                    icon="mdi-chevron-right"
+                    size="small"
+                  />
+                </template>
+              </v-list-item>
+              <v-list-item
+                v-if="canViewLandscape"
+                :to="{ name: 'Settings', query: { namespace }, hash: '#setting=cluster-operations' }"
+                data-test="operations-view-exclusion-criteria"
+                tabindex="0"
+              >
+                <template #prepend>
+                  <v-icon icon="mdi-filter-outline" />
+                </template>
+                <v-list-item-title class="text-wrap">
+                  Edit exclusion criteria…
+                </v-list-item-title>
+                <template #append>
+                  <v-icon
+                    color="medium-emphasis"
+                    icon="mdi-chevron-right"
+                    size="small"
+                  />
+                </template>
+              </v-list-item>
+            </v-list>
+          </v-card>
+        </v-menu>
+      </div>
+      <v-tooltip location="bottom">
+        <template #activator="{ props: tooltipProps }">
+          <div
+            v-bind="tooltipProps"
+            class="focus-mode"
+            :class="{ 'focus-mode--visible': issueSinceColumnVisible }"
+          >
+            <v-badge
+              v-if="issueSinceColumnVisible"
+              class="mr-3"
+              bordered
+              color="primary-lighten-3"
+              :content="numberOfNewItemsSinceFreeze"
+              :model-value="numberOfNewItemsSinceFreeze > 0"
+            >
+              <v-switch
+                v-model="focusModeInternal"
+                density="compact"
+                color="primary-lighten-3"
+                hide-details
+              >
+                <template #label>
+                  <span class="focus-label text-body-large text-toolbar-title">
+                    Focus
+                  </span>
+                </template>
+              </v-switch>
+            </v-badge>
+          </div>
+        </template>
+        <span class="font-weight-bold">Focus Mode</span>
+        <ul class="ml-3">
+          <li>Cluster list sorting is freezed</li>
+          <li>Items in the list will still be updated</li>
+          <li>New clusters will not be added to the list until you disable focus mode</li>
+          <li>Removed items will be shown as stale (greyed out)</li>
+        </ul>
+        <template v-if="numberOfNewItemsSinceFreeze > 0">
+          <v-divider color="white" />
+          <span class="font-weight-bold">{{ numberOfNewItemsSinceFreeze }}</span>
+          new clusters were added to the list since you enabled focus mode.
+        </template>
+      </v-tooltip>
+      <div class="table-actions">
+        <v-btn
+          v-if="canCreateShoots && projectScope"
+          v-tooltip:top="'Create Cluster'"
+          icon="mdi-plus"
+          color="toolbar-title"
+          variant="text"
+          :to="{ name: 'NewShoot', params: { namespace } }"
+        />
+        <g-table-column-selection
+          activator-color="toolbar-title"
+          activator-variant="text"
+          :headers="selectableHeaders"
+          @set-selected-header="$emit('setSelectedHeader', $event)"
+          @reset="$emit('reset')"
+        />
+      </div>
+    </div>
+  </v-sheet>
+</template>
+
+<script setup>
+import {
+  computed,
+  ref,
+} from 'vue'
+
+import { buildSearchTerms } from '@/store/shoot/search'
+
+import GTableColumnSelection from '@/components/GTableColumnSelection.vue'
+import GTableSearch from '@/components/GTableSearch.vue'
+
+import { useShootListFilters } from '@/composables/useShootListFilters'
+import { tokenizeSearch } from '@/composables/useTableFilter/helper'
+
+import isEqual from 'lodash/isEqual'
+import sortBy from 'lodash/sortBy'
+
+const props = defineProps({
+  modelValue: {
+    type: String,
+    default: '',
+  },
+  namespace: {
+    type: String,
+    required: true,
+  },
+  projectScope: {
+    type: Boolean,
+    default: false,
+  },
+  canViewLandscape: {
+    type: Boolean,
+    default: false,
+  },
+  canCreateShoots: {
+    type: Boolean,
+    default: false,
+  },
+  issueSinceColumnVisible: {
+    type: Boolean,
+    default: false,
+  },
+  focusMode: {
+    type: Boolean,
+    default: false,
+  },
+  numberOfNewItemsSinceFreeze: {
+    type: Number,
+    default: 0,
+  },
+  selectableHeaders: {
+    type: Array,
+    default: () => [],
+  },
+})
+
+const emit = defineEmits([
+  'update:modelValue',
+  'update:focusMode',
+  'setSearch',
+  'setSelectedHeader',
+  'reset',
+])
+
+const operationsViewMenuOpen = ref(false)
+
+const {
+  operationsViewFilters,
+  defaultClusterView,
+} = useShootListFilters()
+
+const operationsViewSearch = computed(() => {
+  return buildSearchTerms(operationsViewFilters.value)
+})
+
+const operationsViewSearchTerms = computed(() => {
+  return sortBy(tokenizeSearch(operationsViewSearch.value))
+})
+
+const defaultClusterViewLabel = computed(() => {
+  return defaultClusterView.value === 'operations'
+    ? 'Operations View'
+    : 'All clusters'
+})
+
+const operationsView = computed(() => {
+  if (props.modelValue === '') {
+    return {
+      state: 'all',
+      isApplied: false,
+      activatorIcon: 'mdi-filter-off-outline',
+      statusLabel: 'All clusters',
+      statusIcon: 'mdi-filter-off-outline',
+      tooltip: 'Operations View — showing all clusters',
+      applyActionLabel: 'Apply Operations View',
+      applyActionDescription: 'Uses the Operations View criteria to show clusters that may need attention.',
+    }
+  }
+
+  const shootSearchTerms = sortBy(tokenizeSearch(props.modelValue))
+  if (isEqual(shootSearchTerms, operationsViewSearchTerms.value)) {
+    return {
+      state: 'active',
+      isApplied: true,
+      activatorIcon: 'mdi-filter-check-outline',
+      statusLabel: 'Active',
+      statusIcon: 'mdi-check-circle-outline',
+      statusColor: 'primary',
+      tooltip: 'Operations View is active',
+    }
+  }
+
+  const hasOperationsViewTerms = operationsViewSearchTerms.value.every(searchTerm => {
+    return shootSearchTerms.includes(searchTerm)
+  })
+  if (hasOperationsViewTerms) {
+    return {
+      state: 'refined',
+      isApplied: true,
+      activatorIcon: 'mdi-filter-plus-outline',
+      statusLabel: 'Additional filters',
+      statusIcon: 'mdi-filter-plus-outline',
+      statusColor: 'primary',
+      tooltip: 'Operations View with additional filters',
+      applyActionLabel: 'Reset to Operations View',
+      applyActionDescription: 'Removes every additional term from the current search.',
+    }
+  }
+
+  return {
+    state: 'custom',
+    isApplied: false,
+    activatorIcon: 'mdi-filter-cog-outline',
+    statusLabel: 'Custom search',
+    statusIcon: 'mdi-pencil-outline',
+    tooltip: 'Operations View — custom search',
+    applyActionLabel: 'Apply Operations View',
+    applyActionDescription: 'Replaces every term in the current search with the Operations View criteria.',
+  }
+})
+
+const focusModeInternal = computed({
+  get () {
+    return props.focusMode
+  },
+  set (value) {
+    emit('update:focusMode', value)
+  },
+})
+
+function showAllClusters () {
+  emit('setSearch', '')
+}
+
+function applyOperationsView () {
+  emit('setSearch', operationsViewSearch.value)
+}
+</script>
+
+<style lang="scss" scoped>
+.toolbar {
+  align-items: center;
+  box-sizing: border-box;
+  column-gap: 16px;
+  display: grid;
+  flex-shrink: 0;
+  grid-template-columns: minmax(0, 1fr) auto;
+  min-height: 64px;
+  padding: 0 8px 0 16px;
+}
+
+.heading {
+  align-items: center;
+  display: flex;
+  min-width: 0;
+}
+
+.heading-icon {
+  flex: 0 0 auto;
+  margin-inline-end: 16px;
+}
+
+.heading-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.controls,
+.search-context,
+.table-actions {
+  align-items: center;
+  display: flex;
+}
+
+.controls,
+.search-context {
+  min-width: 0;
+}
+
+.search-context {
+  column-gap: 8px;
+  flex: 0 1 auto;
+  margin-inline-end: 8px;
+}
+
+.search {
+  flex: 0 1 auto;
+  width: clamp(240px, 24vw, 360px);
+
+  &:focus-within,
+  &--expanded {
+    width: clamp(400px, 42vw, 700px);
+  }
+}
+
+.operations-view {
+  flex: 0 0 auto;
+  letter-spacing: normal;
+  text-transform: none;
+}
+
+.operations-view-label {
+  white-space: nowrap;
+}
+
+.operations-view-menu {
+  width: min(420px, calc(100vw - 32px));
+}
+
+.operations-view-heading {
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.operations-view-description {
+  -webkit-line-clamp: unset;
+}
+
+.focus-mode {
+  flex: 0 0 auto;
+}
+
+.focus-mode--visible {
+  margin-inline-start: 8px;
+}
+
+.focus-label {
+  white-space: nowrap;
+  word-break: normal;
+}
+
+.table-actions {
+  flex: 0 0 auto;
+}
+
+@media (max-width: 1200px) {
+  .toolbar {
+    column-gap: 4px;
+    grid-template-columns: minmax(0, 1fr) auto auto;
+    grid-template-rows: minmax(64px, auto) auto;
+  }
+
+  .heading {
+    grid-column: 1;
+    grid-row: 1;
+  }
+
+  .controls {
+    display: contents;
+  }
+
+  .search-context {
+    box-sizing: border-box;
+    grid-column: 1 / -1;
+    grid-row: 2;
+    margin: 0;
+    padding: 0 8px 12px 0;
+    width: 100%;
+  }
+
+  .search {
+    flex: 1 1 auto;
+    width: auto;
+
+    &:focus-within,
+    &--expanded {
+      width: 100%;
+    }
+  }
+
+  .focus-mode {
+    grid-column: 2;
+    grid-row: 1;
+    margin-inline-start: 0;
+  }
+
+  .table-actions {
+    grid-column: 3;
+    grid-row: 1;
+  }
+}
+
+@media (max-width: 1000px) {
+  .operations-view {
+    min-width: 40px;
+    padding-inline: 0;
+    width: 40px;
+  }
+
+  .operations-view-label,
+  .operations-view-chevron {
+    display: none;
+  }
+}
+
+@media (max-width: 600px) {
+  .toolbar {
+    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-rows: minmax(64px, auto) auto auto;
+  }
+
+  .heading {
+    grid-column: 1 / -1;
+  }
+
+  .search-context {
+    padding-inline-end: 8px;
+  }
+
+  .focus-mode {
+    grid-column: 1;
+    grid-row: 3;
+    margin-inline-start: 8px;
+  }
+
+  .table-actions {
+    grid-column: 2;
+    grid-row: 3;
+    padding-bottom: 8px;
+  }
+}
+</style>

--- a/frontend/src/components/GShootListToolbar.vue
+++ b/frontend/src/components/GShootListToolbar.vue
@@ -255,13 +255,13 @@ import {
   ref,
 } from 'vue'
 
+import { parseShootSearch } from '@/store/shoot/helper'
 import { buildSearchTerms } from '@/store/shoot/search'
 
 import GTableColumnSelection from '@/components/GTableColumnSelection.vue'
 import GTableSearch from '@/components/GTableSearch.vue'
 
 import { useShootListFilters } from '@/composables/useShootListFilters'
-import { tokenizeSearch } from '@/composables/useTableFilter/helper'
 
 import isEqual from 'lodash/isEqual'
 import sortBy from 'lodash/sortBy'
@@ -324,8 +324,12 @@ const operationsViewSearch = computed(() => {
   return buildSearchTerms(operationsViewFilters.value)
 })
 
+function canonicalSearchTerms (search) {
+  return sortBy(parseShootSearch(search).terms, ['field', 'value', 'exact', 'exclude'])
+}
+
 const operationsViewSearchTerms = computed(() => {
-  return sortBy(tokenizeSearch(operationsViewSearch.value))
+  return canonicalSearchTerms(operationsViewSearch.value)
 })
 
 const defaultClusterViewLabel = computed(() => {
@@ -335,7 +339,8 @@ const defaultClusterViewLabel = computed(() => {
 })
 
 const operationsView = computed(() => {
-  if (props.modelValue === '') {
+  const shootSearchTerms = canonicalSearchTerms(props.modelValue)
+  if (!shootSearchTerms.length) {
     return {
       state: 'all',
       isApplied: false,
@@ -348,7 +353,6 @@ const operationsView = computed(() => {
     }
   }
 
-  const shootSearchTerms = sortBy(tokenizeSearch(props.modelValue))
   if (isEqual(shootSearchTerms, operationsViewSearchTerms.value)) {
     return {
       state: 'active',
@@ -362,7 +366,7 @@ const operationsView = computed(() => {
   }
 
   const hasOperationsViewTerms = operationsViewSearchTerms.value.every(searchTerm => {
-    return shootSearchTerms.includes(searchTerm)
+    return shootSearchTerms.some(shootSearchTerm => isEqual(shootSearchTerm, searchTerm))
   })
   if (hasOperationsViewTerms) {
     return {

--- a/frontend/src/components/GTableColumnSelection.vue
+++ b/frontend/src/components/GTableColumnSelection.vue
@@ -19,6 +19,8 @@ SPDX-License-Identifier: Apache-2.0
         v-tooltip:top="'Column Selection'"
         v-bind="menuProps"
         icon="mdi-view-column"
+        :color="activatorColor"
+        :variant="activatorVariant"
       />
     </template>
     <v-card>
@@ -69,103 +71,35 @@ SPDX-License-Identifier: Apache-2.0
       </v-card-text>
     </v-card>
   </v-menu>
-  <v-menu
-    v-if="hasFilters"
-    v-model="filterSelectionMenu"
-    location="left"
-    offset="5"
-    :close-on-content-click="false"
-    absolute
-    min-width="240"
-    style="max-height: 80%"
-  >
-    <template #activator="{ props: menuProps }">
-      <v-btn
-        v-tooltip:top="'Filter Selection'"
-        v-bind="menuProps"
-        icon="mdi-filter-outline"
-      />
-    </template>
-    <v-card>
-      <v-card-text
-        v-tooltip:bottom="{
-          text: filterTooltip,
-          disabled: !filterTooltip, maxWidth: 300
-        }"
-        class="pt-1"
-      >
-        <div class="text-title-small text-medium-emphasis py-2">
-          Filter Selection
-        </div>
-        <div
-          v-for="filter in filters"
-          :key="filter.value"
-        >
-          <v-checkbox-btn
-            :model-value="filter.selected"
-            :color="checkboxColor(filter.selected)"
-            :disabled="filter.disabled"
-            density="compact"
-            class="text-body-medium"
-            @update:model-value="onToggleFilter(filter)"
-          >
-            <template #label>
-              <span class="text-body-small">
-                {{ filter.text }}
-              </span>
-            </template>
-          </v-checkbox-btn>
-          <v-tooltip
-            activator="parent"
-            :disabled="!filter.helpTooltip?.length"
-            :open-delay="200"
-            location="right"
-          >
-            <div
-              v-for="(line, index) in filter.helpTooltip"
-              :key="index"
-            >
-              {{ line }}
-            </div>
-          </v-tooltip>
-        </div>
-      </v-card-text>
-    </v-card>
-  </v-menu>
 </template>
 
 <script setup>
 import {
-  computed,
   ref,
   toRefs,
 } from 'vue'
 
 const columnSelectionMenu = ref(false)
-const filterSelectionMenu = ref(false)
 
 // props
 const props = defineProps({
+  activatorColor: {
+    type: String,
+  },
+  activatorVariant: {
+    type: String,
+  },
   headers: {
     type: Array,
   },
-  filters: {
-    type: Array,
-  },
-  filterTooltip: {
-    type: String,
-  },
 })
 
-const { headers, filters, filterTooltip } = toRefs(props)
-
-const hasFilters = computed(() => filters.value?.length > 0)
+const { headers } = toRefs(props)
 
 // emits
 const emit = defineEmits([
   'reset',
   'setSelectedHeader',
-  'toggleFilter',
 ])
 
 function onSetSelectedHeader (header) {
@@ -174,10 +108,6 @@ function onSetSelectedHeader (header) {
 
 function onReset () {
   emit('reset')
-}
-
-function onToggleFilter (filter) {
-  emit('toggleFilter', filter)
 }
 
 function checkboxColor (selected) {

--- a/frontend/src/components/GTableSearch.vue
+++ b/frontend/src/components/GTableSearch.vue
@@ -5,59 +5,63 @@ SPDX-License-Identifier: Apache-2.0
  -->
 
 <template>
-  <v-tooltip
-    location="top"
-    :open-on-focus="false"
-    :open-delay="500"
+  <div
+    class="g-table-search-field"
+    :class="{ fluid }"
   >
-    <template #activator="{ props: tooltipProps }">
-      <v-text-field
-        v-bind="tooltipProps"
-        :model-value="modelValue"
-        prepend-inner-icon="mdi-magnify"
+    <v-tooltip
+      location="top"
+      :open-on-focus="false"
+      :open-delay="500"
+    >
+      <template #activator="{ props: tooltipProps }">
+        <v-text-field
+          v-bind="tooltipProps"
+          :model-value="modelValue"
+          prepend-inner-icon="mdi-magnify"
+          color="primary"
+          label="Search"
+          single-line
+          hide-details
+          variant="solo"
+          flat
+          clearable
+          clear-icon="mdi-close"
+          density="compact"
+          @update:model-value="$emit('update:modelValue', $event)"
+          @keyup.esc="$emit('update:modelValue', '')"
+        />
+      </template>
+      Search terms are <span class="font-weight-bold">ANDed</span>.<br>
+      <span class="font-weight-bold">Use quotes</span> for exact words or phrases:
+      <v-chip
+        v-for="(example, index) in examples"
+        :key="`example-${index}`"
+        label
         color="primary"
-        label="Search"
-        single-line
-        hide-details
-        variant="solo"
-        flat
-        clearable
-        clear-icon="mdi-close"
-        density="compact"
-        class="g-table-search-field mr-3"
-        @update:model-value="$emit('update:modelValue', $event)"
-        @keyup.esc="$emit('update:modelValue', '')"
-      />
-    </template>
-    Search terms are <span class="font-weight-bold">ANDed</span>.<br>
-    <span class="font-weight-bold">Use quotes</span> for exact words or phrases:
-    <v-chip
-      v-for="(example, index) in examples"
-      :key="`example-${index}`"
-      label
-      color="primary"
-      variant="flat"
-      size="small"
-      :class="index < examples.length - 1 ? 'mr-1' : ''"
-    >
-      "{{ example }}"
-    </v-chip>
-    <br>
-    <span class="font-weight-bold">Use minus sign</span>
-    to exclude words that you don't want:
-    <v-chip
-      v-for="(example, index) in excludeExamples"
-      :key="`exclude-${index}`"
-      label
-      color="primary"
-      variant="flat"
-      size="small"
-      :class="index < excludeExamples.length - 1 ? 'mr-1' : ''"
-    >
-      -{{ example.startsWith('"') ? example : `"${example}"` }}
-    </v-chip>
-    <br>
-  </v-tooltip>
+        variant="flat"
+        size="small"
+        :class="index < examples.length - 1 ? 'mr-1' : ''"
+      >
+        "{{ example }}"
+      </v-chip>
+      <br>
+      <span class="font-weight-bold">Use minus sign</span>
+      to exclude words that you don't want:
+      <v-chip
+        v-for="(example, index) in excludeExamples"
+        :key="`exclude-${index}`"
+        label
+        color="primary"
+        variant="flat"
+        size="small"
+        :class="index < excludeExamples.length - 1 ? 'mr-1' : ''"
+      >
+        -{{ example.startsWith('"') ? example : `"${example}"` }}
+      </v-chip>
+      <br>
+    </v-tooltip>
+  </div>
 </template>
 
 <script setup>
@@ -74,7 +78,19 @@ defineProps({
     type: Array,
     default: () => ['exclude1', 'exclude2'],
   },
+  fluid: {
+    type: Boolean,
+    default: false,
+  },
 })
 
 defineEmits(['update:modelValue'])
 </script>
+
+<style scoped>
+.fluid {
+  min-width: 0;
+  max-width: none;
+  width: 100%;
+}
+</style>

--- a/frontend/src/composables/useShootListFilters.js
+++ b/frontend/src/composables/useShootListFilters.js
@@ -132,17 +132,6 @@ export const useShootListFilters = createSharedComposable(function useShootListF
     setOperationsViewFilter('allTicketsIgnored', value)
   }
 
-  const healthy = computed(() => shootListFilters.value.healthy ?? true)
-
-  function toggleShootListFilter (key) {
-    if (key === 'healthy') {
-      defaultClusterView.value = healthy.value ? 'all' : 'operations'
-      return
-    }
-
-    setOperationsViewFilter(key, !operationsViewFilters.value[key]) // eslint-disable-line security/detect-object-injection -- key is a fixed set of strings, not user input
-  }
-
   const unhealthyFilterMask = computed(() => {
     return getUnhealthyFilterMaskFromShootListFilters(shootListFilters.value)
   })
@@ -152,10 +141,10 @@ export const useShootListFilters = createSharedComposable(function useShootListF
     return getEnabledOperationsViewExclusionReasons(effective)
   })
 
-  // Retained until the existing Shoot/Seed list presentations are replaced by
-  // the Operations View controls in their dedicated follow-up tasks.
+  // Retained until the Seed list presentations are replaced in their
+  // dedicated follow-up task.
   const activeFilterLabels = computed(() => {
-    if (!healthy.value) {
+    if (!shootListFilters.value.healthy) {
       return []
     }
 
@@ -168,8 +157,6 @@ export const useShootListFilters = createSharedComposable(function useShootListF
     shootListFilters,
     operationsViewFilters: readonly(operationsViewFilters),
     defaultClusterView,
-    healthy,
-    toggleShootListFilter,
     setHideProgressing,
     setHideWithoutOperatorAction,
     setHideAllTicketsIgnored,

--- a/frontend/src/store/shoot/shoot.js
+++ b/frontend/src/store/shoot/shoot.js
@@ -522,6 +522,9 @@ const useShootStore = defineStore('shoot', () => {
     if (isEqual(state.subscription, nextSubscription) && !state.subscriptionError) {
       return
     }
+    if (state.focusMode) {
+      shootStore.setFocusMode(false)
+    }
     if (isEqual(pendingShootListSubscription?.target, nextSubscription)) {
       return pendingShootListSubscription.promise
     }

--- a/frontend/src/views/GSeedList.vue
+++ b/frontend/src/views/GSeedList.vue
@@ -20,6 +20,7 @@ SPDX-License-Identifier: Apache-2.0
         <template #append>
           <g-table-search
             v-model="searchQuery"
+            class="mr-3"
             :examples="['my-seed', 'aws eu-west-1']"
             :exclude-examples="['azure', 'us-east']"
           />

--- a/frontend/src/views/GShootList.vue
+++ b/frontend/src/views/GShootList.vue
@@ -10,79 +10,22 @@ SPDX-License-Identifier: Apache-2.0
     class="d-flex flex-column overflow-hidden max-h-100"
   >
     <v-card class="ma-3 d-flex flex-column flex-grow-1 overflow-hidden">
-      <g-toolbar
-        prepend-icon="mdi-hexagon-multiple"
-        :height="64"
-      >
-        <div class="text-title-large">
-          Kubernetes Clusters
-        </div>
-        <div class="text-body-small">
-          {{ headlineSubtitle }}
-        </div>
-        <template #append>
-          <v-tooltip location="bottom">
-            <template #activator="{ props }">
-              <div v-bind="props">
-                <v-badge
-                  v-if="issueSinceColumnVisible"
-                  class="mr-5"
-                  bordered
-                  color="primary-lighten-3"
-                  :content="numberOfNewItemsSinceFreeze"
-                  :model-value="numberOfNewItemsSinceFreeze > 0"
-                >
-                  <v-switch
-                    v-model="focusModeInternal"
-                    class="mr-3"
-                    density="compact"
-                    color="primary-lighten-3"
-                    hide-details
-                  >
-                    <template #label>
-                      <span class="text-body-large text-toolbar-title">Focus</span>
-                    </template>
-                  </v-switch>
-                </v-badge>
-              </div>
-            </template>
-            <span class="font-weight-bold">Focus Mode</span>
-            <ul class="ml-3">
-              <li>Cluster list sorting is freezed</li>
-              <li>Items in the list will still be updated</li>
-              <li>New clusters will not be added to the list until you disable focus mode</li>
-              <li>Removed items will be shown as stale (greyed out)</li>
-            </ul>
-            <template v-if="numberOfNewItemsSinceFreeze > 0">
-              <v-divider color="white" />
-              <span class="font-weight-bold">{{ numberOfNewItemsSinceFreeze }}</span>
-              new clusters were added to the list since you enabled focus mode.
-            </template>
-          </v-tooltip>
-          <g-table-search
-            v-if="shootSearch || items.length > 3"
-            :model-value="shootSearch"
-            :examples="['my-shoot', 'John Doe']"
-            :exclude-examples="['myproject', 'Jane Doe']"
-            @update:model-value="onUpdateShootSearch"
-          />
-          <v-btn
-            v-if="canCreateShoots && projectScope"
-            v-tooltip:top="'Create Cluster'"
-            icon="mdi-plus"
-            color="toolbar-title"
-            :to="{ name: 'NewShoot', params: { namespace } }"
-          />
-          <g-table-column-selection
-            :headers="selectableHeaders"
-            :filters="selectableFilters"
-            :filter-tooltip="filterTooltip"
-            @set-selected-header="setSelectedHeader"
-            @reset="resetTableSettings"
-            @toggle-filter="toggleFilter"
-          />
-        </template>
-      </g-toolbar>
+      <g-shoot-list-toolbar
+        :model-value="shootSearch"
+        :namespace="namespace"
+        :project-scope="projectScope"
+        :can-view-landscape="canViewLandscape"
+        :can-create-shoots="canCreateShoots"
+        :issue-since-column-visible="issueSinceColumnVisible"
+        :focus-mode="focusModeInternal"
+        :number-of-new-items-since-freeze="numberOfNewItemsSinceFreeze"
+        :selectable-headers="selectableHeaders"
+        @update:model-value="onUpdateShootSearch"
+        @update:focus-mode="focusModeInternal = $event"
+        @set-search="setShootSearch"
+        @set-selected-header="setSelectedHeader"
+        @reset="resetTableSettings"
+      />
       <v-data-table-virtual
         v-model:sort-by="sortByInternal"
         :headers="visibleHeaders"
@@ -144,18 +87,15 @@ import { useProjectStore } from '@/store/project'
 import { useConfigStore } from '@/store/config'
 import { useLocalStorageStore } from '@/store/localStorage'
 
-import GToolbar from '@/components/GToolbar.vue'
+import GShootListToolbar from '@/components/GShootListToolbar.vue'
 import GShootListRow from '@/components/GShootListRow.vue'
 import GShootListProgress from '@/components/GShootListProgress.vue'
-import GTableColumnSelection from '@/components/GTableColumnSelection.vue'
 import GDataTableFooter from '@/components/GDataTableFooter.vue'
 import GShootListActions from '@/components/GShootListActions.vue'
-import GTableSearch from '@/components/GTableSearch.vue'
 
 import { useProjectShootCustomFields } from '@/composables/useProjectShootCustomFields'
 import { isCustomField } from '@/composables/useProjectShootCustomFields/helper'
 import { useProvideShootAction } from '@/composables/useShootAction'
-import { useShootListFilters } from '@/composables/useShootListFilters'
 import { useShallowRouteSearchQuery } from '@/composables/useRouteSearchQuery'
 
 import { mapTableHeader } from '@/utils'
@@ -172,13 +112,11 @@ import debounce from 'lodash/debounce'
 
 export default {
   components: {
-    GToolbar,
+    GShootListToolbar,
     GShootListRow,
     GShootListProgress,
-    GTableColumnSelection,
     GDataTableFooter,
     GShootListActions,
-    GTableSearch,
   },
   inject: ['logger'],
   beforeRouteUpdate (to, from) {
@@ -240,13 +178,6 @@ export default {
       setDebouncedShootSearch()
     }
 
-    const {
-      activeFilterLabels,
-      shootListFilters,
-      healthy,
-      toggleShootListFilter,
-    } = useShootListFilters()
-
     return {
       activePopoverKey,
       expandedWorkerGroups,
@@ -256,10 +187,6 @@ export default {
       debouncedShootSearch,
       setShootSearch,
       onUpdateShootSearch,
-      activeFilterLabels,
-      shootListFilters,
-      healthy,
-      toggleShootListFilter,
     }
   },
   data () {
@@ -281,6 +208,9 @@ export default {
       accessRestrictionConfig: 'accessRestriction',
       ticketConfig: 'ticket',
     }),
+    gitHubRepoUrl () {
+      return get(this.ticketConfig, ['gitHubRepoUrl'])
+    },
     ...mapState(useProjectStore, [
       'projectName',
     ]),
@@ -567,92 +497,11 @@ export default {
       }
       return value
     },
-    allFilters () {
-      return [
-        {
-          text: 'Hide healthy clusters',
-          value: 'healthy',
-          selected: this.healthy,
-          hidden: this.projectScope,
-          disabled: this.changeFiltersDisabled,
-        },
-        {
-          text: 'Hide progressing clusters',
-          value: 'progressing',
-          selected: this.isFilterActive('progressing'),
-          hidden: this.projectScope || !this.canViewLandscape || this.showAllShoots,
-          disabled: this.changeFiltersDisabled,
-        },
-        {
-          text: 'Hide clusters without operator action needed',
-          value: 'operatorAction',
-          selected: this.isFilterActive('operatorAction'),
-          hidden: this.projectScope || !this.canViewLandscape || this.showAllShoots,
-          helpTooltip: [
-            'Hide clusters that do not require action by an operator',
-            '- Clusters with user issues',
-            '- Clusters with temporary issues that will be retried automatically',
-            '- Clusters with annotation dashboard.gardener.cloud/ignore-issues',
-          ],
-          disabled: this.changeFiltersDisabled,
-        },
-        {
-          text: 'Hide clusters with ignored ticket labels',
-          value: 'allTicketsIgnored',
-          selected: this.isFilterActive('allTicketsIgnored'),
-          hidden: this.projectScope || !this.canViewLandscape || !this.gitHubRepoUrl || !this.hideClustersWithLabels.length || this.showAllShoots,
-          helpTooltip: this.ignoredTicketsTooltip,
-          disabled: this.changeFiltersDisabled,
-        },
-      ]
-    },
-    selectableFilters () {
-      return filter(this.allFilters, ['hidden', false])
-    },
-    ignoredTicketsTooltip () {
-      const labels = this.hideClustersWithLabels.map(label => `- ${label}`)
-      return ['Labels', ...labels]
-    },
     projectScope () {
       return this.namespace !== '_all'
     },
-    hideHealthyShoots: {
-      get () {
-        return this.healthy
-      },
-      set (value) {
-        this.toggleFilter('healthy')
-      },
-    },
     items () {
       return this.shootList ?? []
-    },
-    changeFiltersDisabled () {
-      return this.focusModeInternal
-    },
-    showAllShoots () {
-      return !this.hideHealthyShoots
-    },
-    filterTooltip () {
-      return this.focusModeInternal
-        ? 'Filters cannot be changed when focus mode is active'
-        : ''
-    },
-    headlineSubtitle () {
-      if (this.projectScope || !this.hideHealthyShoots) {
-        return ''
-      }
-      const all = ['Healthy', ...this.activeFilterLabels]
-      const shown = all.slice(0, 2).join(', ')
-      const remaining = all.length - 2
-      const suffix = remaining > 0 ? ` & ${remaining} more` : ''
-      return `Excluding Clusters: ${shown}${suffix}`
-    },
-    gitHubRepoUrl () {
-      return get(this.ticketConfig, ['gitHubRepoUrl'])
-    },
-    hideClustersWithLabels () {
-      return get(this.ticketConfig, ['hideClustersWithLabels'], [])
     },
     filteredItems () {
       const query = this.debouncedShootSearch
@@ -689,7 +538,6 @@ export default {
   },
   methods: {
     ...mapActions(useShootStore, [
-      'subscribeShoots',
       'sortItems',
       'searchItems',
       'setFocusMode',
@@ -730,16 +578,6 @@ export default {
       }
 
       this.sortByInternal = this.defaultSortBy
-    },
-    toggleFilter ({ value: key }) {
-      this.toggleShootListFilter(key)
-      if (key === 'healthy') {
-        this.subscribeShoots()
-      }
-    },
-    isFilterActive (key) {
-      const filters = this.shootListFilters
-      return get(filters, [key], false)
     },
     resetState (reactiveObject, defaultState) {
       for (const key in reactiveObject) {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area quality
  /area usability
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto


"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|cost|dev-productivity|documentation|high-availability|logging|monitoring|networking|open-source|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:

Makes the Operations View visible and controllable from the Shoot list toolbar. Users can identify the current operations view state and intentionally restore it or show all clusters without changing saved configuration.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The all projects Shoot list toolbar now shows the active Operations View state and provides controls to restore it or show all clusters.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dedicated Kubernetes Clusters toolbar with search, focus mode, Operations View controls, cluster creation, and column selection.
  - Added responsive layouts for desktop, tablet, and mobile screens.
  - Search fields can expand to full width when needed.
  - Column-selection controls support customizable button styling.

- **Improvements**
  - Simplified cluster-list filtering and updated active filter labels.
  - Improved preservation and handling of search, route, project-scope, and Operations View settings.
  - Focus mode now exits automatically when switching to a different cluster-list subscription.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->