### PR TITLE
Update vendor configuration documentation

### DIFF
--- a/docs/operations/customization.md
+++ b/docs/operations/customization.md
@@ -42,7 +42,7 @@ Each entry must be an object with a `name` key that identifies the vendor. The f
 | ------------- |------|
 | `name`        | Unique vendor identifier (required) |
 | `displayName` | Name displayed in the dashboard |
-| `weight`      | Sorting weight. Lower values appear first. See default weights in `frontend/src/store/config.js` |
+| `weight`      | Sorting weight. Lower values appear first. See the default weights in the built-in [infrastructure](../../frontend/src/data/vendors/infra), [DNS](../../frontend/src/data/vendors/dns), and [machine image](../../frontend/src/data/vendors/machineImage) vendor registries. |
 | `icon`        | File name of the icon located in the `public/static/assets` folder. See [Logos and Icons](#logos-and-icons) for instructions on replacing assets |
 
 ## Colors


### PR DESCRIPTION
## Summary

- update the vendor branding documentation to link to the built-in infrastructure, DNS, and machine-image registries
- remove the stale reference to `frontend/src/store/config.js`

## Why

The built-in vendor definitions and their default weights were extracted from the configuration store into dedicated vendor registry directories. The documentation still pointed readers to the old location.

## Impact

Documentation only. This makes the default vendor weights easier to locate and does not change runtime behavior.

## Validation

- `git diff --check`
- repository pre-commit hook


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated vendor customization guidance to reference the current built-in registries for infrastructure, DNS, and machine-image sorting weights.
  * Removed reference to the deprecated configuration location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->