### PR TITLE
[operations-view 7/7] feat(frontend): link seeds to filtered shoot lists

### DIFF
--- a/frontend/__tests__/components/GSeedCapacityIndicator.spec.js
+++ b/frontend/__tests__/components/GSeedCapacityIndicator.spec.js
@@ -48,6 +48,22 @@ describe('components', () => {
       expect(wrapper.find('.capacity-summary').text()).toContain('224 remaining')
     })
 
+    it('should render an accessible router link when a target is provided', () => {
+      const wrapper = mountComponent({
+        to: {
+          name: 'ShootList',
+          query: {
+            q: 'seed:"infra1-seed"',
+          },
+        },
+        shootCount: 26,
+        allocatableShoots: 250,
+      })
+
+      expect(wrapper.find('a.router-link-stub').exists()).toBe(true)
+      expect(wrapper.attributes('aria-label')).toContain('View assigned shoots for this seed')
+    })
+
     it('should explain when allocatable capacity is unknown', () => {
       const wrapper = mountComponent({ shootCount: 26 })
 

--- a/frontend/__tests__/components/GSeedInfrastructureCard.spec.js
+++ b/frontend/__tests__/components/GSeedInfrastructureCard.spec.js
@@ -82,12 +82,12 @@ describe('components', () => {
               template: '<div class="g-vendor-stub" />',
             },
             GShootHealthDonut: {
-              props: ['shootCount', 'totalUnhealthyShoots', 'matchingUnhealthyShoots'],
-              template: '<div class="shoot-health-donut-stub" :data-shoot-count="shootCount" :data-unhealthy-total="totalUnhealthyShoots" :data-unhealthy-matching="matchingUnhealthyShoots" />',
+              props: ['shootCount', 'totalUnhealthyShoots', 'matchingUnhealthyShoots', 'to'],
+              template: '<div class="shoot-health-donut-stub" :data-shoot-count="shootCount" :data-unhealthy-total="totalUnhealthyShoots" :data-unhealthy-matching="matchingUnhealthyShoots" :data-to-query="to.query.q" />',
             },
             GSeedCapacityIndicator: {
-              props: ['allocatableShoots', 'shootCount'],
-              template: '<div class="seed-capacity-indicator-stub" :data-allocatable-shoots="allocatableShoots" :data-shoot-count="shootCount" />',
+              props: ['allocatableShoots', 'shootCount', 'to'],
+              template: '<div class="seed-capacity-indicator-stub" :data-allocatable-shoots="allocatableShoots" :data-shoot-count="shootCount" :data-to-query="to.query.q" />',
             },
           },
         },
@@ -117,10 +117,12 @@ describe('components', () => {
       expect(capacityIndicator.exists()).toBe(true)
       expect(capacityIndicator.attributes('data-allocatable-shoots')).toBe('20')
       expect(capacityIndicator.attributes('data-shoot-count')).toBe('7')
+      expect(capacityIndicator.attributes('data-to-query')).toBe('seed:"infra1-seed"')
       expect(healthDonut.exists()).toBe(true)
       expect(healthDonut.attributes('data-shoot-count')).toBe('7')
       expect(healthDonut.attributes('data-unhealthy-total')).toBe('4')
       expect(healthDonut.attributes('data-unhealthy-matching')).toBe('2')
+      expect(healthDonut.attributes('data-to-query')).toBe('seed:"infra1-seed" health:unhealthy')
       expect(wrapper.text()).not.toContain('total unhealthy')
       expect(subscribeSpy).toHaveBeenCalledWith({
         name: 'infra1-seed',

--- a/frontend/__tests__/components/GShootHealthDonut.spec.js
+++ b/frontend/__tests__/components/GShootHealthDonut.spec.js
@@ -23,8 +23,12 @@ describe('components', () => {
             GDetailTooltip: {
               template: '<div><slot /><slot name="footer" /></div>',
             },
-            'v-card': {
-              template: '<div><slot /></div>',
+            RouterLink: {
+              props: ['to'],
+              template: '<a class="router-link-stub"><slot /></a>',
+            },
+            'v-chip': {
+              template: '<span><slot /></span>',
             },
             'v-icon': true,
           },
@@ -34,7 +38,7 @@ describe('components', () => {
 
     function findRow (wrapper, label) {
       return wrapper.findAll('.health-row').find(item => {
-        return item.find('span').text() === label
+        return item.find('.health-label-text').text() === label
       })
     }
 
@@ -55,6 +59,24 @@ describe('components', () => {
     })
 
     describe('donut rendering', () => {
+      it('should render as a router link when a target is provided', () => {
+        const wrapper = mountComponent({
+          to: {
+            name: 'ShootList',
+            query: {
+              q: 'seed:"infra1-seed" health:unhealthy',
+            },
+          },
+          shootCount: 10,
+          totalUnhealthyShoots: 3,
+          matchingUnhealthyShoots: 1,
+        })
+
+        expect(wrapper.find('a.router-link-stub').exists()).toBe(true)
+        expect(wrapper.find('svg').exists()).toBe(true)
+        expect(wrapper.attributes('aria-label')).toContain('View unhealthy shoots for this seed')
+      })
+
       it('should render an SVG when there are shoots', () => {
         const wrapper = mountComponent({
           shootCount: 10,
@@ -212,7 +234,7 @@ describe('components', () => {
         expect(unhealthy).toBeDefined()
         expect(unhealthy.find('strong').text()).toBe('5')
 
-        const excluded = findRow(wrapper, 'Unhealthy filtered out')
+        const excluded = findRow(wrapper, 'Other unhealthy')
         expect(excluded).toBeUndefined()
       })
 
@@ -221,29 +243,38 @@ describe('components', () => {
           shootCount: 10,
           totalUnhealthyShoots: 5,
           matchingUnhealthyShoots: 2,
-          activeFilterLabels: ['User Errors', 'Progressing'],
+          activeFilterReasons: ['do not require operator action', 'are progressing'],
         })
 
-        const unhealthy = findRow(wrapper, 'Unhealthy shown')
+        const unhealthy = findRow(wrapper, 'Unhealthy')
         expect(unhealthy.find('strong').text()).toBe('2')
+        expect(unhealthy.find('.operations-view-chip').text()).toBe('Operations View')
 
-        const excluded = findRow(wrapper, 'Unhealthy filtered out')
+        const excluded = findRow(wrapper, 'Other unhealthy')
         expect(excluded).toBeDefined()
         expect(excluded.find('strong').text()).toBe('3')
-        expect(wrapper.find('.filter-summary').text()).toContain('User Errors, Progressing')
+        expect(wrapper.find('.exclusion-description').text()).toBe(
+          'Not shown in Operations View because they do not require operator action or are progressing.',
+        )
       })
 
-      it('should truncate filter labels after 2 with "& N more"', () => {
+      it('should explain all configured exclusion reasons', () => {
         const wrapper = mountComponent({
           shootCount: 20,
           totalUnhealthyShoots: 10,
           matchingUnhealthyShoots: 4,
-          activeFilterLabels: ['Progressing', 'User Errors', 'Deactivated Reconciliation', 'Ignored Ticket Labels'],
+          activeFilterReasons: [
+            'are progressing',
+            'do not require operator action',
+            'have only ignored tickets',
+          ],
         })
 
-        const excluded = findRow(wrapper, 'Unhealthy filtered out')
+        const excluded = findRow(wrapper, 'Other unhealthy')
         expect(excluded.find('strong').text()).toBe('6')
-        expect(wrapper.find('.filter-summary').text()).toContain('Progressing, User Errors & 2 more')
+        expect(wrapper.find('.exclusion-description').text()).toBe(
+          'Not shown in Operations View because they are progressing, do not require operator action, or have only ignored tickets.',
+        )
       })
 
       it('should not show excluded row when no filter labels provided', () => {
@@ -253,7 +284,7 @@ describe('components', () => {
           matchingUnhealthyShoots: 2,
         })
 
-        const excluded = findRow(wrapper, 'Unhealthy filtered out')
+        const excluded = findRow(wrapper, 'Other unhealthy')
         expect(excluded).toBeUndefined()
       })
 
@@ -262,13 +293,15 @@ describe('components', () => {
           shootCount: 10,
           totalUnhealthyShoots: 5,
           matchingUnhealthyShoots: 5,
-          activeFilterLabels: ['Progressing'],
+          activeFilterReasons: ['are progressing'],
         })
 
-        const excluded = findRow(wrapper, 'Unhealthy filtered out')
+        const excluded = findRow(wrapper, 'Other unhealthy')
         expect(excluded).toBeDefined()
         expect(excluded.find('strong').text()).toBe('0')
-        expect(wrapper.find('.filter-summary').text()).toContain('Progressing')
+        expect(wrapper.find('.exclusion-description').text()).toBe(
+          'Not shown in Operations View because they are progressing.',
+        )
       })
 
       it('should show healthy legend when there are healthy shoots', () => {
@@ -290,7 +323,7 @@ describe('components', () => {
           shootCount: 10,
           totalUnhealthyShoots: 3,
           matchingUnhealthyShoots: 1,
-          activeFilterLabels: ['User Errors'],
+          activeFilterReasons: ['do not require operator action'],
         })
 
         const label = wrapper.attributes('aria-label')
@@ -298,10 +331,33 @@ describe('components', () => {
         expect(label).toBe([
           'Shoot health distribution',
           '10 shoots',
-          '1 unhealthy shoot',
-          '2 unhealthy shoots excluded by Cluster Operations filters (User Errors)',
+          '1 unhealthy shoot in Operations View',
+          '2 unhealthy shoots outside Operations View because they do not require operator action',
           '7 healthy shoots.',
         ].join(', '))
+      })
+
+      it('should pluralize each shoot count correctly', () => {
+        const wrapper = mountComponent({
+          shootCount: 1,
+          totalUnhealthyShoots: 0,
+          matchingUnhealthyShoots: 0,
+        })
+
+        expect(wrapper.attributes('aria-label')).toBe(
+          'Shoot health distribution, 1 shoot, 0 unhealthy shoots, 1 healthy shoot.',
+        )
+      })
+
+      it('should describe the link purpose in the empty state', () => {
+        const wrapper = mountComponent({
+          to: { name: 'ShootList' },
+          shootCount: 0,
+        })
+
+        expect(wrapper.attributes('aria-label')).toBe(
+          'View unhealthy shoots for this seed; no shoots are assigned.',
+        )
       })
     })
 

--- a/frontend/__tests__/composables/useSeedShootListNavigation.spec.js
+++ b/frontend/__tests__/composables/useSeedShootListNavigation.spec.js
@@ -1,0 +1,83 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import {
+  createMemoryHistory,
+  createRouter,
+} from 'vue-router'
+
+import { createSeedShootListRoute } from '@/composables/useSeedShootListNavigation'
+
+describe('composables', () => {
+  describe('useSeedShootListNavigation', () => {
+    it('should create an assigned-shoots route with only the seed filter', () => {
+      expect(createSeedShootListRoute('infra1-seed')).toEqual({
+        name: 'ShootList',
+        params: {
+          namespace: '_all',
+        },
+        query: {
+          q: 'seed:"infra1-seed"',
+        },
+      })
+    })
+
+    it('should not apply inactive refinements to an unhealthy-shoots route', () => {
+      const shootListFilters = {
+        healthy: false,
+        progressing: true,
+        operatorAction: true,
+        allTicketsIgnored: false,
+      }
+
+      expect(createSeedShootListRoute('infra1-seed', shootListFilters)).toEqual({
+        name: 'ShootList',
+        params: {
+          namespace: '_all',
+        },
+        query: {
+          q: 'seed:"infra1-seed" health:unhealthy',
+        },
+      })
+    })
+
+    it('should include all enabled unhealthy sub-filters', () => {
+      const shootListFilters = {
+        healthy: true,
+        progressing: true,
+        operatorAction: true,
+        allTicketsIgnored: true,
+      }
+
+      expect(createSeedShootListRoute('infra1-seed', shootListFilters).query.q).toBe(
+        'seed:"infra1-seed" health:unhealthy progressing:false operatorAction:true allTicketsIgnored:false',
+      )
+    })
+
+    it('should survive Vue Router encoding and decode to the intended search', () => {
+      const router = createRouter({
+        history: createMemoryHistory(),
+        routes: [{
+          name: 'ShootList',
+          path: '/namespace/:namespace/shoots',
+          component: {},
+        }],
+      })
+      const route = createSeedShootListRoute('aws-ha', {
+        healthy: true,
+        progressing: true,
+        operatorAction: true,
+        allTicketsIgnored: true,
+      })
+
+      const href = router.resolve(route).href
+      const searchParams = new URLSearchParams(href.split('?')[1])
+
+      expect(href).toBe('/namespace/_all/shoots?q=seed:%22aws-ha%22+health:unhealthy+progressing:false+operatorAction:true+allTicketsIgnored:false')
+      expect(searchParams.get('q')).toBe('seed:"aws-ha" health:unhealthy progressing:false operatorAction:true allTicketsIgnored:false')
+    })
+  })
+})

--- a/frontend/__tests__/composables/useShootListFilters.spec.js
+++ b/frontend/__tests__/composables/useShootListFilters.spec.js
@@ -222,28 +222,6 @@ describe('composables', () => {
       expect(localStorageStore.allProjectsShootFilter.progressing).toBe(true)
     })
 
-    it('should keep the existing Seed filter label consumer working', async () => {
-      await grantLandscapeAccess()
-
-      const { activeFilterLabels } = useShootListFilters()
-
-      expect(activeFilterLabels.value).toEqual([
-        'Progressing',
-        'User Errors',
-        'Ignored Ticket Labels',
-      ])
-
-      localStorageStore.allProjectsShootFilter = {
-        progressing: true,
-        operatorAction: false,
-        allTicketsIgnored: true,
-      }
-      expect(activeFilterLabels.value).toEqual([
-        'Progressing',
-        'Ignored Ticket Labels',
-      ])
-    })
-
     it('should default non-landscape users to all clusters', () => {
       const {
         defaultClusterView,

--- a/frontend/src/components/GSeedListRow.vue
+++ b/frontend/src/components/GSeedListRow.vue
@@ -36,6 +36,7 @@ SPDX-License-Identifier: Apache-2.0
         <g-seed-capacity-indicator
           :allocatable-shoots="seedAllocatableShoots"
           :shoot-count="seedShootCount"
+          :to="assignedShootsRoute"
         />
       </template>
       <template v-else-if="header.key === 'unhealthyShoots'">
@@ -44,7 +45,8 @@ SPDX-License-Identifier: Apache-2.0
             :shoot-count="seedShootCount"
             :total-unhealthy-shoots="seedTotalUnhealthyShoots"
             :matching-unhealthy-shoots="seedUnhealthyShoots"
-            :active-filter-labels="activeFilterLabels"
+            :active-filter-reasons="activeFilterReasons"
+            :to="unhealthyShootsRoute"
           />
         </div>
       </template>
@@ -129,7 +131,7 @@ import GScrollContainer from '@/components/GScrollContainer'
 
 import { useProvideManagedSeedShoot } from '@/composables/useManagedSeedShootForSeed'
 import { useProvideSeedItem } from '@/composables/useSeedItem/index'
-import { useShootListFilters } from '@/composables/useShootListFilters'
+import { useSeedShootListNavigation } from '@/composables/useSeedShootListNavigation'
 
 const props = defineProps({
   modelValue: {
@@ -166,7 +168,11 @@ const {
   managedSeedShootName,
 } = useProvideManagedSeedShoot(seedName)
 
-const { activeFilterLabels } = useShootListFilters()
+const {
+  activeFilterReasons,
+  assignedShootsRoute,
+  unhealthyShootsRoute,
+} = useSeedShootListNavigation(seedName)
 
 const seedItemLink = computed(() => ({
   name: 'SeedItem',

--- a/frontend/src/components/GShootHealthDonut.vue
+++ b/frontend/src/components/GShootHealthDonut.vue
@@ -5,11 +5,13 @@ SPDX-License-Identifier: Apache-2.0
 -->
 
 <template>
-  <div
+  <component
+    :is="to ? RouterLink : 'div'"
+    :to="to"
     class="activator d-inline-flex align-center justify-center"
     :style="{ minWidth: `${donut.size}px`, minHeight: `${donut.size}px` }"
     tabindex="0"
-    role="img"
+    :role="to ? undefined : 'img'"
     :aria-label="ariaLabel"
   >
     <span
@@ -82,7 +84,18 @@ SPDX-License-Identifier: Apache-2.0
             icon="mdi-alert-circle-outline"
             size="small"
           />
-          <span>{{ hasActiveFilters ? 'Unhealthy shown' : 'Unhealthy' }}</span>
+          <div class="health-label">
+            <span class="health-label-text">Unhealthy</span>
+            <v-chip
+              v-if="hasActiveFilters"
+              class="operations-view-chip"
+              label
+              size="x-small"
+              variant="tonal"
+            >
+              Operations View
+            </v-chip>
+          </div>
           <strong>{{ matchingUnhealthy }}</strong>
         </div>
         <div
@@ -94,8 +107,14 @@ SPDX-License-Identifier: Apache-2.0
             icon="mdi-filter-minus-outline"
             size="small"
           />
-          <span>Unhealthy filtered out</span>
+          <span class="health-label-text">Other unhealthy</span>
           <strong>{{ hiddenUnhealthy }}</strong>
+        </div>
+        <div
+          v-if="hasActiveFilters"
+          class="exclusion-description text-medium-emphasis"
+        >
+          {{ exclusionDescription }}
         </div>
         <div class="health-row">
           <v-icon
@@ -103,21 +122,12 @@ SPDX-License-Identifier: Apache-2.0
             icon="mdi-check-circle-outline"
             size="small"
           />
-          <span>Healthy</span>
+          <span class="health-label-text">Healthy</span>
           <strong>{{ healthyShoots }}</strong>
         </div>
       </template>
-      <template
-        v-if="hasActiveFilters"
-        #footer
-      >
-        <div class="filter-summary">
-          <span>Cluster Operations excludes</span>
-          <span>{{ filterDescription }}</span>
-        </div>
-      </template>
     </g-detail-tooltip>
-  </div>
+  </component>
 </template>
 
 <script setup>
@@ -125,6 +135,7 @@ import {
   computed,
   toRefs,
 } from 'vue'
+import { RouterLink } from 'vue-router'
 import { useTheme } from 'vuetify'
 
 import GDetailTooltip from '@/components/GDetailTooltip.vue'
@@ -132,6 +143,9 @@ import GDetailTooltip from '@/components/GDetailTooltip.vue'
 import { useDonutChart } from '@/composables/useDonutChart'
 
 const props = defineProps({
+  to: {
+    type: [String, Object],
+  },
   shootCount: {
     type: Number,
     default: 0,
@@ -148,7 +162,7 @@ const props = defineProps({
     default: 0,
     validator: v => Number.isInteger(v) && v >= 0,
   },
-  activeFilterLabels: {
+  activeFilterReasons: {
     type: Array,
     default: () => [],
   },
@@ -158,27 +172,32 @@ const {
   shootCount,
   totalUnhealthyShoots: totalUnhealthy,
   matchingUnhealthyShoots: matchingUnhealthy,
-  activeFilterLabels,
+  activeFilterReasons,
 } = toRefs(props)
 
 const hiddenUnhealthy = computed(() => totalUnhealthy.value - matchingUnhealthy.value)
 const healthyShoots = computed(() => shootCount.value - totalUnhealthy.value)
-const hasActiveFilters = computed(() => activeFilterLabels.value.length > 0)
+const hasActiveFilters = computed(() => activeFilterReasons.value.length > 0)
 
 const theme = useTheme()
 const isDark = computed(() => theme.current.value.dark)
 const errorColor = computed(() => isDark.value ? 'error-lighten-2' : 'error')
 const warningColor = computed(() => isDark.value ? 'warning-lighten-2' : 'warning')
 
-const filterDescription = computed(() => {
-  const labels = activeFilterLabels.value
-  if (!labels.length) {
-    return undefined
+function formatList (values) {
+  if (values.length < 2) {
+    return values[0] ?? ''
   }
-  const shown = labels.slice(0, 2).join(', ')
-  const remaining = labels.length - 2
-  const suffix = remaining > 0 ? ` & ${remaining} more` : ''
-  return `${shown}${suffix}`
+
+  if (values.length === 2) {
+    return values.join(' or ')
+  }
+
+  return `${values.slice(0, -1).join(', ')}, or ${values.at(-1)}`
+}
+
+const exclusionDescription = computed(() => {
+  return `Not shown in Operations View because they ${formatList(activeFilterReasons.value)}.`
 })
 
 // --- donut chart (two layers sharing the same total) ---
@@ -247,18 +266,19 @@ function formatShootCount (count, qualifier) {
 
 const ariaLabel = computed(() => {
   if (shootCount.value === 0) {
-    return 'No shoots assigned to this seed.'
+    return props.to
+      ? 'View unhealthy shoots for this seed; no shoots are assigned.'
+      : 'No shoots assigned to this seed.'
   }
   const parts = [
-    'Shoot health distribution',
+    props.to ? 'View unhealthy shoots for this seed' : 'Shoot health distribution',
     formatShootCount(shootCount.value),
-    formatShootCount(matchingUnhealthy.value, 'unhealthy'),
+    hasActiveFilters.value
+      ? `${formatShootCount(matchingUnhealthy.value, 'unhealthy')} in Operations View`
+      : formatShootCount(matchingUnhealthy.value, 'unhealthy'),
   ]
-  if (activeFilterLabels.value.length > 0) {
-    const desc = filterDescription.value
-      ? ` (${filterDescription.value})`
-      : ''
-    parts.push(`${formatShootCount(hiddenUnhealthy.value, 'unhealthy')} excluded by Cluster Operations filters${desc}`)
+  if (hasActiveFilters.value) {
+    parts.push(`${formatShootCount(hiddenUnhealthy.value, 'unhealthy')} outside Operations View because they ${formatList(activeFilterReasons.value)}`)
   }
   parts.push(formatShootCount(healthyShoots.value, 'healthy'))
   return parts.join(', ') + '.'
@@ -283,9 +303,22 @@ const ariaLabel = computed(() => {
     }
   }
 
-  .filter-summary {
-    display: grid;
-    gap: 2px;
+  .health-label {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .operations-view-chip {
+    pointer-events: none;
+  }
+
+  .exclusion-description {
+    margin-top: -4px;
+    margin-left: 30px;
+    font-size: 0.75rem;
+    line-height: 1.4;
   }
 
   .center-text {

--- a/frontend/src/components/SeedDetails/GSeedInfrastructureCard.vue
+++ b/frontend/src/components/SeedDetails/GSeedInfrastructureCard.vue
@@ -47,6 +47,7 @@ SPDX-License-Identifier: Apache-2.0
           <g-seed-capacity-indicator
             :allocatable-shoots="seedAllocatableShoots"
             :shoot-count="seedShootCount"
+            :to="assignedShootsRoute"
           />
         </g-list-item-content>
       </g-list-item>
@@ -56,7 +57,8 @@ SPDX-License-Identifier: Apache-2.0
             :shoot-count="seedShootCount"
             :total-unhealthy-shoots="seedTotalUnhealthyShoots"
             :matching-unhealthy-shoots="seedUnhealthyShoots"
-            :active-filter-labels="activeFilterLabels"
+            :active-filter-reasons="activeFilterReasons"
+            :to="unhealthyShootsRoute"
           />
         </g-list-item-content>
       </g-list-item>
@@ -114,7 +116,7 @@ import GShootHealthDonut from '@/components/GShootHealthDonut.vue'
 import GVendor from '@/components/GVendor.vue'
 
 import { useSeedItem } from '@/composables/useSeedItem/index'
-import { useShootListFilters } from '@/composables/useShootListFilters'
+import { useSeedShootListNavigation } from '@/composables/useSeedShootListNavigation'
 
 const seedStatStore = useSeedStatStore()
 
@@ -135,7 +137,11 @@ const {
   seedName,
 } = useSeedItem()
 
-const { activeFilterLabels } = useShootListFilters()
+const {
+  activeFilterReasons,
+  assignedShootsRoute,
+  unhealthyShootsRoute,
+} = useSeedShootListNavigation(seedName)
 
 const seedNetworksBlockCIDRsText = computed(() => {
   return seedNetworksBlockCIDRs.value?.join(', ') ?? ''

--- a/frontend/src/components/Seeds/GSeedCapacityIndicator.vue
+++ b/frontend/src/components/Seeds/GSeedCapacityIndicator.vue
@@ -5,7 +5,9 @@ SPDX-License-Identifier: Apache-2.0
 -->
 
 <template>
-  <div
+  <component
+    :is="to ? RouterLink : 'div'"
+    :to="to"
     class="activator"
     tabindex="0"
     :aria-label="ariaLabel"
@@ -65,16 +67,20 @@ SPDX-License-Identifier: Apache-2.0
         This seed does not report its allocatable shoot capacity.
       </template>
     </g-detail-tooltip>
-  </div>
+  </component>
 </template>
 
 <script setup>
 import { computed } from 'vue'
+import { RouterLink } from 'vue-router'
 import { useTheme } from 'vuetify'
 
 import GDetailTooltip from '@/components/GDetailTooltip.vue'
 
 const props = defineProps({
+  to: {
+    type: [String, Object],
+  },
   allocatableShoots: {
     type: Number,
   },
@@ -128,11 +134,15 @@ const remainingCapacity = computed(() => {
 })
 
 const ariaLabel = computed(() => {
+  const linkPurpose = props.to
+    ? 'View assigned shoots for this seed; '
+    : ''
+
   if (!hasKnownCapacity.value) {
-    return `Seed capacity: ${props.shootCount} assigned shoots, allocatable capacity unknown`
+    return `${linkPurpose}Seed capacity: ${props.shootCount} assigned shoots, allocatable capacity unknown`
   }
   const percent = Math.round(capacityUsagePercent.value)
-  return `Seed capacity: ${props.shootCount} of ${props.allocatableShoots} allocatable shoots assigned (${percent}%)`
+  return `${linkPurpose}Seed capacity: ${props.shootCount} of ${props.allocatableShoots} allocatable shoots assigned (${percent}%)`
 })
 </script>
 

--- a/frontend/src/composables/useSeedShootListNavigation.js
+++ b/frontend/src/composables/useSeedShootListNavigation.js
@@ -1,0 +1,56 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import { computed } from 'vue'
+
+import {
+  buildSearchTerms,
+  resolveShootListFiltersForDonut,
+} from '@/store/shoot/search'
+
+import { useShootListFilters } from '@/composables/useShootListFilters'
+
+export function createSeedShootListRoute (seedName, shootListFilters) {
+  const terms = [`seed:"${seedName}"`]
+
+  if (shootListFilters) {
+    const filters = resolveShootListFiltersForDonut(shootListFilters)
+    terms.push(buildSearchTerms(filters))
+  }
+
+  const search = terms.filter(Boolean).join(' ')
+
+  return {
+    name: 'ShootList',
+    params: {
+      namespace: '_all',
+    },
+    query: {
+      q: search,
+    },
+  }
+}
+
+export function useSeedShootListNavigation (seedName) {
+  const {
+    activeFilterReasons,
+    shootListFilters,
+  } = useShootListFilters()
+
+  const assignedShootsRoute = computed(() => {
+    return createSeedShootListRoute(seedName.value)
+  })
+
+  const unhealthyShootsRoute = computed(() => {
+    return createSeedShootListRoute(seedName.value, shootListFilters.value)
+  })
+
+  return {
+    activeFilterReasons,
+    assignedShootsRoute,
+    unhealthyShootsRoute,
+  }
+}

--- a/frontend/src/composables/useShootListFilters.js
+++ b/frontend/src/composables/useShootListFilters.js
@@ -18,9 +18,9 @@ import { resolveShootListFiltersForDonut } from '@/store/shoot/search'
 import pick from 'lodash/pick'
 
 const OPERATIONS_VIEW_EXCLUSION_CRITERIA = [
-  { key: 'progressing', exclusionReason: 'are progressing', label: 'Progressing' },
-  { key: 'operatorAction', exclusionReason: 'do not require operator action', label: 'User Errors' },
-  { key: 'allTicketsIgnored', exclusionReason: 'have only ignored tickets', label: 'Ignored Ticket Labels' },
+  { key: 'progressing', exclusionReason: 'are progressing' },
+  { key: 'operatorAction', exclusionReason: 'do not require operator action' },
+  { key: 'allTicketsIgnored', exclusionReason: 'have only ignored tickets' },
 ]
 
 const FILTER_KEYS = [
@@ -141,18 +141,6 @@ export const useShootListFilters = createSharedComposable(function useShootListF
     return getEnabledOperationsViewExclusionReasons(effective)
   })
 
-  // Retained until the Seed list presentations are replaced in their
-  // dedicated follow-up task.
-  const activeFilterLabels = computed(() => {
-    if (!shootListFilters.value.healthy) {
-      return []
-    }
-
-    return OPERATIONS_VIEW_EXCLUSION_CRITERIA
-      .filter(({ key }) => shootListFilters.value[key]) // eslint-disable-line security/detect-object-injection -- key is a fixed set of strings, not user input
-      .map(({ label }) => label)
-  })
-
   return {
     shootListFilters,
     operationsViewFilters: readonly(operationsViewFilters),
@@ -162,6 +150,5 @@ export const useShootListFilters = createSharedComposable(function useShootListF
     setHideAllTicketsIgnored,
     unhealthyFilterMask,
     activeFilterReasons,
-    activeFilterLabels,
   }
 })

--- a/frontend/src/views/GSeedList.vue
+++ b/frontend/src/views/GSeedList.vue
@@ -192,7 +192,7 @@ const allHeaders = computed(() => [
     },
   },
   {
-    title: 'SHOOT HEALTH',
+    title: 'UNHEALTHY SHOOTS',
     key: 'unhealthyShoots',
     sortable: true,
     align: 'center',


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area usability
/kind enhancement

**What this PR does / why we need it**:

Turns Seed capacity and health summaries into deterministic drill-downs. Generated links encode the complete Shoot-list query, so recipients see the intended assigned or unhealthy subset independently of local defaults.

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:


**Release note**:
```feature user
Seed capacity indicators and health donuts link to the corresponding filtered Shoot list.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Seed capacity indicators now link directly to assigned shoots.
  - Shoot health indicators now link to unhealthy shoots with relevant filters applied.
  - Added clearer Operations View exclusion explanations and accessibility labels.
  - Navigation preserves seed context and supports filtered, encoded routes.

- **UI Updates**
  - Renamed the seed table column to **Unhealthy Shoots**.
  - Improved health indicator tooltips and empty-state link descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->