### PR TITLE
fix(frontend): temporarily hide VictoriaLogs links

### DIFF
--- a/frontend/src/components/GClusterMetrics.vue
+++ b/frontend/src/components/GClusterMetrics.vue
@@ -47,14 +47,15 @@ SPDX-License-Identifier: Apache-2.0
           :is-shoot-status-hibernated="isShootStatusHibernated"
           content-class="pt-0"
         />
-        <g-link-list-tile
+        <!-- TODO: Re-enable after the Dashboard release. -->
+        <!-- <g-link-list-tile
           v-if="victoriaLogsUrl"
           app-title="VictoriaLogs"
           :url="victoriaLogsUrl"
           :url-text="victoriaLogsUrl"
           :is-shoot-status-hibernated="isShootStatusHibernated"
           content-class="pt-0"
-        />
+        /> -->
         <v-divider
           v-show="!!username && !!password"
           inset
@@ -91,7 +92,8 @@ import GLinkListTile from '@/components/GLinkListTile'
 import { useShootItem } from '@/composables/useShootItem'
 import { useShootHelper } from '@/composables/useShootHelper'
 import { useShootStatus } from '@/composables/useShootStatus'
-import { useShootAdvertisedAddresses } from '@/composables/useShootAdvertisedAddresses'
+// TODO: Re-enable after the Dashboard release.
+// import { useShootAdvertisedAddresses } from '@/composables/useShootAdvertisedAddresses'
 
 import {
   getSeedPlutonoUrl,
@@ -131,9 +133,10 @@ export default {
       shootTechnicalId,
     } = useShootStatus(shootItem)
 
-    const {
-      shootVictoriaLogsUrl,
-    } = useShootAdvertisedAddresses(shootItem)
+    // TODO: Re-enable after the Dashboard release.
+    // const {
+    //   shootVictoriaLogsUrl,
+    // } = useShootAdvertisedAddresses(shootItem)
 
     return {
       shootItem,
@@ -144,7 +147,7 @@ export default {
       isOidcObservabilityUrlsEnabled,
       canViewLandscape,
       isTestingCluster,
-      shootVictoriaLogsUrl,
+      // shootVictoriaLogsUrl,
     }
   },
   computed: {
@@ -175,19 +178,20 @@ export default {
 
       return `https://au-${this.prefix}.${this.seedIngressDomain}`
     },
-    victoriaLogsUrl () {
-      // Prefer the advertised address; fall back to the hardcoded url until
-      // the migration to advertisedAddresses is complete.
-      if (this.shootVictoriaLogsUrl) {
-        return this.shootVictoriaLogsUrl
-      }
+    // TODO: Re-enable after the Dashboard release.
+    // victoriaLogsUrl () {
+    //   // Prefer the advertised address; fall back to the hardcoded url until
+    //   // the migration to advertisedAddresses is complete.
+    //   if (this.shootVictoriaLogsUrl) {
+    //     return this.shootVictoriaLogsUrl
+    //   }
 
-      if (this.isOidcObservabilityUrlsEnabled) {
-        return `${this.getOidcDeploymentUrl('victoria-logs')}/select/vmui`
-      }
+    //   if (this.isOidcObservabilityUrlsEnabled) {
+    //     return `${this.getOidcDeploymentUrl('victoria-logs')}/select/vmui`
+    //   }
 
-      return `https://vl-${this.prefix}.${this.seedIngressDomain}/select/vmui`
-    },
+    //   return `https://vl-${this.prefix}.${this.seedIngressDomain}/select/vmui`
+    // },
     seedPlutonoUrl () {
       return getSeedPlutonoUrl(this.seedIngressDomain)
     },

--- a/frontend/src/components/SeedDetails/GSeedMonitoringCard.vue
+++ b/frontend/src/components/SeedDetails/GSeedMonitoringCard.vue
@@ -70,13 +70,14 @@ SPDX-License-Identifier: Apache-2.0
         :url-text="managedSeedShootPrometheusUrl"
         content-class="pt-0"
       />
-      <g-link-list-tile
+      <!-- TODO: Re-enable after the Dashboard release. -->
+      <!-- <g-link-list-tile
         v-if="managedSeedShootVictoriaLogsUrl"
         app-title="Shoot VictoriaLogs"
         :url="managedSeedShootVictoriaLogsUrl"
         :url-text="managedSeedShootVictoriaLogsUrl"
         content-class="pt-0"
-      />
+      /> -->
     </g-list>
   </v-card>
 </template>
@@ -101,7 +102,8 @@ const {
 const {
   managedSeedShootPlutonoUrl,
   managedSeedShootPrometheusUrl,
-  managedSeedShootVictoriaLogsUrl,
+  // TODO: Re-enable after the Dashboard release.
+  // managedSeedShootVictoriaLogsUrl,
 } = useManagedSeedShoot()
 
 const seedPlutonoUrl = computed(() => getSeedPlutonoUrl(seedIngressDomain.value))


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area usability
/kind cleanup

**What this PR does / why we need it**:
Temporarily hides the VictoriaLogs links in cluster metrics and seed monitoring until the next Dashboard release.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```bugfix user
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Temporarily removed VictoriaLogs links from cluster metrics and seed monitoring views.
  - VictoriaLogs dashboard access will be restored after the Dashboard release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->