### PR TITLE
feat(local-dashboard): add managed local environment

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -28,6 +28,19 @@
       ],
       datasourceTemplate: 'docker',
     },
+    {
+      customType: 'regex',
+      fileMatch: [
+        '^hack/local-dashboard/internal/configuration\\.mjs$',
+      ],
+      matchStrings: [
+        "export const GARDENERLESS_COMMIT = '(?<currentDigest>[0-9a-f]{40})'",
+      ],
+      currentValueTemplate: 'main',
+      depNameTemplate: 'gardenerless-local-setup',
+      packageNameTemplate: 'https://github.com/grolu/gardenerless-local-setup',
+      datasourceTemplate: 'git-refs',
+    },
   ],
   packageRules: [
     {

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,10 @@ kubeconfig*
 
 # Claude Code local settings
 .claude/settings.local.json
+
+# Managed UI-verification checkout, runtime, state, and logs
+# Managed local Dashboard checkout, runtime, state, and logs
+.local-dashboard/
+
+# Local Dashboard session secret (never commit)
+hack/local-dashboard/.local-dashboard-session-secret.local

--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,6 @@ kubeconfig*
 # Claude Code local settings
 .claude/settings.local.json
 
-# Managed UI-verification checkout, runtime, state, and logs
 # Managed local Dashboard checkout, runtime, state, and logs
 .local-dashboard/
 

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -79,11 +79,17 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./",\
         "packageDependencies": [\
           ["@microsoft/eslint-formatter-sarif", "npm:3.1.0"],\
+          ["@vitest/coverage-v8", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:4.1.10"],\
+          ["@vitest/eslint-plugin", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:1.6.26"],\
           ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
+          ["eslint-plugin-import", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:2.32.0"],\
+          ["eslint-plugin-import-newlines", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:1.4.1"],\
+          ["eslint-plugin-security", "npm:3.0.1"],\
           ["gardener-dashboard", "workspace:."],\
           ["husky", "npm:9.1.7"],\
           ["jsdom", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:26.1.0"],\
           ["lodash-es", "npm:4.18.1"],\
+          ["neostandard", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:0.13.0"],\
           ["vitest", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:4.1.10"]\
         ],\
         "linkType": "SOFT"\
@@ -735,10 +741,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:69947eb79a108297ef883fbc634b733d5cb177862b9ca665df089a1af6c4f235d205dc292bbdf0129577ea9a99f4b6a132653f28ed7feb24ce44563be88ab4c0#npm:4.9.1", {\
-        "packageLocation": "./.yarn/__virtual__/@eslint-community-eslint-utils-virtual-66b0b10cf2/0/cache/@eslint-community-eslint-utils-npm-4.9.1-30ad3d49de-dc4ab5e3e3.zip/node_modules/@eslint-community/eslint-utils/",\
+      ["virtual:ba2edf52feb929207d15f55aba8550a059ca9e171e9ee6604a08a4228972fc5181ed0504723546323646dd479aacc4cad73bc05d9420c619a309b06222382745#npm:4.9.1", {\
+        "packageLocation": "./.yarn/__virtual__/@eslint-community-eslint-utils-virtual-f59f230af4/0/cache/@eslint-community-eslint-utils-npm-4.9.1-30ad3d49de-dc4ab5e3e3.zip/node_modules/@eslint-community/eslint-utils/",\
         "packageDependencies": [\
-          ["@eslint-community/eslint-utils", "virtual:69947eb79a108297ef883fbc634b733d5cb177862b9ca665df089a1af6c4f235d205dc292bbdf0129577ea9a99f4b6a132653f28ed7feb24ce44563be88ab4c0#npm:4.9.1"],\
+          ["@eslint-community/eslint-utils", "virtual:ba2edf52feb929207d15f55aba8550a059ca9e171e9ee6604a08a4228972fc5181ed0504723546323646dd479aacc4cad73bc05d9420c619a309b06222382745#npm:4.9.1"],\
           ["@types/eslint", null],\
           ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
           ["eslint-visitor-keys", "npm:3.4.3"]\
@@ -943,8 +949,8 @@ const RAW_RUNTIME_STATE =
           ["dockerfile-ast", "npm:0.7.1"],\
           ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
           ["eslint-import-resolver-alias", "virtual:91da830b29af2704bfc9679729fb85d00ca0b8eeb24a837747a5bc0b5aec0e922594580a901a48c34c06a65b9b376f23fa3cbb88dc9fd35cddc5076ab48a067f#npm:1.1.2"],\
-          ["eslint-plugin-import", "virtual:91da830b29af2704bfc9679729fb85d00ca0b8eeb24a837747a5bc0b5aec0e922594580a901a48c34c06a65b9b376f23fa3cbb88dc9fd35cddc5076ab48a067f#npm:2.32.0"],\
-          ["eslint-plugin-import-newlines", "virtual:91da830b29af2704bfc9679729fb85d00ca0b8eeb24a837747a5bc0b5aec0e922594580a901a48c34c06a65b9b376f23fa3cbb88dc9fd35cddc5076ab48a067f#npm:1.4.1"],\
+          ["eslint-plugin-import", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:2.32.0"],\
+          ["eslint-plugin-import-newlines", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:1.4.1"],\
           ["eslint-plugin-lodash", "virtual:faee47847dc7127a4fda44fca2035ae541a9af6260b1926ad890f5f677339c049ea62d6b398ffa233a226c0b5c370a517802e428d53b03a3356e9a04d51e8e42#npm:8.0.0"],\
           ["eslint-plugin-security", "npm:3.0.1"],\
           ["express", "npm:5.2.1"],\
@@ -959,7 +965,7 @@ const RAW_RUNTIME_STATE =
           ["lodash", "npm:4.18.1"],\
           ["lodash-es", "npm:4.18.1"],\
           ["morgan", "npm:1.11.0"],\
-          ["neostandard", "virtual:faee47847dc7127a4fda44fca2035ae541a9af6260b1926ad890f5f677339c049ea62d6b398ffa233a226c0b5c370a517802e428d53b03a3356e9a04d51e8e42#npm:0.13.0"],\
+          ["neostandard", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:0.13.0"],\
           ["object-hash", "npm:3.0.0"],\
           ["openapi-types", "npm:12.1.3"],\
           ["openid-client", "npm:6.8.4"],\
@@ -998,11 +1004,11 @@ const RAW_RUNTIME_STATE =
           ["@vitest/coverage-v8", "virtual:dee42bbf2b8a9fdc35f5ff723774d473a27fbd01ca23e57b4dfc5e6f05027029778468ff50260c9f7c32df316ded00563e6ff4412b3cc55fa5cf2903cb91f445#npm:4.1.10"],\
           ["@vitest/eslint-plugin", "virtual:dee42bbf2b8a9fdc35f5ff723774d473a27fbd01ca23e57b4dfc5e6f05027029778468ff50260c9f7c32df316ded00563e6ff4412b3cc55fa5cf2903cb91f445#npm:1.6.26"],\
           ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
-          ["eslint-plugin-import", "virtual:91da830b29af2704bfc9679729fb85d00ca0b8eeb24a837747a5bc0b5aec0e922594580a901a48c34c06a65b9b376f23fa3cbb88dc9fd35cddc5076ab48a067f#npm:2.32.0"],\
+          ["eslint-plugin-import", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:2.32.0"],\
           ["eslint-plugin-lodash", "virtual:faee47847dc7127a4fda44fca2035ae541a9af6260b1926ad890f5f677339c049ea62d6b398ffa233a226c0b5c370a517802e428d53b03a3356e9a04d51e8e42#npm:8.0.0"],\
           ["js-yaml", "npm:5.2.3"],\
           ["lodash-es", "npm:4.18.1"],\
-          ["neostandard", "virtual:faee47847dc7127a4fda44fca2035ae541a9af6260b1926ad890f5f677339c049ea62d6b398ffa233a226c0b5c370a517802e428d53b03a3356e9a04d51e8e42#npm:0.13.0"],\
+          ["neostandard", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:0.13.0"],\
           ["vitest", "virtual:dee42bbf2b8a9fdc35f5ff723774d473a27fbd01ca23e57b4dfc5e6f05027029778468ff50260c9f7c32df316ded00563e6ff4412b3cc55fa5cf2903cb91f445#npm:4.1.10"]\
         ],\
         "linkType": "SOFT"\
@@ -1051,8 +1057,8 @@ const RAW_RUNTIME_STATE =
           ["downloadjs", "npm:1.4.7"],\
           ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
           ["eslint-import-resolver-alias", "virtual:91da830b29af2704bfc9679729fb85d00ca0b8eeb24a837747a5bc0b5aec0e922594580a901a48c34c06a65b9b376f23fa3cbb88dc9fd35cddc5076ab48a067f#npm:1.1.2"],\
-          ["eslint-plugin-import", "virtual:91da830b29af2704bfc9679729fb85d00ca0b8eeb24a837747a5bc0b5aec0e922594580a901a48c34c06a65b9b376f23fa3cbb88dc9fd35cddc5076ab48a067f#npm:2.32.0"],\
-          ["eslint-plugin-import-newlines", "virtual:91da830b29af2704bfc9679729fb85d00ca0b8eeb24a837747a5bc0b5aec0e922594580a901a48c34c06a65b9b376f23fa3cbb88dc9fd35cddc5076ab48a067f#npm:1.4.1"],\
+          ["eslint-plugin-import", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:2.32.0"],\
+          ["eslint-plugin-import-newlines", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:1.4.1"],\
           ["eslint-plugin-lodash", "virtual:faee47847dc7127a4fda44fca2035ae541a9af6260b1926ad890f5f677339c049ea62d6b398ffa233a226c0b5c370a517802e428d53b03a3356e9a04d51e8e42#npm:8.0.0"],\
           ["eslint-plugin-security", "npm:3.0.1"],\
           ["eslint-plugin-vue", "virtual:8d919ffb8fd728f827df3f6a566e8e923223ffcec68f7450d83bbbc2dc25d6b8c987e111cbab484b209f253bdf2f2e00663b01a986262c44511128466462a76f#npm:10.10.0"],\
@@ -1068,7 +1074,7 @@ const RAW_RUNTIME_STATE =
           ["lodash", "npm:4.18.1"],\
           ["md5", "npm:2.3.0"],\
           ["mitt", "npm:3.0.1"],\
-          ["neostandard", "virtual:faee47847dc7127a4fda44fca2035ae541a9af6260b1926ad890f5f677339c049ea62d6b398ffa233a226c0b5c370a517802e428d53b03a3356e9a04d51e8e42#npm:0.13.0"],\
+          ["neostandard", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:0.13.0"],\
           ["netmask", "npm:2.1.1"],\
           ["pinia", "virtual:8d919ffb8fd728f827df3f6a566e8e923223ffcec68f7450d83bbbc2dc25d6b8c987e111cbab484b209f253bdf2f2e00663b01a986262c44511128466462a76f#npm:4.0.2"],\
           ["rollup-plugin-visualizer", "virtual:8d919ffb8fd728f827df3f6a566e8e923223ffcec68f7450d83bbbc2dc25d6b8c987e111cbab484b209f253bdf2f2e00663b01a986262c44511128466462a76f#npm:6.0.11"],\
@@ -1120,7 +1126,7 @@ const RAW_RUNTIME_STATE =
           ["jsonwebtoken", "npm:9.0.3"],\
           ["lodash-es", "npm:4.18.1"],\
           ["mixwith", "npm:0.1.1"],\
-          ["neostandard", "virtual:faee47847dc7127a4fda44fca2035ae541a9af6260b1926ad890f5f677339c049ea62d6b398ffa233a226c0b5c370a517802e428d53b03a3356e9a04d51e8e42#npm:0.13.0"],\
+          ["neostandard", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:0.13.0"],\
           ["uuid", "npm:14.0.1"],\
           ["vitest", "virtual:6e2c4c5999ef7336f2366c028c6e208518bd5e4636dbc07154eda26f900c9d3306eb27557764a142dd0ed454b5cb8f5c908fde8502e9e0d5089dffde5a1840e1#npm:4.1.10"]\
         ],\
@@ -1153,7 +1159,7 @@ const RAW_RUNTIME_STATE =
           ["jsonwebtoken", "npm:9.0.3"],\
           ["lodash-es", "npm:4.18.1"],\
           ["mixwith", "npm:0.1.1"],\
-          ["neostandard", "virtual:faee47847dc7127a4fda44fca2035ae541a9af6260b1926ad890f5f677339c049ea62d6b398ffa233a226c0b5c370a517802e428d53b03a3356e9a04d51e8e42#npm:0.13.0"],\
+          ["neostandard", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:0.13.0"],\
           ["uuid", "npm:14.0.1"],\
           ["vitest", "virtual:5610037bb1511542640ade95602b1c5470f325fae9ddb84de90506a220dbd946b9cefcd0530b3f57dc1a220633c595e044cfd68f018e331afd37c33546f3ca6c#npm:4.1.10"]\
         ],\
@@ -1176,7 +1182,7 @@ const RAW_RUNTIME_STATE =
           ["gtoken", "npm:8.0.0"],\
           ["js-yaml", "npm:5.2.3"],\
           ["lodash-es", "npm:4.18.1"],\
-          ["neostandard", "virtual:faee47847dc7127a4fda44fca2035ae541a9af6260b1926ad890f5f677339c049ea62d6b398ffa233a226c0b5c370a517802e428d53b03a3356e9a04d51e8e42#npm:0.13.0"],\
+          ["neostandard", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:0.13.0"],\
           ["vitest", "virtual:2c923f59c4675c87278ce3aa7d501b2831091130d417bde2a24ce2608345e7844c4d71578f103362589eb4d651e2514ad746bccd32508a2feda0d63dda053573#npm:4.1.10"]\
         ],\
         "linkType": "SOFT"\
@@ -1194,7 +1200,7 @@ const RAW_RUNTIME_STATE =
           ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
           ["eslint-plugin-lodash", "virtual:faee47847dc7127a4fda44fca2035ae541a9af6260b1926ad890f5f677339c049ea62d6b398ffa233a226c0b5c370a517802e428d53b03a3356e9a04d51e8e42#npm:8.0.0"],\
           ["eslint-plugin-security", "npm:3.0.1"],\
-          ["neostandard", "virtual:faee47847dc7127a4fda44fca2035ae541a9af6260b1926ad890f5f677339c049ea62d6b398ffa233a226c0b5c370a517802e428d53b03a3356e9a04d51e8e42#npm:0.13.0"],\
+          ["neostandard", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:0.13.0"],\
           ["vitest", "virtual:feaa032e1ffbff8da5dad8429b8494744ade8373389ef8e26f3d1f1980ceff327ab996fdc7c1977df285edeb918372fa01d7c87d79c9d7218f8701c70203bfe5#npm:4.1.10"]\
         ],\
         "linkType": "SOFT"\
@@ -1216,7 +1222,7 @@ const RAW_RUNTIME_STATE =
           ["eslint-plugin-security", "npm:3.0.1"],\
           ["express", "npm:5.2.1"],\
           ["http-errors", "npm:2.0.1"],\
-          ["neostandard", "virtual:faee47847dc7127a4fda44fca2035ae541a9af6260b1926ad890f5f677339c049ea62d6b398ffa233a226c0b5c370a517802e428d53b03a3356e9a04d51e8e42#npm:0.13.0"],\
+          ["neostandard", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:0.13.0"],\
           ["prom-client", "npm:15.1.3"],\
           ["response-time", "npm:2.3.4"],\
           ["supertest", "npm:7.2.2"],\
@@ -1242,7 +1248,7 @@ const RAW_RUNTIME_STATE =
           ["eslint-plugin-security", "npm:3.0.1"],\
           ["express", "npm:5.2.1"],\
           ["http-errors", "npm:2.0.1"],\
-          ["neostandard", "virtual:faee47847dc7127a4fda44fca2035ae541a9af6260b1926ad890f5f677339c049ea62d6b398ffa233a226c0b5c370a517802e428d53b03a3356e9a04d51e8e42#npm:0.13.0"],\
+          ["neostandard", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:0.13.0"],\
           ["prom-client", "npm:15.1.3"],\
           ["response-time", "npm:2.3.4"],\
           ["supertest", "npm:7.2.2"],\
@@ -1265,7 +1271,7 @@ const RAW_RUNTIME_STATE =
           ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
           ["eslint-plugin-lodash", "virtual:faee47847dc7127a4fda44fca2035ae541a9af6260b1926ad890f5f677339c049ea62d6b398ffa233a226c0b5c370a517802e428d53b03a3356e9a04d51e8e42#npm:8.0.0"],\
           ["eslint-plugin-security", "npm:3.0.1"],\
-          ["neostandard", "virtual:faee47847dc7127a4fda44fca2035ae541a9af6260b1926ad890f5f677339c049ea62d6b398ffa233a226c0b5c370a517802e428d53b03a3356e9a04d51e8e42#npm:0.13.0"],\
+          ["neostandard", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:0.13.0"],\
           ["vitest", "virtual:f966e7aeb7c55583fd75c7557c3a1bc5c402d6b0b046ba107cf42de8ba43cf7067dc5f63013392d15bc07cbcc8692e71b6eb89164b32ef3640c94873538925b0#npm:4.1.10"]\
         ],\
         "packagePeers": [\
@@ -1285,7 +1291,7 @@ const RAW_RUNTIME_STATE =
           ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
           ["eslint-plugin-lodash", "virtual:faee47847dc7127a4fda44fca2035ae541a9af6260b1926ad890f5f677339c049ea62d6b398ffa233a226c0b5c370a517802e428d53b03a3356e9a04d51e8e42#npm:8.0.0"],\
           ["eslint-plugin-security", "npm:3.0.1"],\
-          ["neostandard", "virtual:faee47847dc7127a4fda44fca2035ae541a9af6260b1926ad890f5f677339c049ea62d6b398ffa233a226c0b5c370a517802e428d53b03a3356e9a04d51e8e42#npm:0.13.0"],\
+          ["neostandard", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:0.13.0"],\
           ["vitest", "virtual:e4cd5705e1c344e12c9b35de8f14cee55dfb19ddb91518014763e55515c03ad1ff16a60cd4a8aabce2fd607a04df60d0ce645c4f47235dc4ece846d082e33885#npm:4.1.10"]\
         ],\
         "linkType": "SOFT"\
@@ -1307,7 +1313,7 @@ const RAW_RUNTIME_STATE =
           ["eslint-plugin-security", "npm:3.0.1"],\
           ["http-errors", "npm:2.0.1"],\
           ["lodash-es", "npm:4.18.1"],\
-          ["neostandard", "virtual:faee47847dc7127a4fda44fca2035ae541a9af6260b1926ad890f5f677339c049ea62d6b398ffa233a226c0b5c370a517802e428d53b03a3356e9a04d51e8e42#npm:0.13.0"],\
+          ["neostandard", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:0.13.0"],\
           ["type-is", "npm:2.1.0"],\
           ["vitest", "virtual:da5c259967d05763f37b857188cc51d834f07841d7f256ee31fca651fde6eb0ee4baf7a619bba67c191201184011519f8e83142e0030ce0ac1ed9b709ad7dfc2#npm:4.1.10"]\
         ],\
@@ -1331,7 +1337,7 @@ const RAW_RUNTIME_STATE =
           ["eslint-plugin-security", "npm:3.0.1"],\
           ["http-errors", "npm:2.0.1"],\
           ["lodash-es", "npm:4.18.1"],\
-          ["neostandard", "virtual:faee47847dc7127a4fda44fca2035ae541a9af6260b1926ad890f5f677339c049ea62d6b398ffa233a226c0b5c370a517802e428d53b03a3356e9a04d51e8e42#npm:0.13.0"],\
+          ["neostandard", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:0.13.0"],\
           ["type-is", "npm:2.1.0"],\
           ["vitest", "virtual:167c898d89436663a7a547cd240a0f77e183060e54bab1fd8e9ad3b783292e7bee2c1aaecd5e22bd0f54c8b102c8a6713b919970f45193ff335a90f5b65daa58#npm:4.1.10"]\
         ],\
@@ -1347,7 +1353,7 @@ const RAW_RUNTIME_STATE =
           ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
           ["eslint-plugin-lodash", "virtual:faee47847dc7127a4fda44fca2035ae541a9af6260b1926ad890f5f677339c049ea62d6b398ffa233a226c0b5c370a517802e428d53b03a3356e9a04d51e8e42#npm:8.0.0"],\
           ["eslint-plugin-security", "npm:3.0.1"],\
-          ["neostandard", "virtual:faee47847dc7127a4fda44fca2035ae541a9af6260b1926ad890f5f677339c049ea62d6b398ffa233a226c0b5c370a517802e428d53b03a3356e9a04d51e8e42#npm:0.13.0"]\
+          ["neostandard", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:0.13.0"]\
         ],\
         "linkType": "SOFT"\
       }]\
@@ -2634,12 +2640,12 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:3425432411246eef340d7f80ca5ba0066bedd24f3d9cfff2446edead87fe038ff137db2ba210f5820a2e1cc71cc10dc26fa703b44653ade6be2ac8c5a29555ae#npm:2.11.0", {\
-        "packageLocation": "./.yarn/__virtual__/@stylistic-eslint-plugin-virtual-bc949ddf0f/0/cache/@stylistic-eslint-plugin-npm-2.11.0-29144d1d02-6ca19b6656.zip/node_modules/@stylistic/eslint-plugin/",\
+      ["virtual:d21dc05974df5027fa89029a3d44beee5f6c798db93c3fcdc9a235bc4b93d329d0e253bbab255263085d795a4f4f09d66fa9d106c193a50771fef6ac8d03b3fb#npm:2.11.0", {\
+        "packageLocation": "./.yarn/__virtual__/@stylistic-eslint-plugin-virtual-eb1989b04b/0/cache/@stylistic-eslint-plugin-npm-2.11.0-29144d1d02-6ca19b6656.zip/node_modules/@stylistic/eslint-plugin/",\
         "packageDependencies": [\
-          ["@stylistic/eslint-plugin", "virtual:3425432411246eef340d7f80ca5ba0066bedd24f3d9cfff2446edead87fe038ff137db2ba210f5820a2e1cc71cc10dc26fa703b44653ade6be2ac8c5a29555ae#npm:2.11.0"],\
+          ["@stylistic/eslint-plugin", "virtual:d21dc05974df5027fa89029a3d44beee5f6c798db93c3fcdc9a235bc4b93d329d0e253bbab255263085d795a4f4f09d66fa9d106c193a50771fef6ac8d03b3fb#npm:2.11.0"],\
           ["@types/eslint", null],\
-          ["@typescript-eslint/utils", "virtual:bc949ddf0f1ade49095936c008773d64c06e758027f148b65bac6dfbd2a8a17b386930a4b94df127d18bca4119aafb8822c9e8f26c56759acabe54ad4df2d843#npm:8.66.0"],\
+          ["@typescript-eslint/utils", "virtual:2e2eb2b148e0dd5594028029910a1e2f7e7dbafb3a0bfa7000d342032e0462f3c951bd5823563b256aecfc6da06cf711cf07645bfb5a6219faa29225f1b37ded#npm:8.66.0"],\
           ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
           ["eslint-visitor-keys", "npm:4.2.1"],\
           ["espree", "npm:10.4.0"],\
@@ -2838,23 +2844,23 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:b2ce8114c6a09945c16f9024af866d293a40ce97bba68792156fc7fdba2aee89b2e65b0353c5ce06ae17e64cd6b05f70a2026214cd0ce8f123aecf369b55ad30#npm:8.60.0", {\
-        "packageLocation": "./.yarn/__virtual__/@typescript-eslint-eslint-plugin-virtual-0506b0a2e7/0/cache/@typescript-eslint-eslint-plugin-npm-8.60.0-567a8fce90-76dc44d218.zip/node_modules/@typescript-eslint/eslint-plugin/",\
+      ["virtual:28810e244b2c0a95073ad69eec1bf9bdbea24314d1cfdc745ba7b63fb342b9314b5c5b46d205b50a948d471bda7fc3ec1418d5c879a9dcc0bba8eafb506227ba#npm:8.60.0", {\
+        "packageLocation": "./.yarn/__virtual__/@typescript-eslint-eslint-plugin-virtual-6075b38011/0/cache/@typescript-eslint-eslint-plugin-npm-8.60.0-567a8fce90-76dc44d218.zip/node_modules/@typescript-eslint/eslint-plugin/",\
         "packageDependencies": [\
           ["@eslint-community/regexpp", "npm:4.12.2"],\
           ["@types/eslint", null],\
           ["@types/typescript", null],\
           ["@types/typescript-eslint__parser", null],\
-          ["@typescript-eslint/eslint-plugin", "virtual:b2ce8114c6a09945c16f9024af866d293a40ce97bba68792156fc7fdba2aee89b2e65b0353c5ce06ae17e64cd6b05f70a2026214cd0ce8f123aecf369b55ad30#npm:8.60.0"],\
-          ["@typescript-eslint/parser", "virtual:b2ce8114c6a09945c16f9024af866d293a40ce97bba68792156fc7fdba2aee89b2e65b0353c5ce06ae17e64cd6b05f70a2026214cd0ce8f123aecf369b55ad30#npm:8.60.0"],\
+          ["@typescript-eslint/eslint-plugin", "virtual:28810e244b2c0a95073ad69eec1bf9bdbea24314d1cfdc745ba7b63fb342b9314b5c5b46d205b50a948d471bda7fc3ec1418d5c879a9dcc0bba8eafb506227ba#npm:8.60.0"],\
+          ["@typescript-eslint/parser", "virtual:28810e244b2c0a95073ad69eec1bf9bdbea24314d1cfdc745ba7b63fb342b9314b5c5b46d205b50a948d471bda7fc3ec1418d5c879a9dcc0bba8eafb506227ba#npm:8.60.0"],\
           ["@typescript-eslint/scope-manager", "npm:8.60.0"],\
-          ["@typescript-eslint/type-utils", "virtual:0506b0a2e76b6f9819e3ba28b4beef58b958aeab24ae11dcee1f18cabfc52a5d62ba09478b80c5318e452e58bd7d5ab394314198f1909b88063c5ddad0c632bf#npm:8.60.0"],\
-          ["@typescript-eslint/utils", "virtual:b2ce8114c6a09945c16f9024af866d293a40ce97bba68792156fc7fdba2aee89b2e65b0353c5ce06ae17e64cd6b05f70a2026214cd0ce8f123aecf369b55ad30#npm:8.60.0"],\
+          ["@typescript-eslint/type-utils", "virtual:6075b380118fa9d158a4752b2a8865e550708867f02969d83bb75cf6275815479ffc8d505cb14a6dd9c47c3ce3618f96d920e6f5b59ed2021e8e4fd229f30fa5#npm:8.60.0"],\
+          ["@typescript-eslint/utils", "virtual:28810e244b2c0a95073ad69eec1bf9bdbea24314d1cfdc745ba7b63fb342b9314b5c5b46d205b50a948d471bda7fc3ec1418d5c879a9dcc0bba8eafb506227ba#npm:8.60.0"],\
           ["@typescript-eslint/visitor-keys", "npm:8.60.0"],\
           ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
           ["ignore", "npm:7.0.5"],\
           ["natural-compare", "npm:1.4.0"],\
-          ["ts-api-utils", "virtual:3f54d31c88eb7813ed2c5083497e61594df5d51ade0b0da052e2a5fe7129e5938172318afff3f1646167f3fe9af2146954482e3cfe994afd8cf12d86ba64dfec#npm:2.5.0"],\
+          ["ts-api-utils", "virtual:c2790fc160f26db570e782a78b67da7a14838eb6f1e8a3695be5e14cfd4ac2763345c3f30689e70651b0c61a367aa657106663f25fc63057d596c0fa9e8a2d2a#npm:2.5.0"],\
           ["typescript", null]\
         ],\
         "packagePeers": [\
@@ -2876,15 +2882,15 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:b2ce8114c6a09945c16f9024af866d293a40ce97bba68792156fc7fdba2aee89b2e65b0353c5ce06ae17e64cd6b05f70a2026214cd0ce8f123aecf369b55ad30#npm:8.60.0", {\
-        "packageLocation": "./.yarn/__virtual__/@typescript-eslint-parser-virtual-6d4b826146/0/cache/@typescript-eslint-parser-npm-8.60.0-6e386fb5c1-1012911e3e.zip/node_modules/@typescript-eslint/parser/",\
+      ["virtual:28810e244b2c0a95073ad69eec1bf9bdbea24314d1cfdc745ba7b63fb342b9314b5c5b46d205b50a948d471bda7fc3ec1418d5c879a9dcc0bba8eafb506227ba#npm:8.60.0", {\
+        "packageLocation": "./.yarn/__virtual__/@typescript-eslint-parser-virtual-066f611a30/0/cache/@typescript-eslint-parser-npm-8.60.0-6e386fb5c1-1012911e3e.zip/node_modules/@typescript-eslint/parser/",\
         "packageDependencies": [\
           ["@types/eslint", null],\
           ["@types/typescript", null],\
-          ["@typescript-eslint/parser", "virtual:b2ce8114c6a09945c16f9024af866d293a40ce97bba68792156fc7fdba2aee89b2e65b0353c5ce06ae17e64cd6b05f70a2026214cd0ce8f123aecf369b55ad30#npm:8.60.0"],\
+          ["@typescript-eslint/parser", "virtual:28810e244b2c0a95073ad69eec1bf9bdbea24314d1cfdc745ba7b63fb342b9314b5c5b46d205b50a948d471bda7fc3ec1418d5c879a9dcc0bba8eafb506227ba#npm:8.60.0"],\
           ["@typescript-eslint/scope-manager", "npm:8.60.0"],\
           ["@typescript-eslint/types", "npm:8.60.0"],\
-          ["@typescript-eslint/typescript-estree", "virtual:b2ce8114c6a09945c16f9024af866d293a40ce97bba68792156fc7fdba2aee89b2e65b0353c5ce06ae17e64cd6b05f70a2026214cd0ce8f123aecf369b55ad30#npm:8.60.0"],\
+          ["@typescript-eslint/typescript-estree", "virtual:28810e244b2c0a95073ad69eec1bf9bdbea24314d1cfdc745ba7b63fb342b9314b5c5b46d205b50a948d471bda7fc3ec1418d5c879a9dcc0bba8eafb506227ba#npm:8.60.0"],\
           ["@typescript-eslint/visitor-keys", "npm:8.60.0"],\
           ["debug", "virtual:1ff4b5f90832ba0a9c93ba1223af226e44ba70c1126a3740d93562b97bc36544e896a5e95908196f7458713e6a6089a34bfc67362fc6df7fa093bd06c878be47#npm:4.4.3"],\
           ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
@@ -2930,12 +2936,12 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["virtual:3f54d31c88eb7813ed2c5083497e61594df5d51ade0b0da052e2a5fe7129e5938172318afff3f1646167f3fe9af2146954482e3cfe994afd8cf12d86ba64dfec#npm:8.66.0", {\
-        "packageLocation": "./.yarn/__virtual__/@typescript-eslint-project-service-virtual-e3ae014eb9/0/cache/@typescript-eslint-project-service-npm-8.66.0-23d466cc55-1b8129da70.zip/node_modules/@typescript-eslint/project-service/",\
+      ["virtual:1da82d6d63c1562092342352a125ba42cd6fe5ca8b8f58cced0fbc2b8656b60683c8ee8fa02b465763510bb40c0a2a3590c2296bea3d84bb614680c1cd44051f#npm:8.60.0", {\
+        "packageLocation": "./.yarn/__virtual__/@typescript-eslint-project-service-virtual-fb03d22c19/0/cache/@typescript-eslint-project-service-npm-8.60.0-cd81e016c2-8f72c2f102.zip/node_modules/@typescript-eslint/project-service/",\
         "packageDependencies": [\
           ["@types/typescript", null],\
-          ["@typescript-eslint/project-service", "virtual:3f54d31c88eb7813ed2c5083497e61594df5d51ade0b0da052e2a5fe7129e5938172318afff3f1646167f3fe9af2146954482e3cfe994afd8cf12d86ba64dfec#npm:8.66.0"],\
-          ["@typescript-eslint/tsconfig-utils", "virtual:3f54d31c88eb7813ed2c5083497e61594df5d51ade0b0da052e2a5fe7129e5938172318afff3f1646167f3fe9af2146954482e3cfe994afd8cf12d86ba64dfec#npm:8.66.0"],\
+          ["@typescript-eslint/project-service", "virtual:1da82d6d63c1562092342352a125ba42cd6fe5ca8b8f58cced0fbc2b8656b60683c8ee8fa02b465763510bb40c0a2a3590c2296bea3d84bb614680c1cd44051f#npm:8.60.0"],\
+          ["@typescript-eslint/tsconfig-utils", "virtual:c2790fc160f26db570e782a78b67da7a14838eb6f1e8a3695be5e14cfd4ac2763345c3f30689e70651b0c61a367aa657106663f25fc63057d596c0fa9e8a2d2a#npm:8.66.0"],\
           ["@typescript-eslint/types", "npm:8.66.0"],\
           ["debug", "virtual:1ff4b5f90832ba0a9c93ba1223af226e44ba70c1126a3740d93562b97bc36544e896a5e95908196f7458713e6a6089a34bfc67362fc6df7fa093bd06c878be47#npm:4.4.3"],\
           ["typescript", null]\
@@ -2946,12 +2952,12 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["virtual:5014c8313f140afe95d3b3f2542823409cad2ce5ee5019d3f5fdcbd987f4eeb122fad26e7d103814ce3d75cdb535c505c386ff5c9bd01ce60bf6a2b9c17e00dd#npm:8.60.0", {\
-        "packageLocation": "./.yarn/__virtual__/@typescript-eslint-project-service-virtual-56c47838b4/0/cache/@typescript-eslint-project-service-npm-8.60.0-cd81e016c2-8f72c2f102.zip/node_modules/@typescript-eslint/project-service/",\
+      ["virtual:c2790fc160f26db570e782a78b67da7a14838eb6f1e8a3695be5e14cfd4ac2763345c3f30689e70651b0c61a367aa657106663f25fc63057d596c0fa9e8a2d2a#npm:8.66.0", {\
+        "packageLocation": "./.yarn/__virtual__/@typescript-eslint-project-service-virtual-c9a31da7d0/0/cache/@typescript-eslint-project-service-npm-8.66.0-23d466cc55-1b8129da70.zip/node_modules/@typescript-eslint/project-service/",\
         "packageDependencies": [\
           ["@types/typescript", null],\
-          ["@typescript-eslint/project-service", "virtual:5014c8313f140afe95d3b3f2542823409cad2ce5ee5019d3f5fdcbd987f4eeb122fad26e7d103814ce3d75cdb535c505c386ff5c9bd01ce60bf6a2b9c17e00dd#npm:8.60.0"],\
-          ["@typescript-eslint/tsconfig-utils", "virtual:3f54d31c88eb7813ed2c5083497e61594df5d51ade0b0da052e2a5fe7129e5938172318afff3f1646167f3fe9af2146954482e3cfe994afd8cf12d86ba64dfec#npm:8.66.0"],\
+          ["@typescript-eslint/project-service", "virtual:c2790fc160f26db570e782a78b67da7a14838eb6f1e8a3695be5e14cfd4ac2763345c3f30689e70651b0c61a367aa657106663f25fc63057d596c0fa9e8a2d2a#npm:8.66.0"],\
+          ["@typescript-eslint/tsconfig-utils", "virtual:c2790fc160f26db570e782a78b67da7a14838eb6f1e8a3695be5e14cfd4ac2763345c3f30689e70651b0c61a367aa657106663f25fc63057d596c0fa9e8a2d2a#npm:8.66.0"],\
           ["@typescript-eslint/types", "npm:8.66.0"],\
           ["debug", "virtual:1ff4b5f90832ba0a9c93ba1223af226e44ba70c1126a3740d93562b97bc36544e896a5e95908196f7458713e6a6089a34bfc67362fc6df7fa093bd06c878be47#npm:4.4.3"],\
           ["typescript", null]\
@@ -3011,11 +3017,11 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["virtual:3f54d31c88eb7813ed2c5083497e61594df5d51ade0b0da052e2a5fe7129e5938172318afff3f1646167f3fe9af2146954482e3cfe994afd8cf12d86ba64dfec#npm:8.66.0", {\
-        "packageLocation": "./.yarn/__virtual__/@typescript-eslint-tsconfig-utils-virtual-0ae878761a/0/cache/@typescript-eslint-tsconfig-utils-npm-8.66.0-7d95a51cc5-1267e1f0ad.zip/node_modules/@typescript-eslint/tsconfig-utils/",\
+      ["virtual:1da82d6d63c1562092342352a125ba42cd6fe5ca8b8f58cced0fbc2b8656b60683c8ee8fa02b465763510bb40c0a2a3590c2296bea3d84bb614680c1cd44051f#npm:8.60.0", {\
+        "packageLocation": "./.yarn/__virtual__/@typescript-eslint-tsconfig-utils-virtual-12fdce16f6/0/cache/@typescript-eslint-tsconfig-utils-npm-8.60.0-7ce70e8526-701eae9a50.zip/node_modules/@typescript-eslint/tsconfig-utils/",\
         "packageDependencies": [\
           ["@types/typescript", null],\
-          ["@typescript-eslint/tsconfig-utils", "virtual:3f54d31c88eb7813ed2c5083497e61594df5d51ade0b0da052e2a5fe7129e5938172318afff3f1646167f3fe9af2146954482e3cfe994afd8cf12d86ba64dfec#npm:8.66.0"],\
+          ["@typescript-eslint/tsconfig-utils", "virtual:1da82d6d63c1562092342352a125ba42cd6fe5ca8b8f58cced0fbc2b8656b60683c8ee8fa02b465763510bb40c0a2a3590c2296bea3d84bb614680c1cd44051f#npm:8.60.0"],\
           ["typescript", null]\
         ],\
         "packagePeers": [\
@@ -3024,11 +3030,11 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["virtual:5014c8313f140afe95d3b3f2542823409cad2ce5ee5019d3f5fdcbd987f4eeb122fad26e7d103814ce3d75cdb535c505c386ff5c9bd01ce60bf6a2b9c17e00dd#npm:8.60.0", {\
-        "packageLocation": "./.yarn/__virtual__/@typescript-eslint-tsconfig-utils-virtual-671e13d6eb/0/cache/@typescript-eslint-tsconfig-utils-npm-8.60.0-7ce70e8526-701eae9a50.zip/node_modules/@typescript-eslint/tsconfig-utils/",\
+      ["virtual:c2790fc160f26db570e782a78b67da7a14838eb6f1e8a3695be5e14cfd4ac2763345c3f30689e70651b0c61a367aa657106663f25fc63057d596c0fa9e8a2d2a#npm:8.66.0", {\
+        "packageLocation": "./.yarn/__virtual__/@typescript-eslint-tsconfig-utils-virtual-f33d0e3725/0/cache/@typescript-eslint-tsconfig-utils-npm-8.66.0-7d95a51cc5-1267e1f0ad.zip/node_modules/@typescript-eslint/tsconfig-utils/",\
         "packageDependencies": [\
           ["@types/typescript", null],\
-          ["@typescript-eslint/tsconfig-utils", "virtual:5014c8313f140afe95d3b3f2542823409cad2ce5ee5019d3f5fdcbd987f4eeb122fad26e7d103814ce3d75cdb535c505c386ff5c9bd01ce60bf6a2b9c17e00dd#npm:8.60.0"],\
+          ["@typescript-eslint/tsconfig-utils", "virtual:c2790fc160f26db570e782a78b67da7a14838eb6f1e8a3695be5e14cfd4ac2763345c3f30689e70651b0c61a367aa657106663f25fc63057d596c0fa9e8a2d2a#npm:8.66.0"],\
           ["typescript", null]\
         ],\
         "packagePeers": [\
@@ -3046,18 +3052,18 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:0506b0a2e76b6f9819e3ba28b4beef58b958aeab24ae11dcee1f18cabfc52a5d62ba09478b80c5318e452e58bd7d5ab394314198f1909b88063c5ddad0c632bf#npm:8.60.0", {\
-        "packageLocation": "./.yarn/__virtual__/@typescript-eslint-type-utils-virtual-5ddda24dea/0/cache/@typescript-eslint-type-utils-npm-8.60.0-5c9c0a6891-2b6d8efe6b.zip/node_modules/@typescript-eslint/type-utils/",\
+      ["virtual:6075b380118fa9d158a4752b2a8865e550708867f02969d83bb75cf6275815479ffc8d505cb14a6dd9c47c3ce3618f96d920e6f5b59ed2021e8e4fd229f30fa5#npm:8.60.0", {\
+        "packageLocation": "./.yarn/__virtual__/@typescript-eslint-type-utils-virtual-ac18bafcba/0/cache/@typescript-eslint-type-utils-npm-8.60.0-5c9c0a6891-2b6d8efe6b.zip/node_modules/@typescript-eslint/type-utils/",\
         "packageDependencies": [\
           ["@types/eslint", null],\
           ["@types/typescript", null],\
-          ["@typescript-eslint/type-utils", "virtual:0506b0a2e76b6f9819e3ba28b4beef58b958aeab24ae11dcee1f18cabfc52a5d62ba09478b80c5318e452e58bd7d5ab394314198f1909b88063c5ddad0c632bf#npm:8.60.0"],\
+          ["@typescript-eslint/type-utils", "virtual:6075b380118fa9d158a4752b2a8865e550708867f02969d83bb75cf6275815479ffc8d505cb14a6dd9c47c3ce3618f96d920e6f5b59ed2021e8e4fd229f30fa5#npm:8.60.0"],\
           ["@typescript-eslint/types", "npm:8.60.0"],\
-          ["@typescript-eslint/typescript-estree", "virtual:b2ce8114c6a09945c16f9024af866d293a40ce97bba68792156fc7fdba2aee89b2e65b0353c5ce06ae17e64cd6b05f70a2026214cd0ce8f123aecf369b55ad30#npm:8.60.0"],\
-          ["@typescript-eslint/utils", "virtual:b2ce8114c6a09945c16f9024af866d293a40ce97bba68792156fc7fdba2aee89b2e65b0353c5ce06ae17e64cd6b05f70a2026214cd0ce8f123aecf369b55ad30#npm:8.60.0"],\
+          ["@typescript-eslint/typescript-estree", "virtual:28810e244b2c0a95073ad69eec1bf9bdbea24314d1cfdc745ba7b63fb342b9314b5c5b46d205b50a948d471bda7fc3ec1418d5c879a9dcc0bba8eafb506227ba#npm:8.60.0"],\
+          ["@typescript-eslint/utils", "virtual:28810e244b2c0a95073ad69eec1bf9bdbea24314d1cfdc745ba7b63fb342b9314b5c5b46d205b50a948d471bda7fc3ec1418d5c879a9dcc0bba8eafb506227ba#npm:8.60.0"],\
           ["debug", "virtual:1ff4b5f90832ba0a9c93ba1223af226e44ba70c1126a3740d93562b97bc36544e896a5e95908196f7458713e6a6089a34bfc67362fc6df7fa093bd06c878be47#npm:4.4.3"],\
           ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
-          ["ts-api-utils", "virtual:3f54d31c88eb7813ed2c5083497e61594df5d51ade0b0da052e2a5fe7129e5938172318afff3f1646167f3fe9af2146954482e3cfe994afd8cf12d86ba64dfec#npm:2.5.0"],\
+          ["ts-api-utils", "virtual:c2790fc160f26db570e782a78b67da7a14838eb6f1e8a3695be5e14cfd4ac2763345c3f30689e70651b0c61a367aa657106663f25fc63057d596c0fa9e8a2d2a#npm:2.5.0"],\
           ["typescript", null]\
         ],\
         "packagePeers": [\
@@ -3122,20 +3128,20 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["virtual:b2ce8114c6a09945c16f9024af866d293a40ce97bba68792156fc7fdba2aee89b2e65b0353c5ce06ae17e64cd6b05f70a2026214cd0ce8f123aecf369b55ad30#npm:8.60.0", {\
-        "packageLocation": "./.yarn/__virtual__/@typescript-eslint-typescript-estree-virtual-5014c8313f/0/cache/@typescript-eslint-typescript-estree-npm-8.60.0-ab6e1f2206-9a24a3c476.zip/node_modules/@typescript-eslint/typescript-estree/",\
+      ["virtual:28810e244b2c0a95073ad69eec1bf9bdbea24314d1cfdc745ba7b63fb342b9314b5c5b46d205b50a948d471bda7fc3ec1418d5c879a9dcc0bba8eafb506227ba#npm:8.60.0", {\
+        "packageLocation": "./.yarn/__virtual__/@typescript-eslint-typescript-estree-virtual-1da82d6d63/0/cache/@typescript-eslint-typescript-estree-npm-8.60.0-ab6e1f2206-9a24a3c476.zip/node_modules/@typescript-eslint/typescript-estree/",\
         "packageDependencies": [\
           ["@types/typescript", null],\
-          ["@typescript-eslint/project-service", "virtual:5014c8313f140afe95d3b3f2542823409cad2ce5ee5019d3f5fdcbd987f4eeb122fad26e7d103814ce3d75cdb535c505c386ff5c9bd01ce60bf6a2b9c17e00dd#npm:8.60.0"],\
-          ["@typescript-eslint/tsconfig-utils", "virtual:5014c8313f140afe95d3b3f2542823409cad2ce5ee5019d3f5fdcbd987f4eeb122fad26e7d103814ce3d75cdb535c505c386ff5c9bd01ce60bf6a2b9c17e00dd#npm:8.60.0"],\
+          ["@typescript-eslint/project-service", "virtual:1da82d6d63c1562092342352a125ba42cd6fe5ca8b8f58cced0fbc2b8656b60683c8ee8fa02b465763510bb40c0a2a3590c2296bea3d84bb614680c1cd44051f#npm:8.60.0"],\
+          ["@typescript-eslint/tsconfig-utils", "virtual:1da82d6d63c1562092342352a125ba42cd6fe5ca8b8f58cced0fbc2b8656b60683c8ee8fa02b465763510bb40c0a2a3590c2296bea3d84bb614680c1cd44051f#npm:8.60.0"],\
           ["@typescript-eslint/types", "npm:8.60.0"],\
-          ["@typescript-eslint/typescript-estree", "virtual:b2ce8114c6a09945c16f9024af866d293a40ce97bba68792156fc7fdba2aee89b2e65b0353c5ce06ae17e64cd6b05f70a2026214cd0ce8f123aecf369b55ad30#npm:8.60.0"],\
+          ["@typescript-eslint/typescript-estree", "virtual:28810e244b2c0a95073ad69eec1bf9bdbea24314d1cfdc745ba7b63fb342b9314b5c5b46d205b50a948d471bda7fc3ec1418d5c879a9dcc0bba8eafb506227ba#npm:8.60.0"],\
           ["@typescript-eslint/visitor-keys", "npm:8.60.0"],\
           ["debug", "virtual:1ff4b5f90832ba0a9c93ba1223af226e44ba70c1126a3740d93562b97bc36544e896a5e95908196f7458713e6a6089a34bfc67362fc6df7fa093bd06c878be47#npm:4.4.3"],\
           ["minimatch", "npm:10.2.5"],\
           ["semver", "npm:7.8.5"],\
           ["tinyglobby", "npm:0.2.17"],\
-          ["ts-api-utils", "virtual:3f54d31c88eb7813ed2c5083497e61594df5d51ade0b0da052e2a5fe7129e5938172318afff3f1646167f3fe9af2146954482e3cfe994afd8cf12d86ba64dfec#npm:2.5.0"],\
+          ["ts-api-utils", "virtual:c2790fc160f26db570e782a78b67da7a14838eb6f1e8a3695be5e14cfd4ac2763345c3f30689e70651b0c61a367aa657106663f25fc63057d596c0fa9e8a2d2a#npm:2.5.0"],\
           ["typescript", null]\
         ],\
         "packagePeers": [\
@@ -3144,20 +3150,20 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["virtual:c8bbe138bb822c9299c2e2e0384661d0e1f1e1f3a6d583303d6e68b0ea686a18fd0a231b7b7fe13c9f8d822f67c0cbf4417c80353ff01aa35ae30e11f542864a#npm:8.66.0", {\
-        "packageLocation": "./.yarn/__virtual__/@typescript-eslint-typescript-estree-virtual-3f54d31c88/0/cache/@typescript-eslint-typescript-estree-npm-8.66.0-8179df0438-4a75566634.zip/node_modules/@typescript-eslint/typescript-estree/",\
+      ["virtual:ba2edf52feb929207d15f55aba8550a059ca9e171e9ee6604a08a4228972fc5181ed0504723546323646dd479aacc4cad73bc05d9420c619a309b06222382745#npm:8.66.0", {\
+        "packageLocation": "./.yarn/__virtual__/@typescript-eslint-typescript-estree-virtual-c2790fc160/0/cache/@typescript-eslint-typescript-estree-npm-8.66.0-8179df0438-4a75566634.zip/node_modules/@typescript-eslint/typescript-estree/",\
         "packageDependencies": [\
           ["@types/typescript", null],\
-          ["@typescript-eslint/project-service", "virtual:3f54d31c88eb7813ed2c5083497e61594df5d51ade0b0da052e2a5fe7129e5938172318afff3f1646167f3fe9af2146954482e3cfe994afd8cf12d86ba64dfec#npm:8.66.0"],\
-          ["@typescript-eslint/tsconfig-utils", "virtual:3f54d31c88eb7813ed2c5083497e61594df5d51ade0b0da052e2a5fe7129e5938172318afff3f1646167f3fe9af2146954482e3cfe994afd8cf12d86ba64dfec#npm:8.66.0"],\
+          ["@typescript-eslint/project-service", "virtual:c2790fc160f26db570e782a78b67da7a14838eb6f1e8a3695be5e14cfd4ac2763345c3f30689e70651b0c61a367aa657106663f25fc63057d596c0fa9e8a2d2a#npm:8.66.0"],\
+          ["@typescript-eslint/tsconfig-utils", "virtual:c2790fc160f26db570e782a78b67da7a14838eb6f1e8a3695be5e14cfd4ac2763345c3f30689e70651b0c61a367aa657106663f25fc63057d596c0fa9e8a2d2a#npm:8.66.0"],\
           ["@typescript-eslint/types", "npm:8.66.0"],\
-          ["@typescript-eslint/typescript-estree", "virtual:c8bbe138bb822c9299c2e2e0384661d0e1f1e1f3a6d583303d6e68b0ea686a18fd0a231b7b7fe13c9f8d822f67c0cbf4417c80353ff01aa35ae30e11f542864a#npm:8.66.0"],\
+          ["@typescript-eslint/typescript-estree", "virtual:ba2edf52feb929207d15f55aba8550a059ca9e171e9ee6604a08a4228972fc5181ed0504723546323646dd479aacc4cad73bc05d9420c619a309b06222382745#npm:8.66.0"],\
           ["@typescript-eslint/visitor-keys", "npm:8.66.0"],\
           ["debug", "virtual:1ff4b5f90832ba0a9c93ba1223af226e44ba70c1126a3740d93562b97bc36544e896a5e95908196f7458713e6a6089a34bfc67362fc6df7fa093bd06c878be47#npm:4.4.3"],\
           ["minimatch", "npm:10.2.5"],\
           ["semver", "npm:7.8.5"],\
           ["tinyglobby", "npm:0.2.17"],\
-          ["ts-api-utils", "virtual:3f54d31c88eb7813ed2c5083497e61594df5d51ade0b0da052e2a5fe7129e5938172318afff3f1646167f3fe9af2146954482e3cfe994afd8cf12d86ba64dfec#npm:2.5.0"],\
+          ["ts-api-utils", "virtual:c2790fc160f26db570e782a78b67da7a14838eb6f1e8a3695be5e14cfd4ac2763345c3f30689e70651b0c61a367aa657106663f25fc63057d596c0fa9e8a2d2a#npm:2.5.0"],\
           ["typescript", null]\
         ],\
         "packagePeers": [\
@@ -3182,10 +3188,52 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
+      ["virtual:28810e244b2c0a95073ad69eec1bf9bdbea24314d1cfdc745ba7b63fb342b9314b5c5b46d205b50a948d471bda7fc3ec1418d5c879a9dcc0bba8eafb506227ba#npm:8.60.0", {\
+        "packageLocation": "./.yarn/__virtual__/@typescript-eslint-utils-virtual-209a177c79/0/cache/@typescript-eslint-utils-npm-8.60.0-789b037d93-c1fe25bc90.zip/node_modules/@typescript-eslint/utils/",\
+        "packageDependencies": [\
+          ["@eslint-community/eslint-utils", "virtual:ba2edf52feb929207d15f55aba8550a059ca9e171e9ee6604a08a4228972fc5181ed0504723546323646dd479aacc4cad73bc05d9420c619a309b06222382745#npm:4.9.1"],\
+          ["@types/eslint", null],\
+          ["@types/typescript", null],\
+          ["@typescript-eslint/scope-manager", "npm:8.60.0"],\
+          ["@typescript-eslint/types", "npm:8.60.0"],\
+          ["@typescript-eslint/typescript-estree", "virtual:28810e244b2c0a95073ad69eec1bf9bdbea24314d1cfdc745ba7b63fb342b9314b5c5b46d205b50a948d471bda7fc3ec1418d5c879a9dcc0bba8eafb506227ba#npm:8.60.0"],\
+          ["@typescript-eslint/utils", "virtual:28810e244b2c0a95073ad69eec1bf9bdbea24314d1cfdc745ba7b63fb342b9314b5c5b46d205b50a948d471bda7fc3ec1418d5c879a9dcc0bba8eafb506227ba#npm:8.60.0"],\
+          ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
+          ["typescript", null]\
+        ],\
+        "packagePeers": [\
+          "@types/eslint",\
+          "@types/typescript",\
+          "eslint",\
+          "typescript"\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["virtual:2e2eb2b148e0dd5594028029910a1e2f7e7dbafb3a0bfa7000d342032e0462f3c951bd5823563b256aecfc6da06cf711cf07645bfb5a6219faa29225f1b37ded#npm:8.66.0", {\
+        "packageLocation": "./.yarn/__virtual__/@typescript-eslint-utils-virtual-ba2edf52fe/0/cache/@typescript-eslint-utils-npm-8.66.0-cfa59d1872-8bce52462a.zip/node_modules/@typescript-eslint/utils/",\
+        "packageDependencies": [\
+          ["@eslint-community/eslint-utils", "virtual:ba2edf52feb929207d15f55aba8550a059ca9e171e9ee6604a08a4228972fc5181ed0504723546323646dd479aacc4cad73bc05d9420c619a309b06222382745#npm:4.9.1"],\
+          ["@types/eslint", null],\
+          ["@types/typescript", null],\
+          ["@typescript-eslint/scope-manager", "npm:8.66.0"],\
+          ["@typescript-eslint/types", "npm:8.66.0"],\
+          ["@typescript-eslint/typescript-estree", "virtual:ba2edf52feb929207d15f55aba8550a059ca9e171e9ee6604a08a4228972fc5181ed0504723546323646dd479aacc4cad73bc05d9420c619a309b06222382745#npm:8.66.0"],\
+          ["@typescript-eslint/utils", "virtual:2e2eb2b148e0dd5594028029910a1e2f7e7dbafb3a0bfa7000d342032e0462f3c951bd5823563b256aecfc6da06cf711cf07645bfb5a6219faa29225f1b37ded#npm:8.66.0"],\
+          ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
+          ["typescript", null]\
+        ],\
+        "packagePeers": [\
+          "@types/eslint",\
+          "@types/typescript",\
+          "eslint",\
+          "typescript"\
+        ],\
+        "linkType": "HARD"\
+      }],\
       ["virtual:8d919ffb8fd728f827df3f6a566e8e923223ffcec68f7450d83bbbc2dc25d6b8c987e111cbab484b209f253bdf2f2e00663b01a986262c44511128466462a76f#npm:8.66.0", {\
         "packageLocation": "./.yarn/__virtual__/@typescript-eslint-utils-virtual-1ed325a4e3/0/cache/@typescript-eslint-utils-npm-8.66.0-cfa59d1872-8bce52462a.zip/node_modules/@typescript-eslint/utils/",\
         "packageDependencies": [\
-          ["@eslint-community/eslint-utils", "virtual:69947eb79a108297ef883fbc634b733d5cb177862b9ca665df089a1af6c4f235d205dc292bbdf0129577ea9a99f4b6a132653f28ed7feb24ce44563be88ab4c0#npm:4.9.1"],\
+          ["@eslint-community/eslint-utils", "virtual:ba2edf52feb929207d15f55aba8550a059ca9e171e9ee6604a08a4228972fc5181ed0504723546323646dd479aacc4cad73bc05d9420c619a309b06222382745#npm:4.9.1"],\
           ["@types/eslint", null],\
           ["@types/typescript", null],\
           ["@typescript-eslint/scope-manager", "npm:8.66.0"],\
@@ -3194,48 +3242,6 @@ const RAW_RUNTIME_STATE =
           ["@typescript-eslint/utils", "virtual:8d919ffb8fd728f827df3f6a566e8e923223ffcec68f7450d83bbbc2dc25d6b8c987e111cbab484b209f253bdf2f2e00663b01a986262c44511128466462a76f#npm:8.66.0"],\
           ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
           ["typescript", "patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"]\
-        ],\
-        "packagePeers": [\
-          "@types/eslint",\
-          "@types/typescript",\
-          "eslint",\
-          "typescript"\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["virtual:b2ce8114c6a09945c16f9024af866d293a40ce97bba68792156fc7fdba2aee89b2e65b0353c5ce06ae17e64cd6b05f70a2026214cd0ce8f123aecf369b55ad30#npm:8.60.0", {\
-        "packageLocation": "./.yarn/__virtual__/@typescript-eslint-utils-virtual-7f76f0ca8f/0/cache/@typescript-eslint-utils-npm-8.60.0-789b037d93-c1fe25bc90.zip/node_modules/@typescript-eslint/utils/",\
-        "packageDependencies": [\
-          ["@eslint-community/eslint-utils", "virtual:69947eb79a108297ef883fbc634b733d5cb177862b9ca665df089a1af6c4f235d205dc292bbdf0129577ea9a99f4b6a132653f28ed7feb24ce44563be88ab4c0#npm:4.9.1"],\
-          ["@types/eslint", null],\
-          ["@types/typescript", null],\
-          ["@typescript-eslint/scope-manager", "npm:8.60.0"],\
-          ["@typescript-eslint/types", "npm:8.60.0"],\
-          ["@typescript-eslint/typescript-estree", "virtual:b2ce8114c6a09945c16f9024af866d293a40ce97bba68792156fc7fdba2aee89b2e65b0353c5ce06ae17e64cd6b05f70a2026214cd0ce8f123aecf369b55ad30#npm:8.60.0"],\
-          ["@typescript-eslint/utils", "virtual:b2ce8114c6a09945c16f9024af866d293a40ce97bba68792156fc7fdba2aee89b2e65b0353c5ce06ae17e64cd6b05f70a2026214cd0ce8f123aecf369b55ad30#npm:8.60.0"],\
-          ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
-          ["typescript", null]\
-        ],\
-        "packagePeers": [\
-          "@types/eslint",\
-          "@types/typescript",\
-          "eslint",\
-          "typescript"\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["virtual:bc949ddf0f1ade49095936c008773d64c06e758027f148b65bac6dfbd2a8a17b386930a4b94df127d18bca4119aafb8822c9e8f26c56759acabe54ad4df2d843#npm:8.66.0", {\
-        "packageLocation": "./.yarn/__virtual__/@typescript-eslint-utils-virtual-c8bbe138bb/0/cache/@typescript-eslint-utils-npm-8.66.0-cfa59d1872-8bce52462a.zip/node_modules/@typescript-eslint/utils/",\
-        "packageDependencies": [\
-          ["@eslint-community/eslint-utils", "virtual:69947eb79a108297ef883fbc634b733d5cb177862b9ca665df089a1af6c4f235d205dc292bbdf0129577ea9a99f4b6a132653f28ed7feb24ce44563be88ab4c0#npm:4.9.1"],\
-          ["@types/eslint", null],\
-          ["@types/typescript", null],\
-          ["@typescript-eslint/scope-manager", "npm:8.66.0"],\
-          ["@typescript-eslint/types", "npm:8.66.0"],\
-          ["@typescript-eslint/typescript-estree", "virtual:c8bbe138bb822c9299c2e2e0384661d0e1f1e1f3a6d583303d6e68b0ea686a18fd0a231b7b7fe13c9f8d822f67c0cbf4417c80353ff01aa35ae30e11f542864a#npm:8.66.0"],\
-          ["@typescript-eslint/utils", "virtual:bc949ddf0f1ade49095936c008773d64c06e758027f148b65bac6dfbd2a8a17b386930a4b94df127d18bca4119aafb8822c9e8f26c56759acabe54ad4df2d843#npm:8.66.0"],\
-          ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
-          ["typescript", null]\
         ],\
         "packagePeers": [\
           "@types/eslint",\
@@ -3629,6 +3635,33 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
+      ["virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:4.1.10", {\
+        "packageLocation": "./.yarn/__virtual__/@vitest-coverage-v8-virtual-3b88386673/0/cache/@vitest-coverage-v8-npm-4.1.10-de4d655b9a-f607ab5610.zip/node_modules/@vitest/coverage-v8/",\
+        "packageDependencies": [\
+          ["@bcoe/v8-coverage", "npm:1.0.2"],\
+          ["@types/vitest", null],\
+          ["@types/vitest__browser", null],\
+          ["@vitest/browser", null],\
+          ["@vitest/coverage-v8", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:4.1.10"],\
+          ["@vitest/utils", "npm:4.1.10"],\
+          ["ast-v8-to-istanbul", "npm:1.0.3"],\
+          ["istanbul-lib-coverage", "npm:3.2.2"],\
+          ["istanbul-lib-report", "npm:3.0.1"],\
+          ["istanbul-reports", "npm:3.2.0"],\
+          ["magicast", "npm:0.5.3"],\
+          ["obug", "npm:2.1.1"],\
+          ["std-env", "npm:4.1.0"],\
+          ["tinyrainbow", "npm:3.1.0"],\
+          ["vitest", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:4.1.10"]\
+        ],\
+        "packagePeers": [\
+          "@types/vitest",\
+          "@types/vitest__browser",\
+          "@vitest/browser",\
+          "vitest"\
+        ],\
+        "linkType": "HARD"\
+      }],\
       ["virtual:f966e7aeb7c55583fd75c7557c3a1bc5c402d6b0b046ba107cf42de8ba43cf7067dc5f63013392d15bc07cbcc8692e71b6eb89164b32ef3640c94873538925b0#npm:4.1.10", {\
         "packageLocation": "./.yarn/__virtual__/@vitest-coverage-v8-virtual-72558d8c8b/0/cache/@vitest-coverage-v8-npm-4.1.10-de4d655b9a-f607ab5610.zip/node_modules/@vitest/coverage-v8/",\
         "packageDependencies": [\
@@ -3701,7 +3734,7 @@ const RAW_RUNTIME_STATE =
           ["@types/vitest", null],\
           ["@typescript-eslint/eslint-plugin", null],\
           ["@typescript-eslint/scope-manager", "npm:8.66.0"],\
-          ["@typescript-eslint/utils", "virtual:bc949ddf0f1ade49095936c008773d64c06e758027f148b65bac6dfbd2a8a17b386930a4b94df127d18bca4119aafb8822c9e8f26c56759acabe54ad4df2d843#npm:8.66.0"],\
+          ["@typescript-eslint/utils", "virtual:2e2eb2b148e0dd5594028029910a1e2f7e7dbafb3a0bfa7000d342032e0462f3c951bd5823563b256aecfc6da06cf711cf07645bfb5a6219faa29225f1b37ded#npm:8.66.0"],\
           ["@vitest/eslint-plugin", "virtual:167c898d89436663a7a547cd240a0f77e183060e54bab1fd8e9ad3b783292e7bee2c1aaecd5e22bd0f54c8b102c8a6713b919970f45193ff335a90f5b65daa58#npm:1.6.26"],\
           ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
           ["typescript", null],\
@@ -3728,7 +3761,7 @@ const RAW_RUNTIME_STATE =
           ["@types/vitest", null],\
           ["@typescript-eslint/eslint-plugin", null],\
           ["@typescript-eslint/scope-manager", "npm:8.66.0"],\
-          ["@typescript-eslint/utils", "virtual:bc949ddf0f1ade49095936c008773d64c06e758027f148b65bac6dfbd2a8a17b386930a4b94df127d18bca4119aafb8822c9e8f26c56759acabe54ad4df2d843#npm:8.66.0"],\
+          ["@typescript-eslint/utils", "virtual:2e2eb2b148e0dd5594028029910a1e2f7e7dbafb3a0bfa7000d342032e0462f3c951bd5823563b256aecfc6da06cf711cf07645bfb5a6219faa29225f1b37ded#npm:8.66.0"],\
           ["@vitest/eslint-plugin", "virtual:2c923f59c4675c87278ce3aa7d501b2831091130d417bde2a24ce2608345e7844c4d71578f103362589eb4d651e2514ad746bccd32508a2feda0d63dda053573#npm:1.6.26"],\
           ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
           ["typescript", null],\
@@ -3755,7 +3788,7 @@ const RAW_RUNTIME_STATE =
           ["@types/vitest", null],\
           ["@typescript-eslint/eslint-plugin", null],\
           ["@typescript-eslint/scope-manager", "npm:8.66.0"],\
-          ["@typescript-eslint/utils", "virtual:bc949ddf0f1ade49095936c008773d64c06e758027f148b65bac6dfbd2a8a17b386930a4b94df127d18bca4119aafb8822c9e8f26c56759acabe54ad4df2d843#npm:8.66.0"],\
+          ["@typescript-eslint/utils", "virtual:2e2eb2b148e0dd5594028029910a1e2f7e7dbafb3a0bfa7000d342032e0462f3c951bd5823563b256aecfc6da06cf711cf07645bfb5a6219faa29225f1b37ded#npm:8.66.0"],\
           ["@vitest/eslint-plugin", "virtual:5610037bb1511542640ade95602b1c5470f325fae9ddb84de90506a220dbd946b9cefcd0530b3f57dc1a220633c595e044cfd68f018e331afd37c33546f3ca6c#npm:1.6.26"],\
           ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
           ["typescript", null],\
@@ -3782,7 +3815,7 @@ const RAW_RUNTIME_STATE =
           ["@types/vitest", null],\
           ["@typescript-eslint/eslint-plugin", null],\
           ["@typescript-eslint/scope-manager", "npm:8.66.0"],\
-          ["@typescript-eslint/utils", "virtual:bc949ddf0f1ade49095936c008773d64c06e758027f148b65bac6dfbd2a8a17b386930a4b94df127d18bca4119aafb8822c9e8f26c56759acabe54ad4df2d843#npm:8.66.0"],\
+          ["@typescript-eslint/utils", "virtual:2e2eb2b148e0dd5594028029910a1e2f7e7dbafb3a0bfa7000d342032e0462f3c951bd5823563b256aecfc6da06cf711cf07645bfb5a6219faa29225f1b37ded#npm:8.66.0"],\
           ["@vitest/eslint-plugin", "virtual:6e2c4c5999ef7336f2366c028c6e208518bd5e4636dbc07154eda26f900c9d3306eb27557764a142dd0ed454b5cb8f5c908fde8502e9e0d5089dffde5a1840e1#npm:1.6.26"],\
           ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
           ["typescript", null],\
@@ -3836,7 +3869,7 @@ const RAW_RUNTIME_STATE =
           ["@types/vitest", null],\
           ["@typescript-eslint/eslint-plugin", null],\
           ["@typescript-eslint/scope-manager", "npm:8.66.0"],\
-          ["@typescript-eslint/utils", "virtual:bc949ddf0f1ade49095936c008773d64c06e758027f148b65bac6dfbd2a8a17b386930a4b94df127d18bca4119aafb8822c9e8f26c56759acabe54ad4df2d843#npm:8.66.0"],\
+          ["@typescript-eslint/utils", "virtual:2e2eb2b148e0dd5594028029910a1e2f7e7dbafb3a0bfa7000d342032e0462f3c951bd5823563b256aecfc6da06cf711cf07645bfb5a6219faa29225f1b37ded#npm:8.66.0"],\
           ["@vitest/eslint-plugin", "virtual:91da830b29af2704bfc9679729fb85d00ca0b8eeb24a837747a5bc0b5aec0e922594580a901a48c34c06a65b9b376f23fa3cbb88dc9fd35cddc5076ab48a067f#npm:1.6.26"],\
           ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
           ["typescript", null],\
@@ -3863,7 +3896,7 @@ const RAW_RUNTIME_STATE =
           ["@types/vitest", null],\
           ["@typescript-eslint/eslint-plugin", null],\
           ["@typescript-eslint/scope-manager", "npm:8.66.0"],\
-          ["@typescript-eslint/utils", "virtual:bc949ddf0f1ade49095936c008773d64c06e758027f148b65bac6dfbd2a8a17b386930a4b94df127d18bca4119aafb8822c9e8f26c56759acabe54ad4df2d843#npm:8.66.0"],\
+          ["@typescript-eslint/utils", "virtual:2e2eb2b148e0dd5594028029910a1e2f7e7dbafb3a0bfa7000d342032e0462f3c951bd5823563b256aecfc6da06cf711cf07645bfb5a6219faa29225f1b37ded#npm:8.66.0"],\
           ["@vitest/eslint-plugin", "virtual:cfb59f52db931439eb14a47d99c6d8e602c14483d7dcfb0a236c44522c1caf76628ef60a9ab9501c1ea33a268c652322842aea7c72977de7ffa2e241262638c0#npm:1.6.26"],\
           ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
           ["typescript", null],\
@@ -3890,7 +3923,7 @@ const RAW_RUNTIME_STATE =
           ["@types/vitest", null],\
           ["@typescript-eslint/eslint-plugin", null],\
           ["@typescript-eslint/scope-manager", "npm:8.66.0"],\
-          ["@typescript-eslint/utils", "virtual:bc949ddf0f1ade49095936c008773d64c06e758027f148b65bac6dfbd2a8a17b386930a4b94df127d18bca4119aafb8822c9e8f26c56759acabe54ad4df2d843#npm:8.66.0"],\
+          ["@typescript-eslint/utils", "virtual:2e2eb2b148e0dd5594028029910a1e2f7e7dbafb3a0bfa7000d342032e0462f3c951bd5823563b256aecfc6da06cf711cf07645bfb5a6219faa29225f1b37ded#npm:8.66.0"],\
           ["@vitest/eslint-plugin", "virtual:da5c259967d05763f37b857188cc51d834f07841d7f256ee31fca651fde6eb0ee4baf7a619bba67c191201184011519f8e83142e0030ce0ac1ed9b709ad7dfc2#npm:1.6.26"],\
           ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
           ["typescript", null],\
@@ -3917,7 +3950,7 @@ const RAW_RUNTIME_STATE =
           ["@types/vitest", null],\
           ["@typescript-eslint/eslint-plugin", null],\
           ["@typescript-eslint/scope-manager", "npm:8.66.0"],\
-          ["@typescript-eslint/utils", "virtual:bc949ddf0f1ade49095936c008773d64c06e758027f148b65bac6dfbd2a8a17b386930a4b94df127d18bca4119aafb8822c9e8f26c56759acabe54ad4df2d843#npm:8.66.0"],\
+          ["@typescript-eslint/utils", "virtual:2e2eb2b148e0dd5594028029910a1e2f7e7dbafb3a0bfa7000d342032e0462f3c951bd5823563b256aecfc6da06cf711cf07645bfb5a6219faa29225f1b37ded#npm:8.66.0"],\
           ["@vitest/eslint-plugin", "virtual:dee42bbf2b8a9fdc35f5ff723774d473a27fbd01ca23e57b4dfc5e6f05027029778468ff50260c9f7c32df316ded00563e6ff4412b3cc55fa5cf2903cb91f445#npm:1.6.26"],\
           ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
           ["typescript", null],\
@@ -3944,7 +3977,7 @@ const RAW_RUNTIME_STATE =
           ["@types/vitest", null],\
           ["@typescript-eslint/eslint-plugin", null],\
           ["@typescript-eslint/scope-manager", "npm:8.66.0"],\
-          ["@typescript-eslint/utils", "virtual:bc949ddf0f1ade49095936c008773d64c06e758027f148b65bac6dfbd2a8a17b386930a4b94df127d18bca4119aafb8822c9e8f26c56759acabe54ad4df2d843#npm:8.66.0"],\
+          ["@typescript-eslint/utils", "virtual:2e2eb2b148e0dd5594028029910a1e2f7e7dbafb3a0bfa7000d342032e0462f3c951bd5823563b256aecfc6da06cf711cf07645bfb5a6219faa29225f1b37ded#npm:8.66.0"],\
           ["@vitest/eslint-plugin", "virtual:e15c1daf1a4567721560be9b273fb77dba8d5c7497bda4b1dd746ae877b634671a382dc32e7018309cfa8dc2b42e8f4348670f01a6ab32cf5380f8eab0b8ff5d#npm:1.6.26"],\
           ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
           ["typescript", null],\
@@ -3971,11 +4004,38 @@ const RAW_RUNTIME_STATE =
           ["@types/vitest", null],\
           ["@typescript-eslint/eslint-plugin", null],\
           ["@typescript-eslint/scope-manager", "npm:8.66.0"],\
-          ["@typescript-eslint/utils", "virtual:bc949ddf0f1ade49095936c008773d64c06e758027f148b65bac6dfbd2a8a17b386930a4b94df127d18bca4119aafb8822c9e8f26c56759acabe54ad4df2d843#npm:8.66.0"],\
+          ["@typescript-eslint/utils", "virtual:2e2eb2b148e0dd5594028029910a1e2f7e7dbafb3a0bfa7000d342032e0462f3c951bd5823563b256aecfc6da06cf711cf07645bfb5a6219faa29225f1b37ded#npm:8.66.0"],\
           ["@vitest/eslint-plugin", "virtual:e4cd5705e1c344e12c9b35de8f14cee55dfb19ddb91518014763e55515c03ad1ff16a60cd4a8aabce2fd607a04df60d0ce645c4f47235dc4ece846d082e33885#npm:1.6.26"],\
           ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
           ["typescript", null],\
           ["vitest", "virtual:e4cd5705e1c344e12c9b35de8f14cee55dfb19ddb91518014763e55515c03ad1ff16a60cd4a8aabce2fd607a04df60d0ce645c4f47235dc4ece846d082e33885#npm:4.1.10"]\
+        ],\
+        "packagePeers": [\
+          "@types/eslint",\
+          "@types/typescript-eslint__eslint-plugin",\
+          "@types/typescript",\
+          "@types/vitest",\
+          "@typescript-eslint/eslint-plugin",\
+          "eslint",\
+          "typescript",\
+          "vitest"\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:1.6.26", {\
+        "packageLocation": "./.yarn/__virtual__/@vitest-eslint-plugin-virtual-2e2eb2b148/0/cache/@vitest-eslint-plugin-npm-1.6.26-aaeb5a0045-e1dd39f6ae.zip/node_modules/@vitest/eslint-plugin/",\
+        "packageDependencies": [\
+          ["@types/eslint", null],\
+          ["@types/typescript", null],\
+          ["@types/typescript-eslint__eslint-plugin", null],\
+          ["@types/vitest", null],\
+          ["@typescript-eslint/eslint-plugin", null],\
+          ["@typescript-eslint/scope-manager", "npm:8.66.0"],\
+          ["@typescript-eslint/utils", "virtual:2e2eb2b148e0dd5594028029910a1e2f7e7dbafb3a0bfa7000d342032e0462f3c951bd5823563b256aecfc6da06cf711cf07645bfb5a6219faa29225f1b37ded#npm:8.66.0"],\
+          ["@vitest/eslint-plugin", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:1.6.26"],\
+          ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
+          ["typescript", null],\
+          ["vitest", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:4.1.10"]\
         ],\
         "packagePeers": [\
           "@types/eslint",\
@@ -3998,7 +4058,7 @@ const RAW_RUNTIME_STATE =
           ["@types/vitest", null],\
           ["@typescript-eslint/eslint-plugin", null],\
           ["@typescript-eslint/scope-manager", "npm:8.66.0"],\
-          ["@typescript-eslint/utils", "virtual:bc949ddf0f1ade49095936c008773d64c06e758027f148b65bac6dfbd2a8a17b386930a4b94df127d18bca4119aafb8822c9e8f26c56759acabe54ad4df2d843#npm:8.66.0"],\
+          ["@typescript-eslint/utils", "virtual:2e2eb2b148e0dd5594028029910a1e2f7e7dbafb3a0bfa7000d342032e0462f3c951bd5823563b256aecfc6da06cf711cf07645bfb5a6219faa29225f1b37ded#npm:8.66.0"],\
           ["@vitest/eslint-plugin", "virtual:f966e7aeb7c55583fd75c7557c3a1bc5c402d6b0b046ba107cf42de8ba43cf7067dc5f63013392d15bc07cbcc8692e71b6eb89164b32ef3640c94873538925b0#npm:1.6.26"],\
           ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
           ["typescript", null],\
@@ -4025,7 +4085,7 @@ const RAW_RUNTIME_STATE =
           ["@types/vitest", null],\
           ["@typescript-eslint/eslint-plugin", null],\
           ["@typescript-eslint/scope-manager", "npm:8.66.0"],\
-          ["@typescript-eslint/utils", "virtual:bc949ddf0f1ade49095936c008773d64c06e758027f148b65bac6dfbd2a8a17b386930a4b94df127d18bca4119aafb8822c9e8f26c56759acabe54ad4df2d843#npm:8.66.0"],\
+          ["@typescript-eslint/utils", "virtual:2e2eb2b148e0dd5594028029910a1e2f7e7dbafb3a0bfa7000d342032e0462f3c951bd5823563b256aecfc6da06cf711cf07645bfb5a6219faa29225f1b37ded#npm:8.66.0"],\
           ["@vitest/eslint-plugin", "virtual:feaa032e1ffbff8da5dad8429b8494744ade8373389ef8e26f3d1f1980ceff327ab996fdc7c1977df285edeb918372fa01d7c87d79c9d7218f8701c70203bfe5#npm:1.6.26"],\
           ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
           ["typescript", null],\
@@ -6536,7 +6596,7 @@ const RAW_RUNTIME_STATE =
       ["virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5", {\
         "packageLocation": "./.yarn/__virtual__/eslint-virtual-69947eb79a/0/cache/eslint-npm-9.39.5-afc737ac74-46335bfcf1.zip/node_modules/eslint/",\
         "packageDependencies": [\
-          ["@eslint-community/eslint-utils", "virtual:69947eb79a108297ef883fbc634b733d5cb177862b9ca665df089a1af6c4f235d205dc292bbdf0129577ea9a99f4b6a132653f28ed7feb24ce44563be88ab4c0#npm:4.9.1"],\
+          ["@eslint-community/eslint-utils", "virtual:ba2edf52feb929207d15f55aba8550a059ca9e171e9ee6604a08a4228972fc5181ed0504723546323646dd479aacc4cad73bc05d9420c619a309b06222382745#npm:4.9.1"],\
           ["@eslint-community/regexpp", "npm:4.12.2"],\
           ["@eslint/config-array", "npm:0.21.2"],\
           ["@eslint/config-helpers", "npm:0.4.2"],\
@@ -6589,12 +6649,12 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:c270d4fbfb825c090cc61718df6a3292f6d52fa322f9e0529d9486252d61f6a0d902e3149a2b71b0af18095e2a3cacf3b6de9ff2e069aef0f278068e0cf1a592#npm:0.5.1", {\
-        "packageLocation": "./.yarn/__virtual__/eslint-compat-utils-virtual-b92f08ba3f/0/cache/eslint-compat-utils-npm-0.5.1-f1f8ade49a-325e815205.zip/node_modules/eslint-compat-utils/",\
+      ["virtual:78ad954e63a614aeb5c302c35d50b7fd931214efae36d640eca7af22660067e92ccdaabe69a928b88758adea2ba4ce7000c9ea5e204a39329c155518de7589b1#npm:0.5.1", {\
+        "packageLocation": "./.yarn/__virtual__/eslint-compat-utils-virtual-eeee61200f/0/cache/eslint-compat-utils-npm-0.5.1-f1f8ade49a-325e815205.zip/node_modules/eslint-compat-utils/",\
         "packageDependencies": [\
           ["@types/eslint", null],\
           ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
-          ["eslint-compat-utils", "virtual:c270d4fbfb825c090cc61718df6a3292f6d52fa322f9e0529d9486252d61f6a0d902e3149a2b71b0af18095e2a3cacf3b6de9ff2e069aef0f278068e0cf1a592#npm:0.5.1"],\
+          ["eslint-compat-utils", "virtual:78ad954e63a614aeb5c302c35d50b7fd931214efae36d640eca7af22660067e92ccdaabe69a928b88758adea2ba4ce7000c9ea5e204a39329c155518de7589b1#npm:0.5.1"],\
           ["semver", "npm:7.8.5"]\
         ],\
         "packagePeers": [\
@@ -6612,11 +6672,11 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:2fbee8f25f72876fa0145ec31ecef179f809ad8414311baa5be5cdff87207a9d16f52057c937c18bb98076c568ff28156c2016fb7d864af6c2e9c0e9c812eb2d#npm:1.1.2", {\
-        "packageLocation": "./.yarn/__virtual__/eslint-import-resolver-alias-virtual-c34449160d/0/cache/eslint-import-resolver-alias-npm-1.1.2-19bb9eab39-71f156e131.zip/node_modules/eslint-import-resolver-alias/",\
+      ["virtual:6d0f9b5892a1cb3cda8c768eb240ec482cf9618cdcf15ef2c026b11937db2a3b4db65a6683461adbbbcba1e7c4f4abeb4fa766ebc31376b24e3c9c053388fdad#npm:1.1.2", {\
+        "packageLocation": "./.yarn/__virtual__/eslint-import-resolver-alias-virtual-d7f98d2024/0/cache/eslint-import-resolver-alias-npm-1.1.2-19bb9eab39-71f156e131.zip/node_modules/eslint-import-resolver-alias/",\
         "packageDependencies": [\
           ["@types/eslint-plugin-import", null],\
-          ["eslint-import-resolver-alias", "virtual:2fbee8f25f72876fa0145ec31ecef179f809ad8414311baa5be5cdff87207a9d16f52057c937c18bb98076c568ff28156c2016fb7d864af6c2e9c0e9c812eb2d#npm:1.1.2"],\
+          ["eslint-import-resolver-alias", "virtual:6d0f9b5892a1cb3cda8c768eb240ec482cf9618cdcf15ef2c026b11937db2a3b4db65a6683461adbbbcba1e7c4f4abeb4fa766ebc31376b24e3c9c053388fdad#npm:1.1.2"],\
           ["eslint-plugin-import", null]\
         ],\
         "packagePeers": [\
@@ -6630,7 +6690,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@types/eslint-plugin-import", null],\
           ["eslint-import-resolver-alias", "virtual:91da830b29af2704bfc9679729fb85d00ca0b8eeb24a837747a5bc0b5aec0e922594580a901a48c34c06a65b9b376f23fa3cbb88dc9fd35cddc5076ab48a067f#npm:1.1.2"],\
-          ["eslint-plugin-import", "virtual:91da830b29af2704bfc9679729fb85d00ca0b8eeb24a837747a5bc0b5aec0e922594580a901a48c34c06a65b9b376f23fa3cbb88dc9fd35cddc5076ab48a067f#npm:2.32.0"]\
+          ["eslint-plugin-import", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:2.32.0"]\
         ],\
         "packagePeers": [\
           "@types/eslint-plugin-import",\
@@ -6659,8 +6719,8 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:3ac9fd9bbbdad96a28fdcd4411f4647f555a1db4115eae90eb42a44d45100bea31900b992dcfbd62426e69fd3d557ac8450b927a441e86e49e0d307516b367a0#npm:2.12.1", {\
-        "packageLocation": "./.yarn/__virtual__/eslint-module-utils-virtual-2fbee8f25f/0/cache/eslint-module-utils-npm-2.12.1-11995f0970-6f4efbe7a9.zip/node_modules/eslint-module-utils/",\
+      ["virtual:dbd2195a159fa439db8a4e5ef8673355f895073ad2d98ecc173a0e1f47c908b0158cab8c3b6ce4c62a31a81a604ef31ec7bf423a1903c84c2af4bff395401dde#npm:2.12.1", {\
+        "packageLocation": "./.yarn/__virtual__/eslint-module-utils-virtual-6d0f9b5892/0/cache/eslint-module-utils-npm-2.12.1-11995f0970-6f4efbe7a9.zip/node_modules/eslint-module-utils/",\
         "packageDependencies": [\
           ["@types/eslint", null],\
           ["@types/eslint-import-resolver-node", null],\
@@ -6670,11 +6730,11 @@ const RAW_RUNTIME_STATE =
           ["@typescript-eslint/parser", null],\
           ["debug", "virtual:2a426afc4b2eef43db12a540d29c2b5476640459bfcd5c24f86bb401cf8cce97e63bd81794d206a5643057e7f662643afd5ce3dfc4d4bfd8e706006c6309c5fa#npm:3.2.7"],\
           ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
-          ["eslint-import-resolver-alias", "virtual:2fbee8f25f72876fa0145ec31ecef179f809ad8414311baa5be5cdff87207a9d16f52057c937c18bb98076c568ff28156c2016fb7d864af6c2e9c0e9c812eb2d#npm:1.1.2"],\
+          ["eslint-import-resolver-alias", "virtual:6d0f9b5892a1cb3cda8c768eb240ec482cf9618cdcf15ef2c026b11937db2a3b4db65a6683461adbbbcba1e7c4f4abeb4fa766ebc31376b24e3c9c053388fdad#npm:1.1.2"],\
           ["eslint-import-resolver-node", "npm:0.3.9"],\
           ["eslint-import-resolver-typescript", null],\
           ["eslint-import-resolver-webpack", null],\
-          ["eslint-module-utils", "virtual:3ac9fd9bbbdad96a28fdcd4411f4647f555a1db4115eae90eb42a44d45100bea31900b992dcfbd62426e69fd3d557ac8450b927a441e86e49e0d307516b367a0#npm:2.12.1"]\
+          ["eslint-module-utils", "virtual:dbd2195a159fa439db8a4e5ef8673355f895073ad2d98ecc173a0e1f47c908b0158cab8c3b6ce4c62a31a81a604ef31ec7bf423a1903c84c2af4bff395401dde#npm:2.12.1"]\
         ],\
         "packagePeers": [\
           "@types/eslint-import-resolver-node",\
@@ -6699,15 +6759,15 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:8b6e6e4b0fe72349aca23da2a4504afd759ac6896e41b0dafbd2dc43328a82f9c35ab19362d34618cc3567808171900d334a0b7edfd7a63cbd9c2d1247bf694c#npm:7.8.0", {\
-        "packageLocation": "./.yarn/__virtual__/eslint-plugin-es-x-virtual-c270d4fbfb/0/cache/eslint-plugin-es-x-npm-7.8.0-8237bd972e-002fda8c02.zip/node_modules/eslint-plugin-es-x/",\
+      ["virtual:64c1cec773f6808c088d065be80b22041942601bd3b3c5c27ca5d7d757eaba0e3ab2b8dd939d56713ec5ac0a5cef9d00e0434fff92f0e78b5fd334c6605d3a01#npm:7.8.0", {\
+        "packageLocation": "./.yarn/__virtual__/eslint-plugin-es-x-virtual-78ad954e63/0/cache/eslint-plugin-es-x-npm-7.8.0-8237bd972e-002fda8c02.zip/node_modules/eslint-plugin-es-x/",\
         "packageDependencies": [\
-          ["@eslint-community/eslint-utils", "virtual:69947eb79a108297ef883fbc634b733d5cb177862b9ca665df089a1af6c4f235d205dc292bbdf0129577ea9a99f4b6a132653f28ed7feb24ce44563be88ab4c0#npm:4.9.1"],\
+          ["@eslint-community/eslint-utils", "virtual:ba2edf52feb929207d15f55aba8550a059ca9e171e9ee6604a08a4228972fc5181ed0504723546323646dd479aacc4cad73bc05d9420c619a309b06222382745#npm:4.9.1"],\
           ["@eslint-community/regexpp", "npm:4.12.2"],\
           ["@types/eslint", null],\
           ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
-          ["eslint-compat-utils", "virtual:c270d4fbfb825c090cc61718df6a3292f6d52fa322f9e0529d9486252d61f6a0d902e3149a2b71b0af18095e2a3cacf3b6de9ff2e069aef0f278068e0cf1a592#npm:0.5.1"],\
-          ["eslint-plugin-es-x", "virtual:8b6e6e4b0fe72349aca23da2a4504afd759ac6896e41b0dafbd2dc43328a82f9c35ab19362d34618cc3567808171900d334a0b7edfd7a63cbd9c2d1247bf694c#npm:7.8.0"]\
+          ["eslint-compat-utils", "virtual:78ad954e63a614aeb5c302c35d50b7fd931214efae36d640eca7af22660067e92ccdaabe69a928b88758adea2ba4ce7000c9ea5e204a39329c155518de7589b1#npm:0.5.1"],\
+          ["eslint-plugin-es-x", "virtual:64c1cec773f6808c088d065be80b22041942601bd3b3c5c27ca5d7d757eaba0e3ab2b8dd939d56713ec5ac0a5cef9d00e0434fff92f0e78b5fd334c6605d3a01#npm:7.8.0"]\
         ],\
         "packagePeers": [\
           "@types/eslint",\
@@ -6724,8 +6784,8 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:91da830b29af2704bfc9679729fb85d00ca0b8eeb24a837747a5bc0b5aec0e922594580a901a48c34c06a65b9b376f23fa3cbb88dc9fd35cddc5076ab48a067f#npm:2.32.0", {\
-        "packageLocation": "./.yarn/__virtual__/eslint-plugin-import-virtual-3ac9fd9bbb/0/cache/eslint-plugin-import-npm-2.32.0-a1643bce9b-bfb1b8fc88.zip/node_modules/eslint-plugin-import/",\
+      ["virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:2.32.0", {\
+        "packageLocation": "./.yarn/__virtual__/eslint-plugin-import-virtual-dbd2195a15/0/cache/eslint-plugin-import-npm-2.32.0-a1643bce9b-bfb1b8fc88.zip/node_modules/eslint-plugin-import/",\
         "packageDependencies": [\
           ["@rtsao/scc", "npm:1.1.0"],\
           ["@types/eslint", null],\
@@ -6739,8 +6799,8 @@ const RAW_RUNTIME_STATE =
           ["doctrine", "npm:2.1.0"],\
           ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
           ["eslint-import-resolver-node", "npm:0.3.9"],\
-          ["eslint-module-utils", "virtual:3ac9fd9bbbdad96a28fdcd4411f4647f555a1db4115eae90eb42a44d45100bea31900b992dcfbd62426e69fd3d557ac8450b927a441e86e49e0d307516b367a0#npm:2.12.1"],\
-          ["eslint-plugin-import", "virtual:91da830b29af2704bfc9679729fb85d00ca0b8eeb24a837747a5bc0b5aec0e922594580a901a48c34c06a65b9b376f23fa3cbb88dc9fd35cddc5076ab48a067f#npm:2.32.0"],\
+          ["eslint-module-utils", "virtual:dbd2195a159fa439db8a4e5ef8673355f895073ad2d98ecc173a0e1f47c908b0158cab8c3b6ce4c62a31a81a604ef31ec7bf423a1903c84c2af4bff395401dde#npm:2.12.1"],\
+          ["eslint-plugin-import", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:2.32.0"],\
           ["hasown", "npm:2.0.4"],\
           ["is-core-module", "npm:2.16.1"],\
           ["is-glob", "npm:4.0.3"],\
@@ -6769,12 +6829,12 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:91da830b29af2704bfc9679729fb85d00ca0b8eeb24a837747a5bc0b5aec0e922594580a901a48c34c06a65b9b376f23fa3cbb88dc9fd35cddc5076ab48a067f#npm:1.4.1", {\
-        "packageLocation": "./.yarn/__virtual__/eslint-plugin-import-newlines-virtual-964b0f3c0c/0/cache/eslint-plugin-import-newlines-npm-1.4.1-c66498af33-3851501faa.zip/node_modules/eslint-plugin-import-newlines/",\
+      ["virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:1.4.1", {\
+        "packageLocation": "./.yarn/__virtual__/eslint-plugin-import-newlines-virtual-5af61dcea3/0/cache/eslint-plugin-import-newlines-npm-1.4.1-c66498af33-3851501faa.zip/node_modules/eslint-plugin-import-newlines/",\
         "packageDependencies": [\
           ["@types/eslint", null],\
           ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
-          ["eslint-plugin-import-newlines", "virtual:91da830b29af2704bfc9679729fb85d00ca0b8eeb24a837747a5bc0b5aec0e922594580a901a48c34c06a65b9b376f23fa3cbb88dc9fd35cddc5076ab48a067f#npm:1.4.1"]\
+          ["eslint-plugin-import-newlines", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:1.4.1"]\
         ],\
         "packagePeers": [\
           "@types/eslint",\
@@ -6814,21 +6874,21 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:3425432411246eef340d7f80ca5ba0066bedd24f3d9cfff2446edead87fe038ff137db2ba210f5820a2e1cc71cc10dc26fa703b44653ade6be2ac8c5a29555ae#npm:17.24.0", {\
-        "packageLocation": "./.yarn/__virtual__/eslint-plugin-n-virtual-8b6e6e4b0f/0/cache/eslint-plugin-n-npm-17.24.0-c1ef994d06-65b6c9ccd4.zip/node_modules/eslint-plugin-n/",\
+      ["virtual:d21dc05974df5027fa89029a3d44beee5f6c798db93c3fcdc9a235bc4b93d329d0e253bbab255263085d795a4f4f09d66fa9d106c193a50771fef6ac8d03b3fb#npm:17.24.0", {\
+        "packageLocation": "./.yarn/__virtual__/eslint-plugin-n-virtual-64c1cec773/0/cache/eslint-plugin-n-npm-17.24.0-c1ef994d06-65b6c9ccd4.zip/node_modules/eslint-plugin-n/",\
         "packageDependencies": [\
-          ["@eslint-community/eslint-utils", "virtual:69947eb79a108297ef883fbc634b733d5cb177862b9ca665df089a1af6c4f235d205dc292bbdf0129577ea9a99f4b6a132653f28ed7feb24ce44563be88ab4c0#npm:4.9.1"],\
+          ["@eslint-community/eslint-utils", "virtual:ba2edf52feb929207d15f55aba8550a059ca9e171e9ee6604a08a4228972fc5181ed0504723546323646dd479aacc4cad73bc05d9420c619a309b06222382745#npm:4.9.1"],\
           ["@types/eslint", null],\
           ["enhanced-resolve", "npm:5.18.2"],\
           ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
-          ["eslint-plugin-es-x", "virtual:8b6e6e4b0fe72349aca23da2a4504afd759ac6896e41b0dafbd2dc43328a82f9c35ab19362d34618cc3567808171900d334a0b7edfd7a63cbd9c2d1247bf694c#npm:7.8.0"],\
-          ["eslint-plugin-n", "virtual:3425432411246eef340d7f80ca5ba0066bedd24f3d9cfff2446edead87fe038ff137db2ba210f5820a2e1cc71cc10dc26fa703b44653ade6be2ac8c5a29555ae#npm:17.24.0"],\
+          ["eslint-plugin-es-x", "virtual:64c1cec773f6808c088d065be80b22041942601bd3b3c5c27ca5d7d757eaba0e3ab2b8dd939d56713ec5ac0a5cef9d00e0434fff92f0e78b5fd334c6605d3a01#npm:7.8.0"],\
+          ["eslint-plugin-n", "virtual:d21dc05974df5027fa89029a3d44beee5f6c798db93c3fcdc9a235bc4b93d329d0e253bbab255263085d795a4f4f09d66fa9d106c193a50771fef6ac8d03b3fb#npm:17.24.0"],\
           ["get-tsconfig", "npm:4.10.1"],\
           ["globals", "npm:15.15.0"],\
           ["globrex", "npm:0.1.2"],\
           ["ignore", "npm:5.3.2"],\
           ["semver", "npm:7.8.5"],\
-          ["ts-declaration-location", "virtual:8b6e6e4b0fe72349aca23da2a4504afd759ac6896e41b0dafbd2dc43328a82f9c35ab19362d34618cc3567808171900d334a0b7edfd7a63cbd9c2d1247bf694c#npm:1.0.7"]\
+          ["ts-declaration-location", "virtual:64c1cec773f6808c088d065be80b22041942601bd3b3c5c27ca5d7d757eaba0e3ab2b8dd939d56713ec5ac0a5cef9d00e0434fff92f0e78b5fd334c6605d3a01#npm:1.0.7"]\
         ],\
         "packagePeers": [\
           "@types/eslint",\
@@ -6845,13 +6905,13 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:3425432411246eef340d7f80ca5ba0066bedd24f3d9cfff2446edead87fe038ff137db2ba210f5820a2e1cc71cc10dc26fa703b44653ade6be2ac8c5a29555ae#npm:7.2.1", {\
-        "packageLocation": "./.yarn/__virtual__/eslint-plugin-promise-virtual-1451bce677/0/cache/eslint-plugin-promise-npm-7.2.1-cfb562cc2e-d494982fae.zip/node_modules/eslint-plugin-promise/",\
+      ["virtual:d21dc05974df5027fa89029a3d44beee5f6c798db93c3fcdc9a235bc4b93d329d0e253bbab255263085d795a4f4f09d66fa9d106c193a50771fef6ac8d03b3fb#npm:7.2.1", {\
+        "packageLocation": "./.yarn/__virtual__/eslint-plugin-promise-virtual-311eb7d351/0/cache/eslint-plugin-promise-npm-7.2.1-cfb562cc2e-d494982fae.zip/node_modules/eslint-plugin-promise/",\
         "packageDependencies": [\
-          ["@eslint-community/eslint-utils", "virtual:69947eb79a108297ef883fbc634b733d5cb177862b9ca665df089a1af6c4f235d205dc292bbdf0129577ea9a99f4b6a132653f28ed7feb24ce44563be88ab4c0#npm:4.9.1"],\
+          ["@eslint-community/eslint-utils", "virtual:ba2edf52feb929207d15f55aba8550a059ca9e171e9ee6604a08a4228972fc5181ed0504723546323646dd479aacc4cad73bc05d9420c619a309b06222382745#npm:4.9.1"],\
           ["@types/eslint", null],\
           ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
-          ["eslint-plugin-promise", "virtual:3425432411246eef340d7f80ca5ba0066bedd24f3d9cfff2446edead87fe038ff137db2ba210f5820a2e1cc71cc10dc26fa703b44653ade6be2ac8c5a29555ae#npm:7.2.1"]\
+          ["eslint-plugin-promise", "virtual:d21dc05974df5027fa89029a3d44beee5f6c798db93c3fcdc9a235bc4b93d329d0e253bbab255263085d795a4f4f09d66fa9d106c193a50771fef6ac8d03b3fb#npm:7.2.1"]\
         ],\
         "packagePeers": [\
           "@types/eslint",\
@@ -6868,8 +6928,8 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:3425432411246eef340d7f80ca5ba0066bedd24f3d9cfff2446edead87fe038ff137db2ba210f5820a2e1cc71cc10dc26fa703b44653ade6be2ac8c5a29555ae#npm:7.37.5", {\
-        "packageLocation": "./.yarn/__virtual__/eslint-plugin-react-virtual-6c7a08c62d/0/cache/eslint-plugin-react-npm-7.37.5-d03f6b6543-c850bfd556.zip/node_modules/eslint-plugin-react/",\
+      ["virtual:d21dc05974df5027fa89029a3d44beee5f6c798db93c3fcdc9a235bc4b93d329d0e253bbab255263085d795a4f4f09d66fa9d106c193a50771fef6ac8d03b3fb#npm:7.37.5", {\
+        "packageLocation": "./.yarn/__virtual__/eslint-plugin-react-virtual-bb9745ebd2/0/cache/eslint-plugin-react-npm-7.37.5-d03f6b6543-c850bfd556.zip/node_modules/eslint-plugin-react/",\
         "packageDependencies": [\
           ["@types/eslint", null],\
           ["array-includes", "npm:3.1.9"],\
@@ -6879,7 +6939,7 @@ const RAW_RUNTIME_STATE =
           ["doctrine", "npm:2.1.0"],\
           ["es-iterator-helpers", "npm:1.2.1"],\
           ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
-          ["eslint-plugin-react", "virtual:3425432411246eef340d7f80ca5ba0066bedd24f3d9cfff2446edead87fe038ff137db2ba210f5820a2e1cc71cc10dc26fa703b44653ade6be2ac8c5a29555ae#npm:7.37.5"],\
+          ["eslint-plugin-react", "virtual:d21dc05974df5027fa89029a3d44beee5f6c798db93c3fcdc9a235bc4b93d329d0e253bbab255263085d795a4f4f09d66fa9d106c193a50771fef6ac8d03b3fb#npm:7.37.5"],\
           ["estraverse", "npm:5.3.0"],\
           ["hasown", "npm:2.0.4"],\
           ["jsx-ast-utils", "npm:3.3.5"],\
@@ -6921,7 +6981,7 @@ const RAW_RUNTIME_STATE =
       ["virtual:8d919ffb8fd728f827df3f6a566e8e923223ffcec68f7450d83bbbc2dc25d6b8c987e111cbab484b209f253bdf2f2e00663b01a986262c44511128466462a76f#npm:10.10.0", {\
         "packageLocation": "./.yarn/__virtual__/eslint-plugin-vue-virtual-b50d04501d/0/cache/eslint-plugin-vue-npm-10.10.0-593d74b9e9-d863fa667f.zip/node_modules/eslint-plugin-vue/",\
         "packageDependencies": [\
-          ["@eslint-community/eslint-utils", "virtual:69947eb79a108297ef883fbc634b733d5cb177862b9ca665df089a1af6c4f235d205dc292bbdf0129577ea9a99f4b6a132653f28ed7feb24ce44563be88ab4c0#npm:4.9.1"],\
+          ["@eslint-community/eslint-utils", "virtual:ba2edf52feb929207d15f55aba8550a059ca9e171e9ee6604a08a4228972fc5181ed0504723546323646dd479aacc4cad73bc05d9420c619a309b06222382745#npm:4.9.1"],\
           ["@stylistic/eslint-plugin", null],\
           ["@types/eslint", null],\
           ["@types/stylistic__eslint-plugin", null],\
@@ -7607,11 +7667,17 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./",\
         "packageDependencies": [\
           ["@microsoft/eslint-formatter-sarif", "npm:3.1.0"],\
+          ["@vitest/coverage-v8", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:4.1.10"],\
+          ["@vitest/eslint-plugin", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:1.6.26"],\
           ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
+          ["eslint-plugin-import", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:2.32.0"],\
+          ["eslint-plugin-import-newlines", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:1.4.1"],\
+          ["eslint-plugin-security", "npm:3.0.1"],\
           ["gardener-dashboard", "workspace:."],\
           ["husky", "npm:9.1.7"],\
           ["jsdom", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:26.1.0"],\
           ["lodash-es", "npm:4.18.1"],\
+          ["neostandard", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:0.13.0"],\
           ["vitest", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:4.1.10"]\
         ],\
         "linkType": "SOFT"\
@@ -10242,21 +10308,21 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:faee47847dc7127a4fda44fca2035ae541a9af6260b1926ad890f5f677339c049ea62d6b398ffa233a226c0b5c370a517802e428d53b03a3356e9a04d51e8e42#npm:0.13.0", {\
-        "packageLocation": "./.yarn/__virtual__/neostandard-virtual-3425432411/0/cache/neostandard-npm-0.13.0-c5a3bf9166-8fc50c3d42.zip/node_modules/neostandard/",\
+      ["virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:0.13.0", {\
+        "packageLocation": "./.yarn/__virtual__/neostandard-virtual-d21dc05974/0/cache/neostandard-npm-0.13.0-c5a3bf9166-8fc50c3d42.zip/node_modules/neostandard/",\
         "packageDependencies": [\
           ["@humanwhocodes/gitignore-to-minimatch", "npm:1.0.2"],\
-          ["@stylistic/eslint-plugin", "virtual:3425432411246eef340d7f80ca5ba0066bedd24f3d9cfff2446edead87fe038ff137db2ba210f5820a2e1cc71cc10dc26fa703b44653ade6be2ac8c5a29555ae#npm:2.11.0"],\
+          ["@stylistic/eslint-plugin", "virtual:d21dc05974df5027fa89029a3d44beee5f6c798db93c3fcdc9a235bc4b93d329d0e253bbab255263085d795a4f4f09d66fa9d106c193a50771fef6ac8d03b3fb#npm:2.11.0"],\
           ["@types/eslint", null],\
           ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
-          ["eslint-plugin-n", "virtual:3425432411246eef340d7f80ca5ba0066bedd24f3d9cfff2446edead87fe038ff137db2ba210f5820a2e1cc71cc10dc26fa703b44653ade6be2ac8c5a29555ae#npm:17.24.0"],\
-          ["eslint-plugin-promise", "virtual:3425432411246eef340d7f80ca5ba0066bedd24f3d9cfff2446edead87fe038ff137db2ba210f5820a2e1cc71cc10dc26fa703b44653ade6be2ac8c5a29555ae#npm:7.2.1"],\
-          ["eslint-plugin-react", "virtual:3425432411246eef340d7f80ca5ba0066bedd24f3d9cfff2446edead87fe038ff137db2ba210f5820a2e1cc71cc10dc26fa703b44653ade6be2ac8c5a29555ae#npm:7.37.5"],\
+          ["eslint-plugin-n", "virtual:d21dc05974df5027fa89029a3d44beee5f6c798db93c3fcdc9a235bc4b93d329d0e253bbab255263085d795a4f4f09d66fa9d106c193a50771fef6ac8d03b3fb#npm:17.24.0"],\
+          ["eslint-plugin-promise", "virtual:d21dc05974df5027fa89029a3d44beee5f6c798db93c3fcdc9a235bc4b93d329d0e253bbab255263085d795a4f4f09d66fa9d106c193a50771fef6ac8d03b3fb#npm:7.2.1"],\
+          ["eslint-plugin-react", "virtual:d21dc05974df5027fa89029a3d44beee5f6c798db93c3fcdc9a235bc4b93d329d0e253bbab255263085d795a4f4f09d66fa9d106c193a50771fef6ac8d03b3fb#npm:7.37.5"],\
           ["find-up", "npm:8.0.0"],\
           ["globals", "npm:17.6.0"],\
-          ["neostandard", "virtual:faee47847dc7127a4fda44fca2035ae541a9af6260b1926ad890f5f677339c049ea62d6b398ffa233a226c0b5c370a517802e428d53b03a3356e9a04d51e8e42#npm:0.13.0"],\
+          ["neostandard", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:0.13.0"],\
           ["peowly", "npm:1.3.3"],\
-          ["typescript-eslint", "virtual:3425432411246eef340d7f80ca5ba0066bedd24f3d9cfff2446edead87fe038ff137db2ba210f5820a2e1cc71cc10dc26fa703b44653ade6be2ac8c5a29555ae#npm:8.60.0"]\
+          ["typescript-eslint", "virtual:d21dc05974df5027fa89029a3d44beee5f6c798db93c3fcdc9a235bc4b93d329d0e253bbab255263085d795a4f4f09d66fa9d106c193a50771fef6ac8d03b3fb#npm:8.60.0"]\
         ],\
         "packagePeers": [\
           "@types/eslint",\
@@ -12417,11 +12483,11 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["virtual:3f54d31c88eb7813ed2c5083497e61594df5d51ade0b0da052e2a5fe7129e5938172318afff3f1646167f3fe9af2146954482e3cfe994afd8cf12d86ba64dfec#npm:2.5.0", {\
-        "packageLocation": "./.yarn/__virtual__/ts-api-utils-virtual-295879d41d/0/cache/ts-api-utils-npm-2.5.0-6bde2b2eb9-767849383c.zip/node_modules/ts-api-utils/",\
+      ["virtual:c2790fc160f26db570e782a78b67da7a14838eb6f1e8a3695be5e14cfd4ac2763345c3f30689e70651b0c61a367aa657106663f25fc63057d596c0fa9e8a2d2a#npm:2.5.0", {\
+        "packageLocation": "./.yarn/__virtual__/ts-api-utils-virtual-789a1acbd0/0/cache/ts-api-utils-npm-2.5.0-6bde2b2eb9-767849383c.zip/node_modules/ts-api-utils/",\
         "packageDependencies": [\
           ["@types/typescript", null],\
-          ["ts-api-utils", "virtual:3f54d31c88eb7813ed2c5083497e61594df5d51ade0b0da052e2a5fe7129e5938172318afff3f1646167f3fe9af2146954482e3cfe994afd8cf12d86ba64dfec#npm:2.5.0"],\
+          ["ts-api-utils", "virtual:c2790fc160f26db570e782a78b67da7a14838eb6f1e8a3695be5e14cfd4ac2763345c3f30689e70651b0c61a367aa657106663f25fc63057d596c0fa9e8a2d2a#npm:2.5.0"],\
           ["typescript", null]\
         ],\
         "packagePeers": [\
@@ -12439,12 +12505,12 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:8b6e6e4b0fe72349aca23da2a4504afd759ac6896e41b0dafbd2dc43328a82f9c35ab19362d34618cc3567808171900d334a0b7edfd7a63cbd9c2d1247bf694c#npm:1.0.7", {\
-        "packageLocation": "./.yarn/__virtual__/ts-declaration-location-virtual-e6e0177347/0/cache/ts-declaration-location-npm-1.0.7-804f747b5c-b579b76309.zip/node_modules/ts-declaration-location/",\
+      ["virtual:64c1cec773f6808c088d065be80b22041942601bd3b3c5c27ca5d7d757eaba0e3ab2b8dd939d56713ec5ac0a5cef9d00e0434fff92f0e78b5fd334c6605d3a01#npm:1.0.7", {\
+        "packageLocation": "./.yarn/__virtual__/ts-declaration-location-virtual-399fbd1239/0/cache/ts-declaration-location-npm-1.0.7-804f747b5c-b579b76309.zip/node_modules/ts-declaration-location/",\
         "packageDependencies": [\
           ["@types/typescript", null],\
           ["picomatch", "npm:4.0.5"],\
-          ["ts-declaration-location", "virtual:8b6e6e4b0fe72349aca23da2a4504afd759ac6896e41b0dafbd2dc43328a82f9c35ab19362d34618cc3567808171900d334a0b7edfd7a63cbd9c2d1247bf694c#npm:1.0.7"],\
+          ["ts-declaration-location", "virtual:64c1cec773f6808c088d065be80b22041942601bd3b3c5c27ca5d7d757eaba0e3ab2b8dd939d56713ec5ac0a5cef9d00e0434fff92f0e78b5fd334c6605d3a01#npm:1.0.7"],\
           ["typescript", null]\
         ],\
         "packagePeers": [\
@@ -12581,18 +12647,18 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:3425432411246eef340d7f80ca5ba0066bedd24f3d9cfff2446edead87fe038ff137db2ba210f5820a2e1cc71cc10dc26fa703b44653ade6be2ac8c5a29555ae#npm:8.60.0", {\
-        "packageLocation": "./.yarn/__virtual__/typescript-eslint-virtual-b2ce8114c6/0/cache/typescript-eslint-npm-8.60.0-39a013726c-6968de79ab.zip/node_modules/typescript-eslint/",\
+      ["virtual:d21dc05974df5027fa89029a3d44beee5f6c798db93c3fcdc9a235bc4b93d329d0e253bbab255263085d795a4f4f09d66fa9d106c193a50771fef6ac8d03b3fb#npm:8.60.0", {\
+        "packageLocation": "./.yarn/__virtual__/typescript-eslint-virtual-28810e244b/0/cache/typescript-eslint-npm-8.60.0-39a013726c-6968de79ab.zip/node_modules/typescript-eslint/",\
         "packageDependencies": [\
           ["@types/eslint", null],\
           ["@types/typescript", null],\
-          ["@typescript-eslint/eslint-plugin", "virtual:b2ce8114c6a09945c16f9024af866d293a40ce97bba68792156fc7fdba2aee89b2e65b0353c5ce06ae17e64cd6b05f70a2026214cd0ce8f123aecf369b55ad30#npm:8.60.0"],\
-          ["@typescript-eslint/parser", "virtual:b2ce8114c6a09945c16f9024af866d293a40ce97bba68792156fc7fdba2aee89b2e65b0353c5ce06ae17e64cd6b05f70a2026214cd0ce8f123aecf369b55ad30#npm:8.60.0"],\
-          ["@typescript-eslint/typescript-estree", "virtual:b2ce8114c6a09945c16f9024af866d293a40ce97bba68792156fc7fdba2aee89b2e65b0353c5ce06ae17e64cd6b05f70a2026214cd0ce8f123aecf369b55ad30#npm:8.60.0"],\
-          ["@typescript-eslint/utils", "virtual:b2ce8114c6a09945c16f9024af866d293a40ce97bba68792156fc7fdba2aee89b2e65b0353c5ce06ae17e64cd6b05f70a2026214cd0ce8f123aecf369b55ad30#npm:8.60.0"],\
+          ["@typescript-eslint/eslint-plugin", "virtual:28810e244b2c0a95073ad69eec1bf9bdbea24314d1cfdc745ba7b63fb342b9314b5c5b46d205b50a948d471bda7fc3ec1418d5c879a9dcc0bba8eafb506227ba#npm:8.60.0"],\
+          ["@typescript-eslint/parser", "virtual:28810e244b2c0a95073ad69eec1bf9bdbea24314d1cfdc745ba7b63fb342b9314b5c5b46d205b50a948d471bda7fc3ec1418d5c879a9dcc0bba8eafb506227ba#npm:8.60.0"],\
+          ["@typescript-eslint/typescript-estree", "virtual:28810e244b2c0a95073ad69eec1bf9bdbea24314d1cfdc745ba7b63fb342b9314b5c5b46d205b50a948d471bda7fc3ec1418d5c879a9dcc0bba8eafb506227ba#npm:8.60.0"],\
+          ["@typescript-eslint/utils", "virtual:28810e244b2c0a95073ad69eec1bf9bdbea24314d1cfdc745ba7b63fb342b9314b5c5b46d205b50a948d471bda7fc3ec1418d5c879a9dcc0bba8eafb506227ba#npm:8.60.0"],\
           ["eslint", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:9.39.5"],\
           ["typescript", null],\
-          ["typescript-eslint", "virtual:3425432411246eef340d7f80ca5ba0066bedd24f3d9cfff2446edead87fe038ff137db2ba210f5820a2e1cc71cc10dc26fa703b44653ade6be2ac8c5a29555ae#npm:8.60.0"]\
+          ["typescript-eslint", "virtual:d21dc05974df5027fa89029a3d44beee5f6c798db93c3fcdc9a235bc4b93d329d0e253bbab255263085d795a4f4f09d66fa9d106c193a50771fef6ac8d03b3fb#npm:8.60.0"]\
         ],\
         "packagePeers": [\
           "@types/eslint",\
@@ -14015,7 +14081,7 @@ const RAW_RUNTIME_STATE =
           ["@vitest/browser-preview", null],\
           ["@vitest/browser-webdriverio", null],\
           ["@vitest/coverage-istanbul", null],\
-          ["@vitest/coverage-v8", null],\
+          ["@vitest/coverage-v8", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:4.1.10"],\
           ["@vitest/expect", "npm:4.1.10"],\
           ["@vitest/mocker", "virtual:60555ec9c39838c5d619521acd34bf1624736d20c4b96e3acc53dd63318c3734305f2d44ea198e6bd6f1d88cf174352d2af99cd67f2cf06f7368c522fb9d0572#npm:4.1.10"],\
           ["@vitest/pretty-format", "npm:4.1.10"],\

--- a/Makefile
+++ b/Makefile
@@ -15,18 +15,22 @@ help: ## Display this help.
 
 .PHONY: lint
 lint: ## Run eslint against code.
+	@yarn lint:hack
 	@yarn workspaces foreach --all --parallel --no-private run lint
 
 .PHONY: lint-sarif
 lint-sarif: ## Run eslint and output in sarif format.
+	@yarn lint:hack:sarif
 	@yarn workspaces foreach --all --parallel --no-private run lint-sarif
 
 .PHONY: test
 test: ## Run tests.
+	@yarn test:hack
 	@yarn workspaces foreach --all --parallel --no-private run test
 
 .PHONY: test-cov
 test-cov: ## Run tests with coverage.
+	@yarn test:hack:cov
 	@yarn workspaces foreach --all --parallel --no-private run test --coverage
 
 .PHONY: build

--- a/docs/development/local-setup.md
+++ b/docs/development/local-setup.md
@@ -113,8 +113,24 @@ yarn serve
 
 You can now access the UI on https://localhost:8443/
 
+### Local Gardener Dashboard
+
+For an isolated local environment useful for development and deterministic
+browser verification, use the Local Gardener Dashboard workflow described in
+[`hack/local-dashboard/README.md`](../../hack/local-dashboard/README.md).
+The initial implementation starts the complete Garden API (via gardenerless/KCP),
+backend, and frontend stack with managed defaults, deterministic scenarios, safe
+process ownership, and exact `setup`, `up`, `token`, `status`, and `down`
+commands. `up` never clones automatically; agents must ask before invoking the
+explicit `setup` command.
+
+The regular workflow above against a real landscape or local Gardener remains
+supported.
+
 ### 5. Login to the dashboard
-To login to the dashboard you can either configure `oidc`, or alternatively login using a token:
+For the Local Gardener Dashboard workflow, use the guarded `token` entry point
+described above. For a local Gardener or another landscape, you can either
+configure `oidc` or log in using a token:
 
 To login using a token, first create a service account.
 ```bash

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -6,21 +6,29 @@ We use [Vitest](https://vitest.dev/) as our testing framework.
 * Vitest collects code coverage information via `@vitest/coverage-v8`
 * Vitest supports snapshot testing out of the box
 * It works with Vue.js (jsdom environment) and Node.js projects
-* Each workspace has its own `vitest.config.js`
+* Each workspace and the `hack/` CLI boundary has its own Vitest configuration
 
 To execute all tests, simply run
 ```
-yarn workspaces foreach --all run test
+make test
 ```
 
 or to include test coverage generation
 ```
-yarn workspaces foreach --all run test-coverage
+make test-cov
 ```
 
 You can also run tests for frontend, backend and charts directly inside the respective folder via
 ```
 yarn test
+```
+
+The UI-verification CLI has an independent Node test suite under `hack/`.
+Run it directly with:
+
+```
+yarn test:hack
+yarn test:hack:cov
 ```
 
 ### VS Code Integration
@@ -35,5 +43,7 @@ We use ESLint for static code analyzing.
 To execute, run
 
 ```
-yarn workspaces foreach --all run lint
+make lint
 ```
+
+Run only the UI-verification CLI lint boundary with `yarn lint:hack`.

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -6,27 +6,27 @@ We use [Vitest](https://vitest.dev/) as our testing framework.
 * Vitest collects code coverage information via `@vitest/coverage-v8`
 * Vitest supports snapshot testing out of the box
 * It works with Vue.js (jsdom environment) and Node.js projects
-* Each workspace and the `hack/` CLI boundary has its own Vitest configuration
+* Each workspace and the `hack/` CLI boundary have their own Vitest configurations
 
 To execute all tests, simply run
-```
+```shell
 make test
 ```
 
 or to include test coverage generation
-```
+```shell
 make test-cov
 ```
 
 You can also run tests for frontend, backend and charts directly inside the respective folder via
-```
+```shell
 yarn test
 ```
 
-The UI-verification CLI has an independent Node test suite under `hack/`.
+The local Dashboard CLI has an independent Node test suite under `hack/`.
 Run it directly with:
 
-```
+```shell
 yarn test:hack
 yarn test:hack:cov
 ```
@@ -42,8 +42,8 @@ We use ESLint for static code analyzing.
 
 To execute, run
 
-```
+```shell
 make lint
 ```
 
-Run only the UI-verification CLI lint boundary with `yarn lint:hack`.
+Run only the local Dashboard CLI lint boundary with `yarn lint:hack`.

--- a/hack/eslint.config.cjs
+++ b/hack/eslint.config.cjs
@@ -30,7 +30,6 @@ module.exports = [
   {
     languageOptions: {
       ecmaVersion: 2025,
-      sourceType: 'module',
     },
     rules: {
       '@stylistic/brace-style': ['error', '1tbs', { allowSingleLine: false }],

--- a/hack/eslint.config.cjs
+++ b/hack/eslint.config.cjs
@@ -1,0 +1,81 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+const neostandard = require('neostandard')
+const pluginVitest = require('@vitest/eslint-plugin')
+const pluginSecurity = require('eslint-plugin-security')
+const pluginImport = require('eslint-plugin-import')
+const importNewlines = require('eslint-plugin-import-newlines')
+
+const importNewlinesConfig = {
+  plugins: {
+    'import-newlines': {
+      meta: {
+        name: 'eslint-plugin-import-newlines',
+        version: '1.4.0',
+      },
+      rules: importNewlines.rules,
+    },
+  },
+  rules: {
+    'import-newlines/enforce': ['error', 1],
+  },
+}
+
+module.exports = [
+  ...neostandard({}),
+  {
+    languageOptions: {
+      ecmaVersion: 2025,
+      sourceType: 'module',
+    },
+    rules: {
+      '@stylistic/brace-style': ['error', '1tbs', { allowSingleLine: false }],
+      '@stylistic/comma-dangle': ['error', 'always-multiline'],
+      '@stylistic/multiline-ternary': ['error', 'always-multiline'],
+      // Command output is part of the local-dashboard CLI contract.
+      'no-console': 'off',
+      'no-nested-ternary': 'error',
+      curly: ['error', 'all'],
+      'max-depth': ['error', 3],
+      'max-nested-callbacks': ['warn', 5],
+    },
+  },
+  pluginSecurity.configs.recommended,
+  {
+    files: ['hack/local-dashboard/**'],
+    rules: {
+      // Dynamic, validated paths and keyed configuration are fundamental to this CLI.
+      'security/detect-non-literal-fs-filename': 'off',
+      'security/detect-object-injection': 'off',
+    },
+  },
+  {
+    plugins: {
+      import: pluginImport,
+    },
+    rules: pluginImport.flatConfigs.recommended.rules,
+  },
+  {
+    files: ['hack/local-dashboard/vitest.config.mjs'],
+    rules: {
+      'import/no-unresolved': 'off',
+    },
+  },
+  {
+    files: ['hack/local-dashboard/test/**'],
+    plugins: {
+      vitest: pluginVitest,
+    },
+    rules: {
+      ...pluginVitest.configs.recommended.rules,
+      'security/detect-possible-timing-attacks': 'off',
+      'security/detect-unsafe-regex': 'off',
+      'vitest/no-disabled-tests': 'warn',
+    },
+  },
+  importNewlinesConfig,
+]

--- a/hack/local-dashboard.mjs
+++ b/hack/local-dashboard.mjs
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+import { main } from './local-dashboard/internal/commands.mjs'
+
+export { main }
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  main().catch(error => {
+    console.error(`local-dashboard: ${error.message}`)
+    process.exitCode = 1
+  })
+}

--- a/hack/local-dashboard/README.md
+++ b/hack/local-dashboard/README.md
@@ -1,0 +1,109 @@
+# Local Gardener Dashboard
+
+`node hack/local-dashboard.mjs` manages an isolated local Gardener Dashboard
+environment for development and deterministic browser verification. The initial
+implementation starts the complete Garden API, backend, and frontend stack
+without using ambient kubeconfig or Dashboard configuration.
+
+The local Garden API is implemented with gardenerless/KCP. It is not a complete
+Garden cluster.
+
+## Prerequisites
+
+Install the repository dependencies and create the trusted frontend
+development certificate:
+
+```sh
+yarn
+yarn workspace @gardener-dashboard/frontend setup
+```
+
+## Quick start
+
+```sh
+node hack/local-dashboard.mjs setup
+node hack/local-dashboard.mjs up
+```
+
+Open `https://127.0.0.1:8444`. Run `node hack/local-dashboard.mjs token` when a
+login token is needed, and stop the stack with
+`node hack/local-dashboard.mjs down`.
+
+## Setup
+
+`setup` idempotently prepares the pinned gardenerless checkout and local Garden
+API runtime under `.local-dashboard`. Detailed output is written to
+`.local-dashboard/setup.log`.
+
+To reset the managed checkout and runtime:
+
+```sh
+node hack/local-dashboard.mjs setup --reset
+```
+
+## Commands
+
+```sh
+node hack/local-dashboard.mjs up
+node hack/local-dashboard.mjs up --scenario failing-shoot
+```
+
+Starts the stack and reports the frontend URL. Available scenarios are:
+
+- `healthy-shoot` (default): the `pine-oak` Shoot is healthy
+- `failing-shoot`: the `pine-oak` Shoot is failing
+- `many-shoots`: a bounded deterministic Shoot set is present
+- `operation-in-progress`: the `pine-oak` Shoot has an active operation
+
+```sh
+node hack/local-dashboard.mjs status
+```
+
+Reports stack health and managed prerequisite versions.
+
+```sh
+node hack/local-dashboard.mjs token
+```
+
+Prints a login token for the operator service account
+`garden/dashboard-user` by default.
+
+```sh
+node hack/local-dashboard.mjs token | pbcopy
+```
+
+For landscape viewer access, copy a token for `garden/landscape-viewer`:
+
+```sh
+node hack/local-dashboard.mjs token --namespace garden --name landscape-viewer | pbcopy
+```
+
+```sh
+node hack/local-dashboard.mjs down
+```
+
+Stops the stack.
+
+## Managed resources
+
+The workflow uses these managed paths and fixed loopback endpoints:
+
+- gardenerless checkout: `.local-dashboard/gardenerless`
+- local Garden API runtime: `.local-dashboard/runtime`
+- frontend: `https://127.0.0.1:8444`
+- backend: `http://127.0.0.1:3031` (metrics on port `9051`)
+- garden: `https://127.0.0.1:6443`
+
+Managed components are presented as `garden`, `backend`, and `frontend`.
+
+## Tests
+
+The command contract is covered by
+`hack/local-dashboard/test/local-dashboard.spec.js`:
+
+```sh
+yarn test:hack
+```
+
+Run `yarn test:hack:cov` to write its dedicated coverage report to
+`coverage/local-dashboard`.

--- a/hack/local-dashboard/backend-config.yaml
+++ b/hack/local-dashboard/backend-config.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# The local-dashboard runner injects environment-specific backend settings through a
+# sanitized environment: local API and kubeconfig targets, allowed origins,
+# generated session secrets, selected ports, and loopback listener hosts.
+# This file therefore contains only static settings without an environment mapping.
+frontend:
+  avatarSource: none

--- a/hack/local-dashboard/internal/commands.mjs
+++ b/hack/local-dashboard/internal/commands.mjs
@@ -1,0 +1,367 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  mkdirSync,
+  unlinkSync,
+} from 'node:fs'
+import { join } from 'node:path'
+
+import {
+  BACKEND_CONFIG,
+  STATE_VERSION,
+  YARN_RUNTIME,
+  assertReusableFrontendCertificates,
+  assertSafeDirectory,
+  assertSafeFile,
+  assertSafeManagedRoot,
+  assertSetupTargetsAvailable,
+  backendEnvironment,
+  ensureManagedChildDirectory,
+  fail,
+  frontendEnvironment,
+  isolatedSetupGitEnvironment,
+  parseOptions,
+  pathEntryExists,
+  resolveConfiguration,
+  sanitizedGardenerlessEnvironment,
+} from './configuration.mjs'
+import {
+  convergeSetupPrerequisites,
+  existingTrackedStackForSetup,
+  inspectPrerequisites,
+  resetManagedPrerequisites,
+} from './prerequisites.mjs'
+import {
+  assessTrackedState,
+  assertPortsAvailable,
+  formatElapsedTime,
+  portIsAvailable,
+  readState,
+  reconcileScenario,
+  runForeground,
+  runTimedPhase,
+  serviceDefinitions,
+  startReadyService,
+  stopTrackedProcesses,
+  writeState,
+} from './runtime.mjs'
+
+function printCommits (commits) {
+  console.log(`GARDENERLESS_COMMIT=${commits.gardenerless}`)
+  console.log(`KCP_COMMIT=${commits.kcp}`)
+  console.log(`KCP_RELEASE=${commits.kcpRelease}`)
+}
+
+function requirePrerequisites (configuration, inspect) {
+  try {
+    return inspect(configuration)
+  } catch (error) {
+    fail(`prerequisites missing; run 'node hack/local-dashboard.mjs setup'\n${error.message}`)
+  }
+}
+
+async function occupiedPortLabels (configuration, probe = portIsAvailable) {
+  const occupied = []
+  for (const [name, port] of Object.entries(configuration.ports)) {
+    if (!await probe(port)) {
+      occupied.push(`${name}:${port}`)
+    }
+  }
+  return occupied
+}
+
+export async function commandSetup (configuration, {
+  reset = false,
+  inspect = inspectPrerequisites,
+  existing = existingTrackedStackForSetup,
+  converge = convergeSetupPrerequisites,
+} = {}) {
+  assertSetupTargetsAvailable(configuration, { reset })
+  const tracked = await existing(configuration, { reset })
+  if (tracked) {
+    const commits = inspect(configuration)
+    console.log('ready: healthy tracked stack unchanged')
+    printCommits(commits)
+    return
+  }
+  await assertPortsAvailable(configuration.ports)
+  assertSafeManagedRoot(configuration.managedRoot)
+  if (reset) {
+    resetManagedPrerequisites(configuration)
+  }
+  const result = await converge(configuration, isolatedSetupGitEnvironment())
+  let mode = 'current'
+  if (reset) {
+    mode = 'reset'
+  } else if (result.changed || result.rebuilt) {
+    mode = 'updated'
+  }
+  console.log(`ready: managed prerequisites ${mode}`)
+  console.log(`CHECKOUT_DIR=${configuration.checkoutDir}`)
+  console.log(`RUNTIME_DIR=${configuration.runtimeDir}`)
+  printCommits(result.commits)
+}
+
+export async function commandUp (configuration, { inspect = inspectPrerequisites } = {}) {
+  const commits = requirePrerequisites(configuration, inspect)
+  assertSafeManagedRoot(configuration.managedRoot)
+  assertSafeFile(BACKEND_CONFIG, 'backend isolation configuration')
+  assertSafeFile(YARN_RUNTIME, 'repository Yarn runtime')
+  const frontendSslDirectory = assertReusableFrontendCertificates()
+  if (pathEntryExists(configuration.stateFile)) {
+    const tracked = readState(configuration)
+    const assessment = await assessTrackedState(tracked, configuration, { commits })
+    if (assessment === 'healthy') {
+      console.log('READY (healthy tracked stack)')
+      console.log(`FRONTEND_URL=${configuration.urls.frontend}`)
+      console.log(`LOG_DIR=${tracked.logDir}`)
+      printCommits(tracked.commits)
+      return
+    }
+    fail(assessment === 'configuration-mismatch'
+      ? 'the tracked stack has different configuration; run \'node hack/local-dashboard.mjs down\' first'
+      : 'stale tracked state found; run \'node hack/local-dashboard.mjs down\' before starting')
+  }
+  await assertPortsAvailable(configuration.ports)
+  const logsRoot = join(configuration.managedRoot, 'logs')
+  ensureManagedChildDirectory(logsRoot, configuration.managedRoot)
+  const logDir = join(logsRoot, `${new Date().toISOString().replaceAll(/[:.]/g, '-')}-${process.pid}`)
+  mkdirSync(logDir, { mode: 0o700 })
+  const state = {
+    version: STATE_VERSION,
+    status: 'starting',
+    scenario: configuration.scenario,
+    commits,
+    logDir,
+    processes: [],
+  }
+  writeState(state, configuration)
+  const setupLog = join(logDir, 'setup.log')
+  const [garden, backend, frontend] = serviceDefinitions(configuration)
+  const phases = [
+    {
+      label: 'starting garden',
+      completeLabel: 'garden ready',
+      action: () => startReadyService(state, configuration, {
+        ...garden,
+        env: sanitizedGardenerlessEnvironment(configuration),
+        logPath: join(logDir, 'garden.log'),
+        healthUrl: `${configuration.urls.garden}/readyz`,
+        timeoutMs: 60_000,
+      }),
+    },
+    {
+      label: `reconciling demo fixture, CRDs, and scenario '${configuration.scenario}'`,
+      completeLabel: 'demo fixture and scenario ready',
+      action: async () => {
+        await reconcileScenario(configuration, setupLog)
+        assertSafeFile(
+          join(configuration.runtimeDir, '.kcp', 'dashboard.kubeconfig'),
+          'gardenerless dashboard kubeconfig',
+        )
+      },
+    },
+    {
+      label: 'starting backend',
+      completeLabel: 'backend ready',
+      action: () => startReadyService(state, configuration, {
+        ...backend,
+        env: backendEnvironment(configuration),
+        logPath: join(logDir, 'backend.log'),
+        healthUrl: `${configuration.urls.backend}/healthz`,
+      }),
+    },
+    {
+      label: 'starting frontend',
+      completeLabel: 'frontend ready',
+      action: () => startReadyService(state, configuration, {
+        ...frontend,
+        env: frontendEnvironment(configuration, frontendSslDirectory),
+        logPath: join(logDir, 'frontend.log'),
+        healthUrl: `${configuration.urls.frontend}/`,
+      }),
+    },
+  ]
+  const startupStartedAt = Date.now()
+  try {
+    for (const [index, phase] of phases.entries()) {
+      await runTimedPhase({ command: 'up', index: index + 1, total: phases.length, ...phase })
+    }
+    state.status = 'ready'
+    writeState(state, configuration)
+    console.error(`up: startup complete (${formatElapsedTime(Date.now() - startupStartedAt)} total)`)
+    console.log('READY (started)')
+    console.log(`FRONTEND_URL=${configuration.urls.frontend}`)
+    console.log(`LOG_DIR=${logDir}`)
+    printCommits(commits)
+  } catch (error) {
+    const cleanup = await stopTrackedProcesses(state, configuration)
+    const occupied = await occupiedPortLabels(configuration)
+    if (!cleanup.preserved.length && !occupied.length && pathEntryExists(configuration.stateFile)) {
+      unlinkSync(configuration.stateFile)
+    }
+    if (cleanup.preserved.length || occupied.length) {
+      fail([
+        error.message,
+        'startup cleanup incomplete; tracked state retained',
+        cleanup.preserved.length && `identity mismatches: ${cleanup.preserved.join(', ')}`,
+        occupied.length && `listeners: ${occupied.join(', ')}`,
+      ].filter(Boolean).join('; '))
+    }
+    throw error
+  }
+}
+
+export async function commandDown (configuration, {
+  probe = portIsAvailable,
+  stop = stopTrackedProcesses,
+} = {}) {
+  if (!pathEntryExists(configuration.stateFile)) {
+    const occupied = await occupiedPortLabels(configuration, probe)
+    if (occupied.length) {
+      fail(`no tracked stack; unknown listeners remain on ${occupied.join(', ')}`)
+    }
+    console.log('stopped')
+    return
+  }
+  let state
+  try {
+    state = readState(configuration)
+  } catch (error) {
+    assertSafeDirectory(configuration.managedRoot, 'managed directory')
+    assertSafeFile(configuration.stateFile, 'tracked state')
+    const occupied = await occupiedPortLabels(configuration, probe)
+    if (occupied.length) {
+      fail(`invalid tracked state retained because listeners remain on ${occupied.join(', ')} (${error.message})`)
+    }
+    unlinkSync(configuration.stateFile)
+    console.log(`stale tracked state removed; no process was signalled (${error.message})`)
+    return
+  }
+  const result = await stop(state, configuration)
+  console.log(`stopped groups: ${result.stopped.join(', ') || 'none'}`)
+  const occupied = await occupiedPortLabels(configuration, probe)
+  if (result.preserved.length || occupied.length) {
+    fail([
+      'cleanup incomplete; tracked state retained',
+      result.preserved.length && `identity mismatches: ${result.preserved.join(', ')}`,
+      occupied.length && `listeners: ${occupied.join(', ')}`,
+    ].filter(Boolean).join('; '))
+  }
+  unlinkSync(configuration.stateFile)
+  console.log(`logs retained: ${state.logDir}`)
+  printCommits(state.commits)
+}
+
+export async function commandStatus (configuration, {
+  assess = assessTrackedState,
+  inspect = inspectPrerequisites,
+  probe = portIsAvailable,
+} = {}) {
+  let commits
+  let prerequisiteError
+  try {
+    commits = inspect(configuration)
+  } catch (error) {
+    prerequisiteError = error
+  }
+  if (pathEntryExists(configuration.stateFile)) {
+    try {
+      const state = readState(configuration)
+      const assessment = await assess(state, configuration, {
+        commits,
+        compareScenario: false,
+      })
+      console.log({
+        healthy: `healthy managed stack (${state.scenario})`,
+        'configuration-mismatch': 'tracked stack has different managed configuration',
+        stale: 'stale tracked state',
+      }[assessment])
+      printCommits(state.commits)
+    } catch (error) {
+      console.log(`stale tracked state (${error.message})`)
+    }
+  } else {
+    const blocked = []
+    for (const [name, port] of Object.entries(configuration.ports)) {
+      if (!await probe(port)) {
+        blocked.push(`${name}:${port}`)
+      }
+    }
+    console.log(blocked.length
+      ? `blocked by unknown listener (${blocked.join(', ')})`
+      : 'stopped')
+    if (commits) {
+      printCommits(commits)
+    }
+  }
+  if (prerequisiteError) {
+    console.log('prerequisites missing or mismatched')
+    console.log(`- ${prerequisiteError.message}`)
+  }
+}
+
+export async function commandToken (configuration, {
+  namespace = 'garden',
+  name = 'dashboard-user',
+  inspect = inspectPrerequisites,
+  run = runForeground,
+} = {}) {
+  if (!namespace || !name) {
+    fail('token namespace and name must not be empty')
+  }
+  requirePrerequisites(configuration, inspect)
+  console.error(`system:serviceaccount:${namespace}:${name}\n`)
+  await run(join(configuration.checkoutDir, 'gardenerless-setup.sh'), [
+    'get-token',
+    '--namespace',
+    namespace,
+    '--service-account',
+    name,
+  ], {
+    cwd: configuration.checkoutDir,
+    env: sanitizedGardenerlessEnvironment(configuration),
+    stdio: 'inherit',
+  })
+}
+
+function usage () {
+  return `usage: node hack/local-dashboard.mjs <command> [options]
+
+commands:
+  setup [--reset]
+  up [--scenario NAME]
+  down
+  status
+  token [--namespace NAMESPACE] [--name NAME]`
+}
+
+export async function main (arguments_ = process.argv.slice(2)) {
+  const [command, ...rest] = arguments_
+  if (!command || command === '--help' || command === '-h') {
+    console.log(usage())
+    return
+  }
+  if (!['setup', 'up', 'down', 'status', 'token'].includes(command)) {
+    fail(`unknown command: ${command}\n${usage()}`)
+  }
+  const options = parseOptions(command, rest)
+  if (options.help) {
+    console.log(usage())
+    return
+  }
+  const configuration = resolveConfiguration({ options })
+  await {
+    setup: config => commandSetup(config, { reset: Boolean(options.reset) }),
+    up: commandUp,
+    down: commandDown,
+    status: commandStatus,
+    token: config => commandToken(config, {
+      namespace: options.namespace,
+      name: options.name,
+    }),
+  }[command](configuration)
+}

--- a/hack/local-dashboard/internal/configuration.mjs
+++ b/hack/local-dashboard/internal/configuration.mjs
@@ -4,7 +4,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { randomBytes } from 'node:crypto'
+import {
+  X509Certificate,
+  randomBytes,
+} from 'node:crypto'
 import {
   lstatSync,
   mkdirSync,
@@ -19,6 +22,7 @@ import {
   relative,
   resolve,
 } from 'node:path'
+import { createSecureContext } from 'node:tls'
 import { fileURLToPath } from 'node:url'
 import { parseArgs } from 'node:util'
 
@@ -88,8 +92,10 @@ const BACKEND_ENVIRONMENT_KEYS = [
 const GIT_LOCAL_ENVIRONMENT_KEYS = [
   'GIT_ALTERNATE_OBJECT_DIRECTORIES',
   'GIT_CONFIG',
+  'GIT_CONFIG_GLOBAL',
   'GIT_CONFIG_PARAMETERS',
   'GIT_CONFIG_COUNT',
+  'GIT_CONFIG_SYSTEM',
   'GIT_OBJECT_DIRECTORY',
   'GIT_DIR',
   'GIT_WORK_TREE',
@@ -238,6 +244,19 @@ export function assertReusableFrontendCertificates (sslDirectory = FRONTEND_SSL_
   for (const filename of ['ca.pem', 'key.pem', 'cert.pem']) {
     assertSafeFile(join(sslDirectory, filename), `frontend certificate ${filename}`)
   }
+  const key = readFileSync(join(sslDirectory, 'key.pem'))
+  const certificatePem = readFileSync(join(sslDirectory, 'cert.pem'))
+  let certificate
+  try {
+    createSecureContext({ key, cert: certificatePem })
+    certificate = new X509Certificate(certificatePem)
+  } catch (error) {
+    fail(`frontend TLS key and certificate are invalid: ${error.message}`)
+  }
+  const now = new Date()
+  if (now < certificate.validFromDate || now >= certificate.validToDate) {
+    fail(`frontend TLS certificate is not currently valid: ${join(sslDirectory, 'cert.pem')}`)
+  }
   return sslDirectory
 }
 
@@ -301,6 +320,8 @@ export function gitEnvironment (env = process.env) {
     [...GIT_LOCAL_ENVIRONMENT_KEYS, ...SUBPROCESS_CODE_LOADING_ENVIRONMENT_KEYS],
   )
   environment.GIT_NO_REPLACE_OBJECTS = '1'
+  environment.GIT_CONFIG_GLOBAL = '/dev/null'
+  environment.GIT_CONFIG_NOSYSTEM = '1'
   return environment
 }
 

--- a/hack/local-dashboard/internal/configuration.mjs
+++ b/hack/local-dashboard/internal/configuration.mjs
@@ -1,0 +1,361 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import { randomBytes } from 'node:crypto'
+import {
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+} from 'node:fs'
+import { homedir } from 'node:os'
+import {
+  dirname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+} from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { parseArgs } from 'node:util'
+
+export const GARDENERLESS_REPOSITORY = 'https://github.com/grolu/gardenerless-local-setup.git'
+export const GARDENERLESS_COMMIT = '28ab775a8320ac4bf9a708c692f0918a56b06167'
+export const SCENARIOS = ['healthy-shoot', 'failing-shoot', 'many-shoots', 'operation-in-progress']
+
+export const REPOSITORY_ROOT = realpathSync(resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  '..',
+))
+export const MANAGED_ROOT = join(REPOSITORY_ROOT, '.local-dashboard')
+export const BACKEND_CONFIG = join(
+  REPOSITORY_ROOT,
+  'hack',
+  'local-dashboard',
+  'backend-config.yaml',
+)
+export const FRONTEND_SSL_DIRECTORY = join(homedir(), '.gardener', 'dashboard', 'ssl')
+export const STATE_VERSION = 3
+export const MAX_STATE_BYTES = 64 * 1024
+export const COMMIT_PATTERN = /^[0-9a-f]{40}$/
+
+const BACKEND_ENVIRONMENT_KEYS = [
+  'GARDENER_CONFIG',
+  'KUBECONFIG',
+  'NODE_ENV',
+  'NODE_OPTIONS',
+  'NODE_PATH',
+  'VUE_APP_VERSION',
+  'SESSION_SECRET',
+  'SESSION_SECRET_PREVIOUS',
+  'API_SERVER_URL',
+  'OIDC_ISSUER',
+  'OIDC_CA',
+  'OIDC_CLIENT_ID',
+  'OIDC_CLIENT_SECRET',
+  'GITHUB_AUTHENTICATION_APP_ID',
+  'GITHUB_AUTHENTICATION_CLIENT_ID',
+  'GITHUB_AUTHENTICATION_CLIENT_SECRET',
+  'GITHUB_AUTHENTICATION_INSTALLATION_ID',
+  'GITHUB_AUTHENTICATION_PRIVATE_KEY',
+  'GITHUB_AUTHENTICATION_TOKEN',
+  'GITHUB_WEBHOOK_SECRET',
+  'LOG_LEVEL',
+  'LOG_HTTP_REQUEST_BODY',
+  'PORT',
+  'BIND_HOST',
+  'METRICS_PORT',
+  'METRICS_BIND_HOST',
+  'WEBSOCKET_ALLOWED_ORIGINS',
+  'POD_NAMESPACE',
+  'POD_NAME',
+  'BACKEND_PORT',
+  'BACKEND_METRICS_PORT',
+  'GARDEN_PORT',
+  'KCP_PORT',
+  'SCENARIO',
+  'GARDENERLESS_CHECKOUT_DIR',
+  'GARDENERLESS_KCP_DIR',
+  'VITE_PROXY_TARGET',
+  'VITE_DEV_PORT',
+]
+
+const GIT_LOCAL_ENVIRONMENT_KEYS = [
+  'GIT_ALTERNATE_OBJECT_DIRECTORIES',
+  'GIT_CONFIG',
+  'GIT_CONFIG_PARAMETERS',
+  'GIT_CONFIG_COUNT',
+  'GIT_OBJECT_DIRECTORY',
+  'GIT_DIR',
+  'GIT_WORK_TREE',
+  'GIT_IMPLICIT_WORK_TREE',
+  'GIT_GRAFT_FILE',
+  'GIT_INDEX_FILE',
+  'GIT_REPLACE_REF_BASE',
+  'GIT_PREFIX',
+  'GIT_SHALLOW_FILE',
+  'GIT_COMMON_DIR',
+]
+
+const SUBPROCESS_CODE_LOADING_ENVIRONMENT_KEYS = [
+  'BASH_ENV',
+  'GIT_EXEC_PATH',
+  'GIT_TEMPLATE_DIR',
+  'MAKEFILES',
+  'MAKEFLAGS',
+  'GNUMAKEFLAGS',
+  'MFLAGS',
+]
+
+export function fail (message) {
+  throw new Error(message)
+}
+
+export function pathEntryExists (filename) {
+  return Boolean(lstatSync(filename, { throwIfNoEntry: false }))
+}
+
+function yamlScalar (value, label) {
+  const trimmed = value.trim()
+  if (trimmed.startsWith('"')) {
+    try {
+      return JSON.parse(trimmed)
+    } catch {
+      fail(`${label} is not a valid quoted YAML scalar`)
+    }
+  }
+  if (trimmed.startsWith("'")) {
+    if (!trimmed.endsWith("'")) {
+      fail(`${label} is not a valid quoted YAML scalar`)
+    }
+    return trimmed.slice(1, -1).replaceAll("''", "'")
+  }
+  return trimmed.replace(/\s+#.*$/, '').trim()
+}
+
+export function yarnRuntimeFromConfiguration (repositoryRoot = REPOSITORY_ROOT) {
+  const configurationFile = join(repositoryRoot, '.yarnrc.yml')
+  assertSafeFile(configurationFile, 'Yarn configuration')
+  const matches = [...readFileSync(configurationFile, 'utf8').matchAll(/^yarnPath:\s*(.+)$/gm)]
+  if (matches.length !== 1) {
+    fail(`Yarn configuration must define exactly one yarnPath: ${configurationFile}`)
+  }
+  const yarnPath = yamlScalar(matches[0][1], 'yarnPath')
+  if (!yarnPath) {
+    fail(`Yarn configuration has an empty yarnPath: ${configurationFile}`)
+  }
+  const runtime = resolve(repositoryRoot, yarnPath)
+  const relativeRuntime = relative(repositoryRoot, runtime)
+  if (relativeRuntime.startsWith('..') || isAbsolute(relativeRuntime)) {
+    fail(`yarnPath must resolve inside the repository: ${yarnPath}`)
+  }
+  return runtime
+}
+
+export const YARN_RUNTIME = yarnRuntimeFromConfiguration()
+
+export function parseOptions (command, arguments_) {
+  const options = { help: { type: 'boolean', short: 'h' } }
+  if (command === 'setup') {
+    options.reset = { type: 'boolean' }
+  } else if (command === 'up') {
+    options.scenario = { type: 'string' }
+  } else if (command === 'token') {
+    options.namespace = { type: 'string' }
+    options.name = { type: 'string' }
+  }
+  try {
+    return { ...parseArgs({ args: arguments_, options, strict: true }).values }
+  } catch (error) {
+    fail(error.message)
+  }
+}
+
+export function resolveConfiguration ({
+  options = {},
+  repositoryRoot = REPOSITORY_ROOT,
+} = {}) {
+  const managedRoot = join(repositoryRoot, '.local-dashboard')
+  const checkoutDir = join(managedRoot, 'gardenerless')
+  const runtimeDir = join(managedRoot, 'runtime')
+  const goModCacheDir = join(managedRoot, 'gomodcache')
+  const scenario = options.scenario ?? 'healthy-shoot'
+  if (!SCENARIOS.includes(scenario)) {
+    fail(`unknown scenario '${scenario}'; choose ${SCENARIOS.join(', ')}`)
+  }
+  return {
+    repositoryRoot,
+    managedRoot,
+    stateFile: join(managedRoot, 'state.json'),
+    setupLogFile: join(managedRoot, 'setup.log'),
+    checkoutDir,
+    runtimeDir,
+    goModCacheDir,
+    scenario,
+    ports: { frontend: 8444, backend: 3031, metrics: 9051, garden: 6443 },
+    urls: {
+      frontend: 'https://127.0.0.1:8444',
+      backend: 'http://127.0.0.1:3031',
+      garden: 'https://127.0.0.1:6443',
+      proxy: 'http://127.0.0.1:3031',
+    },
+  }
+}
+
+export function assertSafeDirectory (directory, label) {
+  const stat = lstatSync(directory, { throwIfNoEntry: false })
+  if (!stat || !stat.isDirectory() || stat.isSymbolicLink() ||
+      realpathSync(directory) !== directory) {
+    fail(`${label} is not a real non-symlink directory: ${directory}`)
+  }
+}
+
+export function assertSafeManagedRoot (managedRoot) {
+  if (pathEntryExists(managedRoot)) {
+    assertSafeDirectory(managedRoot, 'managed directory')
+  } else {
+    mkdirSync(managedRoot, { recursive: true, mode: 0o700 })
+  }
+}
+
+export function assertSafeFile (filename, label) {
+  const stat = lstatSync(filename)
+  if (!stat.isFile() || stat.isSymbolicLink() || realpathSync(filename) !== filename) {
+    fail(`${label} is not a regular non-symlink file: ${filename}`)
+  }
+}
+
+export function assertReusableFrontendCertificates (sslDirectory = FRONTEND_SSL_DIRECTORY) {
+  if (!pathEntryExists(sslDirectory)) {
+    fail(`trusted frontend certificates are missing at ${sslDirectory}; run 'yarn workspace @gardener-dashboard/frontend setup' deliberately before starting the local Dashboard`)
+  }
+  assertSafeDirectory(sslDirectory, 'frontend certificate directory')
+  for (const filename of ['key.pem', 'cert.pem']) {
+    assertSafeFile(join(sslDirectory, filename), `frontend certificate ${filename}`)
+  }
+  return sslDirectory
+}
+
+export function ensureManagedChildDirectory (directory, managedRoot) {
+  assertSafeManagedRoot(managedRoot)
+  const child = relative(managedRoot, directory)
+  if (!child || child.startsWith('..') || isAbsolute(child)) {
+    fail(`managed child directory escapes ${managedRoot}: ${directory}`)
+  }
+  if (pathEntryExists(directory)) {
+    assertSafeDirectory(directory, 'managed child')
+  } else {
+    mkdirSync(directory, { mode: 0o700 })
+  }
+}
+
+function assertManagedPrerequisitePaths (configuration) {
+  if (configuration.checkoutDir !== join(configuration.managedRoot, 'gardenerless') ||
+      configuration.runtimeDir !== join(configuration.managedRoot, 'runtime') ||
+      configuration.goModCacheDir !== join(configuration.managedRoot, 'gomodcache')) {
+    fail('setup only manages repository-owned prerequisites')
+  }
+}
+
+export function assertManagedPrerequisiteDirectories (configuration) {
+  assertManagedPrerequisitePaths(configuration)
+  assertSafeDirectory(configuration.managedRoot, 'managed directory')
+  assertSafeDirectory(configuration.checkoutDir, 'gardenerless checkout')
+  assertSafeDirectory(configuration.runtimeDir, 'KCP runtime')
+}
+
+export function assertSetupTargetsAvailable (configuration, { reset = false } = {}) {
+  assertManagedPrerequisitePaths(configuration)
+  if (pathEntryExists(configuration.managedRoot)) {
+    assertSafeDirectory(configuration.managedRoot, 'managed directory')
+  }
+  if (!reset) {
+    for (const [directory, label] of [
+      [configuration.checkoutDir, 'gardenerless checkout'],
+      [configuration.runtimeDir, 'KCP runtime'],
+      [configuration.goModCacheDir, 'Go module cache'],
+    ]) {
+      if (pathEntryExists(directory)) {
+        assertSafeDirectory(directory, label)
+      }
+    }
+  }
+}
+
+function environmentWithout (env, keys) {
+  const environment = { ...env }
+  for (const key of keys) {
+    delete environment[key]
+  }
+  return environment
+}
+
+export function gitEnvironment (env = process.env) {
+  const environment = environmentWithout(
+    env,
+    [...GIT_LOCAL_ENVIRONMENT_KEYS, ...SUBPROCESS_CODE_LOADING_ENVIRONMENT_KEYS],
+  )
+  environment.GIT_NO_REPLACE_OBJECTS = '1'
+  return environment
+}
+
+export function sanitizedGardenerlessEnvironment (configuration, env = process.env) {
+  const environment = gitEnvironment(environmentWithout(env, BACKEND_ENVIRONMENT_KEYS))
+  environment.GARDENERLESS_CHECKOUT_DIR = configuration.checkoutDir
+  environment.GARDENERLESS_KCP_DIR = configuration.runtimeDir
+  environment.GIT_TERMINAL_PROMPT = '0'
+  return environment
+}
+
+export function backendEnvironment (configuration, env = process.env) {
+  const environment = gitEnvironment(environmentWithout(env, BACKEND_ENVIRONMENT_KEYS))
+  return Object.assign(environment, {
+    NODE_ENV: 'development',
+    GARDENER_CONFIG: BACKEND_CONFIG,
+    KUBECONFIG: join(configuration.runtimeDir, '.kcp', 'dashboard.kubeconfig'),
+    API_SERVER_URL: configuration.urls.garden,
+    WEBSOCKET_ALLOWED_ORIGINS: configuration.urls.frontend,
+    SESSION_SECRET: randomBytes(32).toString('hex'),
+    SESSION_SECRET_PREVIOUS: randomBytes(32).toString('hex'),
+    PORT: String(configuration.ports.backend),
+    BIND_HOST: '127.0.0.1',
+    METRICS_PORT: String(configuration.ports.metrics),
+    METRICS_BIND_HOST: '127.0.0.1',
+  })
+}
+
+export function isolatedSetupGitEnvironment (env = process.env) {
+  const environment = Object.fromEntries(
+    Object.entries(gitEnvironment(env)).filter(([key]) => !key.startsWith('GIT_CONFIG_')),
+  )
+  return Object.assign(environment, {
+    GIT_ALLOW_PROTOCOL: 'https',
+    GIT_CONFIG_GLOBAL: '/dev/null',
+    GIT_CONFIG_NOSYSTEM: '1',
+    GIT_TERMINAL_PROMPT: '0',
+  })
+}
+
+export function frontendEnvironment (
+  configuration,
+  sslDirectory = FRONTEND_SSL_DIRECTORY,
+  env = process.env,
+) {
+  return Object.assign(
+    gitEnvironment(environmentWithout(env, [
+      ...BACKEND_ENVIRONMENT_KEYS,
+      'VITE_PROXY_TARGET',
+      'GARDENER_DASHBOARD_SSL_DIR',
+      'VITE_DEV_PORT',
+    ])),
+    {
+      VITE_PROXY_TARGET: configuration.urls.proxy,
+      GARDENER_DASHBOARD_SSL_DIR: sslDirectory,
+    },
+  )
+}

--- a/hack/local-dashboard/internal/configuration.mjs
+++ b/hack/local-dashboard/internal/configuration.mjs
@@ -244,18 +244,40 @@ export function assertReusableFrontendCertificates (sslDirectory = FRONTEND_SSL_
   for (const filename of ['ca.pem', 'key.pem', 'cert.pem']) {
     assertSafeFile(join(sslDirectory, filename), `frontend certificate ${filename}`)
   }
+  const caPath = join(sslDirectory, 'ca.pem')
+  const certificatePath = join(sslDirectory, 'cert.pem')
+  const caPem = readFileSync(caPath)
   const key = readFileSync(join(sslDirectory, 'key.pem'))
-  const certificatePem = readFileSync(join(sslDirectory, 'cert.pem'))
+  const certificatePem = readFileSync(certificatePath)
+  let caCertificate
   let certificate
   try {
-    createSecureContext({ key, cert: certificatePem })
+    caCertificate = new X509Certificate(caPem)
+  } catch {
+    fail(`frontend TLS CA certificate is invalid: ${caPath}`)
+  }
+  try {
     certificate = new X509Certificate(certificatePem)
-  } catch (error) {
-    fail(`frontend TLS key and certificate are invalid: ${error.message}`)
+  } catch {
+    fail(`frontend TLS server certificate is invalid: ${certificatePath}`)
   }
   const now = new Date()
-  if (now < certificate.validFromDate || now >= certificate.validToDate) {
-    fail(`frontend TLS certificate is not currently valid: ${join(sslDirectory, 'cert.pem')}`)
+  for (const [currentCertificate, label, filename] of [
+    [caCertificate, 'CA certificate', caPath],
+    [certificate, 'server certificate', certificatePath],
+  ]) {
+    if (now < currentCertificate.validFromDate || now >= currentCertificate.validToDate) {
+      fail(`frontend TLS ${label} is not currently valid: ${filename}`)
+    }
+  }
+  try {
+    createSecureContext({ ca: caPem, key, cert: certificatePem })
+  } catch {
+    fail(`frontend TLS key and certificate material are invalid or mismatched: ${sslDirectory}`)
+  }
+  if (!certificate.checkIssued(caCertificate) ||
+      !certificate.verify(caCertificate.publicKey)) {
+    fail(`frontend TLS server certificate was not issued and signed by the CA certificate: ${certificatePath}`)
   }
   return sslDirectory
 }

--- a/hack/local-dashboard/internal/configuration.mjs
+++ b/hack/local-dashboard/internal/configuration.mjs
@@ -235,7 +235,7 @@ export function assertReusableFrontendCertificates (sslDirectory = FRONTEND_SSL_
     fail(`trusted frontend certificates are missing at ${sslDirectory}; run 'yarn workspace @gardener-dashboard/frontend setup' deliberately before starting the local Dashboard`)
   }
   assertSafeDirectory(sslDirectory, 'frontend certificate directory')
-  for (const filename of ['key.pem', 'cert.pem']) {
+  for (const filename of ['ca.pem', 'key.pem', 'cert.pem']) {
     assertSafeFile(join(sslDirectory, filename), `frontend certificate ${filename}`)
   }
   return sslDirectory

--- a/hack/local-dashboard/internal/prerequisites.mjs
+++ b/hack/local-dashboard/internal/prerequisites.mjs
@@ -1,0 +1,360 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from 'node:child_process'
+import {
+  accessSync,
+  chmodSync,
+  closeSync,
+  constants as fsConstants,
+  lstatSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  unlinkSync,
+} from 'node:fs'
+
+import {
+  COMMIT_PATTERN,
+  GARDENERLESS_COMMIT,
+  GARDENERLESS_REPOSITORY,
+  assertManagedPrerequisiteDirectories,
+  assertSafeDirectory,
+  assertSafeFile,
+  assertSafeManagedRoot,
+  assertSetupTargetsAvailable,
+  ensureManagedChildDirectory,
+  fail,
+  gitEnvironment,
+  isolatedSetupGitEnvironment,
+  pathEntryExists,
+  sanitizedGardenerlessEnvironment,
+} from './configuration.mjs'
+import {
+  assessTrackedState,
+  openLogFile,
+  readState,
+  runForeground,
+  runTimedPhase,
+  tailFile,
+} from './runtime.mjs'
+
+const GARDENERLESS_PIN_REF = 'refs/local-dashboard/gardenerless-pin'
+const KCP_RELEASE_PATTERN = /^v[0-9]+\.[0-9]+\.[0-9]+$/
+const MAX_VERIFY_OUTPUT = 64 * 1024
+const MAX_DIAGNOSTIC_LENGTH = 4096
+
+function boundedDiagnostic (value) {
+  const text = typeof value === 'string' ? value.trimEnd() : ''
+  return text.slice(-MAX_DIAGNOSTIC_LENGTH)
+}
+
+function commandOutput (command, arguments_, { cwd, env } = {}) {
+  const result = spawnSync(command, arguments_, {
+    cwd,
+    env,
+    encoding: 'utf8',
+    maxBuffer: 4 * 1024 * 1024,
+  })
+  if (result.error) {
+    fail(`${command} could not be run: ${result.error.message}`)
+  }
+  if (result.status !== 0) {
+    const detail = boundedDiagnostic(result.stderr) || boundedDiagnostic(result.stdout) ||
+      `exit code ${result.status}`
+    fail(`${command} ${arguments_.join(' ')} failed: ${detail}`)
+  }
+  return result.stdout.trim()
+}
+
+function gitOutput (checkoutDir, ...arguments_) {
+  return commandOutput('git', ['-C', checkoutDir, ...arguments_], {
+    env: gitEnvironment(),
+  })
+}
+
+function inspectCheckout (directory, label) {
+  assertSafeDirectory(directory, label)
+  assertSafeDirectory(`${directory}/.git`, `${label} Git directory`)
+  const worktreeRoot = gitOutput(directory, 'rev-parse', '--show-toplevel')
+  if (realpathSync(worktreeRoot) !== directory) {
+    fail(`${label} is not a Git worktree root: ${directory}`)
+  }
+  const unexpected = gitOutput(
+    directory,
+    'status',
+    '--porcelain=v1',
+    '--untracked-files=normal',
+  ).split('\n').filter(Boolean)
+  if (unexpected.length) {
+    fail(`${label} is dirty or contains unknown files:\n${unexpected.join('\n')}`)
+  }
+  const head = gitOutput(directory, 'rev-parse', '--verify', 'HEAD^{commit}')
+  if (!COMMIT_PATTERN.test(head)) {
+    fail(`${label} did not resolve a valid Git commit`)
+  }
+  return { head }
+}
+
+function assertExpectedCommit (actual, expected, label) {
+  if (actual !== expected) {
+    fail(`${label} resolved unexpected commit ${actual}; expected pinned commit ${expected}`)
+  }
+}
+
+export function inspectGardenerlessCheckout (configuration, { requireCurrent = true } = {}) {
+  const details = inspectCheckout(configuration.checkoutDir, 'gardenerless checkout')
+  const executable = `${configuration.checkoutDir}/gardenerless-setup.sh`
+  assertSafeFile(executable, 'gardenerless executable')
+  try {
+    accessSync(executable, fsConstants.X_OK)
+  } catch {
+    fail(`gardenerless executable is not executable: ${executable}`)
+  }
+  if (requireCurrent) {
+    assertExpectedCommit(details.head, GARDENERLESS_COMMIT, 'gardenerless checkout')
+  }
+  return details
+}
+
+export function parseKcpVerification (stdout) {
+  if (typeof stdout !== 'string') {
+    fail('gardenerless verify-kcp returned non-text output')
+  }
+  let result
+  try {
+    result = JSON.parse(stdout.replace(/\s+$/u, ''))
+  } catch {
+    fail('gardenerless verify-kcp returned malformed JSON')
+  }
+  if (!result || typeof result !== 'object' || Array.isArray(result)) {
+    fail('gardenerless verify-kcp returned an unexpected result shape')
+  }
+  const keys = Object.keys(result).sort()
+  if (keys.join(',') !== 'commit,release,schemaVersion') {
+    fail('gardenerless verify-kcp returned an unexpected result shape')
+  }
+  if (result.schemaVersion !== 1) {
+    fail(`gardenerless verify-kcp returned unsupported schema version ${result.schemaVersion}`)
+  }
+  if (!KCP_RELEASE_PATTERN.test(result.release)) {
+    fail(`gardenerless verify-kcp returned invalid release '${result.release}'`)
+  }
+  if (!COMMIT_PATTERN.test(result.commit)) {
+    fail(`gardenerless verify-kcp returned invalid commit '${result.commit}'`)
+  }
+  return { release: result.release, commit: result.commit }
+}
+
+export function verifyKcp (configuration, { execute = spawnSync } = {}) {
+  const executable = `${configuration.checkoutDir}/gardenerless-setup.sh`
+  const result = execute(executable, ['verify-kcp', '--format=json'], {
+    cwd: configuration.checkoutDir,
+    env: sanitizedGardenerlessEnvironment(configuration),
+    encoding: 'utf8',
+    maxBuffer: MAX_VERIFY_OUTPUT,
+  })
+  if (result.error || result.status !== 0) {
+    const detail = boundedDiagnostic(result.stderr) || result.error?.message ||
+      `exit code ${result.status}`
+    fail(`gardenerless verify-kcp failed: ${detail}`)
+  }
+  return parseKcpVerification(result.stdout)
+}
+
+export function inspectPrerequisites (configuration, {
+  inspect = inspectGardenerlessCheckout,
+  verify = verifyKcp,
+} = {}) {
+  assertManagedPrerequisiteDirectories(configuration)
+  const gardenerless = inspect(configuration)
+  const kcp = verify(configuration)
+  return {
+    gardenerless: gardenerless.head,
+    kcp: kcp.commit,
+    kcpRelease: kcp.release,
+  }
+}
+
+function makeManagedTreeRemovable (directory) {
+  const stat = lstatSync(directory)
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    return
+  }
+  chmodSync(directory, stat.mode | 0o700)
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    if (entry.isDirectory() && !entry.isSymbolicLink()) {
+      makeManagedTreeRemovable(`${directory}/${entry.name}`)
+    }
+  }
+}
+
+function removeManagedPrerequisite (configuration, target, remove) {
+  if (![configuration.checkoutDir, configuration.runtimeDir, configuration.goModCacheDir]
+    .includes(target)) {
+    fail(`refusing to reset path outside managed prerequisites: ${target}`)
+  }
+  if (!pathEntryExists(target)) {
+    return
+  }
+  const stat = lstatSync(target)
+  if (stat.isSymbolicLink() || !stat.isDirectory()) {
+    unlinkSync(target)
+    return
+  }
+  if (realpathSync(target) !== target) {
+    fail(`refusing to reset non-canonical managed prerequisite: ${target}`)
+  }
+  try {
+    makeManagedTreeRemovable(target)
+    remove(target, { force: true, maxRetries: 5, recursive: true, retryDelay: 100 })
+  } catch (error) {
+    fail(`could not reset managed prerequisite at ${target}: ${error.message}`)
+  }
+}
+
+export function resetManagedPrerequisites (configuration, { remove = rmSync } = {}) {
+  assertSetupTargetsAvailable(configuration, { reset: true })
+  assertSafeManagedRoot(configuration.managedRoot)
+  removeManagedPrerequisite(configuration, configuration.checkoutDir, remove)
+  removeManagedPrerequisite(configuration, configuration.runtimeDir, remove)
+  removeManagedPrerequisite(configuration, configuration.goModCacheDir, remove)
+}
+
+async function fetchPinnedCommit (directory, repository, commit, environment, stdio) {
+  await runForeground('git', [
+    '-C', directory, 'fetch', '--no-tags', repository, `+${commit}:${GARDENERLESS_PIN_REF}`,
+  ], { env: environment, stdio })
+}
+
+export async function clonePinnedCheckout (repository, commit, target, {
+  cwd,
+  env = process.env,
+  stdio,
+} = {}) {
+  const environment = gitEnvironment(env)
+  await runForeground('git', ['init', '--initial-branch', 'main', target], {
+    cwd,
+    env: environment,
+    stdio,
+  })
+  await fetchPinnedCommit(target, repository, commit, environment, stdio)
+  await runForeground('git', ['-C', target, 'checkout', '--detach', GARDENERLESS_PIN_REF], {
+    env: environment,
+    stdio,
+  })
+}
+
+async function convergeGardenerlessCheckout (configuration, environment, stdio) {
+  const existed = pathEntryExists(configuration.checkoutDir)
+  const previous = existed
+    ? inspectCheckout(configuration.checkoutDir, 'gardenerless checkout')
+    : undefined
+  if (existed) {
+    await fetchPinnedCommit(
+      configuration.checkoutDir,
+      GARDENERLESS_REPOSITORY,
+      GARDENERLESS_COMMIT,
+      environment,
+      stdio,
+    )
+  } else {
+    await clonePinnedCheckout(
+      GARDENERLESS_REPOSITORY,
+      GARDENERLESS_COMMIT,
+      configuration.checkoutDir,
+      { cwd: configuration.repositoryRoot, env: environment, stdio },
+    )
+  }
+  const fetchedCommit = gitOutput(
+    configuration.checkoutDir,
+    'rev-parse',
+    '--verify',
+    `${GARDENERLESS_PIN_REF}^{commit}`,
+  )
+  assertExpectedCommit(fetchedCommit, GARDENERLESS_COMMIT, 'gardenerless fetched ref')
+  await runForeground('git', [
+    '-C', configuration.checkoutDir, 'checkout', '--detach', GARDENERLESS_PIN_REF,
+  ], { env: environment, stdio })
+  const current = inspectGardenerlessCheckout(configuration)
+  return { changed: !existed || previous.head !== current.head, ...current }
+}
+
+export async function setupKcpRuntime (configuration, environment, stdio, gardenerless, {
+  run = runForeground,
+  inspect = inspectPrerequisites,
+} = {}) {
+  const setupEnvironment = isolatedSetupGitEnvironment(
+    sanitizedGardenerlessEnvironment(configuration, environment),
+  )
+  ensureManagedChildDirectory(configuration.goModCacheDir, configuration.managedRoot)
+  delete setupEnvironment.BUILDFLAGS
+  setupEnvironment.GOMODCACHE = configuration.goModCacheDir
+  setupEnvironment.GOFLAGS = '-modcacherw'
+  setupEnvironment.GOWORK = 'off'
+  await run(`${configuration.checkoutDir}/gardenerless-setup.sh`, ['setup-kcp'], {
+    cwd: configuration.checkoutDir,
+    env: setupEnvironment,
+    stdio,
+  })
+  const commits = inspect(configuration, { inspect: () => gardenerless })
+  return { rebuilt: true, commits }
+}
+
+export async function convergeSetupPrerequisites (configuration, environment, {
+  gardenerless = convergeGardenerlessCheckout,
+  kcp = setupKcpRuntime,
+  phase = runTimedPhase,
+} = {}) {
+  const descriptor = openLogFile(configuration.setupLogFile, { truncate: true })
+  console.log(`setup: converging managed prerequisites; log: ${configuration.setupLogFile}`)
+  try {
+    const stdio = ['ignore', descriptor, descriptor]
+    const checkout = await phase({
+      command: 'setup',
+      index: 1,
+      total: 2,
+      label: 'fetching and verifying pinned gardenerless commit',
+      completeLabel: 'pinned gardenerless checkout ready',
+      action: () => gardenerless(configuration, environment, stdio),
+    })
+    const runtime = await phase({
+      command: 'setup',
+      index: 2,
+      total: 2,
+      label: 'delegating pinned kcp setup to gardenerless',
+      completeLabel: 'gardenerless kcp setup and verification complete',
+      action: () => kcp(configuration, environment, stdio, checkout),
+    })
+    return { changed: checkout.changed, ...runtime }
+  } catch (error) {
+    fail(`${error.message}; log: ${configuration.setupLogFile}\n${tailFile(configuration.setupLogFile)}`)
+  } finally {
+    closeSync(descriptor)
+  }
+}
+
+export async function existingTrackedStackForSetup (configuration, {
+  reset = false,
+  read = readState,
+  assess = assessTrackedState,
+} = {}) {
+  if (!pathEntryExists(configuration.stateFile)) {
+    return undefined
+  }
+  let state
+  try {
+    state = read(configuration)
+  } catch (error) {
+    fail(`stale tracked state blocks setup (${error.message}); run 'node hack/local-dashboard.mjs down'`)
+  }
+  if (await assess(state, configuration) !== 'healthy') {
+    fail('stale tracked state blocks setup; run \'node hack/local-dashboard.mjs down\'')
+  }
+  if (reset) {
+    fail('setup --reset refuses while the tracked stack is running; run \'node hack/local-dashboard.mjs down\' first')
+  }
+  return state
+}

--- a/hack/local-dashboard/internal/prerequisites.mjs
+++ b/hack/local-dashboard/internal/prerequisites.mjs
@@ -290,10 +290,34 @@ export async function setupKcpRuntime (configuration, environment, stdio, garden
     sanitizedGardenerlessEnvironment(configuration, environment),
   )
   ensureManagedChildDirectory(configuration.goModCacheDir, configuration.managedRoot)
-  delete setupEnvironment.BUILDFLAGS
-  setupEnvironment.GOMODCACHE = configuration.goModCacheDir
-  setupEnvironment.GOFLAGS = '-modcacherw'
-  setupEnvironment.GOWORK = 'off'
+  for (const key of [
+    'BUILDFLAGS',
+    'GO111MODULE',
+    'GOAUTH',
+    'GOCACHE',
+    'GOENV',
+    'GOINSECURE',
+    'GONOPROXY',
+    'GONOSUMDB',
+    'GOPATH',
+    'GOPRIVATE',
+    'GOPROXY',
+    'GOSUMDB',
+    'GOTOOLCHAIN',
+    'GOVCS',
+  ]) {
+    delete setupEnvironment[key]
+  }
+  Object.assign(setupEnvironment, {
+    GOAUTH: 'off',
+    GOENV: 'off',
+    GOFLAGS: '-modcacherw',
+    GOMODCACHE: configuration.goModCacheDir,
+    GOPROXY: 'https://proxy.golang.org,direct',
+    GOSUMDB: 'sum.golang.org',
+    GOTOOLCHAIN: 'auto',
+    GOWORK: 'off',
+  })
   await run(`${configuration.checkoutDir}/gardenerless-setup.sh`, ['setup-kcp'], {
     cwd: configuration.checkoutDir,
     env: setupEnvironment,

--- a/hack/local-dashboard/internal/runtime.mjs
+++ b/hack/local-dashboard/internal/runtime.mjs
@@ -277,9 +277,12 @@ export async function assertPortsAvailable (ports, probe = portIsAvailable) {
   }
 }
 
-export function requestReady (url, caPath) {
+export function requestReady (
+  url,
+  caPath,
+  client = url.startsWith('https:') ? https : http,
+) {
   return new Promise(resolve => {
-    const client = url.startsWith('https:') ? https : http
     let ca
     try {
       if (caPath) {
@@ -297,8 +300,12 @@ export function requestReady (url, caPath) {
       response.resume()
       resolve(response.statusCode >= 200 && response.statusCode < 400)
     })
-    request.once('timeout', () => request.destroy())
+    request.once('timeout', () => {
+      resolve(false)
+      request.destroy()
+    })
     request.once('error', () => resolve(false))
+    request.once('close', () => resolve(false))
   })
 }
 
@@ -587,14 +594,37 @@ function detachedService (name, command, arguments_, { cwd, env, logPath }) {
   }
 }
 
-export async function startAndRecord (state, configuration, definition) {
-  const child = detachedService(
+async function stopSpawnedGroup (pgid) {
+  const signalGroup = (pgid, signal) => process.kill(-pgid, signal)
+  signalTrackedGroup(signalGroup, pgid, 'SIGTERM')
+  if (!await waitForGroupExit(pgid, 5_000)) {
+    signalTrackedGroup(signalGroup, pgid, 'SIGKILL')
+    if (!await waitForGroupExit(pgid, 2_000)) {
+      fail(`spawned process group ${pgid} did not stop`)
+    }
+  }
+}
+
+export async function startAndRecord (state, configuration, definition, {
+  spawnService = detachedService,
+  capture = captureProcess,
+  stop = stopSpawnedGroup,
+} = {}) {
+  const child = spawnService(
     definition.name,
     definition.command,
     definition.arguments,
     definition,
   )
-  const identity = await captureProcess(child.pid, definition.commandMarker)
+  let identity
+  try {
+    identity = await capture(child.pid, definition.commandMarker)
+  } catch (error) {
+    if (Number.isInteger(child.pid)) {
+      await stop(child.pid)
+    }
+    throw error
+  }
   const record = { name: definition.name, ...identity, logPath: definition.logPath }
   state.processes.push(record)
   writeState(state, configuration)

--- a/hack/local-dashboard/internal/runtime.mjs
+++ b/hack/local-dashboard/internal/runtime.mjs
@@ -29,6 +29,7 @@ import {
 
 import {
   COMMIT_PATTERN,
+  FRONTEND_SSL_DIRECTORY,
   MANAGED_ROOT,
   MAX_STATE_BYTES,
   REPOSITORY_ROOT,
@@ -276,11 +277,21 @@ export async function assertPortsAvailable (ports, probe = portIsAvailable) {
   }
 }
 
-export function requestReady (url) {
+export function requestReady (url, caPath) {
   return new Promise(resolve => {
     const client = url.startsWith('https:') ? https : http
+    let ca
+    try {
+      if (caPath) {
+        assertSafeFile(caPath, 'readiness certificate')
+        ca = readFileSync(caPath)
+      }
+    } catch {
+      resolve(false)
+      return
+    }
     const request = client.get(url, {
-      rejectUnauthorized: false,
+      ca,
       timeout: 1500,
     }, response => {
       response.resume()
@@ -324,6 +335,7 @@ export function serviceDefinitions (configuration) {
       cwd: configuration.checkoutDir,
       ownershipPort: configuration.ports.garden,
       ports: [configuration.ports.garden],
+      caPath: join(configuration.runtimeDir, '.kcp', 'apiserver.crt'),
       runtimeCwds: [configuration.checkoutDir, configuration.runtimeDir],
       runtimeCommandMarkers: [
         join(configuration.runtimeDir, 'bin', 'kcp'),
@@ -359,6 +371,7 @@ export function serviceDefinitions (configuration) {
       cwd: configuration.repositoryRoot,
       ownershipPort: configuration.ports.frontend,
       ports: [configuration.ports.frontend],
+      caPath: join(FRONTEND_SSL_DIRECTORY, 'ca.pem'),
       runtimeCwds: [join(configuration.repositoryRoot, 'frontend')],
       runtimeCommandMarkers: [
         'vite',
@@ -480,10 +493,11 @@ export async function assessTrackedState (state, configuration, {
       state.commits.kcpRelease !== commits.kcpRelease)) {
     return 'configuration-mismatch'
   }
+  const [garden, , frontend] = serviceDefinitions(configuration)
   const [gardenReady, backendReady, frontendReady] = await Promise.all([
-    request(`${configuration.urls.garden}/readyz`),
+    request(`${configuration.urls.garden}/readyz`, garden.caPath),
     request(`${configuration.urls.backend}/healthz`),
-    request(`${configuration.urls.frontend}/`),
+    request(`${configuration.urls.frontend}/`, frontend.caPath),
   ])
   return gardenReady && backendReady && frontendReady ? 'healthy' : 'stale'
 }
@@ -593,7 +607,7 @@ export async function startReadyService (state, configuration, definition) {
     label: definition.name,
     record,
     configuration,
-    health: () => requestReady(definition.healthUrl),
+    health: () => requestReady(definition.healthUrl, definition.caPath),
     logPath: definition.logPath,
     timeoutMs: definition.timeoutMs,
   })

--- a/hack/local-dashboard/internal/runtime.mjs
+++ b/hack/local-dashboard/internal/runtime.mjs
@@ -1,0 +1,601 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import {
+  spawn,
+  spawnSync,
+} from 'node:child_process'
+import { randomBytes } from 'node:crypto'
+import {
+  closeSync,
+  constants as fsConstants,
+  lstatSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from 'node:fs'
+import http from 'node:http'
+import https from 'node:https'
+import { createServer } from 'node:net'
+import {
+  isAbsolute,
+  join,
+  relative,
+} from 'node:path'
+
+import {
+  COMMIT_PATTERN,
+  MANAGED_ROOT,
+  MAX_STATE_BYTES,
+  REPOSITORY_ROOT,
+  SCENARIOS,
+  STATE_VERSION,
+  YARN_RUNTIME,
+  assertSafeDirectory,
+  assertSafeFile,
+  assertSafeManagedRoot,
+  fail,
+  pathEntryExists,
+  sanitizedGardenerlessEnvironment,
+} from './configuration.mjs'
+
+const delay = milliseconds => new Promise(resolve => setTimeout(resolve, milliseconds))
+
+export async function runForeground (
+  command,
+  arguments_,
+  { cwd, env, stdio = 'inherit' } = {},
+) {
+  await new Promise((resolve, reject) => {
+    const child = spawn(command, arguments_, { cwd, env, stdio })
+    child.once('error', reject)
+    child.once('exit', (code, signal) => {
+      if (code === 0) {
+        resolve()
+      } else {
+        reject(new Error(`${command} exited with ${signal ? `signal ${signal}` : `code ${code}`}`))
+      }
+    })
+  })
+}
+
+export function tailFile (filename) {
+  try {
+    const stat = lstatSync(filename)
+    if (!stat.isFile() || stat.isSymbolicLink()) {
+      return '(log unavailable)'
+    }
+    return readFileSync(filename, 'utf8').slice(-4096).split('\n').slice(-20).join('\n')
+  } catch {
+    return '(log unavailable)'
+  }
+}
+
+export function openLogFile (filename, { truncate = false } = {}) {
+  if (pathEntryExists(filename)) {
+    assertSafeFile(filename, 'log')
+  }
+  return openSync(
+    filename,
+    fsConstants.O_WRONLY |
+      fsConstants.O_CREAT |
+      (truncate ? fsConstants.O_TRUNC : fsConstants.O_APPEND) |
+      fsConstants.O_NOFOLLOW,
+    0o600,
+  )
+}
+
+export async function runGardenerless (configuration, arguments_, logPath) {
+  const setup = join(configuration.checkoutDir, 'gardenerless-setup.sh')
+  const descriptor = openLogFile(logPath)
+  try {
+    await runForeground(setup, arguments_, {
+      cwd: configuration.checkoutDir,
+      env: sanitizedGardenerlessEnvironment(configuration),
+      stdio: ['ignore', descriptor, descriptor],
+    })
+  } catch (error) {
+    fail(`${error.message}; log: ${logPath}\n${tailFile(logPath)}`)
+  } finally {
+    closeSync(descriptor)
+  }
+}
+
+export function formatElapsedTime (milliseconds) {
+  const totalSeconds = Math.round(Math.max(0, milliseconds) / 1000)
+  if (milliseconds < 10_000) {
+    return `${(Math.max(0, milliseconds) / 1000).toFixed(1)}s`
+  }
+  if (totalSeconds < 60) {
+    return `${totalSeconds}s`
+  }
+  return `${Math.floor(totalSeconds / 60)}m ${totalSeconds % 60}s`
+}
+
+export async function runTimedPhase ({
+  command,
+  index,
+  total,
+  label,
+  completeLabel,
+  action,
+  now = Date.now,
+  log = message => console.error(message),
+  progressIntervalMs = 30_000,
+  schedule = setInterval,
+  cancel = clearInterval,
+}) {
+  const prefix = `${command}: [${index}/${total}]`
+  const startedAt = now()
+  log(`${prefix} ${label}`)
+  const progress = schedule(() => {
+    log(`${prefix} ${label} (${formatElapsedTime(now() - startedAt)} elapsed)`)
+  }, progressIntervalMs)
+  progress.unref?.()
+  try {
+    const result = await action()
+    log(`${prefix} ${completeLabel} (${formatElapsedTime(now() - startedAt)})`)
+    return result
+  } finally {
+    cancel(progress)
+  }
+}
+
+export async function reconcileScenario (configuration, logPath, {
+  run = runGardenerless,
+} = {}) {
+  await run(configuration, ['scenario', configuration.scenario], logPath)
+}
+
+export function inspectProcess (pid) {
+  if (!Number.isInteger(pid) || pid < 1) {
+    return undefined
+  }
+  const result = spawnSync('/bin/ps', ['-ww', '-o', 'pgid=,lstart=,command=', '-p', String(pid)], {
+    encoding: 'utf8',
+  })
+  const match = result.status === 0
+    ? /^\s*(\d+)\s+(\S+\s+\S+\s+\d+\s+\S+\s+\d+)\s+(.+)$/.exec(result.stdout.trim())
+    : undefined
+  return match
+    ? { pgid: Number(match[1]), startSignature: match[2], command: match[3] }
+    : undefined
+}
+
+export function inspectListeningPids (port, execute = spawnSync) {
+  const result = execute('lsof', [
+    '-nP',
+    '-a',
+    `-iTCP:${port}`,
+    '-sTCP:LISTEN',
+    '-Fp',
+  ], { encoding: 'utf8' })
+  if (result.status !== 0) {
+    return []
+  }
+  return result.stdout
+    .split('\n')
+    .map(line => /^p(\d+)$/.exec(line)?.[1])
+    .filter(Boolean)
+    .map(Number)
+}
+
+export function inspectProcessCwd (pid, execute = spawnSync) {
+  const result = execute('lsof', [
+    '-nP',
+    '-a',
+    '-p',
+    String(pid),
+    '-d',
+    'cwd',
+    '-Fn',
+  ], { encoding: 'utf8' })
+  if (result.status !== 0) {
+    return undefined
+  }
+  return result.stdout
+    .split('\n')
+    .find(line => line.startsWith('n'))
+    ?.slice(1)
+}
+
+export function processMatches (record, configuration, inspector = inspectProcess, {
+  listeningPids = inspectListeningPids,
+  processCwd = inspectProcessCwd,
+} = {}) {
+  const actual = inspector(record.pid)
+  const definition = serviceDefinition(configuration, record.name)
+  const exactMatch = Boolean(
+    definition?.commandMarker &&
+    actual &&
+    actual.pgid === record.pgid &&
+    actual.startSignature === record.startSignature &&
+    actual.command === record.command &&
+    actual.command.includes(definition.commandMarker),
+  )
+  if (exactMatch) {
+    return true
+  }
+
+  const candidatePids = [record.pid, ...(definition ? listeningPids(definition.ownershipPort) : [])]
+  return Boolean(
+    definition &&
+    [...new Set(candidatePids)].some(pid => {
+      const listener = inspector(pid)
+      return listener &&
+        listener.pgid === record.pgid &&
+        (pid !== record.pid || listener.startSignature === record.startSignature) &&
+        definition.runtimeCwds.includes(processCwd(pid)) &&
+        definition.runtimeCommandMarkers.every(marker => listener.command.includes(marker))
+    }),
+  )
+}
+
+async function captureProcess (pid, commandMarker, inspector = inspectProcess) {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    const actual = inspector(pid)
+    if (actual?.pgid === pid && actual.command.includes(commandMarker)) {
+      return {
+        pid,
+        pgid: actual.pgid,
+        startSignature: actual.startSignature,
+        command: actual.command,
+      }
+    }
+    await delay(50)
+  }
+  fail(`child ${pid} exited before its process identity could be validated`)
+}
+
+export async function portIsAvailable (port, host = '127.0.0.1') {
+  return await new Promise((resolve, reject) => {
+    const server = createServer()
+    server.unref()
+    server.once('error', error => {
+      if (['EADDRINUSE', 'EACCES'].includes(error.code)) {
+        resolve(false)
+      } else {
+        reject(error)
+      }
+    })
+    server.listen({ port, host, exclusive: true }, () => {
+      server.close(() => resolve(true))
+    })
+  })
+}
+
+export async function assertPortsAvailable (ports, probe = portIsAvailable) {
+  for (const [name, port] of Object.entries(ports)) {
+    if (!await probe(port)) {
+      fail(`port ${port} (${name}) has an unknown listener; it will not be stopped or replaced`)
+    }
+  }
+}
+
+export function requestReady (url) {
+  return new Promise(resolve => {
+    const client = url.startsWith('https:') ? https : http
+    const request = client.get(url, {
+      rejectUnauthorized: false,
+      timeout: 1500,
+    }, response => {
+      response.resume()
+      resolve(response.statusCode >= 200 && response.statusCode < 400)
+    })
+    request.once('timeout', () => request.destroy())
+    request.once('error', () => resolve(false))
+  })
+}
+
+export async function waitUntilReady ({
+  label,
+  record,
+  configuration,
+  health,
+  logPath,
+  timeoutMs = 20_000,
+  intervalMs = 200,
+  inspector = inspectProcess,
+}) {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (!processMatches(record, configuration, inspector)) {
+      fail(`${label} exited during startup; log: ${logPath}\n${tailFile(logPath)}`)
+    }
+    if (await health()) {
+      return
+    }
+    await delay(intervalMs)
+  }
+  fail(`${label} readiness timed out; log: ${logPath}\n${tailFile(logPath)}`)
+}
+
+export function serviceDefinitions (configuration) {
+  return [
+    {
+      name: 'garden',
+      command: join(configuration.checkoutDir, 'gardenerless-setup.sh'),
+      arguments: ['start-kcp'],
+      commandMarker: `${join(configuration.runtimeDir, 'bin', 'kcp')} start --bind-address=127.0.0.1`,
+      cwd: configuration.checkoutDir,
+      ownershipPort: configuration.ports.garden,
+      ports: [configuration.ports.garden],
+      runtimeCwds: [configuration.checkoutDir, configuration.runtimeDir],
+      runtimeCommandMarkers: [
+        join(configuration.runtimeDir, 'bin', 'kcp'),
+        'start',
+        '--bind-address=127.0.0.1',
+      ],
+    },
+    {
+      name: 'backend',
+      command: process.execPath,
+      arguments: [YARN_RUNTIME, 'workspace', '@gardener-dashboard/backend', 'serve'],
+      commandMarker: `${YARN_RUNTIME} workspace @gardener-dashboard/backend serve`,
+      cwd: configuration.repositoryRoot,
+      ownershipPort: configuration.ports.backend,
+      ports: [configuration.ports.backend, configuration.ports.metrics],
+      runtimeCwds: [join(configuration.repositoryRoot, 'backend')],
+      runtimeCommandMarkers: ['node', 'server.js'],
+    },
+    {
+      name: 'frontend',
+      command: process.execPath,
+      arguments: [
+        YARN_RUNTIME,
+        'workspace',
+        '@gardener-dashboard/frontend',
+        'serve',
+        '--port',
+        String(configuration.ports.frontend),
+        '--host',
+        '127.0.0.1',
+      ],
+      commandMarker: `${YARN_RUNTIME} workspace @gardener-dashboard/frontend serve --port ${configuration.ports.frontend} --host 127.0.0.1`,
+      cwd: configuration.repositoryRoot,
+      ownershipPort: configuration.ports.frontend,
+      ports: [configuration.ports.frontend],
+      runtimeCwds: [join(configuration.repositoryRoot, 'frontend')],
+      runtimeCommandMarkers: [
+        'vite',
+        `--port ${configuration.ports.frontend}`,
+        '--host 127.0.0.1',
+      ],
+    },
+  ]
+}
+
+function serviceDefinition (configuration, name) {
+  return serviceDefinitions(configuration).find(definition => definition.name === name)
+}
+
+export function serializeState (state) {
+  return `${JSON.stringify(state, null, 2)}\n`
+}
+
+function hasExactKeys (value, keys) {
+  return value && typeof value === 'object' && !Array.isArray(value) &&
+    Object.keys(value).sort().join(',') === [...keys].sort().join(',')
+}
+
+export function validateState (state, configuration = {
+  repositoryRoot: REPOSITORY_ROOT,
+  managedRoot: MANAGED_ROOT,
+  checkoutDir: join(MANAGED_ROOT, 'gardenerless'),
+  runtimeDir: join(MANAGED_ROOT, 'runtime'),
+  ports: { frontend: 8444 },
+}) {
+  const stateKeys = ['version', 'status', 'scenario', 'commits', 'logDir', 'processes']
+  if (!state || state.version !== STATE_VERSION ||
+      !['starting', 'ready'].includes(state.status) ||
+      !hasExactKeys(state, stateKeys) ||
+      !SCENARIOS.includes(state.scenario) ||
+      !hasExactKeys(state.commits, ['gardenerless', 'kcp', 'kcpRelease']) ||
+      !COMMIT_PATTERN.test(state.commits.gardenerless) ||
+      !COMMIT_PATTERN.test(state.commits.kcp) ||
+      !/^v[0-9]+\.[0-9]+\.[0-9]+$/.test(state.commits.kcpRelease) ||
+      !Array.isArray(state.processes) ||
+      state.processes.length > 3) {
+    fail('tracked state has an invalid structure')
+  }
+  const relativeLogDir = relative(configuration.managedRoot, state.logDir || '')
+  if (!state.logDir || relativeLogDir.startsWith('..') || isAbsolute(relativeLogDir)) {
+    fail('tracked state contains an unsafe log directory')
+  }
+  const expectedNames = ['garden', 'backend', 'frontend']
+  const seenPids = new Set()
+  const seenPgids = new Set()
+  for (const [index, record] of state.processes.entries()) {
+    const definition = serviceDefinition(configuration, record.name)
+    const expectedMarker = definition?.commandMarker
+    const relativeLog = relative(state.logDir, record.logPath || '')
+    if (!hasExactKeys(record, ['name', 'pid', 'pgid', 'startSignature', 'command', 'logPath']) ||
+        !definition || record.name !== expectedNames[index] ||
+        !Number.isInteger(record.pid) || !Number.isInteger(record.pgid) ||
+        record.pid !== record.pgid || seenPids.has(record.pid) || seenPgids.has(record.pgid) ||
+        typeof record.startSignature !== 'string' ||
+        !record.startSignature || typeof record.command !== 'string' ||
+        !record.command.includes(expectedMarker) ||
+        relativeLog.startsWith('..') || isAbsolute(relativeLog)) {
+      fail('tracked state contains an invalid process identity')
+    }
+    seenPids.add(record.pid)
+    seenPgids.add(record.pgid)
+  }
+  if (state.status === 'ready' && state.processes.length !== 3) {
+    fail('ready state must describe exactly three processes')
+  }
+  return state
+}
+
+export function parseState (text, configuration) {
+  if (Buffer.byteLength(text) > MAX_STATE_BYTES) {
+    fail('tracked state is too large')
+  }
+  let state
+  try {
+    state = JSON.parse(text)
+  } catch {
+    fail('tracked state is not valid JSON')
+  }
+  return validateState(state, configuration)
+}
+
+export function writeState (state, configuration) {
+  assertSafeManagedRoot(configuration.managedRoot)
+  if (pathEntryExists(configuration.stateFile)) {
+    assertSafeFile(configuration.stateFile, 'tracked state')
+  }
+  const temporary = `${configuration.stateFile}.${process.pid}.${randomBytes(4).toString('hex')}.tmp`
+  writeFileSync(temporary, serializeState(state), { mode: 0o600, flag: 'wx' })
+  renameSync(temporary, configuration.stateFile)
+}
+
+export function readState (configuration) {
+  assertSafeDirectory(configuration.managedRoot, 'managed directory')
+  assertSafeFile(configuration.stateFile, 'tracked state')
+  return parseState(
+    readFileSync(configuration.stateFile, 'utf8'),
+    configuration,
+  )
+}
+
+export async function assessTrackedState (state, configuration, {
+  inspector = inspectProcess,
+  request = requestReady,
+  commits,
+  compareScenario = true,
+} = {}) {
+  if (state.status !== 'ready' ||
+      state.processes.some(record => !processMatches(record, configuration, inspector))) {
+    return 'stale'
+  }
+  if (commits && ((compareScenario && state.scenario !== configuration.scenario) ||
+      state.commits.gardenerless !== commits.gardenerless ||
+      state.commits.kcp !== commits.kcp ||
+      state.commits.kcpRelease !== commits.kcpRelease)) {
+    return 'configuration-mismatch'
+  }
+  const [gardenReady, backendReady, frontendReady] = await Promise.all([
+    request(`${configuration.urls.garden}/readyz`),
+    request(`${configuration.urls.backend}/healthz`),
+    request(`${configuration.urls.frontend}/`),
+  ])
+  return gardenReady && backendReady && frontendReady ? 'healthy' : 'stale'
+}
+
+function groupExists (pgid) {
+  try {
+    process.kill(-pgid, 0)
+    return true
+  } catch (error) {
+    return error.code === 'EPERM'
+  }
+}
+
+async function waitForGroupExit (pgid, timeoutMs) {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (!groupExists(pgid)) {
+      return true
+    }
+    await delay(100)
+  }
+  return !groupExists(pgid)
+}
+
+function signalTrackedGroup (signalGroup, pgid, signal) {
+  try {
+    signalGroup(pgid, signal)
+  } catch (error) {
+    if (error.code !== 'ESRCH') {
+      throw error
+    }
+  }
+}
+
+export async function stopTrackedProcesses (state, configuration, {
+  inspector = inspectProcess,
+  matcher = processMatches,
+  probe = portIsAvailable,
+  groupPresent = groupExists,
+  signalGroup = (pgid, signal) => process.kill(-pgid, signal),
+  waitGroup = waitForGroupExit,
+} = {}) {
+  const stopped = []
+  const preserved = []
+  for (const record of [...state.processes].reverse()) {
+    if (!matcher(record, configuration, inspector)) {
+      const definition = serviceDefinition(configuration, record.name)
+      const portsAreFree = (await Promise.all(definition.ports.map(port => probe(port))))
+        .every(Boolean)
+      if (!groupPresent(record.pgid) && portsAreFree) {
+        stopped.push(record.name)
+        continue
+      }
+      preserved.push(record.name)
+      continue
+    }
+    signalTrackedGroup(signalGroup, record.pgid, 'SIGTERM')
+    if (!await waitGroup(record.pgid, 5_000)) {
+      if (!matcher(record, configuration, inspector)) {
+        preserved.push(record.name)
+        continue
+      }
+      signalTrackedGroup(signalGroup, record.pgid, 'SIGKILL')
+      if (!await waitGroup(record.pgid, 2_000)) {
+        fail(`${record.name} process group ${record.pgid} did not stop`)
+      }
+    }
+    stopped.push(record.name)
+  }
+  return { stopped, preserved }
+}
+
+function detachedService (name, command, arguments_, { cwd, env, logPath }) {
+  const descriptor = openLogFile(logPath)
+  try {
+    const child = spawn(command, arguments_, {
+      cwd,
+      env,
+      detached: true,
+      stdio: ['ignore', descriptor, descriptor],
+    })
+    child.on('error', () => {})
+    child.unref()
+    return { name, pid: child.pid }
+  } finally {
+    closeSync(descriptor)
+  }
+}
+
+export async function startAndRecord (state, configuration, definition) {
+  const child = detachedService(
+    definition.name,
+    definition.command,
+    definition.arguments,
+    definition,
+  )
+  const identity = await captureProcess(child.pid, definition.commandMarker)
+  const record = { name: definition.name, ...identity, logPath: definition.logPath }
+  state.processes.push(record)
+  writeState(state, configuration)
+  return record
+}
+
+export async function startReadyService (state, configuration, definition) {
+  const record = await startAndRecord(state, configuration, definition)
+  await waitUntilReady({
+    label: definition.name,
+    record,
+    configuration,
+    health: () => requestReady(definition.healthUrl),
+    logPath: definition.logPath,
+    timeoutMs: definition.timeoutMs,
+  })
+  return record
+}

--- a/hack/local-dashboard/test/local-dashboard.spec.js
+++ b/hack/local-dashboard/test/local-dashboard.spec.js
@@ -76,9 +76,11 @@ import {
   parseState,
   processMatches,
   reconcileScenario,
+  requestReady,
   runTimedPhase,
   serializeState,
   serviceDefinitions,
+  startAndRecord,
   stopTrackedProcesses,
   waitUntilReady,
 } from '../internal/runtime.mjs'
@@ -653,6 +655,24 @@ describe('Gardenerless prerequisite contract', () => {
 })
 
 describe('compact state and process safety', () => {
+  it('settles failed readiness requests on timeout and close', async () => {
+    for (const event of ['timeout', 'close']) {
+      const listeners = {}
+      const request = {
+        destroy: vi.fn(),
+        once: (name, listener) => {
+          listeners[name] = listener
+        },
+      }
+      const ready = requestReady('http://127.0.0.1/healthz', undefined, {
+        get: () => request,
+      })
+      listeners[event]()
+      await expect(ready).resolves.toBe(false)
+      expect(request.destroy).toHaveBeenCalledTimes(event === 'timeout' ? 1 : 0)
+    }
+  })
+
   it('reads listener PIDs and process working directories from bounded lsof queries', () => {
     const listeners = vi.fn(() => ({ status: 0, stdout: 'p101\np202\n' }))
     expect(inspectListeningPids(8444, listeners)).toEqual([101, 202])
@@ -848,22 +868,38 @@ describe('compact state and process safety', () => {
     expect(signals).toEqual([[101, 'SIGTERM'], [101, 'SIGKILL']])
   })
 
-  it('fails promptly with bounded logs when a child identity disappears', async () => {
+  it('stops a spawned child group when identity capture fails', async () => {
+    const config = configuration()
+    const state = { processes: [] }
+    const definition = serviceDefinitions(config)[0]
+    const stop = vi.fn(async () => {})
+    await expect(startAndRecord(state, config, definition, {
+      spawnService: () => ({ name: definition.name, pid: 101 }),
+      capture: async () => {
+        throw new Error('identity capture failed')
+      },
+      stop,
+    })).rejects.toThrow('identity capture failed')
+    expect(stop).toHaveBeenCalledExactlyOnceWith(101)
+    expect(state.processes).toEqual([])
+  })
+
+  it('fails with bounded logs when a child identity disappears', async () => {
     const directory = temporaryDirectory('local-dashboard-log-')
     const config = configuration()
     const logPath = join(directory, 'child.log')
     writeFileSync(logPath, `${'discarded\n'.repeat(1000)}intentional failure\n`)
-    const started = Date.now()
+    const health = vi.fn(async () => false)
     await expect(waitUntilReady({
       label: 'garden',
       record: processRecord(config, 'garden', 101),
       configuration: config,
-      health: async () => false,
+      health,
       logPath,
       timeoutMs: 5_000,
       inspector: () => undefined,
     })).rejects.toThrow('intentional failure')
-    expect(Date.now() - started).toBeLessThan(500)
+    expect(health).not.toHaveBeenCalled()
   })
 })
 

--- a/hack/local-dashboard/test/local-dashboard.spec.js
+++ b/hack/local-dashboard/test/local-dashboard.spec.js
@@ -113,8 +113,15 @@ function temporaryDirectory (prefix = 'local-dashboard-') {
   return directory
 }
 
-function generateCertificate (directory, prefix = '') {
+function generateCertificate (
+  directory,
+  prefix = '',
+  { caDays = 3650, certificateDays = 3650 } = {},
+) {
+  const caKey = join(directory, `${prefix}ca-key.pem`)
+  const ca = join(directory, `${prefix}ca.pem`)
   const key = join(directory, `${prefix}key.pem`)
+  const certificateRequest = join(directory, `${prefix}csr.pem`)
   const certificate = join(directory, `${prefix}cert.pem`)
   execFileSync('openssl', [
     'req',
@@ -122,12 +129,31 @@ function generateCertificate (directory, prefix = '') {
     '-newkey',
     'rsa:2048',
     '-nodes',
+    '-keyout', caKey,
+    '-out', ca,
+    '-days', String(caDays),
+    '-subj', '/CN=local-dashboard-ca',
+  ], { stdio: 'ignore' })
+  execFileSync('openssl', [
+    'req',
+    '-new',
+    '-newkey', 'rsa:2048',
+    '-nodes',
     '-keyout', key,
-    '-out', certificate,
-    '-days', '1',
+    '-out', certificateRequest,
     '-subj', '/CN=localhost',
   ], { stdio: 'ignore' })
-  return { key, certificate }
+  execFileSync('openssl', [
+    'x509',
+    '-req',
+    '-in', certificateRequest,
+    '-CA', ca,
+    '-CAkey', caKey,
+    '-CAcreateserial',
+    '-out', certificate,
+    '-days', String(certificateDays),
+  ], { stdio: 'ignore' })
+  return { ca, key, certificate }
 }
 
 function silenceConsole (method = 'log') {
@@ -333,12 +359,12 @@ describe('managed configuration and environments', () => {
 
   it('isolates backend settings and only reuses safe frontend certificates', () => {
     const directory = temporaryDirectory('local-dashboard-ssl-')
-    const { key, certificate } = generateCertificate(directory)
-    writeFileSync(join(directory, 'ca.pem'), 'ca\n')
+    const { ca, key, certificate } = generateCertificate(directory)
     expect(assertReusableFrontendCertificates(directory)).toBe(directory)
-    rmSync(join(directory, 'ca.pem'))
+    const caPem = readFileSync(ca)
+    rmSync(ca)
     expect(() => assertReusableFrontendCertificates(directory)).toThrow('ca.pem')
-    writeFileSync(join(directory, 'ca.pem'), 'ca\n')
+    writeFileSync(ca, caPem)
     expect(frontendEnvironment(configuration(), directory, {
       VITE_PROXY_TARGET: 'https://remote.example.org',
       VITE_DEV_PORT: '443',
@@ -367,9 +393,26 @@ describe('managed configuration and environments', () => {
     expect(backend.GIT_DIR).toBeUndefined()
     expect(backend.BASH_ENV).toBeUndefined()
 
+    writeFileSync(ca, 'ca\n')
+    expect(() => assertReusableFrontendCertificates(directory)).toThrow('CA certificate is invalid')
+    writeFileSync(ca, caPem)
+
+    const unrelated = generateCertificate(directory, 'unrelated-')
+    cpSync(unrelated.ca, ca)
+    expect(() => assertReusableFrontendCertificates(directory)).toThrow('not issued and signed')
+    writeFileSync(ca, caPem)
+
     vi.useFakeTimers()
-    vi.setSystemTime(new Date('2100-01-01'))
-    expect(() => assertReusableFrontendCertificates(directory)).toThrow('not currently valid')
+    onTestFinished(() => vi.useRealTimers())
+    const expiredServerDirectory = temporaryDirectory('local-dashboard-expired-server-')
+    generateCertificate(expiredServerDirectory, '', { certificateDays: 1 })
+    vi.setSystemTime(Date.now() + 2 * 24 * 60 * 60 * 1000)
+    expect(() => assertReusableFrontendCertificates(expiredServerDirectory))
+      .toThrow('server certificate is not currently valid')
+    const expiredCaDirectory = temporaryDirectory('local-dashboard-expired-ca-')
+    generateCertificate(expiredCaDirectory, '', { caDays: 1 })
+    expect(() => assertReusableFrontendCertificates(expiredCaDirectory))
+      .toThrow('CA certificate is not currently valid')
     vi.useRealTimers()
 
     const other = generateCertificate(directory, 'other-')

--- a/hack/local-dashboard/test/local-dashboard.spec.js
+++ b/hack/local-dashboard/test/local-dashboard.spec.js
@@ -111,6 +111,23 @@ function temporaryDirectory (prefix = 'local-dashboard-') {
   return directory
 }
 
+function generateCertificate (directory, prefix = '') {
+  const key = join(directory, `${prefix}key.pem`)
+  const certificate = join(directory, `${prefix}cert.pem`)
+  execFileSync('openssl', [
+    'req',
+    '-x509',
+    '-newkey',
+    'rsa:2048',
+    '-nodes',
+    '-keyout', key,
+    '-out', certificate,
+    '-days', '1',
+    '-subj', '/CN=localhost',
+  ], { stdio: 'ignore' })
+  return { key, certificate }
+}
+
 function silenceConsole (method = 'log') {
   const spy = vi.spyOn(console, method).mockImplementation(() => {})
   onTestFinished(() => spy.mockRestore())
@@ -298,17 +315,24 @@ describe('managed configuration and environments', () => {
     for (const key of Object.keys(codeLoadingEnvironment)) {
       expect(env[key]).toBeUndefined()
     }
-    expect(gitEnvironment({ PATH: '/usr/bin', GIT_DIR: '/tmp/git', BASH_ENV: '/tmp/env' }))
-      .toEqual({ PATH: '/usr/bin', GIT_NO_REPLACE_OBJECTS: '1' })
+    expect(gitEnvironment({
+      PATH: '/usr/bin',
+      GIT_DIR: '/tmp/git',
+      GIT_CONFIG_GLOBAL: '/tmp/global-gitconfig',
+      GIT_CONFIG_SYSTEM: '/tmp/system-gitconfig',
+      BASH_ENV: '/tmp/env',
+    })).toEqual({
+      PATH: '/usr/bin',
+      GIT_NO_REPLACE_OBJECTS: '1',
+      GIT_CONFIG_GLOBAL: '/dev/null',
+      GIT_CONFIG_NOSYSTEM: '1',
+    })
   })
 
   it('isolates backend settings and only reuses safe frontend certificates', () => {
     const directory = temporaryDirectory('local-dashboard-ssl-')
-    const key = join(directory, 'key.pem')
-    const certificate = join(directory, 'cert.pem')
+    const { key, certificate } = generateCertificate(directory)
     writeFileSync(join(directory, 'ca.pem'), 'ca\n')
-    writeFileSync(key, 'key\n')
-    writeFileSync(certificate, 'certificate\n')
     expect(assertReusableFrontendCertificates(directory)).toBe(directory)
     rmSync(join(directory, 'ca.pem'))
     expect(() => assertReusableFrontendCertificates(directory)).toThrow('ca.pem')
@@ -340,6 +364,16 @@ describe('managed configuration and environments', () => {
     expect(backend.GITHUB_AUTHENTICATION_TOKEN).toBeUndefined()
     expect(backend.GIT_DIR).toBeUndefined()
     expect(backend.BASH_ENV).toBeUndefined()
+
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2100-01-01'))
+    expect(() => assertReusableFrontendCertificates(directory)).toThrow('not currently valid')
+    vi.useRealTimers()
+
+    const other = generateCertificate(directory, 'other-')
+    cpSync(other.key, key)
+    expect(() => assertReusableFrontendCertificates(directory)).toThrow('invalid')
+
     rmSync(key)
     symlinkSync(certificate, key)
     expect(() => assertReusableFrontendCertificates(directory)).toThrow('non-symlink file')
@@ -444,8 +478,20 @@ describe('Gardenerless prerequisite contract', () => {
       config,
       {
         PATH: '/trusted/tools:/usr/bin',
+        GOAUTH: 'netrc',
+        GOCACHE: '/tmp/ambient-gocache',
+        GOENV: '/tmp/ambient-goenv',
+        GOINSECURE: '*',
         GOMODCACHE: ambientModuleCache,
         GOFLAGS: '-mod=vendor',
+        GONOPROXY: '*',
+        GONOSUMDB: '*',
+        GOPATH: '/tmp/ambient-gopath',
+        GOPRIVATE: '*',
+        GOPROXY: 'https://proxy.example.test',
+        GOSUMDB: 'off',
+        GOTOOLCHAIN: 'local',
+        GOWORK: '/tmp/ambient-go.work',
         KUBECONFIG: '/remote/kubeconfig',
         BUILDFLAGS: '-ambient',
         ...codeLoadingEnvironment,
@@ -458,13 +504,24 @@ describe('Gardenerless prerequisite contract', () => {
           expect(arguments_).toEqual(['setup-kcp'])
           expect(options.env).toMatchObject({
             PATH: '/trusted/tools:/usr/bin',
+            GOAUTH: 'off',
+            GOENV: 'off',
             GOMODCACHE: config.goModCacheDir,
             GOFLAGS: '-modcacherw',
+            GOPROXY: 'https://proxy.golang.org,direct',
+            GOSUMDB: 'sum.golang.org',
+            GOTOOLCHAIN: 'auto',
             GOWORK: 'off',
             GIT_ALLOW_PROTOCOL: 'https',
           })
           expect(options.env.KUBECONFIG).toBeUndefined()
           expect(options.env.BUILDFLAGS).toBeUndefined()
+          expect(options.env.GOCACHE).toBeUndefined()
+          expect(options.env.GOINSECURE).toBeUndefined()
+          expect(options.env.GONOPROXY).toBeUndefined()
+          expect(options.env.GONOSUMDB).toBeUndefined()
+          expect(options.env.GOPATH).toBeUndefined()
+          expect(options.env.GOPRIVATE).toBeUndefined()
           expect(realpathSync(options.env.GOMODCACHE)).toBe(config.goModCacheDir)
           mkdirSync(join(config.runtimeDir, '.kcp'), { recursive: true })
           mkdirSync(join(config.runtimeDir, 'bin'))

--- a/hack/local-dashboard/test/local-dashboard.spec.js
+++ b/hack/local-dashboard/test/local-dashboard.spec.js
@@ -41,6 +41,7 @@ import {
 } from '../internal/commands.mjs'
 import {
   COMMIT_PATTERN,
+  FRONTEND_SSL_DIRECTORY,
   GARDENERLESS_COMMIT,
   SCENARIOS,
   STATE_VERSION,
@@ -305,9 +306,13 @@ describe('managed configuration and environments', () => {
     const directory = temporaryDirectory('local-dashboard-ssl-')
     const key = join(directory, 'key.pem')
     const certificate = join(directory, 'cert.pem')
+    writeFileSync(join(directory, 'ca.pem'), 'ca\n')
     writeFileSync(key, 'key\n')
     writeFileSync(certificate, 'certificate\n')
     expect(assertReusableFrontendCertificates(directory)).toBe(directory)
+    rmSync(join(directory, 'ca.pem'))
+    expect(() => assertReusableFrontendCertificates(directory)).toThrow('ca.pem')
+    writeFileSync(join(directory, 'ca.pem'), 'ca\n')
     expect(frontendEnvironment(configuration(), directory, {
       VITE_PROXY_TARGET: 'https://remote.example.org',
       VITE_DEV_PORT: '443',
@@ -657,22 +662,34 @@ describe('compact state and process safety', () => {
   })
 
   it('derives markers from the same definitions used to start services', () => {
-    const definitions = serviceDefinitions(configuration())
+    const config = configuration()
+    const definitions = serviceDefinitions(config)
     expect(definitions.map(({ name, commandMarker }) => [name, commandMarker])).toEqual([
       ['garden', '/work/dashboard/.local-dashboard/runtime/bin/kcp start --bind-address=127.0.0.1'],
       ['backend', `${YARN_RUNTIME} workspace @gardener-dashboard/backend serve`],
       ['frontend', `${YARN_RUNTIME} workspace @gardener-dashboard/frontend serve --port 8444 --host 127.0.0.1`],
+    ])
+    expect(definitions.map(({ name, caPath }) => [name, caPath])).toEqual([
+      ['garden', join(config.runtimeDir, '.kcp', 'apiserver.crt')],
+      ['backend', undefined],
+      ['frontend', join(FRONTEND_SSL_DIRECTORY, 'ca.pem')],
     ])
   })
 
   it('assesses matching health and rejects stale or changed identities', async () => {
     const config = configuration()
     const state = trackedState(config)
+    const request = vi.fn(async () => true)
     await expect(assessTrackedState(state, config, {
       inspector: matchingInspector(state),
-      request: async () => true,
+      request,
       commits,
     })).resolves.toBe('healthy')
+    expect(request.mock.calls).toEqual([
+      [`${config.urls.garden}/readyz`, join(config.runtimeDir, '.kcp', 'apiserver.crt')],
+      [`${config.urls.backend}/healthz`],
+      [`${config.urls.frontend}/`, join(FRONTEND_SSL_DIRECTORY, 'ca.pem')],
+    ])
     await expect(assessTrackedState(state, { ...config, scenario: 'many-shoots' }, {
       inspector: matchingInspector(state),
       request: async () => true,

--- a/hack/local-dashboard/test/local-dashboard.spec.js
+++ b/hack/local-dashboard/test/local-dashboard.spec.js
@@ -1,0 +1,970 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { execFileSync } from 'node:child_process'
+import {
+  chmodSync,
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import {
+  delimiter,
+  join,
+} from 'node:path'
+
+import {
+  describe,
+  expect,
+  it,
+  onTestFinished,
+  vi,
+} from 'vitest'
+
+import {
+  commandDown,
+  commandSetup,
+  commandStatus,
+  commandToken,
+  commandUp,
+  main,
+} from '../internal/commands.mjs'
+import {
+  COMMIT_PATTERN,
+  GARDENERLESS_COMMIT,
+  SCENARIOS,
+  STATE_VERSION,
+  YARN_RUNTIME,
+  assertReusableFrontendCertificates,
+  assertSetupTargetsAvailable,
+  backendEnvironment,
+  frontendEnvironment,
+  gitEnvironment,
+  isolatedSetupGitEnvironment,
+  parseOptions,
+  resolveConfiguration,
+  sanitizedGardenerlessEnvironment,
+  yarnRuntimeFromConfiguration,
+} from '../internal/configuration.mjs'
+import {
+  clonePinnedCheckout,
+  convergeSetupPrerequisites,
+  inspectGardenerlessCheckout,
+  inspectPrerequisites,
+  parseKcpVerification,
+  resetManagedPrerequisites,
+  setupKcpRuntime,
+  verifyKcp,
+} from '../internal/prerequisites.mjs'
+import {
+  assessTrackedState,
+  assertPortsAvailable,
+  formatElapsedTime,
+  inspectListeningPids,
+  inspectProcessCwd,
+  parseState,
+  processMatches,
+  reconcileScenario,
+  runTimedPhase,
+  serializeState,
+  serviceDefinitions,
+  stopTrackedProcesses,
+  waitUntilReady,
+} from '../internal/runtime.mjs'
+
+const repositoryRoot = '/work/dashboard'
+const gardenerlessCommit = 'a'.repeat(40)
+const kcpCommit = 'b'.repeat(40)
+const commits = {
+  gardenerless: gardenerlessCommit,
+  kcp: kcpCommit,
+  kcpRelease: 'v1.2.3',
+}
+const codeLoadingEnvironment = Object.fromEntries([
+  'BASH_ENV',
+  'GIT_EXEC_PATH',
+  'GIT_TEMPLATE_DIR',
+  'MAKEFILES',
+  'MAKEFLAGS',
+  'GNUMAKEFLAGS',
+  'MFLAGS',
+].map(key => [key, `/ambient/${key}`]))
+const fixtureGitEnvironment = {
+  ...isolatedSetupGitEnvironment(),
+  GIT_ALLOW_PROTOCOL: 'file:https',
+}
+
+function temporaryDirectory (prefix = 'local-dashboard-') {
+  const directory = realpathSync(mkdtempSync(join(tmpdir(), prefix)))
+  onTestFinished(() => rmSync(directory, { force: true, recursive: true }))
+  return directory
+}
+
+function silenceConsole (method = 'log') {
+  const spy = vi.spyOn(console, method).mockImplementation(() => {})
+  onTestFinished(() => spy.mockRestore())
+  return spy
+}
+
+function configuration (root = repositoryRoot, options = {}) {
+  return resolveConfiguration({ repositoryRoot: root, options })
+}
+
+function git (directory, ...arguments_) {
+  return execFileSync('git', ['-C', directory, ...arguments_], {
+    env: fixtureGitEnvironment,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim()
+}
+
+function createCheckout (directory, executable = 'gardenerless-setup.sh') {
+  mkdirSync(directory, { recursive: true })
+  execFileSync('git', ['init', '--initial-branch=main', directory], {
+    env: fixtureGitEnvironment,
+  })
+  git(directory, 'config', 'user.email', 'local-dashboard@example.invalid')
+  git(directory, 'config', 'user.name', 'Local Dashboard Test')
+  git(directory, 'config', 'commit.gpgsign', 'false')
+  git(directory, 'config', 'core.hooksPath', '/dev/null')
+  const executablePath = join(directory, executable)
+  mkdirSync(join(executablePath, '..'), { recursive: true })
+  writeFileSync(executablePath, '#!/bin/sh\nexit 0\n')
+  chmodSync(executablePath, 0o755)
+  git(directory, 'add', executable)
+  git(directory, 'commit', '-m', 'fixture')
+  return git(directory, 'rev-parse', 'HEAD')
+}
+
+function processRecord (config, name, pid) {
+  const definition = serviceDefinitions(config).find(item => item.name === name)
+  return {
+    name,
+    pid,
+    pgid: pid,
+    startSignature: 'Fri Jul 24 10:00:00 2026',
+    command: `node ${definition.commandMarker}`,
+    logPath: join(config.managedRoot, 'logs', 'run', `${name}.log`),
+  }
+}
+
+function trackedState (config = configuration(), overrides = {}) {
+  return {
+    version: STATE_VERSION,
+    status: 'ready',
+    scenario: config.scenario,
+    commits,
+    logDir: join(config.managedRoot, 'logs', 'run'),
+    processes: [
+      processRecord(config, 'garden', 101),
+      processRecord(config, 'backend', 102),
+      processRecord(config, 'frontend', 103),
+    ],
+    ...overrides,
+  }
+}
+
+function matchingInspector (state) {
+  return pid => {
+    const record = state.processes.find(item => item.pid === pid)
+    return record && {
+      pgid: record.pgid,
+      startSignature: record.startSignature,
+      command: record.command,
+    }
+  }
+}
+
+describe('managed configuration and environments', () => {
+  it('uses only fixed managed paths, loopback endpoints, and the reviewed pin', () => {
+    const config = resolveConfiguration({
+      repositoryRoot,
+      env: {
+        GARDENERLESS_CHECKOUT_DIR: '/ambient/checkout',
+        GARDENERLESS_KCP_DIR: '/ambient/runtime',
+        VITE_DEV_PORT: '443',
+        SCENARIO: 'failing-shoot',
+      },
+    })
+    expect(GARDENERLESS_COMMIT).toMatch(COMMIT_PATTERN)
+    expect(config).toMatchObject({
+      checkoutDir: '/work/dashboard/.local-dashboard/gardenerless',
+      runtimeDir: '/work/dashboard/.local-dashboard/runtime',
+      goModCacheDir: '/work/dashboard/.local-dashboard/gomodcache',
+      scenario: 'healthy-shoot',
+      ports: { frontend: 8444, backend: 3031, metrics: 9051, garden: 6443 },
+      urls: {
+        frontend: 'https://127.0.0.1:8444',
+        backend: 'http://127.0.0.1:3031',
+        garden: 'https://127.0.0.1:6443',
+        proxy: 'http://127.0.0.1:3031',
+      },
+    })
+  })
+
+  it('parses only options supported by each command', () => {
+    expect(parseOptions('setup', ['--reset'])).toEqual({ reset: true })
+    expect(parseOptions('up', ['--scenario', 'many-shoots'])).toEqual({
+      scenario: 'many-shoots',
+    })
+    expect(parseOptions('token', [
+      '--namespace',
+      'garden-foo',
+      '--name',
+      'viewer',
+    ])).toEqual({ namespace: 'garden-foo', name: 'viewer' })
+    expect(parseOptions('status', ['-h'])).toEqual({ help: true })
+    for (const [command, option] of [
+      ['down', '--reset'],
+      ['status', '--scenario=healthy-shoot'],
+      ['up', '--frontend-port=8445'],
+      ['setup', '--checkout-dir=/tmp/checkout'],
+    ]) {
+      expect(() => parseOptions(command, [option])).toThrow('Unknown option')
+    }
+    expect(() => configuration(repositoryRoot, { scenario: 'production' }))
+      .toThrow('unknown scenario')
+  })
+
+  it('derives the repository Yarn runtime without allowing path escape', () => {
+    const directory = temporaryDirectory('local-dashboard-yarn-')
+    mkdirSync(join(directory, '.yarn', 'releases'), { recursive: true })
+    writeFileSync(join(directory, '.yarnrc.yml'), 'yarnPath: .yarn/releases/yarn.cjs\n')
+    writeFileSync(join(directory, '.yarn', 'releases', 'yarn.cjs'), '')
+    expect(yarnRuntimeFromConfiguration(directory))
+      .toBe(join(directory, '.yarn', 'releases', 'yarn.cjs'))
+    writeFileSync(join(directory, '.yarnrc.yml'), 'yarnPath: ../outside.cjs\n')
+    expect(() => yarnRuntimeFromConfiguration(directory)).toThrow('inside the repository')
+  })
+
+  it('rejects symlinked managed roots and existing prerequisite directories', () => {
+    const directory = temporaryDirectory()
+    const config = configuration(directory)
+    mkdirSync(config.managedRoot)
+    expect(() => assertSetupTargetsAvailable(config)).not.toThrow()
+    const external = join(directory, 'external')
+    mkdirSync(external)
+    symlinkSync(external, config.checkoutDir)
+    expect(() => assertSetupTargetsAvailable(config)).toThrow('gardenerless checkout')
+    rmSync(config.checkoutDir)
+    symlinkSync(external, config.runtimeDir)
+    expect(() => assertSetupTargetsAvailable(config)).toThrow('KCP runtime')
+    expect(() => assertSetupTargetsAvailable(config, { reset: true })).not.toThrow()
+    rmSync(config.runtimeDir)
+    symlinkSync(external, config.goModCacheDir)
+    expect(() => assertSetupTargetsAvailable(config)).toThrow('Go module cache')
+    expect(() => assertSetupTargetsAvailable(config, { reset: true })).not.toThrow()
+    rmSync(config.goModCacheDir)
+    rmSync(config.managedRoot, { recursive: true })
+    symlinkSync('/missing/local-dashboard-root', config.managedRoot)
+    expect(() => assertSetupTargetsAvailable(config)).toThrow('non-symlink directory')
+  })
+
+  it('preserves trusted toolchain variables while removing routing and code-loading inputs', () => {
+    const config = configuration()
+    const env = sanitizedGardenerlessEnvironment(config, {
+      PATH: '/trusted/tools:/usr/bin',
+      HTTPS_PROXY: 'http://proxy.example.test',
+      SSL_CERT_FILE: '/trusted/certificates.pem',
+      GOPATH: '/go/path',
+      KUBECONFIG: '/remote/kubeconfig',
+      GIT_DIR: '/ambient/.git',
+      GIT_NO_REPLACE_OBJECTS: '0',
+      ...codeLoadingEnvironment,
+    })
+    expect(env).toMatchObject({
+      PATH: '/trusted/tools:/usr/bin',
+      HTTPS_PROXY: 'http://proxy.example.test',
+      SSL_CERT_FILE: '/trusted/certificates.pem',
+      GOPATH: '/go/path',
+      GARDENERLESS_CHECKOUT_DIR: config.checkoutDir,
+      GARDENERLESS_KCP_DIR: config.runtimeDir,
+      GIT_NO_REPLACE_OBJECTS: '1',
+    })
+    expect(env.PATH.split(delimiter)).not.toContain(join(config.runtimeDir, 'bin'))
+    expect(env.KUBECONFIG).toBeUndefined()
+    expect(env.GIT_DIR).toBeUndefined()
+    for (const key of Object.keys(codeLoadingEnvironment)) {
+      expect(env[key]).toBeUndefined()
+    }
+    expect(gitEnvironment({ PATH: '/usr/bin', GIT_DIR: '/tmp/git', BASH_ENV: '/tmp/env' }))
+      .toEqual({ PATH: '/usr/bin', GIT_NO_REPLACE_OBJECTS: '1' })
+  })
+
+  it('isolates backend settings and only reuses safe frontend certificates', () => {
+    const directory = temporaryDirectory('local-dashboard-ssl-')
+    const key = join(directory, 'key.pem')
+    const certificate = join(directory, 'cert.pem')
+    writeFileSync(key, 'key\n')
+    writeFileSync(certificate, 'certificate\n')
+    expect(assertReusableFrontendCertificates(directory)).toBe(directory)
+    expect(frontendEnvironment(configuration(), directory, {
+      VITE_PROXY_TARGET: 'https://remote.example.org',
+      VITE_DEV_PORT: '443',
+      GIT_DIR: '/ambient/.git',
+      BASH_ENV: '/ambient/bash-env',
+    })).toMatchObject({
+      GARDENER_DASHBOARD_SSL_DIR: directory,
+      VITE_PROXY_TARGET: 'http://127.0.0.1:3031',
+    })
+    const backend = backendEnvironment(configuration(), {
+      KUBECONFIG: '/remote/kubeconfig',
+      OIDC_ISSUER: 'https://remote.example.org',
+      GITHUB_AUTHENTICATION_TOKEN: 'secret',
+      GIT_DIR: '/ambient/.git',
+      BASH_ENV: '/ambient/bash-env',
+    })
+    expect(backend).toMatchObject({
+      KUBECONFIG: '/work/dashboard/.local-dashboard/runtime/.kcp/dashboard.kubeconfig',
+      API_SERVER_URL: 'https://127.0.0.1:6443',
+      BIND_HOST: '127.0.0.1',
+      METRICS_BIND_HOST: '127.0.0.1',
+      SESSION_SECRET: expect.stringMatching(/^[0-9a-f]{64}$/),
+    })
+    expect(backend.OIDC_ISSUER).toBeUndefined()
+    expect(backend.GITHUB_AUTHENTICATION_TOKEN).toBeUndefined()
+    expect(backend.GIT_DIR).toBeUndefined()
+    expect(backend.BASH_ENV).toBeUndefined()
+    rmSync(key)
+    symlinkSync(certificate, key)
+    expect(() => assertReusableFrontendCertificates(directory)).toThrow('non-symlink file')
+  })
+})
+
+describe('Gardenerless prerequisite contract', () => {
+  it('strictly parses a valid verify-kcp result', () => {
+    expect(parseKcpVerification(`${JSON.stringify({
+      schemaVersion: 1,
+      release: 'v1.2.3',
+      commit: kcpCommit,
+    })}\n`)).toEqual({ release: 'v1.2.3', commit: kcpCommit })
+  })
+
+  it.each([
+    ['malformed JSON', '{', 'malformed JSON'],
+    ['array', '[]\n', 'unexpected result shape'],
+    ['missing field', '{"schemaVersion":1,"release":"v1.2.3"}\n', 'unexpected result shape'],
+    ['extra field', `{"schemaVersion":1,"release":"v1.2.3","commit":"${kcpCommit}","extra":true}\n`, 'unexpected result shape'],
+    ['schema', `{"schemaVersion":2,"release":"v1.2.3","commit":"${kcpCommit}"}\n`, 'unsupported schema'],
+    ['release', `{"schemaVersion":1,"release":"main","commit":"${kcpCommit}"}\n`, 'invalid release'],
+    ['uppercase commit', `{"schemaVersion":1,"release":"v1.2.3","commit":"${'A'.repeat(40)}"}\n`, 'invalid commit'],
+    ['long commit', `{"schemaVersion":1,"release":"v1.2.3","commit":"${'a'.repeat(64)}"}\n`, 'invalid commit'],
+  ])('rejects %s', (_label, value, message) => {
+    expect(() => parseKcpVerification(value)).toThrow(message)
+  })
+
+  it('invokes verify-kcp once with managed paths and separate output', () => {
+    const config = configuration()
+    const execute = vi.fn(() => ({
+      status: 0,
+      stdout: `{"schemaVersion":1,"release":"v1.2.3","commit":"${kcpCommit}"}\n`,
+      stderr: '',
+    }))
+    expect(verifyKcp(config, { execute })).toEqual({ release: 'v1.2.3', commit: kcpCommit })
+    expect(execute).toHaveBeenCalledExactlyOnceWith(
+      join(config.checkoutDir, 'gardenerless-setup.sh'),
+      ['verify-kcp', '--format=json'],
+      expect.objectContaining({
+        cwd: config.checkoutDir,
+        encoding: 'utf8',
+        env: expect.objectContaining({
+          GARDENERLESS_CHECKOUT_DIR: config.checkoutDir,
+          GARDENERLESS_KCP_DIR: config.runtimeDir,
+        }),
+      }),
+    )
+  })
+
+  it('reports bounded stderr diagnostics on verification failure', () => {
+    let error
+    try {
+      verifyKcp(configuration(), {
+        execute: () => ({
+          status: 42,
+          stdout: '',
+          stderr: `${'discarded diagnostic\n'.repeat(1000)}actionable failure\n`,
+        }),
+      })
+    } catch (caught) {
+      error = caught
+    }
+    expect(error.message).toContain('actionable failure')
+    expect(error.message).not.toContain('discarded diagnostic'.repeat(100))
+    expect(error.message.length).toBeLessThan(4200)
+  })
+
+  it('performs exactly one checkout and KCP inspection', () => {
+    const directory = temporaryDirectory()
+    const config = configuration(directory)
+    mkdirSync(config.checkoutDir, { recursive: true })
+    mkdirSync(config.runtimeDir)
+    const inspect = vi.fn(() => ({ head: gardenerlessCommit }))
+    const verify = vi.fn(() => ({ release: 'v1.2.3', commit: kcpCommit }))
+    expect(inspectPrerequisites(config, { inspect, verify })).toEqual(commits)
+    expect(inspect).toHaveBeenCalledOnce()
+    expect(verify).toHaveBeenCalledOnce()
+
+    for (const key of ['checkoutDir', 'runtimeDir']) {
+      rmSync(config[key], { recursive: true })
+      const external = join(directory, `external-${key}`)
+      mkdirSync(external)
+      symlinkSync(external, config[key])
+      inspect.mockClear()
+      verify.mockClear()
+      expect(() => inspectPrerequisites(config, { inspect, verify })).toThrow('non-symlink directory')
+      expect(inspect).not.toHaveBeenCalled()
+      expect(verify).not.toHaveBeenCalled()
+      rmSync(config[key])
+      mkdirSync(config[key])
+    }
+  })
+
+  it('keeps the module cache outside the KCP worktree and verifies its clean layout once', async () => {
+    const directory = temporaryDirectory()
+    const config = configuration(directory)
+    const ambientModuleCache = join(directory, 'ambient-gomodcache')
+    const events = []
+    const gardenerless = { changed: true, head: gardenerlessCommit }
+    const result = await setupKcpRuntime(
+      config,
+      {
+        PATH: '/trusted/tools:/usr/bin',
+        GOMODCACHE: ambientModuleCache,
+        GOFLAGS: '-mod=vendor',
+        KUBECONFIG: '/remote/kubeconfig',
+        BUILDFLAGS: '-ambient',
+        ...codeLoadingEnvironment,
+      },
+      'stdio',
+      gardenerless,
+      {
+        run: async (_command, arguments_, options) => {
+          events.push('setup-kcp')
+          expect(arguments_).toEqual(['setup-kcp'])
+          expect(options.env).toMatchObject({
+            PATH: '/trusted/tools:/usr/bin',
+            GOMODCACHE: config.goModCacheDir,
+            GOFLAGS: '-modcacherw',
+            GOWORK: 'off',
+            GIT_ALLOW_PROTOCOL: 'https',
+          })
+          expect(options.env.KUBECONFIG).toBeUndefined()
+          expect(options.env.BUILDFLAGS).toBeUndefined()
+          expect(realpathSync(options.env.GOMODCACHE)).toBe(config.goModCacheDir)
+          mkdirSync(join(config.runtimeDir, '.kcp'), { recursive: true })
+          mkdirSync(join(config.runtimeDir, 'bin'))
+        },
+        inspect: (_configuration, { inspect }) => {
+          events.push('verify-kcp')
+          expect(inspect()).toBe(gardenerless)
+          expect(readdirSync(config.runtimeDir).sort()).toEqual(['.kcp', 'bin'])
+          return commits
+        },
+      },
+    )
+    expect(events).toEqual(['setup-kcp', 'verify-kcp'])
+    expect(result).toEqual({ rebuilt: true, commits })
+    expect(readdirSync(config.goModCacheDir)).toEqual([])
+    expect(() => realpathSync(ambientModuleCache)).toThrow()
+  })
+
+  it('checks out only the requested commit and validates the trust anchor', async () => {
+    const directory = temporaryDirectory('local-dashboard-clone-')
+    const source = join(directory, 'source')
+    const target = join(directory, 'target')
+    const pinned = createCheckout(source)
+    writeFileSync(join(source, 'gardenerless-setup.sh'), '#!/bin/sh\nexit 73\n')
+    git(source, 'add', 'gardenerless-setup.sh')
+    git(source, 'commit', '-m', 'newer head')
+    await clonePinnedCheckout(source, pinned, target, {
+      cwd: directory,
+      env: fixtureGitEnvironment,
+    })
+    expect(git(target, 'rev-parse', '--abbrev-ref', 'HEAD')).toBe('HEAD')
+    expect(git(target, 'rev-parse', 'HEAD')).toBe(pinned)
+    expect(git(target, 'remote')).toBe('')
+    expect(readFileSync(join(target, 'gardenerless-setup.sh'), 'utf8'))
+      .toBe('#!/bin/sh\nexit 0\n')
+
+    const config = configuration(directory)
+    rmSync(config.checkoutDir, { recursive: true, force: true })
+    mkdirSync(config.managedRoot)
+    cpSync(target, config.checkoutDir, { recursive: true })
+    expect(() => inspectGardenerlessCheckout(config)).toThrow(`expected pinned commit ${GARDENERLESS_COMMIT}`)
+    writeFileSync(join(config.checkoutDir, 'unknown'), 'drift\n')
+    expect(() => inspectGardenerlessCheckout(config, { requireCurrent: false }))
+      .toThrow('dirty or contains unknown')
+    rmSync(join(config.checkoutDir, 'unknown'))
+    rmSync(join(config.checkoutDir, 'gardenerless-setup.sh'))
+    symlinkSync('/bin/sh', join(config.checkoutDir, 'gardenerless-setup.sh'))
+    git(config.checkoutDir, 'config', 'user.email', 'local-dashboard@example.invalid')
+    git(config.checkoutDir, 'config', 'user.name', 'Local Dashboard Test')
+    git(config.checkoutDir, 'add', 'gardenerless-setup.sh')
+    git(config.checkoutDir, 'commit', '-m', 'unsafe executable')
+    expect(() => inspectGardenerlessCheckout(config, { requireCurrent: false }))
+      .toThrow('regular non-symlink file')
+  })
+
+  it.each(['external', 'linked', 'symlinked'])(
+    'rejects a %s Gardenerless Git directory',
+    kind => {
+      const directory = temporaryDirectory(`local-dashboard-${kind}-git-`)
+      const config = configuration(directory)
+      mkdirSync(config.managedRoot)
+      const externalGit = join(directory, 'external.git')
+      if (kind === 'external') {
+        execFileSync('git', ['init', `--separate-git-dir=${externalGit}`, config.checkoutDir], {
+          env: fixtureGitEnvironment,
+        })
+      } else if (kind === 'linked') {
+        const source = join(directory, 'source')
+        createCheckout(source)
+        git(source, 'worktree', 'add', '--detach', config.checkoutDir)
+      } else {
+        createCheckout(config.checkoutDir)
+        renameSync(join(config.checkoutDir, '.git'), externalGit)
+        symlinkSync(externalGit, join(config.checkoutDir, '.git'))
+      }
+      expect(() => inspectGardenerlessCheckout(config, { requireCurrent: false }))
+        .toThrow('Git directory')
+    },
+  )
+
+  it('runs two concise setup phases and returns the verified result directly', async () => {
+    const directory = temporaryDirectory('local-dashboard-setup-')
+    const config = configuration(directory)
+    mkdirSync(config.managedRoot)
+    const phases = []
+    silenceConsole()
+    const result = await convergeSetupPrerequisites(config, {}, {
+      gardenerless: async () => ({ changed: true, head: gardenerlessCommit }),
+      kcp: async (_configuration, _environment, _stdio, checkout) => {
+        expect(checkout.head).toBe(gardenerlessCommit)
+        return { rebuilt: true, commits }
+      },
+      phase: async options => {
+        phases.push(options.completeLabel)
+        return options.action()
+      },
+    })
+    expect(result).toEqual({ changed: true, rebuilt: true, commits })
+    expect(phases).toEqual([
+      'pinned gardenerless checkout ready',
+      'gardenerless kcp setup and verification complete',
+    ])
+  })
+
+  it('resets only managed prerequisites and preserves logs', () => {
+    const directory = temporaryDirectory('local-dashboard-reset-')
+    const config = configuration(directory)
+    const log = join(config.managedRoot, 'logs', 'run', 'frontend.log')
+    mkdirSync(config.checkoutDir, { recursive: true })
+    mkdirSync(config.runtimeDir)
+    mkdirSync(config.goModCacheDir)
+    mkdirSync(join(log, '..'), { recursive: true })
+    writeFileSync(log, 'retained\n')
+    resetManagedPrerequisites(config)
+    expect(() => realpathSync(config.checkoutDir)).toThrow()
+    expect(() => realpathSync(config.runtimeDir)).toThrow()
+    expect(() => realpathSync(config.goModCacheDir)).toThrow()
+    expect(readFileSync(log, 'utf8')).toBe('retained\n')
+
+    const external = join(directory, 'external')
+    mkdirSync(external)
+    writeFileSync(join(external, 'sentinel'), 'retained\n')
+    symlinkSync(external, config.checkoutDir)
+    symlinkSync(external, config.runtimeDir)
+    symlinkSync(external, config.goModCacheDir)
+    resetManagedPrerequisites(config)
+    expect(readFileSync(join(external, 'sentinel'), 'utf8')).toBe('retained\n')
+  })
+})
+
+describe('compact state and process safety', () => {
+  it('reads listener PIDs and process working directories from bounded lsof queries', () => {
+    const listeners = vi.fn(() => ({ status: 0, stdout: 'p101\np202\n' }))
+    expect(inspectListeningPids(8444, listeners)).toEqual([101, 202])
+    expect(listeners).toHaveBeenCalledWith('lsof', [
+      '-nP',
+      '-a',
+      '-iTCP:8444',
+      '-sTCP:LISTEN',
+      '-Fp',
+    ], { encoding: 'utf8' })
+
+    const cwd = vi.fn(() => ({ status: 0, stdout: 'p101\nfcwd\nn/work/dashboard/frontend\n' }))
+    expect(inspectProcessCwd(101, cwd)).toBe('/work/dashboard/frontend')
+    expect(inspectListeningPids(8444, () => ({ status: 1, stdout: '' }))).toEqual([])
+    expect(inspectProcessCwd(101, () => ({ status: 1, stdout: '' }))).toBeUndefined()
+  })
+
+  it('serializes only compact managed state and validates every identity field', () => {
+    const config = configuration()
+    const state = trackedState(config)
+    expect(parseState(serializeState(state), config)).toEqual(state)
+    expect(serializeState(state)).not.toContain('checkoutDir')
+    expect(serializeState(state)).not.toContain('commandMarker')
+
+    const invalidStates = [
+      { ...state, version: 2 },
+      { ...state, extra: true },
+      { ...state, logDir: '/tmp/escaped' },
+      { ...state, commits: { ...commits, kcp: 'unknown' } },
+      { ...state, commits: { ...commits, kcpRelease: 'main' } },
+      { ...state, processes: [processRecord(config, 'garden', 101)] },
+      {
+        ...state,
+        status: 'starting',
+        processes: [{ ...processRecord(config, 'garden', 101), pgid: 999 }],
+      },
+      {
+        ...state,
+        status: 'starting',
+        processes: [{ ...processRecord(config, 'backend', 102), command: '/unknown' }],
+      },
+    ]
+    for (const invalid of invalidStates) {
+      expect(() => parseState(serializeState(invalid), config)).toThrow()
+    }
+  })
+
+  it('rejects impossible process prefixes, permutations, and duplicate PIDs', () => {
+    const config = configuration()
+    const state = trackedState(config)
+    for (const names of [
+      ['backend'],
+      ['garden', 'frontend'],
+      ['backend', 'garden', 'frontend'],
+      ['garden', 'frontend', 'backend'],
+    ]) {
+      const processes = names.map((name, index) => processRecord(config, name, 201 + index))
+      expect(() => parseState(serializeState({ ...state, status: 'starting', processes }), config))
+        .toThrow('invalid process identity')
+    }
+    const processes = [processRecord(config, 'garden', 201), processRecord(config, 'backend', 201)]
+    expect(() => parseState(serializeState({ ...state, status: 'starting', processes }), config))
+      .toThrow('invalid process identity')
+  })
+
+  it('derives markers from the same definitions used to start services', () => {
+    const definitions = serviceDefinitions(configuration())
+    expect(definitions.map(({ name, commandMarker }) => [name, commandMarker])).toEqual([
+      ['garden', '/work/dashboard/.local-dashboard/runtime/bin/kcp start --bind-address=127.0.0.1'],
+      ['backend', `${YARN_RUNTIME} workspace @gardener-dashboard/backend serve`],
+      ['frontend', `${YARN_RUNTIME} workspace @gardener-dashboard/frontend serve --port 8444 --host 127.0.0.1`],
+    ])
+  })
+
+  it('assesses matching health and rejects stale or changed identities', async () => {
+    const config = configuration()
+    const state = trackedState(config)
+    await expect(assessTrackedState(state, config, {
+      inspector: matchingInspector(state),
+      request: async () => true,
+      commits,
+    })).resolves.toBe('healthy')
+    await expect(assessTrackedState(state, { ...config, scenario: 'many-shoots' }, {
+      inspector: matchingInspector(state),
+      request: async () => true,
+      commits,
+    })).resolves.toBe('configuration-mismatch')
+    await expect(assessTrackedState(state, config, {
+      inspector: () => undefined,
+    })).resolves.toBe('stale')
+  })
+
+  it('recognizes a managed listener after a launcher hands off to its runtime child', () => {
+    const config = configuration()
+    const record = processRecord(config, 'backend', 101)
+    const listener = {
+      pgid: record.pgid,
+      startSignature: 'Fri Jul 24 10:00:01 2026',
+      command: '/usr/local/bin/node server.js',
+    }
+    const inspector = pid => pid === 202 ? listener : undefined
+    const ownership = {
+      listeningPids: () => [202],
+      processCwd: () => join(config.repositoryRoot, 'backend'),
+    }
+    expect(processMatches(record, config, inspector, ownership)).toBe(true)
+    expect(processMatches(record, config, inspector, {
+      ...ownership,
+      processCwd: () => config.repositoryRoot,
+    })).toBe(false)
+    expect(processMatches(record, config, () => ({ ...listener, pgid: 999 }), ownership))
+      .toBe(false)
+  })
+
+  it('tears down validated groups in reverse order with SIGTERM', async () => {
+    const config = configuration()
+    const state = trackedState(config)
+    const signals = []
+    const result = await stopTrackedProcesses(state, config, {
+      inspector: matchingInspector(state),
+      signalGroup: (pgid, signal) => signals.push([pgid, signal]),
+      waitGroup: async () => true,
+    })
+    expect(result).toEqual({ stopped: ['frontend', 'backend', 'garden'], preserved: [] })
+    expect(signals).toEqual([
+      [103, 'SIGTERM'],
+      [102, 'SIGTERM'],
+      [101, 'SIGTERM'],
+    ])
+  })
+
+  it('preserves mismatches and revalidates identity before SIGKILL', async () => {
+    const config = configuration()
+    const record = processRecord(config, 'garden', 101)
+    let inspections = 0
+    const signals = []
+    const result = await stopTrackedProcesses({ processes: [record] }, config, {
+      inspector: () => ++inspections === 1
+        ? { pgid: record.pgid, startSignature: record.startSignature, command: record.command }
+        : { pgid: record.pgid, startSignature: 'reused', command: '/unknown' },
+      signalGroup: (pgid, signal) => signals.push([pgid, signal]),
+      waitGroup: async () => false,
+    })
+    expect(signals).toEqual([[101, 'SIGTERM']])
+    expect(result.preserved).toEqual(['garden'])
+  })
+
+  it('treats a vanished group with free ports as stopped but preserves an unknown group', async () => {
+    const config = configuration()
+    const record = processRecord(config, 'garden', 101)
+    const options = {
+      matcher: () => false,
+      probe: async () => true,
+      signalGroup: vi.fn(),
+      waitGroup: vi.fn(),
+    }
+    await expect(stopTrackedProcesses({ processes: [record] }, config, {
+      ...options,
+      groupPresent: () => false,
+    })).resolves.toEqual({ stopped: ['garden'], preserved: [] })
+    await expect(stopTrackedProcesses({ processes: [record] }, config, {
+      ...options,
+      groupPresent: () => true,
+    })).resolves.toEqual({ stopped: [], preserved: ['garden'] })
+  })
+
+  it('uses bounded SIGTERM then SIGKILL when the exact group remains', async () => {
+    const config = configuration()
+    const record = processRecord(config, 'garden', 101)
+    const signals = []
+    let waits = 0
+    await expect(stopTrackedProcesses({ processes: [record] }, config, {
+      inspector: () => ({
+        pgid: record.pgid,
+        startSignature: record.startSignature,
+        command: record.command,
+      }),
+      signalGroup: (pgid, signal) => signals.push([pgid, signal]),
+      waitGroup: async () => ++waits === 2,
+    })).resolves.toEqual({ stopped: ['garden'], preserved: [] })
+    expect(signals).toEqual([[101, 'SIGTERM'], [101, 'SIGKILL']])
+  })
+
+  it('fails promptly with bounded logs when a child identity disappears', async () => {
+    const directory = temporaryDirectory('local-dashboard-log-')
+    const config = configuration()
+    const logPath = join(directory, 'child.log')
+    writeFileSync(logPath, `${'discarded\n'.repeat(1000)}intentional failure\n`)
+    const started = Date.now()
+    await expect(waitUntilReady({
+      label: 'garden',
+      record: processRecord(config, 'garden', 101),
+      configuration: config,
+      health: async () => false,
+      logPath,
+      timeoutMs: 5_000,
+      inspector: () => undefined,
+    })).rejects.toThrow('intentional failure')
+    expect(Date.now() - started).toBeLessThan(500)
+  })
+})
+
+describe('command workflow', () => {
+  it('inspects once on setup reuse, up failure, status failure, and token success', async () => {
+    const directory = temporaryDirectory('local-dashboard-commands-')
+    const config = configuration(directory)
+    mkdirSync(config.managedRoot)
+    const setupInspect = vi.fn(() => commits)
+    silenceConsole()
+    await commandSetup(config, {
+      existing: async () => trackedState(config),
+      inspect: setupInspect,
+    })
+    expect(setupInspect).toHaveBeenCalledOnce()
+
+    const upInspect = vi.fn(() => {
+      throw new Error('missing runtime')
+    })
+    await expect(commandUp(config, { inspect: upInspect })).rejects.toThrow('run')
+    expect(upInspect).toHaveBeenCalledOnce()
+
+    const statusInspect = vi.fn(() => {
+      throw new Error('missing runtime')
+    })
+    await commandStatus(config, { inspect: statusInspect, probe: async () => true })
+    expect(statusInspect).toHaveBeenCalledOnce()
+
+    const tokenInspect = vi.fn(() => commits)
+    const run = vi.fn(async () => {})
+    const error = silenceConsole('error')
+    await commandToken(config, {
+      namespace: 'garden-foo',
+      name: 'viewer',
+      inspect: tokenInspect,
+      run,
+    })
+    expect(tokenInspect).toHaveBeenCalledOnce()
+    expect(error).toHaveBeenCalledExactlyOnceWith(
+      'system:serviceaccount:garden-foo:viewer\n',
+    )
+    expect(run).toHaveBeenCalledExactlyOnceWith(
+      join(config.checkoutDir, 'gardenerless-setup.sh'),
+      [
+        'get-token',
+        '--namespace',
+        'garden-foo',
+        '--service-account',
+        'viewer',
+      ], {
+        cwd: config.checkoutDir,
+        env: sanitizedGardenerlessEnvironment(config),
+        stdio: 'inherit',
+      },
+    )
+  })
+
+  it('uses the default operator service account without writing to stdout', async () => {
+    const config = configuration()
+    const output = silenceConsole()
+    const error = silenceConsole('error')
+    const run = vi.fn(async () => {})
+    await commandToken(config, { inspect: () => commits, run })
+    expect(output).not.toHaveBeenCalled()
+    expect(error).toHaveBeenCalledExactlyOnceWith(
+      'system:serviceaccount:garden:dashboard-user\n',
+    )
+    expect(run).toHaveBeenCalledExactlyOnceWith(
+      join(config.checkoutDir, 'gardenerless-setup.sh'),
+      [
+        'get-token',
+        '--namespace',
+        'garden',
+        '--service-account',
+        'dashboard-user',
+      ], {
+        cwd: config.checkoutDir,
+        env: sanitizedGardenerlessEnvironment(config),
+        stdio: 'inherit',
+      },
+    )
+  })
+
+  it('down removes malformed state without inspecting or signalling a process', async () => {
+    const directory = temporaryDirectory('local-dashboard-down-')
+    const config = configuration(directory)
+    mkdirSync(config.managedRoot)
+    writeFileSync(config.stateFile, '{"version":2}\n')
+    silenceConsole()
+    await commandDown(config, { probe: async () => true })
+    expect(() => realpathSync(config.stateFile)).toThrow()
+  })
+
+  it('down retains tracked state and fails when ownership or listener cleanup is unproven', async () => {
+    const directory = temporaryDirectory('local-dashboard-down-incomplete-')
+    const config = configuration(directory)
+    mkdirSync(config.managedRoot)
+    writeFileSync(config.stateFile, serializeState(trackedState(config)))
+    silenceConsole()
+    await expect(commandDown(config, {
+      stop: async () => ({ stopped: ['backend', 'garden'], preserved: ['frontend'] }),
+      probe: async () => true,
+    })).rejects.toThrow('tracked state retained')
+    expect(readFileSync(config.stateFile, 'utf8')).toContain('frontend')
+
+    await expect(commandDown(config, {
+      stop: async () => ({ stopped: ['frontend', 'backend', 'garden'], preserved: [] }),
+      probe: async port => port !== config.ports.frontend,
+    })).rejects.toThrow('frontend:8444')
+    expect(readFileSync(config.stateFile, 'utf8')).toContain('frontend')
+  })
+
+  it('down refuses unknown listeners when no tracked state exists', async () => {
+    const directory = temporaryDirectory('local-dashboard-down-untracked-')
+    const config = configuration(directory)
+    await expect(commandDown(config, {
+      probe: async port => port !== config.ports.frontend,
+    })).rejects.toThrow('unknown listeners remain on frontend:8444')
+  })
+
+  it('down refuses state reached through a symlinked managed root', async () => {
+    const directory = temporaryDirectory('local-dashboard-down-symlink-')
+    const config = configuration(directory)
+    const external = join(directory, 'external')
+    mkdirSync(external)
+    writeFileSync(join(external, 'state.json'), '{}\n')
+    symlinkSync(external, config.managedRoot)
+    await expect(commandDown(config)).rejects.toThrow('non-symlink directory')
+    expect(readFileSync(join(external, 'state.json'), 'utf8')).toBe('{}\n')
+  })
+
+  it('rejects unsupported command options before executing commands', async () => {
+    await expect(main(['down', '--runtime-dir=/tmp/runtime'])).rejects.toThrow('Unknown option')
+    await expect(main(['status', '--reset'])).rejects.toThrow('Unknown option')
+  })
+
+  it('reconciles every scenario with exactly one managed gardenerless command', async () => {
+    for (const scenario of SCENARIOS) {
+      const config = configuration(repositoryRoot, { scenario })
+      const run = vi.fn(async () => {})
+      await reconcileScenario(config, '/work/dashboard/.local-dashboard/logs/run/setup.log', { run })
+      expect(run).toHaveBeenCalledExactlyOnceWith(
+        config,
+        ['scenario', scenario],
+        '/work/dashboard/.local-dashboard/logs/run/setup.log',
+      )
+    }
+  })
+
+  it('reports timed phase progress and preserves unknown occupied ports', async () => {
+    let now = 0
+    let progress
+    const output = []
+    const timer = { unref: vi.fn() }
+    const result = runTimedPhase({
+      command: 'up',
+      index: 1,
+      total: 4,
+      label: 'starting garden',
+      completeLabel: 'garden ready',
+      action: async () => 'ready',
+      now: () => now,
+      log: message => output.push(message),
+      schedule: callback => {
+        progress = callback
+        return timer
+      },
+      cancel: vi.fn(),
+    })
+    now = 30_000
+    progress()
+    await expect(result).resolves.toBe('ready')
+    expect(output).toContain('up: [1/4] starting garden (30s elapsed)')
+    expect(formatElapsedTime(320_000)).toBe('5m 20s')
+    await expect(assertPortsAvailable({ frontend: 8444 }, async () => false))
+      .rejects.toThrow('unknown listener')
+  })
+})

--- a/hack/local-dashboard/vitest.config.mjs
+++ b/hack/local-dashboard/vitest.config.mjs
@@ -1,0 +1,36 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import { fileURLToPath } from 'node:url'
+
+import { defineConfig } from 'vitest/config'
+
+const repositoryRoot = fileURLToPath(new URL('../..', import.meta.url))
+
+export default defineConfig({
+  root: repositoryRoot,
+  test: {
+    include: ['hack/local-dashboard/test/**/*.spec.js'],
+    globals: false,
+    environment: 'node',
+    clearMocks: true,
+    setupFiles: [],
+    coverage: {
+      provider: 'v8',
+      include: [
+        'hack/local-dashboard.mjs',
+        'hack/local-dashboard/internal/**/*.mjs',
+      ],
+      reportsDirectory: 'coverage/local-dashboard',
+      thresholds: {
+        statements: 47,
+        branches: 58,
+        functions: 56,
+        lines: 47,
+      },
+    },
+  },
+})

--- a/package.json
+++ b/package.json
@@ -20,6 +20,10 @@
     "Sutter, Peter <peter.sutter@sap.com>"
   ],
   "scripts": {
+    "lint:hack": "eslint --config hack/eslint.config.cjs hack/eslint.config.cjs hack/local-dashboard.mjs hack/local-dashboard",
+    "lint:hack:sarif": "yarn lint:hack --format=@microsoft/eslint-formatter-sarif",
+    "test:hack": "vitest run --config hack/local-dashboard/vitest.config.mjs",
+    "test:hack:cov": "yarn test:hack --coverage",
     "serve": "yarn workspaces foreach --all --parallel --interlaced --include '@gardener-dashboard/frontend' --include '@gardener-dashboard/backend' run serve",
     "packages-test-all": "yarn workspaces foreach --all --parallel --no-private --include 'packages/*' run test",
     "packages-lint-all": "yarn workspaces foreach --all --parallel --no-private --include 'packages/*' run lint",
@@ -35,9 +39,15 @@
   },
   "devDependencies": {
     "@microsoft/eslint-formatter-sarif": "^3.1.0",
+    "@vitest/coverage-v8": "^4.0.0",
+    "@vitest/eslint-plugin": "^1.6.15",
     "eslint": "^9.11.0",
+    "eslint-plugin-import": "^2.31.0",
+    "eslint-plugin-import-newlines": "^1.4.0",
+    "eslint-plugin-security": "^3.0.1",
     "husky": "^9.1.7",
     "jsdom": "^26.0.0",
+    "neostandard": "^0.13.0",
     "vitest": "^4.0.0"
   },
   "bin": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5348,10 +5348,16 @@ __metadata:
   resolution: "gardener-dashboard@workspace:."
   dependencies:
     "@microsoft/eslint-formatter-sarif": "npm:^3.1.0"
+    "@vitest/coverage-v8": "npm:^4.0.0"
+    "@vitest/eslint-plugin": "npm:^1.6.15"
     eslint: "npm:^9.11.0"
+    eslint-plugin-import: "npm:^2.31.0"
+    eslint-plugin-import-newlines: "npm:^1.4.0"
+    eslint-plugin-security: "npm:^3.0.1"
     husky: "npm:^9.1.7"
     jsdom: "npm:^26.0.0"
     lodash-es: "npm:^4.17.21"
+    neostandard: "npm:^0.13.0"
     vitest: "npm:^4.0.0"
   dependenciesMeta:
     deasync:


### PR DESCRIPTION
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Adds a managed local development environment for the Gardener Dashboard that uses the gardenerless/KCP setup to provide a lightweight Garden API without requiring a full Gardener installation. Developers can run the complete dashboard stack (Garden API, backend, frontend) locally with deterministic scenarios for development and browser verification.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
```feature developer
Added managed local development environment using gardenerless/KCP that allows running the full dashboard stack locally without a Gardener installation.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a local Gardener Dashboard workflow with setup, startup, shutdown, status, and token commands.
  - Supports deterministic scenarios, prerequisite validation, health checks, secure isolated configuration, and automatic cleanup.
  - Added safeguards for managed files, processes, ports, certificates, and stale runtime state.

- **Documentation**
  - Added comprehensive local Dashboard setup and usage guidance.
  - Updated development instructions for testing, coverage, and linting.

- **Tests**
  - Added extensive automated coverage for Dashboard workflows, security checks, runtime management, and failure handling.
  - Added dedicated linting and coverage commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->