### PR TITLE
Select credentials by vendor type

### DIFF
--- a/frontend/__tests__/composables/useShootDns.spec.js
+++ b/frontend/__tests__/composables/useShootDns.spec.js
@@ -38,17 +38,40 @@ describe('composables', () => {
 
     it('should return dns credentials as a plain array for a dns provider type', () => {
       const credentialStore = useCredentialStore()
-      const gardenerExtensionStore = useGardenerExtensionStore()
-      const cloudProfileStore = useCloudProfileStore()
 
       const credentialsForProviderType = getCloudProviderEntityList('aws-route53', {
         credentialStore,
-        gardenerExtensionStore,
-        cloudProfileStore,
+        vendorType: 'dns',
       })
 
       expect(Array.isArray(credentialsForProviderType)).toBe(true)
       expect(credentialsForProviderType).toEqual(credentialStore.dnsCredentialList.filter(credential => credential.metadata?.labels?.['dashboard.gardener.cloud/dnsProviderType'] === 'aws-route53'))
+    })
+
+    it('should select the entity list by vendor type when provider names overlap', () => {
+      const infrastructureBinding = {
+        provider: { type: 'shared-provider' },
+      }
+      const dnsCredential = {
+        metadata: {
+          labels: {
+            'dashboard.gardener.cloud/dnsProviderType': 'shared-provider',
+          },
+        },
+      }
+      const credentialStore = {
+        infrastructureBindingList: [infrastructureBinding],
+        dnsCredentialList: [dnsCredential],
+      }
+
+      expect(getCloudProviderEntityList('shared-provider', {
+        credentialStore,
+        vendorType: 'infra',
+      })).toEqual([infrastructureBinding])
+      expect(getCloudProviderEntityList('shared-provider', {
+        credentialStore,
+        vendorType: 'dns',
+      })).toEqual([dnsCredential])
     })
   })
 

--- a/frontend/src/components/Credentials/GSecretDialog.vue
+++ b/frontend/src/components/Credentials/GSecretDialog.vue
@@ -138,7 +138,6 @@ SPDX-License-Identifier: Apache-2.0
 import {
   mapActions,
   mapState,
-  storeToRefs,
 } from 'pinia'
 import { useVuelidate } from '@vuelidate/core'
 import {
@@ -151,7 +150,6 @@ import {
 } from 'vue'
 
 import { useCredentialStore } from '@/store/credential'
-import { useGardenerExtensionStore } from '@/store/gardenerExtension'
 import { useShootStore } from '@/store/shoot'
 import { useConfigStore } from '@/store/config'
 
@@ -221,11 +219,8 @@ export default {
     'update:modelValue',
   ],
   setup (props) {
-    const { credential, binding, providerType } = toRefs(props)
-    const gardenerExtensionStore = useGardenerExtensionStore()
-    const { dnsProviderTypes } = storeToRefs(gardenerExtensionStore)
-
-    const isDnsProvider = computed(() => dnsProviderTypes.value.includes(providerType.value))
+    const { credential, binding, vendorType } = toRefs(props)
+    const isDnsProvider = computed(() => vendorType.value === 'dns')
 
     let credentialComposable = {}
 
@@ -248,7 +243,7 @@ export default {
     let bindingContext = {}
     if (!isDnsProvider.value) {
       const { isSecretBinding } = credentialComposable
-      if (isSecretBinding) {
+      if (isSecretBinding?.value) {
         // Legacy SecretBinding for existing SecrertBindings
         bindingContext = useSecretBindingContext()
       } else {
@@ -321,7 +316,6 @@ export default {
     return rules
   },
   computed: {
-    ...mapState(useGardenerExtensionStore, ['dnsProviderTypes']),
     ...mapState(useShootStore, ['shootList']),
     ...mapState(useCredentialStore, [
       'infrastructureBindingList',

--- a/frontend/src/components/Credentials/GSelectCredential.vue
+++ b/frontend/src/components/Credentials/GSelectCredential.vue
@@ -64,7 +64,7 @@ SPDX-License-Identifier: Apache-2.0
     </v-select>
     <g-secret-dialog-wrapper
       :visible-dialog="visibleSecretDialog"
-      :visible-dialog-vendor-type="isDnsProvider ? 'dns' : 'infra'"
+      :visible-dialog-vendor-type="vendorType"
       @dialog-closed="onSecretDialogClosed"
     />
   </div>
@@ -77,12 +77,9 @@ import {
 } from 'vue'
 import { useVuelidate } from '@vuelidate/core'
 import { required } from '@vuelidate/validators'
-import { storeToRefs } from 'pinia'
 
 import { useProjectStore } from '@/store/project'
 import { useCredentialStore } from '@/store/credential'
-import { useGardenerExtensionStore } from '@/store/gardenerExtension'
-import { useCloudProfileStore } from '@/store/cloudProfile'
 
 import GSecretDialogWrapper from '@/components/Credentials/GSecretDialogWrapper'
 import GCredentialName from '@/components/Credentials/GCredentialName'
@@ -122,6 +119,11 @@ export default {
     providerType: {
       type: String,
     },
+    vendorType: {
+      type: String,
+      required: true,
+      validator: value => ['infra', 'dns'].includes(value),
+    },
     registerVuelidateAs: {
       type: String,
     },
@@ -145,20 +147,18 @@ export default {
       costObject,
     } = useProjectCostObject(projectItem)
     const credentialStore = useCredentialStore()
-    const gardenerExtensionStore = useGardenerExtensionStore()
-    const cloudProfileStore = useCloudProfileStore()
 
     const v$ = useVuelidate({
       $registerAs: props.registerVuelidateAs,
     })
 
     const providerType = toRef(props, 'providerType')
+    const vendorType = toRef(props, 'vendorType')
     const credential = toRef(props, 'modelValue')
 
-    const cloudProviderEntityList = useCloudProviderEntityList(providerType, { credentialStore, gardenerExtensionStore, cloudProfileStore })
+    const cloudProviderEntityList = useCloudProviderEntityList(providerType, { credentialStore, vendorType })
 
-    const { dnsProviderTypes } = storeToRefs(gardenerExtensionStore)
-    const isDnsProvider = computed(() => dnsProviderTypes.value.includes(providerType.value))
+    const isDnsProvider = computed(() => vendorType.value === 'dns')
     let composable
     if (isDnsProvider.value) {
       composable = useDnsProviderCredential(credential)

--- a/frontend/src/components/Credentials/GShootCredentialConfiguration.vue
+++ b/frontend/src/components/Credentials/GShootCredentialConfiguration.vue
@@ -18,6 +18,7 @@ SPDX-License-Identifier: Apache-2.0
         <g-select-credential
           v-model="infrastructureBinding"
           :provider-type="shootProviderType"
+          vendor-type="infra"
           :filter-fn="credentialFilterFn"
         />
         <template v-if="migrationMode">

--- a/frontend/src/components/NewShoot/GNewShootInfrastructureDetails.vue
+++ b/frontend/src/components/NewShoot/GNewShootInfrastructureDetails.vue
@@ -22,6 +22,7 @@ SPDX-License-Identifier: Apache-2.0
         <g-select-credential
           v-model="infrastructureBinding"
           :provider-type="providerType"
+          vendor-type="infra"
         />
       </v-col>
       <v-col cols="3">

--- a/frontend/src/components/ShootDns/GDnsProviderRow.vue
+++ b/frontend/src/components/ShootDns/GDnsProviderRow.vue
@@ -42,6 +42,7 @@ SPDX-License-Identifier: Apache-2.0
         <g-select-credential
           v-model="dnsProviderCredential"
           :provider-type="dnsProviderType"
+          vendor-type="dns"
           :filter-fn="credentialFilter"
           register-vuelidate-as="dnsProviderCredential"
         />
@@ -101,7 +102,6 @@ import { useVuelidate } from '@vuelidate/core'
 
 import { useGardenerExtensionStore } from '@/store/gardenerExtension'
 import { useCredentialStore } from '@/store/credential'
-import { useCloudProfileStore } from '@/store/cloudProfile'
 
 import GSelectCredential from '@/components/Credentials/GSelectCredential'
 import GVendorIcon from '@/components/GVendorIcon'
@@ -140,11 +140,9 @@ export default {
     } = useShootContext()
 
     const credentialStore = useCredentialStore()
-    const gardenerExtensionStore = useGardenerExtensionStore()
-    const cloudProfileStore = useCloudProfileStore()
 
     const dnsProviderType = toRef(props.dnsProvider, 'type')
-    const dnsCloudProviderCredentials = useCloudProviderEntityList(dnsProviderType, { credentialStore, gardenerExtensionStore, cloudProfileStore })
+    const dnsCloudProviderCredentials = useCloudProviderEntityList(dnsProviderType, { credentialStore, vendorType: 'dns' })
 
     return {
       v$: useVuelidate(),

--- a/frontend/src/components/ShootDns/GManageDns.vue
+++ b/frontend/src/components/ShootDns/GManageDns.vue
@@ -73,6 +73,7 @@ SPDX-License-Identifier: Apache-2.0
           <g-select-credential
             v-model="primaryDnsProviderCredential"
             :provider-type="dnsPrimaryProviderType"
+            vendor-type="dns"
             register-vuelidate-as="dnsProviderCredential"
             label="Primary DNS Provider Credential"
           />
@@ -162,7 +163,6 @@ import {
 
 import { useGardenerExtensionStore } from '@/store/gardenerExtension'
 import { useCredentialStore } from '@/store/credential'
-import { useCloudProfileStore } from '@/store/cloudProfile'
 
 import GSelectCredential from '@/components/Credentials/GSelectCredential'
 import GDnsProviderRow from '@/components/ShootDns/GDnsProviderRow'
@@ -202,8 +202,6 @@ export default {
     } = useShootContext()
 
     const credentialStore = useCredentialStore()
-    const gardenerExtensionStore = useGardenerExtensionStore()
-    const cloudProfileStore = useCloudProfileStore()
 
     const customDomainEnabled = ref(
       isNewCluster.value
@@ -211,7 +209,7 @@ export default {
         : !!dnsPrimaryProviderType.value,
     )
 
-    const availableCredentialsForPrimaryDnsProvider = useCloudProviderEntityList(dnsPrimaryProviderType, { credentialStore, gardenerExtensionStore, cloudProfileStore })
+    const availableCredentialsForPrimaryDnsProvider = useCloudProviderEntityList(dnsPrimaryProviderType, { credentialStore, vendorType: 'dns' })
 
     return {
       v$: useVuelidate(),

--- a/frontend/src/composables/credential/helper.js
+++ b/frontend/src/composables/credential/helper.js
@@ -4,8 +4,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { storeToRefs } from 'pinia'
-
 import {
   decodeBase64,
   isTruthyValue,
@@ -180,18 +178,14 @@ export function isDNSCredential ({ credential, dnsProviderTypes }) {
 
 export function getCloudProviderEntityList (providerType, {
   credentialStore,
-  gardenerExtensionStore,
-  cloudProfileStore,
+  vendorType,
 }) {
-  const { dnsProviderTypes } = storeToRefs(gardenerExtensionStore)
-  const { sortedInfraProviderTypeList } = storeToRefs(cloudProfileStore)
-
-  if (sortedInfraProviderTypeList.value.includes(providerType)) {
+  if (vendorType === 'infra') {
     return filter(credentialStore.infrastructureBindingList, binding => {
       return bindingProviderType(binding) === providerType
     })
   }
-  if (dnsProviderTypes.value.includes(providerType)) {
+  if (vendorType === 'dns') {
     return filter(credentialStore.dnsCredentialList, credential => {
       return credentialProviderType(credential) === providerType
     })

--- a/frontend/src/composables/credential/useCloudProviderEntityList.js
+++ b/frontend/src/composables/credential/useCloudProviderEntityList.js
@@ -7,11 +7,10 @@
 import {
   computed,
   isRef,
+  unref,
 } from 'vue'
 
 import { useCredentialStore } from '@/store/credential'
-import { useGardenerExtensionStore } from '@/store/gardenerExtension'
-import { useCloudProfileStore } from '@/store/cloudProfile'
 
 import { getCloudProviderEntityList } from './helper'
 
@@ -22,15 +21,13 @@ export const useCloudProviderEntityList = (providerType, options = {}) => {
 
   const {
     credentialStore = useCredentialStore(),
-    gardenerExtensionStore = useGardenerExtensionStore(),
-    cloudProfileStore = useCloudProfileStore(),
+    vendorType,
   } = options
 
   return computed(() => {
     return getCloudProviderEntityList(providerType.value, {
       credentialStore,
-      gardenerExtensionStore,
-      cloudProfileStore,
+      vendorType: unref(vendorType),
     })
   })
 }

--- a/frontend/src/composables/useShootDns.js
+++ b/frontend/src/composables/useShootDns.js
@@ -8,7 +8,6 @@ import { computed } from 'vue'
 
 import { useGardenerExtensionStore } from '@/store/gardenerExtension'
 import { useCredentialStore } from '@/store/credential'
-import { useCloudProfileStore } from '@/store/cloudProfile'
 
 import { useShootResources } from '@/composables/useShootResources'
 import { useShootExtensions } from '@/composables/useShootExtensions'
@@ -53,7 +52,6 @@ export const useShootDns = (manifest, options) => {
   const {
     gardenerExtensionStore = useGardenerExtensionStore(),
     credentialStore = useCredentialStore(),
-    cloudProfileStore = useCloudProfileStore(),
   } = options
 
   /* resources */
@@ -205,8 +203,7 @@ export const useShootDns = (manifest, options) => {
   function getDefaultCredential (providerType) {
     const credentials = getCloudProviderEntityList(providerType, {
       credentialStore,
-      gardenerExtensionStore,
-      cloudProfileStore,
+      vendorType: 'dns',
     })
 
     const usedResourceRefs = map(resources.value, 'resourceRef')
@@ -245,7 +242,7 @@ export const useShootDns = (manifest, options) => {
   }
 
   function resolveResourceRef (type, credentialsRef) {
-    const credentialsForProviderType = getCloudProviderEntityList(type, { credentialStore, gardenerExtensionStore, cloudProfileStore })
+    const credentialsForProviderType = getCloudProviderEntityList(type, { credentialStore, vendorType: 'dns' })
     const credential = find(credentialsForProviderType, credential => {
       return dnsCredentialResourceNamePart({
         kind: credential?.kind,

--- a/frontend/src/composables/useShootHelper.js
+++ b/frontend/src/composables/useShootHelper.js
@@ -178,7 +178,7 @@ export function createShootHelperComposable (shootItem, options = {}) {
 
   const { defaultNodesCIDR } = useDefaultNodesCIDR(cloudProfile)
 
-  const infrastructureBindings = useCloudProviderEntityList(providerType, { credentialStore, gardenerExtensionStore, cloudProfileStore })
+  const infrastructureBindings = useCloudProviderEntityList(providerType, { credentialStore, vendorType: 'infra' })
 
   const kubernetesVersionIsNotLatestPatch = useKubernetesVersionIsNotLatestPatch(kubernetesVersion)
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**

/area usability
/area quality
/kind cleanup

**What this PR does / why we need it**:

This is the fifth preparatory refactoring extracted from #2824. It follows #3075, #3082, #3085, and #3101.

Credential selection previously inferred the vendor domain from the provider name by checking the configured infrastructure and DNS provider lists. This was ambiguous when the same provider name existed in both domains: infrastructure was checked first, so a DNS selector could receive infrastructure bindings. It also coupled credential selection to provider-registry stores even though each caller already knows whether it is handling infrastructure or DNS credentials.

This change:

- requires credential selectors to provide an explicit vendor type (`infra` or `dns`)
- propagates that type through credential-list selection and the Secret dialog
- selects infrastructure bindings or DNS credentials directly from the caller's known context
- fixes access to the computed `isSecretBinding` value while selecting the binding context
- adds regression coverage proving that infrastructure and DNS credentials with the same provider name remain independent

For existing providers without overlapping names, behavior remains unchanged. Configurations that reuse a provider name across vendor domains now resolve the intended credential type deterministically.

**Which issue(s) this PR fixes**:

Part of #2824.

**Special notes for your reviewer**:

This applies the same principle introduced by #3082 for `vendorDisplayName({ type, name })` and other vendor lookups: a provider name does not identify its vendor domain, so callers pass the domain they already know. Here, that explicit domain controls credential storage and dialog behavior rather than branding lookup.

Validation:

- `make verify` (including 76 frontend test files / 747 tests and 45 backend test files / 423 tests)
- focused `useShootDns` tests (16 tests)
- pre-commit checks

**Release note**:

```other developer
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential selection when infrastructure and DNS providers share the same name.
  * Infrastructure and DNS credential lists now consistently show credentials matching the selected credential type.
  * Updated credential dialogs and selectors to correctly preserve the selected binding context.

* **Tests**
  * Added coverage for provider names shared across infrastructure and DNS credential types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->