### PR TITLE
fix(frontend): prevent cold-cache Vite reloads

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -196,6 +196,9 @@ export default defineConfig(({ command, mode }) => {
       }))
     }
 
+    config.optimizeDeps = {
+      exclude: ['vuetify'],
+    }
     config.server = {
       port: 8443,
       strictPort: true,


### PR DESCRIPTION
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
With a cold dependency cache, Vite can discover auto-imported Vuetify components after its initial dependency scan. When the optimized dependencies change, Vite performs a full-page reload, interrupting SPA navigation.
This change excludes Vuetify from development dependency pre-bundling, preventing those imports from triggering optimization reloads. Production builds are unaffected.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```bugfix developer
Exclude Vuetify from Vite dependency pre-bundling in development to prevent full-page reloads caused by cold-cache dependency optimization changes.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local development startup by excluding Vuetify from dependency optimization during serve mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->