### PR TITLE
docs: update description for EveryNodeReady condition to clarify node health criteria

### DIFF
--- a/frontend/src/store/config.js
+++ b/frontend/src/store/config.js
@@ -55,7 +55,7 @@ const wellKnownConditions = {
   EveryNodeReady: {
     name: 'Nodes',
     shortName: 'N',
-    description: 'Indicates whether all nodes registered to the cluster are healthy and up-to-date. If this is in error state there then there is probably an issue with the cluster nodes. In worst case there is currently not enough capacity to schedule all the workloads/pods running in the cluster and that might cause a service disruption of your applications.',
+    description: 'Indicates whether all worker nodes are healthy, at their desired Kubernetes and OS versions, and present in the expected number. Often transiently unhealthy during node rollouts, scaling, or maintenance. A persistent error usually means nodes failed to join or turn ready, a rollout is stuck, or nodes are under resource pressure - which can disrupt their workloads.',
     sortOrder: '3',
   },
   ObservabilityComponentsHealthy: {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area quality
  /area usability
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|cost|dev-productivity|documentation|high-availability|logging|monitoring|networking|open-source|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
Small enhancement to the current node condition description.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the node readiness condition description to better explain healthy states, version alignment, expected node count, temporary rollout/scaling behavior, and common failure causes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->