### PR TITLE
feat(frontend) Move shoot-specific defaults from branching logic to vendor configurations

### DIFF
--- a/frontend/__fixtures__/cloudprofiles.js
+++ b/frontend/__fixtures__/cloudprofiles.js
@@ -4,6 +4,118 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+const DEFAULT_ARCHITECTURE = 'amd64'
+
+const createMachineType = ({
+  name,
+  cpu,
+  memory,
+  gpu = '0',
+  architecture = DEFAULT_ARCHITECTURE,
+  usable = true,
+  storage,
+}) => ({
+  name,
+  cpu,
+  gpu,
+  memory,
+  usable,
+  architecture,
+  ...(storage ? { storage: { ...storage } } : {}),
+})
+
+const createVolumeType = ({
+  name,
+  class: volumeClass,
+  usable = true,
+  minSize,
+}) => ({
+  name,
+  class: volumeClass,
+  usable,
+  ...(minSize ? { minSize } : {}),
+})
+
+const createZone = ({
+  name,
+  unavailableMachineTypes,
+  unavailableVolumeTypes,
+}) => ({
+  name,
+  ...(unavailableMachineTypes ? { unavailableMachineTypes } : {}),
+  ...(unavailableVolumeTypes ? { unavailableVolumeTypes } : {}),
+})
+
+const createRegion = ({
+  name,
+  zones,
+  accessRestrictions,
+}) => ({
+  name,
+  zones,
+  ...(accessRestrictions?.length
+    ? {
+        accessRestrictions: accessRestrictions.map(name => ({ name })),
+      }
+    : {}),
+})
+
+const createCloudProfile = ({
+  metadataName,
+  displayName,
+  type,
+  seedNames,
+  providerConfig,
+  machineTypes,
+  regions,
+  volumeTypes,
+  kubernetes = { versions: [...kubernetesVersions] },
+  machineImagesProfile = [...machineImages],
+}) => ({
+  metadata: {
+    name: metadataName,
+    annotations: {
+      'garden.sapcloud.io/displayName': displayName,
+    },
+  },
+  spec: {
+    ...(seedNames ? { seedNames } : {}),
+    kubernetes,
+    machineImages: machineImagesProfile,
+    machineTypes,
+    providerConfig,
+    regions,
+    type,
+    ...(volumeTypes ? { volumeTypes } : {}),
+  },
+})
+
+const createOpenstackMachineTypes = ({ prefix, gpuType }) => {
+  const storage = {
+    class: 'standard',
+    size: '64Gi',
+    type: 'default',
+  }
+  return [
+    createMachineType({ name: `${prefix}_c2_m16`, cpu: '2', memory: '16Gi', storage }),
+    createMachineType({ name: `${prefix}_c4_m32`, cpu: '4', memory: '32Gi', storage }),
+    createMachineType({ name: `${prefix}_c8_m64`, cpu: '8', memory: '64Gi', storage }),
+    createMachineType({ name: `${prefix}_c16_m128`, cpu: '16', memory: '128Gi', storage }),
+    createMachineType({ name: `${prefix}_c32_m256`, cpu: '32', memory: '256Gi', storage }),
+    createMachineType({
+      name: gpuType,
+      cpu: '32',
+      gpu: '3',
+      memory: '384Gi',
+      storage: {
+        class: 'standard',
+        size: '1966Gi',
+        type: 'default',
+      },
+    }),
+  ]
+}
+
 export const kubernetesVersions = [
   {
     version: '1.29.2',
@@ -153,1007 +265,635 @@ export const machineImages = [
   },
 ]
 
+const alicloudMachineTypes = [
+  createMachineType({ name: 'ecs.c1.small', cpu: '8', memory: '8Gi' }),
+  createMachineType({ name: 'ecs.c2.medium', cpu: '16', memory: '16Gi' }),
+  createMachineType({ name: 'ecs.c2.large', cpu: '16', memory: '32Gi' }),
+  createMachineType({ name: 'ecs.c2.xlarge', cpu: '16', memory: '64Gi' }),
+  createMachineType({ name: 'ecs.c6.large', cpu: '2', memory: '4Gi' }),
+  createMachineType({ name: 'ecs.c6.xlarge', cpu: '4', memory: '8Gi' }),
+]
+
+const awsMachineTypes = [
+  createMachineType({ name: 'm4.large', cpu: '2', memory: '8Gi' }),
+  createMachineType({ name: 'm4.xlarge', cpu: '4', memory: '16Gi' }),
+  createMachineType({ name: 'm4.2xlarge', cpu: '8', memory: '32Gi' }),
+  createMachineType({ name: 'a1.large', cpu: '2', memory: '4Gi', architecture: 'arm64' }),
+  createMachineType({ name: 'a1.xlarge', cpu: '4', memory: '8Gi', architecture: 'arm64' }),
+  createMachineType({ name: 'a1.2xlarge', cpu: '8', memory: '16Gi', architecture: 'arm64' }),
+  createMachineType({ name: 'g5.large', cpu: '2', memory: '8Gi', gpu: '1' }),
+  createMachineType({ name: 'g5.xlarge', cpu: '4', memory: '16Gi', gpu: '1' }),
+  createMachineType({ name: 'g5.2xlarge', cpu: '8', memory: '32Gi', gpu: '1' }),
+]
+
+const azureMachineTypes = [
+  createMachineType({ name: 'Standard_A4_v2', cpu: '4', memory: '8Gi' }),
+  createMachineType({ name: 'Basic_A3', cpu: '4', memory: '7Gi' }),
+  createMachineType({ name: 'Basic_A4', cpu: '8', memory: '14Gi' }),
+]
+
+const gcpMachineTypes = [
+  createMachineType({ name: 'n1-standard-2', cpu: '2', memory: '7Gi' }),
+  createMachineType({ name: 'n1-standard-4', cpu: '4', memory: '15Gi' }),
+  createMachineType({ name: 'n1-standard-8', cpu: '8', memory: '30Gi' }),
+  createMachineType({ name: 'n1-standard-16', cpu: '16', memory: '60Gi' }),
+  createMachineType({ name: 't2a-standard-2', cpu: '2', memory: '8Gi', architecture: 'arm64' }),
+  createMachineType({ name: 't2a-standard-4', cpu: '4', memory: '16Gi', architecture: 'arm64' }),
+  createMachineType({ name: 't2a-standard-8', cpu: '8', memory: '32Gi', architecture: 'arm64' }),
+  createMachineType({ name: 't2a-standard-16', cpu: '16', memory: '64Gi', architecture: 'arm64' }),
+]
+
+const metalMachineTypes = [
+  createMachineType({ name: 'c1-metal-small', cpu: '2', memory: '4Gi' }),
+  createMachineType({ name: 'c1-metal-medium', cpu: '4', memory: '8Gi' }),
+]
+
+const ironcoreMetalMachineTypes = [
+  createMachineType({ name: 'ironcore-metal-small', cpu: '2', memory: '4Gi' }),
+]
+
+const onmetalMachineTypes = [
+  createMachineType({ name: 'c1-onmetal-small', cpu: '2', memory: '4Gi' }),
+  createMachineType({ name: 'c1-onmetal-medium', cpu: '4', memory: '8Gi' }),
+]
+
+const localMachineTypes = [
+  createMachineType({ name: 'local-dev-small', cpu: '2', memory: '4Gi' }),
+]
+
+const hcloudMachineTypes = [
+  createMachineType({ name: 'cpx11', cpu: '2', memory: '2Gi' }),
+  createMachineType({ name: 'cpx21', cpu: '3', memory: '4Gi' }),
+]
+
+const stackitMachineTypes = [
+  createMachineType({ name: 'stackit-machine-1', cpu: '2', memory: '8Gi' }),
+  createMachineType({ name: 'stackit-machine-2', cpu: '4', memory: '16Gi' }),
+]
+
+const vsphereMachineTypes = [
+  createMachineType({ name: 'vsphere-machine-1', cpu: '2', memory: '4Gi' }),
+  createMachineType({ name: 'vsphere-machine-2', cpu: '4', memory: '8Gi' }),
+]
+
+const openstack1MachineTypes = createOpenstackMachineTypes({
+  prefix: 'g',
+  gpuType: 'xg1bcm1.medium',
+})
+
+const openstack2MachineTypes = createOpenstackMachineTypes({
+  prefix: 'm',
+  gpuType: 'zg1bcm1.medium',
+})
+
 export default [
-  {
-    metadata: {
-      name: 'alicloud',
-      annotations: {
-        'garden.sapcloud.io/displayName': 'Alibaba Cloud',
-      },
+  createCloudProfile({
+    metadataName: 'alicloud',
+    displayName: 'Alibaba Cloud',
+    type: 'alicloud',
+    machineTypes: alicloudMachineTypes,
+    providerConfig: {
+      apiVersion: 'alicloud.provider.extensions.gardener.cloud/v1alpha1',
+      kind: 'CloudProfileConfig',
     },
-    spec: {
-      kubernetes: {
-        versions: [
-          ...kubernetesVersions,
+    regions: [
+      createRegion({
+        name: 'eu-central-1',
+        zones: [
+          createZone({ name: 'eu-central-1a' }),
+          createZone({ name: 'eu-central-1b' }),
+          createZone({
+            name: 'eu-central-1c',
+            unavailableMachineTypes: [
+              alicloudMachineTypes[0].name,
+              alicloudMachineTypes[1].name,
+            ],
+            unavailableVolumeTypes: [
+              'cloud_ssd',
+            ],
+          }),
         ],
-      },
-      machineImages: [
-        ...machineImages,
-      ],
-      machineTypes: [
-        {
-          cpu: '8',
-          gpu: '0',
-          memory: '8Gi',
-          name: 'ecs.c1.small',
-          usable: true,
-          architecture: 'amd64',
-        },
-        {
-          cpu: '16',
-          gpu: '0',
-          memory: '16Gi',
-          name: 'ecs.c2.medium',
-          usable: true,
-          architecture: 'amd64',
-        },
-        {
-          cpu: '16',
-          gpu: '0',
-          memory: '32Gi',
-          name: 'ecs.c2.large',
-          usable: true,
-          architecture: 'amd64',
-        },
-        {
-          cpu: '16',
-          gpu: '0',
-          memory: '64Gi',
-          name: 'ecs.c2.xlarge',
-          usable: true,
-          architecture: 'amd64',
-        },
-        {
-          cpu: '2',
-          gpu: '0',
-          memory: '4Gi',
-          name: 'ecs.c6.large',
-          usable: true,
-          architecture: 'amd64',
-        },
-        {
-          cpu: '4',
-          gpu: '0',
-          memory: '8Gi',
-          name: 'ecs.c6.xlarge',
-          usable: true,
-          architecture: 'amd64',
-        },
-      ],
-      providerConfig: {
-        apiVersion: 'alicloud.provider.extensions.gardener.cloud/v1alpha1',
-        kind: 'CloudProfileConfig',
-      },
-      regions: [
-        {
-          name: 'eu-central-1',
-          zones: [
-            {
-              name: 'eu-central-1a',
-            },
-            {
-              name: 'eu-central-1b',
-            },
-            {
-              name: 'eu-central-1c',
-              unavailableMachineTypes: [
-                'ecs.c1.small',
-                'ecs.c2.medium',
-              ],
-              unavailableVolumeTypes: [
-                'cloud_ssd',
-              ],
-            },
-          ],
-        },
-        {
-          name: 'us-east-1',
-          zones: [
-            {
-              name: 'us-east-1a',
-            },
-            {
-              name: 'us-east-1b',
-            },
-          ],
-        },
-      ],
-      type: 'alicloud',
-      volumeTypes: [
-        {
-          class: 'standard',
-          name: 'cloud',
-          usable: true,
-        },
-        {
-          class: 'standard',
-          name: 'cloud_efficiency',
-          usable: true,
-        },
-        {
-          class: 'premium',
-          name: 'cloud_ssd',
-          usable: true,
-        },
-      ],
-    },
-  },
-  {
-    metadata: {
-      name: 'aws',
-      annotations: {
-        'garden.sapcloud.io/displayName': 'aws',
-      },
-    },
-    spec: {
-      seedNames: [
-        'aws-ha',
-      ],
-      kubernetes: {
-        versions: [
-          ...kubernetesVersions,
+      }),
+      createRegion({
+        name: 'us-east-1',
+        zones: [
+          createZone({ name: 'us-east-1a' }),
+          createZone({ name: 'us-east-1b' }),
         ],
-      },
-      machineImages: [
-        ...machineImages,
-      ],
-      machineTypes: [
-        {
-          cpu: '2',
-          gpu: '0',
-          memory: '8Gi',
-          name: 'm4.large',
-          usable: true,
-          architecture: 'amd64',
-        },
-        {
-          cpu: '4',
-          gpu: '0',
-          memory: '16Gi',
-          name: 'm4.xlarge',
-          usable: true,
-          architecture: 'amd64',
-        },
-        {
-          cpu: '8',
-          gpu: '0',
-          memory: '32Gi',
-          name: 'm4.2xlarge',
-          usable: true,
-          architecture: 'amd64',
-        },
-        {
-          cpu: '2',
-          gpu: '0',
-          memory: '4Gi',
-          name: 'a1.large',
-          usable: true,
-          architecture: 'arm64',
-        },
-        {
-          cpu: '4',
-          gpu: '0',
-          memory: '8Gi',
-          name: 'a1.xlarge',
-          usable: true,
-          architecture: 'arm64',
-        },
-        {
-          cpu: '8',
-          gpu: '0',
-          memory: '16Gi',
-          name: 'a1.2xlarge',
-          usable: true,
-          architecture: 'arm64',
-        },
-        {
-          cpu: '2',
-          gpu: '1',
-          memory: '8Gi',
-          name: 'g5.large',
-          usable: true,
-          architecture: 'amd64',
-        },
-        {
-          cpu: '4',
-          gpu: '1',
-          memory: '16Gi',
-          name: 'g5.xlarge',
-          usable: true,
-          architecture: 'amd64',
-        },
-        {
-          cpu: '8',
-          gpu: '1',
-          memory: '32Gi',
-          name: 'g5.2xlarge',
-          usable: true,
-          architecture: 'amd64',
-        },
-      ],
-      providerConfig: {
-        apiVersion: 'aws.provider.extensions.gardener.cloud/v1alpha1',
-        kind: 'CloudProfileConfig',
-      },
-      regions: [
-        {
-          name: 'eu-central-1',
-          zones: [
-            {
-              name: 'eu-central-1a',
-            },
-            {
-              name: 'eu-central-1b',
-            },
-            {
-              name: 'eu-central-1c',
-              unavailableMachineTypes: [
-                'm4.large',
-                'a1.large',
-                'g5.large',
-              ],
-              unavailableVolumeTypes: [
-                'gp3',
-                'io1',
-              ],
-            },
-          ],
-          accessRestrictions: [{
-            name: 'eu-access-only',
-          }],
-        },
-        {
-          name: 'eu-west-1',
-          zones: [
-            {
-              name: 'eu-west-1a',
-            },
-            {
-              name: 'eu-west-1b',
-            },
-            {
-              name: 'eu-west-1c',
-              unavailableMachineTypes: [
-                'm4.xlarge',
-                'a1.xlarge',
-                'g5.xlarge',
-              ],
-              unavailableVolumeTypes: [
-                'io1',
-              ],
-            },
-          ],
-          accessRestrictions: [{
-            name: 'eu-access-only',
-          }],
-        },
-        {
-          name: 'us-east-1',
-          zones: [
-            {
-              name: 'us-east-1a',
-            },
-            {
-              name: 'us-east-1b',
-            },
-            {
-              name: 'us-east-1c',
-            },
-            {
-              name: 'us-east-1d',
-            },
-          ],
-        },
-      ],
-      type: 'aws',
-      volumeTypes: [
-        {
-          class: 'standard',
-          name: 'gp3',
-          usable: true,
-        },
-        {
-          class: 'standard',
-          name: 'gp2',
-          usable: true,
-        },
-        {
-          class: 'standard',
-          name: 'io1',
-          usable: true,
-          minSize: '4Gi',
-        },
-      ],
+      }),
+    ],
+    volumeTypes: [
+      createVolumeType({ name: 'cloud', class: 'standard' }),
+      createVolumeType({ name: 'cloud_efficiency', class: 'standard' }),
+      createVolumeType({ name: 'cloud_ssd', class: 'premium' }),
+    ],
+  }),
+  createCloudProfile({
+    metadataName: 'aws',
+    displayName: 'aws',
+    type: 'aws',
+    seedNames: [
+      'aws-ha',
+    ],
+    machineTypes: awsMachineTypes,
+    providerConfig: {
+      apiVersion: 'aws.provider.extensions.gardener.cloud/v1alpha1',
+      kind: 'CloudProfileConfig',
     },
-  },
-  {
-    metadata: {
-      name: 'az',
-      annotations: {
-        'garden.sapcloud.io/displayName': 'Azure',
-      },
-    },
-    spec: {
-      seedNames: [
-        'az-ha',
-      ],
-      kubernetes: {
-        versions: [
-          ...kubernetesVersions,
+    regions: [
+      createRegion({
+        name: 'eu-central-1',
+        zones: [
+          createZone({ name: 'eu-central-1a' }),
+          createZone({ name: 'eu-central-1b' }),
+          createZone({
+            name: 'eu-central-1c',
+            unavailableMachineTypes: [
+              awsMachineTypes[0].name,
+              awsMachineTypes[3].name,
+              awsMachineTypes[6].name,
+            ],
+            unavailableVolumeTypes: [
+              'gp3',
+              'io1',
+            ],
+          }),
         ],
-      },
-      machineImages: [
-        ...machineImages,
-      ],
-      machineTypes: [
-        {
-          cpu: '4',
-          gpu: '0',
-          memory: '8Gi',
-          name: 'Standard_A4_v2',
-          usable: true,
-          architecture: 'amd64',
-        },
-        {
-          cpu: '4',
-          gpu: '0',
-          memory: '7Gi',
-          name: 'Basic_A3',
-          usable: true,
-          architecture: 'amd64',
-        },
-        {
-          cpu: '8',
-          gpu: '0',
-          memory: '14Gi',
-          name: 'Basic_A4',
-          usable: true,
-          architecture: 'amd64',
-        },
-      ],
-      providerConfig: {
-        apiVersion: 'azure.provider.extensions.gardener.cloud/v1alpha1',
-        kind: 'CloudProfileConfig',
-      },
-      regions: [
-        {
-          name: 'westeurope',
-          zones: [
-            {
-              name: '1',
-            },
-            {
-              name: '2',
-            },
-            {
-              name: '3',
-              unavailableMachineTypes: [
-                'Standard_A4_v2',
-              ],
-              unavailableVolumeTypes: [
-                'StandardSSD_LRS',
-              ],
-            },
-          ],
-          accessRestrictions: [{
-            name: 'eu-access-only',
-          }],
-        },
-        {
-          name: 'eastus',
-          zones: [
-            {
-              name: '1',
-            },
-            {
-              name: '2',
-            },
-            {
-              name: '3',
-            },
-          ],
-        },
-      ],
-      type: 'azure',
-      volumeTypes: [
-        {
-          class: 'premium',
-          name: 'StandardSSD_LRS',
-          usable: true,
-          minSize: '20Gi',
-        },
-        {
-          class: 'standard',
-          name: 'Standard_LRS',
-          usable: true,
-          minSize: '20Gi',
-        },
-        {
-          class: 'premium',
-          name: 'Premium_LRS',
-          usable: true,
-          minSize: '20Gi',
-        },
-      ],
-    },
-  },
-  {
-    metadata: {
-      name: 'openstack-1',
-      annotations: {
-        'garden.sapcloud.io/displayName': 'Openstack 1',
-      },
-    },
-    spec: {
-      seedNames: [
-        'openstack-ha',
-      ],
-      kubernetes: {
-        versions: [
-          ...kubernetesVersions,
+        accessRestrictions: ['eu-access-only'],
+      }),
+      createRegion({
+        name: 'eu-west-1',
+        zones: [
+          createZone({ name: 'eu-west-1a' }),
+          createZone({ name: 'eu-west-1b' }),
+          createZone({
+            name: 'eu-west-1c',
+            unavailableMachineTypes: [
+              awsMachineTypes[1].name,
+              awsMachineTypes[4].name,
+              awsMachineTypes[7].name,
+            ],
+            unavailableVolumeTypes: [
+              'io1',
+            ],
+          }),
         ],
-      },
-      machineImages: [
-        ...machineImages,
-      ],
-      machineTypes: [
-        {
-          cpu: '2',
-          gpu: '0',
-          memory: '16Gi',
-          name: 'g_c2_m16',
-          storage: {
-            class: 'standard',
-            size: '64Gi',
-            type: 'default',
-          },
-          usable: true,
-          architecture: 'amd64',
-        },
-        {
-          cpu: '4',
-          gpu: '0',
-          memory: '32Gi',
-          name: 'g_c4_m32',
-          storage: {
-            class: 'standard',
-            size: '64Gi',
-            type: 'default',
-          },
-          usable: true,
-          architecture: 'amd64',
-        },
-        {
-          cpu: '8',
-          gpu: '0',
-          memory: '64Gi',
-          name: 'g_c8_m64',
-          storage: {
-            class: 'standard',
-            size: '64Gi',
-            type: 'default',
-          },
-          usable: true,
-          architecture: 'amd64',
-        },
-        {
-          cpu: '16',
-          gpu: '0',
-          memory: '128Gi',
-          name: 'g_c16_m128',
-          storage: {
-            class: 'standard',
-            size: '64Gi',
-            type: 'default',
-          },
-          usable: true,
-          architecture: 'amd64',
-        },
-        {
-          cpu: '32',
-          gpu: '0',
-          memory: '256Gi',
-          name: 'g_c32_m256',
-          storage: {
-            class: 'standard',
-            size: '64Gi',
-            type: 'default',
-          },
-          usable: true,
-          architecture: 'amd64',
-        },
-        {
-          cpu: '32',
-          gpu: '3',
-          memory: '384Gi',
-          name: 'xg1bcm1.medium',
-          storage: {
-            class: 'standard',
-            size: '1966Gi',
-            type: 'default',
-          },
-          usable: true,
-          architecture: 'amd64',
-        },
-      ],
-      providerConfig: {
-        apiVersion: 'openstack.provider.extensions.gardener.cloud/v1alpha1',
-        constraints: {
-          floatingPools: [
-            {
-              name: 'FloatingIP*',
-              region: 'eu-de-1',
-            },
-            {
-              name: 'FloatingIP*',
-              region: 'na-us-1',
-            },
-          ],
-          loadBalancerProviders: [
-            {
-              name: 'f5',
-            },
-          ],
-        },
-        kind: 'CloudProfileConfig',
-      },
-      regions: [
-        {
-          name: 'eu-de-1',
-          zones: [
-            {
-              name: 'eu-de-1a',
-            },
-            {
-              name: 'eu-de-1b',
-            },
-            {
-              name: 'eu-de-1d',
-              unavailableMachineTypes: [
-                'g_c2_m16',
-              ],
-            },
-          ],
-          accessRestrictions: [{
-            name: 'eu-access-only',
-          }],
-        },
-        {
-          name: 'na-us-1',
-          zones: [
-            {
-              name: 'na-us-1a',
-            },
-            {
-              name: 'na-us-1b',
-            },
-            {
-              name: 'na-us-1d',
-            },
-          ],
-        },
-      ],
-      type: 'openstack',
-    },
-  },
-  {
-    metadata: {
-      name: 'openstack-2',
-      annotations: {
-        'garden.sapcloud.io/displayName': 'Openstack 2',
-      },
-    },
-    spec: {
-      seedNames: [
-        'openstack-ha',
-      ],
-      kubernetes: {
-        versions: [
-          ...kubernetesVersions,
+        accessRestrictions: ['eu-access-only'],
+      }),
+      createRegion({
+        name: 'us-east-1',
+        zones: [
+          createZone({ name: 'us-east-1a' }),
+          createZone({ name: 'us-east-1b' }),
+          createZone({ name: 'us-east-1c' }),
+          createZone({ name: 'us-east-1d' }),
         ],
-      },
-      machineImages: [
-        ...machineImages,
-      ],
-      machineTypes: [
-        {
-          cpu: '2',
-          gpu: '0',
-          memory: '16Gi',
-          name: 'm_c2_m16',
-          storage: {
-            class: 'standard',
-            size: '64Gi',
-            type: 'default',
-          },
-          usable: true,
-          architecture: 'amd64',
-        },
-        {
-          cpu: '4',
-          gpu: '0',
-          memory: '32Gi',
-          name: 'm_c4_m32',
-          storage: {
-            class: 'standard',
-            size: '64Gi',
-            type: 'default',
-          },
-          usable: true,
-          architecture: 'amd64',
-        },
-        {
-          cpu: '8',
-          gpu: '0',
-          memory: '64Gi',
-          name: 'm_c8_m64',
-          storage: {
-            class: 'standard',
-            size: '64Gi',
-            type: 'default',
-          },
-          usable: true,
-          architecture: 'amd64',
-        },
-        {
-          cpu: '16',
-          gpu: '0',
-          memory: '128Gi',
-          name: 'm_c16_m128',
-          storage: {
-            class: 'standard',
-            size: '64Gi',
-            type: 'default',
-          },
-          usable: true,
-          architecture: 'amd64',
-        },
-        {
-          cpu: '32',
-          gpu: '0',
-          memory: '256Gi',
-          name: 'm_c32_m256',
-          storage: {
-            class: 'standard',
-            size: '64Gi',
-            type: 'default',
-          },
-          usable: true,
-          architecture: 'amd64',
-        },
-        {
-          cpu: '32',
-          gpu: '3',
-          memory: '384Gi',
-          name: 'zg1bcm1.medium',
-          storage: {
-            class: 'standard',
-            size: '1966Gi',
-            type: 'default',
-          },
-          usable: true,
-          architecture: 'amd64',
-        },
-      ],
-      providerConfig: {
-        apiVersion: 'openstack.provider.extensions.gardener.cloud/v1alpha1',
-        constraints: {
-          floatingPools: [
-            {
-              defaultFloatingSubnet: 'FloatingIP-intranet-*',
-              loadBalancerClasses: [
-                {
-                  floatingSubnetName: 'FloatingIP-internet-*',
-                  name: 'internet',
-                },
-                {
-                  floatingSubnetName: 'FloatingIP-intranet-*',
-                  name: 'intranet',
-                  purpose: 'default',
-                },
-              ],
-              name: 'FloatingIP*',
-              region: 'eu-de-2',
-            },
-            {
-              defaultFloatingSubnet: 'FloatingIP-intranet-*',
-              loadBalancerClasses: [
-                {
-                  floatingSubnetName: 'FloatingIP-internet-*',
-                  name: 'internet',
-                },
-                {
-                  floatingSubnetName: 'FloatingIP-intranet-*',
-                  name: 'intranet',
-                  purpose: 'default',
-                },
-              ],
-              name: 'FloatingIP*',
-              region: 'na-us-2',
-            },
-          ],
-          loadBalancerProviders: [
-            {
-              name: 'f5',
-            },
-          ],
-        },
-        kind: 'CloudProfileConfig',
-      },
-      regions: [
-        {
-          name: 'eu-de-2',
-          zones: [
-            {
-              name: 'eu-de-2a',
-            },
-            {
-              name: 'eu-de-2b',
-            },
-            {
-              name: 'eu-de-2d',
-              unavailableMachineTypes: [
-                'm_c2_m16',
-              ],
-            },
-          ],
-          accessRestrictions: [{
-            name: 'eu-access-only',
-          }],
-        },
-        {
-          name: 'na-us-2',
-          zones: [
-            {
-              name: 'na-us-2a',
-            },
-            {
-              name: 'na-us-2b',
-            },
-            {
-              name: 'na-us-2d',
-            },
-          ],
-        },
-      ],
-      type: 'openstack',
+      }),
+    ],
+    volumeTypes: [
+      createVolumeType({ name: 'gp3', class: 'standard' }),
+      createVolumeType({ name: 'gp2', class: 'standard' }),
+      createVolumeType({ name: 'io1', class: 'standard', minSize: '4Gi' }),
+    ],
+  }),
+  createCloudProfile({
+    metadataName: 'az',
+    displayName: 'Azure',
+    type: 'azure',
+    seedNames: [
+      'az-ha',
+    ],
+    machineTypes: azureMachineTypes,
+    providerConfig: {
+      apiVersion: 'azure.provider.extensions.gardener.cloud/v1alpha1',
+      kind: 'CloudProfileConfig',
     },
-  },
-  {
-    metadata: {
-      name: 'gcp',
-      annotations: {
-        'garden.sapcloud.io/displayName': 'Google Cloud',
-      },
-    },
-    spec: {
-      seedNames: [
-        'gcp-ha',
-      ],
-      kubernetes: {
-        versions: [
-          ...kubernetesVersions,
+    regions: [
+      createRegion({
+        name: 'westeurope',
+        zones: [
+          createZone({ name: '1' }),
+          createZone({ name: '2' }),
+          createZone({
+            name: '3',
+            unavailableMachineTypes: [
+              azureMachineTypes[0].name,
+            ],
+            unavailableVolumeTypes: [
+              'StandardSSD_LRS',
+            ],
+          }),
         ],
-      },
-      machineImages: [
-        ...machineImages,
-      ],
-      machineTypes: [
-        {
-          cpu: '2',
-          gpu: '0',
-          memory: '7Gi',
-          name: 'n1-standard-2',
-          usable: true,
-          architecture: 'amd64',
-        },
-        {
-          cpu: '4',
-          gpu: '0',
-          memory: '15Gi',
-          name: 'n1-standard-4',
-          usable: true,
-          architecture: 'amd64',
-        },
-        {
-          cpu: '8',
-          gpu: '0',
-          memory: '30Gi',
-          name: 'n1-standard-8',
-          usable: true,
-          architecture: 'amd64',
-        },
-        {
-          cpu: '16',
-          gpu: '0',
-          memory: '60Gi',
-          name: 'n1-standard-16',
-          usable: true,
-          architecture: 'amd64',
-        },
-        {
-          cpu: '2',
-          gpu: '0',
-          memory: '8Gi',
-          name: 't2a-standard-2',
-          usable: true,
-          architecture: 'arm64',
-        },
-        {
-          cpu: '4',
-          gpu: '0',
-          memory: '16Gi',
-          name: 't2a-standard-4',
-          usable: true,
-          architecture: 'arm64',
-        },
-        {
-          cpu: '8',
-          gpu: '0',
-          memory: '32Gi',
-          name: 't2a-standard-8',
-          usable: true,
-          architecture: 'arm64',
-        },
-        {
-          cpu: '16',
-          gpu: '0',
-          memory: '64Gi',
-          name: 't2a-standard-16',
-          usable: true,
-          architecture: 'arm64',
-        },
-      ],
-      providerConfig: {
-        apiVersion: 'gcp.provider.extensions.gardener.cloud/v1alpha1',
-        kind: 'CloudProfileConfig',
-      },
-      regions: [
-        {
-          name: 'europe-west1',
-          zones: [
-            {
-              name: 'europe-west1-b',
-            },
-            {
-              name: 'europe-west1-c',
-            },
-            {
-              name: 'europe-west1-d',
-              unavailableMachineTypes: [
-                'n1-standard-2',
-                'n1-standard-4',
-                't2a-standard-2',
-                't2a-standard-8',
-              ],
-              unavailableVolumeTypes: [
-                'pd-balanced',
-                'pd-ssd',
-              ],
-            },
-          ],
-        },
-        {
-          name: 'us-east1',
-          zones: [
-            {
-              name: 'us-east1-b',
-            },
-            {
-              name: 'us-east1-c',
-            },
-            {
-              name: 'us-east1-d',
-            },
-          ],
-        },
-      ],
-      type: 'gcp',
-      volumeTypes: [
-        {
-          class: 'premium',
-          name: 'pd-balanced',
-          usable: true,
-          minSize: '20Gi',
-        },
-        {
-          class: 'standard',
-          name: 'pd-standard',
-          usable: true,
-          minSize: '20Gi',
-        },
-        {
-          class: 'premium',
-          name: 'pd-ssd',
-          usable: true,
-          minSize: '20Gi',
-        },
-      ],
-    },
-  },
-  {
-    metadata: {
-      name: 'ironcore',
-      annotations: {
-        'garden.sapcloud.io/displayName': 'IronCore',
-      },
-    },
-    spec: {
-      seedNames: [
-        'gcp-ha',
-      ],
-      kubernetes: {
-        versions: [
+        accessRestrictions: ['eu-access-only'],
+      }),
+      createRegion({
+        name: 'eastus',
+        zones: [
+          createZone({ name: '1' }),
+          createZone({ name: '2' }),
+          createZone({ name: '3' }),
+        ],
+      }),
+    ],
+    volumeTypes: [
+      createVolumeType({ name: 'StandardSSD_LRS', class: 'premium', minSize: '20Gi' }),
+      createVolumeType({ name: 'Standard_LRS', class: 'standard', minSize: '20Gi' }),
+      createVolumeType({ name: 'Premium_LRS', class: 'premium', minSize: '20Gi' }),
+    ],
+  }),
+  createCloudProfile({
+    metadataName: 'openstack-1',
+    displayName: 'Openstack 1',
+    type: 'openstack',
+    seedNames: [
+      'openstack-ha',
+    ],
+    machineTypes: openstack1MachineTypes,
+    providerConfig: {
+      apiVersion: 'openstack.provider.extensions.gardener.cloud/v1alpha1',
+      constraints: {
+        floatingPools: [
           {
-            version: '1.28.4',
+            name: 'FloatingIP*',
+            region: 'eu-de-1',
           },
           {
-            version: '1.27.8',
+            name: 'FloatingIP*',
+            region: 'na-us-1',
           },
+        ],
+        loadBalancerProviders: [
           {
-            version: '1.26.11',
+            name: 'f5',
           },
         ],
       },
-      machineImages: [
-        {
-          name: 'gardenlinux',
-          versions: [
-            {
-              version: '1312.2.0',
-              cri: [
-                {
-                  name: 'containerd',
-                },
-                {
-                  name: 'docker',
-                },
-              ],
-              architectures: [
-                'amd64',
-              ],
-            },
-          ],
-          updateStrategy: 'major',
-        },
-      ],
-      machineTypes: [
-        {
-          cpu: '4',
-          gpu: '0',
-          memory: '8Gi',
-          name: 'x3-xlarge',
-          usable: true,
-          architecture: 'amd64',
-        },
-      ],
-      providerConfig: {
-        apiVersion: 'ironcore.provider.extensions.gardener.cloud/v1alpha1',
-        kind: 'CloudProfileConfig',
+      kind: 'CloudProfileConfig',
+    },
+    regions: [
+      createRegion({
+        name: 'eu-de-1',
+        zones: [
+          createZone({ name: 'eu-de-1a' }),
+          createZone({ name: 'eu-de-1b' }),
+          createZone({
+            name: 'eu-de-1d',
+            unavailableMachineTypes: [
+              openstack1MachineTypes[0].name,
+            ],
+          }),
+        ],
+        accessRestrictions: ['eu-access-only'],
+      }),
+      createRegion({
+        name: 'na-us-1',
+        zones: [
+          createZone({ name: 'na-us-1a' }),
+          createZone({ name: 'na-us-1b' }),
+          createZone({ name: 'na-us-1d' }),
+        ],
+      }),
+    ],
+  }),
+  createCloudProfile({
+    metadataName: 'openstack-2',
+    displayName: 'Openstack 2',
+    type: 'openstack',
+    seedNames: [
+      'openstack-ha',
+    ],
+    machineTypes: openstack2MachineTypes,
+    providerConfig: {
+      apiVersion: 'openstack.provider.extensions.gardener.cloud/v1alpha1',
+      constraints: {
+        floatingPools: [
+          {
+            defaultFloatingSubnet: 'FloatingIP-intranet-*',
+            loadBalancerClasses: [
+              {
+                floatingSubnetName: 'FloatingIP-internet-*',
+                name: 'internet',
+              },
+              {
+                floatingSubnetName: 'FloatingIP-intranet-*',
+                name: 'intranet',
+                purpose: 'default',
+              },
+            ],
+            name: 'FloatingIP*',
+            region: 'eu-de-2',
+          },
+          {
+            defaultFloatingSubnet: 'FloatingIP-intranet-*',
+            loadBalancerClasses: [
+              {
+                floatingSubnetName: 'FloatingIP-internet-*',
+                name: 'internet',
+              },
+              {
+                floatingSubnetName: 'FloatingIP-intranet-*',
+                name: 'intranet',
+                purpose: 'default',
+              },
+            ],
+            name: 'FloatingIP*',
+            region: 'na-us-2',
+          },
+        ],
+        loadBalancerProviders: [
+          {
+            name: 'f5',
+          },
+        ],
       },
-      regions: [
+      kind: 'CloudProfileConfig',
+    },
+    regions: [
+      createRegion({
+        name: 'eu-de-2',
+        zones: [
+          createZone({ name: 'eu-de-2a' }),
+          createZone({ name: 'eu-de-2b' }),
+          createZone({
+            name: 'eu-de-2d',
+            unavailableMachineTypes: [
+              openstack2MachineTypes[0].name,
+            ],
+          }),
+        ],
+        accessRestrictions: ['eu-access-only'],
+      }),
+      createRegion({
+        name: 'na-us-2',
+        zones: [
+          createZone({ name: 'na-us-2a' }),
+          createZone({ name: 'na-us-2b' }),
+          createZone({ name: 'na-us-2d' }),
+        ],
+      }),
+    ],
+  }),
+  createCloudProfile({
+    metadataName: 'gcp',
+    displayName: 'Google Cloud',
+    type: 'gcp',
+    seedNames: [
+      'gcp-ha',
+    ],
+    machineTypes: gcpMachineTypes,
+    providerConfig: {
+      apiVersion: 'gcp.provider.extensions.gardener.cloud/v1alpha1',
+      kind: 'CloudProfileConfig',
+    },
+    regions: [
+      createRegion({
+        name: 'europe-west1',
+        zones: [
+          createZone({ name: 'europe-west1-b' }),
+          createZone({ name: 'europe-west1-c' }),
+          createZone({
+            name: 'europe-west1-d',
+            unavailableMachineTypes: [
+              gcpMachineTypes[0].name,
+              gcpMachineTypes[1].name,
+              gcpMachineTypes[4].name,
+              gcpMachineTypes[6].name,
+            ],
+            unavailableVolumeTypes: [
+              'pd-balanced',
+              'pd-ssd',
+            ],
+          }),
+        ],
+      }),
+      createRegion({
+        name: 'us-east1',
+        zones: [
+          createZone({ name: 'us-east1-b' }),
+          createZone({ name: 'us-east1-c' }),
+          createZone({ name: 'us-east1-d' }),
+        ],
+      }),
+    ],
+    volumeTypes: [
+      createVolumeType({ name: 'pd-balanced', class: 'premium', minSize: '20Gi' }),
+      createVolumeType({ name: 'pd-standard', class: 'standard', minSize: '20Gi' }),
+      createVolumeType({ name: 'pd-ssd', class: 'premium', minSize: '20Gi' }),
+    ],
+  }),
+  createCloudProfile({
+    metadataName: 'hcloud',
+    displayName: 'Hetzner Cloud',
+    type: 'hcloud',
+    seedNames: [
+      'hcloud-ha',
+    ],
+    machineTypes: hcloudMachineTypes,
+    providerConfig: {
+      apiVersion: 'hcloud.provider.extensions.gardener.cloud/v1alpha1',
+      kind: 'CloudProfileConfig',
+    },
+    regions: [
+      createRegion({
+        name: 'fsn1',
+        zones: [
+          createZone({ name: 'fsn1-dc14' }),
+          createZone({ name: 'fsn1-dc8' }),
+        ],
+      }),
+      createRegion({
+        name: 'hel1',
+        zones: [
+          createZone({ name: 'hel1-dc2' }),
+        ],
+      }),
+    ],
+  }),
+  createCloudProfile({
+    metadataName: 'metal',
+    displayName: 'Metal',
+    type: 'metal',
+    seedNames: [
+      'metal-ha',
+    ],
+    machineTypes: metalMachineTypes,
+    providerConfig: {
+      apiVersion: 'metal.provider.extensions.gardener.cloud/v1alpha1',
+      kind: 'CloudProfileConfig',
+    },
+    regions: [
+      createRegion({
+        name: 'eu01',
+        zones: [
+          createZone({ name: 'eu01-a' }),
+        ],
+      }),
+    ],
+  }),
+  createCloudProfile({
+    metadataName: 'onmetal',
+    displayName: 'OnMetal',
+    type: 'onmetal',
+    seedNames: [
+      'onmetal-ha',
+    ],
+    machineTypes: onmetalMachineTypes,
+    providerConfig: {
+      apiVersion: 'onmetal.provider.extensions.gardener.cloud/v1alpha1',
+      kind: 'CloudProfileConfig',
+    },
+    regions: [
+      createRegion({
+        name: 'on01',
+        zones: [
+          createZone({ name: 'on01-a' }),
+        ],
+      }),
+    ],
+  }),
+  createCloudProfile({
+    metadataName: 'ironcore-metal',
+    displayName: 'IronCore Metal',
+    type: 'ironcore-metal',
+    seedNames: [
+      'ironcore-metal-ha',
+    ],
+    machineTypes: ironcoreMetalMachineTypes,
+    providerConfig: {
+      apiVersion: 'ironcore-metal.provider.extensions.gardener.cloud/v1alpha1',
+      kind: 'CloudProfileConfig',
+    },
+    regions: [
+      createRegion({
+        name: 'region-1',
+        zones: [
+          createZone({ name: 'zone-1' }),
+        ],
+      }),
+    ],
+  }),
+  createCloudProfile({
+    metadataName: 'local',
+    displayName: 'Local',
+    type: 'local',
+    machineTypes: localMachineTypes,
+    providerConfig: {
+      apiVersion: 'local.provider.extensions.gardener.cloud/v1alpha1',
+      kind: 'CloudProfileConfig',
+    },
+    regions: [
+      createRegion({
+        name: 'local',
+        zones: [
+          createZone({ name: 'local-a' }),
+        ],
+      }),
+    ],
+  }),
+  createCloudProfile({
+    metadataName: 'stackit',
+    displayName: 'stackit',
+    type: 'stackit',
+    seedNames: [
+      'stackit-ha',
+    ],
+    machineTypes: stackitMachineTypes,
+    providerConfig: {
+      apiVersion: 'stackit.provider.extensions.gardener.cloud/v1alpha1',
+      kind: 'CloudProfileConfig',
+    },
+    regions: [
+      createRegion({
+        name: 'eu01',
+        zones: [
+          createZone({ name: 'eu01-1' }),
+          createZone({ name: 'eu01-2' }),
+        ],
+      }),
+    ],
+  }),
+  createCloudProfile({
+    metadataName: 'vsphere',
+    displayName: 'vSphere',
+    type: 'vsphere',
+    seedNames: [
+      'vsphere-ha',
+    ],
+    machineTypes: vsphereMachineTypes,
+    providerConfig: {
+      apiVersion: 'vsphere.provider.extensions.gardener.cloud/v1alpha1',
+      kind: 'CloudProfileConfig',
+    },
+    regions: [
+      createRegion({
+        name: 'region1',
+        zones: [
+          createZone({ name: 'zone1' }),
+          createZone({ name: 'zone2' }),
+        ],
+      }),
+    ],
+  }),
+  createCloudProfile({
+    metadataName: 'ironcore',
+    displayName: 'IronCore',
+    type: 'ironcore',
+    seedNames: [
+      'ironcore-ha',
+    ],
+    kubernetes: {
+      versions: [
         {
-          name: 'de-fra',
-          zones: [
-            {
-              name: 'fra3',
-            },
-          ],
+          version: '1.28.4',
         },
-      ],
-      type: 'ironcore',
-      volumeTypes: [
         {
-          class: 'standard',
-          name: 'general-purpose',
-          usable: true,
+          version: '1.27.8',
         },
         {
-          class: 'premium',
-          name: 'io-optimized',
-          usable: true,
+          version: '1.26.11',
         },
       ],
     },
-  },
+    machineImagesProfile: [
+      {
+        name: 'gardenlinux',
+        versions: [
+          {
+            version: '1312.2.0',
+            cri: [
+              {
+                name: 'containerd',
+              },
+              {
+                name: 'docker',
+              },
+            ],
+            architectures: [
+              'amd64',
+            ],
+          },
+        ],
+        updateStrategy: 'major',
+      },
+    ],
+    machineTypes: [
+      createMachineType({ name: 'x3-xlarge', cpu: '4', memory: '8Gi' }),
+    ],
+    providerConfig: {
+      apiVersion: 'ironcore.provider.extensions.gardener.cloud/v1alpha1',
+      kind: 'CloudProfileConfig',
+    },
+    regions: [
+      createRegion({
+        name: 'de-fra',
+        zones: [
+          createZone({ name: 'fra3' }),
+        ],
+      }),
+    ],
+    volumeTypes: [
+      createVolumeType({ name: 'general-purpose', class: 'standard' }),
+      createVolumeType({ name: 'io-optimized', class: 'premium' }),
+    ],
+  }),
 ]

--- a/frontend/__tests__/components/GVolumeType.spec.js
+++ b/frontend/__tests__/components/GVolumeType.spec.js
@@ -1,0 +1,84 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import { nextTick } from 'vue'
+import { shallowMount } from '@vue/test-utils'
+import { createTestingPinia } from '@pinia/testing'
+
+import { useCloudProfileStore } from '@/store/cloudProfile'
+
+import GVolumeType from '@/components/ShootWorkers/GVolumeType.vue'
+
+const { createVuetifyPlugin } = global.fixtures.helper
+
+describe('components', () => {
+  describe('g-volume-type', () => {
+    function mountVolumeType ({ volumeType = 'io2' } = {}) {
+      const pinia = createTestingPinia({ stubActions: false })
+      useCloudProfileStore(pinia).setCloudProfiles([{
+        metadata: {
+          name: 'aws-profile',
+          providerType: 'azure',
+        },
+        spec: {
+          type: 'aws',
+        },
+      }])
+
+      const worker = {
+        volume: {
+          type: volumeType,
+        },
+      }
+      const wrapper = shallowMount(GVolumeType, {
+        global: {
+          plugins: [
+            createVuetifyPlugin(),
+            pinia,
+          ],
+        },
+        props: {
+          worker,
+          volumeTypes: [
+            { name: 'gp2' },
+            { name: 'io1' },
+            { name: 'io2' },
+          ],
+          cloudProfileRef: {
+            kind: 'CloudProfile',
+            name: 'aws-profile',
+          },
+          fieldName: 'Worker Volume Type',
+        },
+      })
+
+      return { worker, wrapper }
+    }
+
+    it('preserves the AWS IOPS rules based on the cloud profile spec type', async () => {
+      const { worker, wrapper } = mountVolumeType()
+
+      expect(wrapper.vm.providerType).toBe('aws')
+      expect(wrapper.vm.showIops).toBe(true)
+      expect(wrapper.vm.isIopsRequired).toBe(true)
+
+      wrapper.vm.onInputIops('200')
+      expect(worker.providerConfig).toEqual({
+        apiVersion: 'aws.provider.extensions.gardener.cloud/v1alpha1',
+        kind: 'WorkerConfig',
+        volume: {
+          iops: 200,
+        },
+      })
+
+      wrapper.vm.worker.volume.type = 'gp2'
+      await nextTick()
+
+      expect(wrapper.vm.showIops).toBe(false)
+      expect(wrapper.vm.isIopsRequired).toBe(false)
+    })
+  })
+})

--- a/frontend/__tests__/composables/__snapshots__/useShootContext.spec.js.snap
+++ b/frontend/__tests__/composables/__snapshots__/useShootContext.spec.js.snap
@@ -622,6 +622,78 @@ exports[`composables > useShootContext > should create a default "gcp" shoot man
 }
 `;
 
+exports[`composables > useShootContext > should create a default "hcloud" shoot manifest 1`] = `
+{
+  "apiVersion": "core.gardener.cloud/v1beta1",
+  "kind": "Shoot",
+  "metadata": {
+    "name": "m6kgstc1b0",
+    "namespace": "garden-test",
+  },
+  "spec": {
+    "cloudProfile": {
+      "kind": "CloudProfile",
+      "name": "hcloud",
+    },
+    "kubernetes": {
+      "version": "1.28.6",
+    },
+    "maintenance": {
+      "autoUpdate": {
+        "kubernetesVersion": true,
+        "machineImageVersion": true,
+      },
+      "timeWindow": {
+        "begin": "220000+0100",
+        "end": "230000+0100",
+      },
+    },
+    "networking": {
+      "nodes": "10.180.0.0/16",
+      "type": "calico",
+    },
+    "provider": {
+      "controlPlaneConfig": {
+        "apiVersion": "hcloud.provider.extensions.gardener.cloud/v1alpha1",
+        "kind": "ControlPlaneConfig",
+        "zone": "fsn1-dc14",
+      },
+      "infrastructureConfig": {
+        "apiVersion": "hcloud.provider.extensions.gardener.cloud/v1alpha1",
+        "kind": "InfrastructureConfig",
+        "networks": {
+          "workers": "10.180.0.0/16",
+        },
+      },
+      "type": "hcloud",
+      "workers": [
+        {
+          "cri": {
+            "name": "containerd",
+          },
+          "machine": {
+            "architecture": "amd64",
+            "image": {
+              "name": "gardenlinux",
+              "version": "1312.3.0",
+            },
+            "type": "cpx11",
+          },
+          "maxSurge": 1,
+          "maximum": 2,
+          "minimum": 1,
+          "name": "worker-m6kgs",
+          "zones": [
+            "fsn1-dc14",
+          ],
+        },
+      ],
+    },
+    "region": "fsn1",
+  },
+}
+`;
+
 exports[`composables > useShootContext > should create a default "ironcore" shoot manifest 1`] = `
 {
   "apiVersion": "core.gardener.cloud/v1beta1",
@@ -692,6 +764,272 @@ exports[`composables > useShootContext > should create a default "ironcore" shoo
     },
     "purpose": "evaluation",
     "region": "de-fra",
+  },
+}
+`;
+
+exports[`composables > useShootContext > should create a default "ironcore-metal" shoot manifest 1`] = `
+{
+  "apiVersion": "core.gardener.cloud/v1beta1",
+  "kind": "Shoot",
+  "metadata": {
+    "name": "m6kgstc1b0",
+    "namespace": "garden-test",
+  },
+  "spec": {
+    "cloudProfile": {
+      "kind": "CloudProfile",
+      "name": "ironcore-metal",
+    },
+    "kubernetes": {
+      "version": "1.28.6",
+    },
+    "maintenance": {
+      "autoUpdate": {
+        "kubernetesVersion": true,
+        "machineImageVersion": true,
+      },
+      "timeWindow": {
+        "begin": "220000+0100",
+        "end": "230000+0100",
+      },
+    },
+    "networking": {
+      "nodes": "10.180.0.0/16",
+      "type": "calico",
+    },
+    "provider": {
+      "type": "ironcore-metal",
+      "workers": [
+        {
+          "cri": {
+            "name": "containerd",
+          },
+          "machine": {
+            "architecture": "amd64",
+            "image": {
+              "name": "gardenlinux",
+              "version": "1312.3.0",
+            },
+            "type": "ironcore-metal-small",
+          },
+          "maxSurge": 1,
+          "maximum": 2,
+          "minimum": 1,
+          "name": "worker-m6kgs",
+          "zones": [
+            "zone-1",
+          ],
+        },
+      ],
+    },
+    "region": "region-1",
+  },
+}
+`;
+
+exports[`composables > useShootContext > should create a default "local" shoot manifest 1`] = `
+{
+  "apiVersion": "core.gardener.cloud/v1beta1",
+  "kind": "Shoot",
+  "metadata": {
+    "name": "m6kgstc1b0",
+    "namespace": "garden-test",
+  },
+  "spec": {
+    "cloudProfile": {
+      "kind": "CloudProfile",
+      "name": "local",
+    },
+    "kubernetes": {
+      "version": "1.28.6",
+    },
+    "maintenance": {
+      "autoUpdate": {
+        "kubernetesVersion": true,
+        "machineImageVersion": true,
+      },
+      "timeWindow": {
+        "begin": "220000+0100",
+        "end": "230000+0100",
+      },
+    },
+    "networking": {
+      "nodes": "10.180.0.0/16",
+      "type": "calico",
+    },
+    "provider": {
+      "type": "local",
+      "workers": [
+        {
+          "cri": {
+            "name": "containerd",
+          },
+          "machine": {
+            "architecture": "amd64",
+            "image": {
+              "name": "gardenlinux",
+              "version": "1312.3.0",
+            },
+            "type": "local-dev-small",
+          },
+          "maxSurge": 1,
+          "maximum": 2,
+          "minimum": 1,
+          "name": "worker-m6kgs",
+        },
+      ],
+    },
+    "region": "local",
+  },
+}
+`;
+
+exports[`composables > useShootContext > should create a default "metal" shoot manifest 1`] = `
+{
+  "apiVersion": "core.gardener.cloud/v1beta1",
+  "kind": "Shoot",
+  "metadata": {
+    "name": "m6kgstc1b0",
+    "namespace": "garden-test",
+  },
+  "spec": {
+    "cloudProfile": {
+      "kind": "CloudProfile",
+      "name": "metal",
+    },
+    "kubernetes": {
+      "kubeControllerManager": {
+        "nodeCIDRMaskSize": 23,
+      },
+      "kubelet": {
+        "maxPods": 510,
+      },
+      "version": "1.28.6",
+    },
+    "maintenance": {
+      "autoUpdate": {
+        "kubernetesVersion": true,
+        "machineImageVersion": true,
+      },
+      "timeWindow": {
+        "begin": "220000+0100",
+        "end": "230000+0100",
+      },
+    },
+    "networking": {
+      "pods": "10.244.128.0/18",
+      "providerConfig": {
+        "apiVersion": "calico.networking.extensions.gardener.cloud/v1alpha1",
+        "backend": "vxlan",
+        "ipv4": {
+          "autoDetectionMethod": "interface=lo",
+          "mode": "Always",
+          "pool": "vxlan",
+        },
+        "kind": "NetworkConfig",
+        "typha": {
+          "enabled": true,
+        },
+      },
+      "services": "10.244.192.0/18",
+      "type": "calico",
+    },
+    "provider": {
+      "controlPlaneConfig": {
+        "apiVersion": "metal.provider.extensions.gardener.cloud/v1alpha1",
+        "kind": "ControlPlaneConfig",
+      },
+      "infrastructureConfig": {
+        "apiVersion": "metal.provider.extensions.gardener.cloud/v1alpha1",
+        "firewall": {
+          "size": "c1-metal-small",
+        },
+        "kind": "InfrastructureConfig",
+        "partitionID": "eu01-a",
+      },
+      "type": "metal",
+      "workers": [
+        {
+          "cri": {
+            "name": "containerd",
+          },
+          "machine": {
+            "architecture": "amd64",
+            "image": {
+              "name": "gardenlinux",
+              "version": "1312.3.0",
+            },
+            "type": "c1-metal-small",
+          },
+          "maxSurge": 1,
+          "maximum": 2,
+          "minimum": 1,
+          "name": "worker-m6kgs",
+        },
+      ],
+    },
+    "region": "eu01",
+  },
+}
+`;
+
+exports[`composables > useShootContext > should create a default "onmetal" shoot manifest 1`] = `
+{
+  "apiVersion": "core.gardener.cloud/v1beta1",
+  "kind": "Shoot",
+  "metadata": {
+    "name": "m6kgstc1b0",
+    "namespace": "garden-test",
+  },
+  "spec": {
+    "cloudProfile": {
+      "kind": "CloudProfile",
+      "name": "onmetal",
+    },
+    "kubernetes": {
+      "version": "1.28.6",
+    },
+    "maintenance": {
+      "autoUpdate": {
+        "kubernetesVersion": true,
+        "machineImageVersion": true,
+      },
+      "timeWindow": {
+        "begin": "220000+0100",
+        "end": "230000+0100",
+      },
+    },
+    "networking": {
+      "nodes": "10.180.0.0/16",
+      "type": "calico",
+    },
+    "provider": {
+      "type": "onmetal",
+      "workers": [
+        {
+          "cri": {
+            "name": "containerd",
+          },
+          "machine": {
+            "architecture": "amd64",
+            "image": {
+              "name": "gardenlinux",
+              "version": "1312.3.0",
+            },
+            "type": "c1-onmetal-small",
+          },
+          "maxSurge": 1,
+          "maximum": 2,
+          "minimum": 1,
+          "name": "worker-m6kgs",
+          "zones": [
+            "on01-a",
+          ],
+        },
+      ],
+    },
+    "region": "on01",
   },
 }
 `;
@@ -775,6 +1113,141 @@ exports[`composables > useShootContext > should create a default "openstack" sho
     },
     "purpose": "evaluation",
     "region": "eu-de-1",
+  },
+}
+`;
+
+exports[`composables > useShootContext > should create a default "stackit" shoot manifest 1`] = `
+{
+  "apiVersion": "core.gardener.cloud/v1beta1",
+  "kind": "Shoot",
+  "metadata": {
+    "name": "m6kgstc1b0",
+    "namespace": "garden-test",
+  },
+  "spec": {
+    "cloudProfile": {
+      "kind": "CloudProfile",
+      "name": "stackit",
+    },
+    "kubernetes": {
+      "version": "1.28.6",
+    },
+    "maintenance": {
+      "autoUpdate": {
+        "kubernetesVersion": true,
+        "machineImageVersion": true,
+      },
+      "timeWindow": {
+        "begin": "220000+0100",
+        "end": "230000+0100",
+      },
+    },
+    "networking": {
+      "nodes": "10.180.0.0/16",
+      "type": "calico",
+    },
+    "provider": {
+      "controlPlaneConfig": {
+        "apiVersion": "stackit.provider.extensions.gardener.cloud/v1alpha1",
+        "kind": "ControlPlaneConfig",
+      },
+      "infrastructureConfig": {
+        "apiVersion": "stackit.provider.extensions.gardener.cloud/v1alpha1",
+        "kind": "InfrastructureConfig",
+        "networks": {
+          "workers": "10.180.0.0/16",
+        },
+      },
+      "type": "stackit",
+      "workers": [
+        {
+          "cri": {
+            "name": "containerd",
+          },
+          "machine": {
+            "architecture": "amd64",
+            "image": {
+              "name": "gardenlinux",
+              "version": "1312.3.0",
+            },
+            "type": "stackit-machine-1",
+          },
+          "maxSurge": 1,
+          "maximum": 2,
+          "minimum": 1,
+          "name": "worker-m6kgs",
+          "zones": [
+            "eu01-1",
+          ],
+        },
+      ],
+    },
+    "region": "eu01",
+  },
+}
+`;
+
+exports[`composables > useShootContext > should create a default "vsphere" shoot manifest 1`] = `
+{
+  "apiVersion": "core.gardener.cloud/v1beta1",
+  "kind": "Shoot",
+  "metadata": {
+    "name": "m6kgstc1b0",
+    "namespace": "garden-test",
+  },
+  "spec": {
+    "cloudProfile": {
+      "kind": "CloudProfile",
+      "name": "vsphere",
+    },
+    "kubernetes": {
+      "version": "1.28.6",
+    },
+    "maintenance": {
+      "autoUpdate": {
+        "kubernetesVersion": true,
+        "machineImageVersion": true,
+      },
+      "timeWindow": {
+        "begin": "220000+0100",
+        "end": "230000+0100",
+      },
+    },
+    "networking": {
+      "nodes": "10.180.0.0/16",
+      "type": "calico",
+    },
+    "provider": {
+      "controlPlaneConfig": {
+        "apiVersion": "vsphere.provider.extensions.gardener.cloud/v1alpha1",
+        "kind": "ControlPlaneConfig",
+      },
+      "type": "vsphere",
+      "workers": [
+        {
+          "cri": {
+            "name": "containerd",
+          },
+          "machine": {
+            "architecture": "amd64",
+            "image": {
+              "name": "gardenlinux",
+              "version": "1312.3.0",
+            },
+            "type": "vsphere-machine-1",
+          },
+          "maxSurge": 1,
+          "maximum": 2,
+          "minimum": 1,
+          "name": "worker-m6kgs",
+          "zones": [
+            "zone1",
+          ],
+        },
+      ],
+    },
+    "region": "region1",
   },
 }
 `;

--- a/frontend/__tests__/composables/useShootContext.spec.js
+++ b/frontend/__tests__/composables/useShootContext.spec.js
@@ -20,12 +20,15 @@ import { useSeedStore } from '@/store/seed'
 
 import { createShootContextComposable } from '@/composables/useShootContext'
 
+import infraProviders from '@/data/vendors/infra'
+
 import cloneDeep from 'lodash/cloneDeep'
 
 describe('composables', () => {
   let shootContextStore
   let configStore
   let seedStore
+  const infraProviderTypes = infraProviders.map(({ name }) => name)
 
   const systemTime = new Date('2024-03-15T14:00:00+01:00')
 
@@ -83,9 +86,11 @@ describe('composables', () => {
   }
 
   describe('useShootContext', () => {
-    it('should create a default "aws" shoot manifest', async () => {
-      expect(createShootManifest('aws')).toMatchSnapshot()
-    })
+    for (const providerType of infraProviderTypes) {
+      it(`should create a default "${providerType}" shoot manifest`, () => {
+        expect(createShootManifest(providerType)).toMatchSnapshot()
+      })
+    }
 
     it('should omit spec.addons if no addon is enabled', () => {
       createShootManifest('aws')
@@ -135,26 +140,6 @@ describe('composables', () => {
           enabled: true,
         },
       })
-    })
-
-    it('should create a default "azure" shoot manifest', async () => {
-      expect(createShootManifest('azure')).toMatchSnapshot()
-    })
-
-    it('should create a default "alicloud" shoot manifest', async () => {
-      expect(createShootManifest('alicloud')).toMatchSnapshot()
-    })
-
-    it('should create a default "gcp" shoot manifest', async () => {
-      expect(createShootManifest('gcp')).toMatchSnapshot()
-    })
-
-    it('should create a default "openstack" shoot manifest', async () => {
-      expect(createShootManifest('openstack')).toMatchSnapshot()
-    })
-
-    it('should create a default "ironcore" shoot manifest', async () => {
-      expect(createShootManifest('ironcore')).toMatchSnapshot()
     })
 
     it('should not mutate high availability state when reading or disabling it', () => {

--- a/frontend/__tests__/composables/useShootContext.spec.js
+++ b/frontend/__tests__/composables/useShootContext.spec.js
@@ -365,6 +365,27 @@ describe('composables', () => {
       expect(shootContextStore.workerless).toBe(true)
     })
 
+    it('should treat new Azure manifests as zoned when the flag is missing', () => {
+      const manifest = {
+        metadata: {
+          name: 'new-azure-shoot',
+        },
+        spec: {
+          provider: {
+            type: 'azure',
+            infrastructureConfig: {},
+          },
+        },
+      }
+
+      shootContextStore.setShootManifest(manifest)
+      expect(shootContextStore.isZonedCluster).toBe(true)
+
+      manifest.metadata.creationTimestamp = '2024-03-01T12:00:00Z'
+      shootContextStore.setShootManifest(manifest)
+      expect(shootContextStore.isZonedCluster).toBe(false)
+    })
+
     it('should change the infrastructure kind', async () => {
       shootContextStore.createShootManifest()
       shootContextStore.providerType = 'gcp'

--- a/frontend/__tests__/stores/__snapshots__/credential.spec.js.snap
+++ b/frontend/__tests__/stores/__snapshots__/credential.spec.js.snap
@@ -24,6 +24,13 @@ exports[`stores > credential > should return infrastructureBindingList 1`] = `
   "gcp",
   "openstack",
   "alicloud",
+  "metal",
+  "vsphere",
+  "hcloud",
+  "onmetal",
+  "ironcore-metal",
   "ironcore",
+  "stackit",
+  "local",
 ]
 `;

--- a/frontend/__tests__/utils/createShoot.spec.js
+++ b/frontend/__tests__/utils/createShoot.spec.js
@@ -9,6 +9,7 @@ import {
   getZonesNetworkConfiguration,
   findFreeNetworks,
   getKubernetesTemplate,
+  getWorkerProviderConfig,
 } from '@/utils/shoot'
 import infraProviders from '@/data/vendors/infra'
 
@@ -332,7 +333,7 @@ describe('utils', () => {
     })
 
     describe('vendor config templates', () => {
-      it('should return cloned kubernetes templates', () => {
+      it('should return cloned kubernetes templates and worker provider configs', () => {
         const shootVendor = {
           shoot: {
             templates: {
@@ -342,14 +343,22 @@ describe('utils', () => {
                 },
               },
             },
+            workerProviderConfig: {
+              volume: {
+                iops: 100,
+              },
+            },
           },
         }
 
         const kubernetesTemplate = getKubernetesTemplate(shootVendor)
+        const workerProviderConfig = getWorkerProviderConfig(shootVendor)
 
         kubernetesTemplate.kubelet.maxPods = 200
+        workerProviderConfig.volume.iops = 200
 
         expect(shootVendor.shoot.templates.kubernetes.kubelet.maxPods).toBe(100)
+        expect(shootVendor.shoot.workerProviderConfig.volume.iops).toBe(100)
       })
     })
   })

--- a/frontend/__tests__/utils/createShoot.spec.js
+++ b/frontend/__tests__/utils/createShoot.spec.js
@@ -8,7 +8,13 @@ import {
   splitCIDR,
   getZonesNetworkConfiguration,
   findFreeNetworks,
+  getKubernetesTemplate,
 } from '@/utils/shoot'
+import infraProviders from '@/data/vendors/infra'
+
+function infraVendor (name) {
+  return infraProviders.find(vendor => vendor.name === name)
+}
 
 describe('utils', () => {
   describe('createShoot', () => {
@@ -79,7 +85,7 @@ describe('utils', () => {
         ]
         const workerCIDR = '10.251.0.0/16'
 
-        const freeNetworks = findFreeNetworks(existingZonesNetworkConfiguration, workerCIDR, 'aws', 4)
+        const freeNetworks = findFreeNetworks(existingZonesNetworkConfiguration, workerCIDR, 4, infraVendor('aws'))
         expect(freeNetworks).toBeInstanceOf(Array)
         expect(freeNetworks).toHaveLength(2)
       })
@@ -113,7 +119,7 @@ describe('utils', () => {
         ]
         const workerCIDR = '10.251.0.0/16'
 
-        const freeNetworks = findFreeNetworks(existingZonesNetworkConfiguration, workerCIDR, 'aws', 4)
+        const freeNetworks = findFreeNetworks(existingZonesNetworkConfiguration, workerCIDR, 4, infraVendor('aws'))
         expect(freeNetworks).toBeInstanceOf(Array)
         expect(freeNetworks).toHaveLength(0)
       })
@@ -129,7 +135,7 @@ describe('utils', () => {
         ]
         const workerCIDR = '10.251.0.0/16'
 
-        const freeNetworks = findFreeNetworks(existingZonesNetworkConfiguration, workerCIDR, 'aws', 4)
+        const freeNetworks = findFreeNetworks(existingZonesNetworkConfiguration, workerCIDR, 4, infraVendor('aws'))
         expect(freeNetworks).toBeInstanceOf(Array)
         expect(freeNetworks).toHaveLength(0)
       })
@@ -137,7 +143,7 @@ describe('utils', () => {
       it('should return networks for all zones if existingZonesNetworkConfiguration is undefined', () => {
         const workerCIDR = '10.251.0.0/16'
 
-        const freeNetworks = findFreeNetworks(undefined, workerCIDR, 'aws', 4)
+        const freeNetworks = findFreeNetworks(undefined, workerCIDR, 4, infraVendor('aws'))
         expect(freeNetworks).toBeInstanceOf(Array)
         expect(freeNetworks).toHaveLength(4)
       })
@@ -185,23 +191,23 @@ describe('utils', () => {
       ]
 
       it('should return undefined for infrastructures that do not require network config for zones (new cluster)', () => {
-        const zonesNetworkConfiguration = getZonesNetworkConfiguration(undefined, workers, 'azure', 3, undefined, nodeCIDR)
+        const zonesNetworkConfiguration = getZonesNetworkConfiguration(undefined, workers, 3, undefined, nodeCIDR, infraVendor('azure'))
         expect(zonesNetworkConfiguration).toBeUndefined()
       })
 
       it('should return undefined for infrastructures that do not require network config for zones (existing cluster)', () => {
-        const zonesNetworkConfiguration = getZonesNetworkConfiguration(undefined, workers, 'azure', 3, nodeCIDR, undefined)
+        const zonesNetworkConfiguration = getZonesNetworkConfiguration(undefined, workers, 3, nodeCIDR, undefined, infraVendor('azure'))
         expect(zonesNetworkConfiguration).toBeUndefined()
       })
 
       it('should return initial network config', () => {
-        const zonesNetworkConfiguration = getZonesNetworkConfiguration(undefined, workers, 'aws', 3, undefined, nodeCIDR)
+        const zonesNetworkConfiguration = getZonesNetworkConfiguration(undefined, workers, 3, undefined, nodeCIDR, infraVendor('aws'))
         expect(zonesNetworkConfiguration).toBeInstanceOf(Array)
         expect(zonesNetworkConfiguration).toHaveLength(2)
       })
 
       it('should keep network config if zones are the same', () => {
-        const zonesNetworkConfiguration = getZonesNetworkConfiguration(customZonesNetworkConfiguration, workers, 'aws', 3, undefined, nodeCIDR)
+        const zonesNetworkConfiguration = getZonesNetworkConfiguration(customZonesNetworkConfiguration, workers, 3, undefined, nodeCIDR, infraVendor('aws'))
         expect(zonesNetworkConfiguration).toBeInstanceOf(Array)
         expect(zonesNetworkConfiguration).toHaveLength(2)
         expect(zonesNetworkConfiguration).toEqual(customZonesNetworkConfiguration)
@@ -225,7 +231,7 @@ describe('utils', () => {
           },
         ]
 
-        const zonesNetworkConfiguration = getZonesNetworkConfiguration(customZonesNetworkConfiguration, workers, 'aws', 3, undefined, newNodeCIDR)
+        const zonesNetworkConfiguration = getZonesNetworkConfiguration(customZonesNetworkConfiguration, workers, 3, undefined, newNodeCIDR, infraVendor('aws'))
         expect(zonesNetworkConfiguration).toBeInstanceOf(Array)
         expect(zonesNetworkConfiguration).toHaveLength(2)
         expect(zonesNetworkConfiguration).toEqual(newCustomZonesNetworkConfiguration)
@@ -245,7 +251,7 @@ describe('utils', () => {
             ],
           },
         ]
-        const zonesNetworkConfiguration = getZonesNetworkConfiguration(customZonesNetworkConfiguration, workersWithDifferentZones, 'aws', 3, undefined, nodeCIDR)
+        const zonesNetworkConfiguration = getZonesNetworkConfiguration(customZonesNetworkConfiguration, workersWithDifferentZones, 3, undefined, nodeCIDR, infraVendor('aws'))
         expect(zonesNetworkConfiguration).toBeInstanceOf(Array)
         expect(zonesNetworkConfiguration).toHaveLength(2)
         expect(zonesNetworkConfiguration).not.toEqual(customZonesNetworkConfiguration)
@@ -260,7 +266,7 @@ describe('utils', () => {
           },
         ]
 
-        const zonesNetworkConfiguration = getZonesNetworkConfiguration(customZonesNetworkConfiguration, oneZoneWorkers, 'aws', 3, nodeCIDR, undefined)
+        const zonesNetworkConfiguration = getZonesNetworkConfiguration(customZonesNetworkConfiguration, oneZoneWorkers, 3, nodeCIDR, undefined, infraVendor('aws'))
         expect(zonesNetworkConfiguration).toBeInstanceOf(Array)
         expect(zonesNetworkConfiguration).toHaveLength(2)
         expect(zonesNetworkConfiguration).toEqual(customZonesNetworkConfiguration)
@@ -298,7 +304,7 @@ describe('utils', () => {
           },
         ]
 
-        const zonesNetworkConfiguration = getZonesNetworkConfiguration(existingZonesNetworkConfiguration, workersWithDifferentZones, 'aws', 3, nodeCIDR, undefined)
+        const zonesNetworkConfiguration = getZonesNetworkConfiguration(existingZonesNetworkConfiguration, workersWithDifferentZones, 3, nodeCIDR, undefined, infraVendor('aws'))
         expect(zonesNetworkConfiguration).toBeInstanceOf(Array)
         expect(zonesNetworkConfiguration).toHaveLength(3)
         expect(zonesNetworkConfiguration).toEqual(newZonesNetworkConfiguration)
@@ -320,8 +326,30 @@ describe('utils', () => {
           },
         ]
 
-        const zonesNetworkConfiguration = getZonesNetworkConfiguration(customZonesNetworkConfiguration, workersWithDifferentZones, 'aws', 3, nodeCIDR, undefined)
+        const zonesNetworkConfiguration = getZonesNetworkConfiguration(customZonesNetworkConfiguration, workersWithDifferentZones, 3, nodeCIDR, undefined, infraVendor('aws'))
         expect(zonesNetworkConfiguration).toBeUndefined()
+      })
+    })
+
+    describe('vendor config templates', () => {
+      it('should return cloned kubernetes templates', () => {
+        const shootVendor = {
+          shoot: {
+            templates: {
+              kubernetes: {
+                kubelet: {
+                  maxPods: 100,
+                },
+              },
+            },
+          },
+        }
+
+        const kubernetesTemplate = getKubernetesTemplate(shootVendor)
+
+        kubernetesTemplate.kubelet.maxPods = 200
+
+        expect(shootVendor.shoot.templates.kubernetes.kubelet.maxPods).toBe(100)
       })
     })
   })

--- a/frontend/src/components/ShootWorkers/GVolumeType.vue
+++ b/frontend/src/components/ShootWorkers/GVolumeType.vue
@@ -31,13 +31,13 @@ SPDX-License-Identifier: Apache-2.0
       </template>
     </v-select>
     <v-text-field
-      v-if="isAWS && worker.volume.type !== 'gp2'"
+      v-if="showIops"
       v-model.number="workerIops"
       class="ml-1"
       color="primary"
       :error-messages="getErrorMessages(v$.workerIops)"
       type="number"
-      min="100"
+      :min="minIops"
       label="IOPS"
       variant="underlined"
       @update:model-value="onInputIops"
@@ -56,6 +56,7 @@ import {
 import { useVuelidate } from '@vuelidate/core'
 
 import { useCloudProfileStore } from '@/store/cloudProfile'
+import { useConfigStore } from '@/store/config'
 
 import { getErrorMessages } from '@/utils'
 import { getWorkerProviderConfig } from '@/utils/shoot'
@@ -107,9 +108,9 @@ export default {
       },
       workerIops: withFieldName(() => `${this.fieldName} IOPS`, {
         required: requiredIf(() => {
-          return this.isAWS && (this.worker.volume.type === 'io1' || this.worker.volume.type === 'io2')
+          return this.isIopsRequired
         }),
-        minValue: minValue(100),
+        minValue: minValue(this.minIops),
       }),
     }
   },
@@ -133,9 +134,38 @@ export default {
       }
       return ''
     },
-    isAWS () {
+    providerType () {
       const cloudProfile = this.cloudProfileByRef(this.cloudProfileRef)
-      return get(cloudProfile, ['spec', 'type']) === 'aws'
+      return get(cloudProfile, ['spec', 'type'])
+    },
+    providerVendor () {
+      if (!this.providerType) {
+        return undefined
+      }
+      return this.vendorDetails({
+        type: 'infra',
+        name: this.providerType,
+      })
+    },
+    iopsConfig () {
+      return get(this.providerVendor, ['shoot', 'workerVolume', 'iops'])
+    },
+    showIops () {
+      if (!this.iopsConfig) {
+        return false
+      }
+      const hiddenForVolumeTypes = get(this.iopsConfig, ['hiddenForVolumeTypes'], [])
+      return !hiddenForVolumeTypes.includes(this.worker.volume.type)
+    },
+    minIops () {
+      return get(this.iopsConfig, ['min'], 100)
+    },
+    isIopsRequired () {
+      if (!this.showIops) {
+        return false
+      }
+      const requiredForVolumeTypes = get(this.iopsConfig, ['requiredForVolumeTypes'], [])
+      return requiredForVolumeTypes.includes(this.worker.volume.type)
     },
   },
   watch: {
@@ -151,6 +181,9 @@ export default {
     ...mapActions(useCloudProfileStore, [
       'cloudProfileByRef',
     ]),
+    ...mapActions(useConfigStore, [
+      'vendorDetails',
+    ]),
     onInputVolumeType () {
       this.v$.worker.volume.type.$touch()
       this.$emit('updateVolumeType')
@@ -159,7 +192,7 @@ export default {
       const iopsValue = parseInt(value)
       if (value && iopsValue > 0) {
         if (!this.worker.providerConfig) {
-          this.worker.providerConfig = getWorkerProviderConfig('aws')
+          this.worker.providerConfig = getWorkerProviderConfig(this.providerVendor) ?? {}
         }
         set(this.worker.providerConfig, ['volume', 'iops'], iopsValue)
       } else {

--- a/frontend/src/composables/useShootContext.js
+++ b/frontend/src/composables/useShootContext.js
@@ -384,12 +384,22 @@ export function createShootContextComposable (options = {}) {
     },
   })
 
+  const providerVendor = computed(() => {
+    if (!providerType.value) {
+      return undefined
+    }
+    return configStore.vendorDetails({
+      type: 'infra',
+      name: providerType.value,
+    })
+  })
+
   function applySpecTemplate (cloudProfileRef) {
     const {
       kubernetes,
       networking,
       provider,
-    } = getSpecTemplate(providerType.value, defaultNodesCIDR.value)
+    } = getSpecTemplate(providerType.value, defaultNodesCIDR.value, providerVendor.value)
     set(manifest.value, ['spec', 'provider', 'infrastructureConfig'], provider.infrastructureConfig)
     set(manifest.value, ['spec', 'provider', 'controlPlaneConfig'], provider.controlPlaneConfig)
     set(manifest.value, ['spec', 'networking'], networking)
@@ -401,14 +411,14 @@ export function createShootContextComposable (options = {}) {
       const value = get(manifest.value, ['spec', 'provider', 'controlPlaneConfig', 'zone'])
       return getControlPlaneZone(
         providerWorkers.value,
-        providerType.value,
+        providerVendor.value,
         value,
       )
     },
     set (value) {
       value = getControlPlaneZone(
         providerWorkers.value,
-        providerType.value,
+        providerVendor.value,
         value,
       )
       if (value) {
@@ -624,9 +634,9 @@ export function createShootContextComposable (options = {}) {
       return getZonesNetworkConfiguration(
         value,
         providerWorkers.value,
-        providerType.value,
         size(allZones.value),
         ...args,
+        providerVendor.value,
       )
     },
     set (value) {
@@ -647,16 +657,12 @@ export function createShootContextComposable (options = {}) {
   })
 
   const isZonedCluster = computed(() => {
-    switch (providerType.value) {
-      case 'azure':
-        if (isNewCluster.value) {
-          return true // new clusters are always created as zoned clusters by the dashboard
-        }
+    switch (providerVendor.value?.shoot?.zones?.mode) {
+      case 'infrastructure-config-zoned':
         return get(manifest.value, ['spec', 'provider', 'infrastructureConfig', 'zoned'], false)
-      case 'metal':
-        return false // metal clusters do not support zones for worker groups
-      case 'local':
-        return false // local development provider does not support zones
+      case 'never':
+        return false
+      case 'always':
       default:
         return true
     }
@@ -687,8 +693,8 @@ export function createShootContextComposable (options = {}) {
     return findFreeNetworks(
       providerInfrastructureConfigNetworksZones.value,
       networkingNodes.value ?? defaultNodesCIDR.value,
-      providerType.value,
       size(allZones.value),
+      providerVendor.value,
     )
   })
 

--- a/frontend/src/composables/useShootContext.js
+++ b/frontend/src/composables/useShootContext.js
@@ -659,7 +659,7 @@ export function createShootContextComposable (options = {}) {
   const isZonedCluster = computed(() => {
     switch (providerVendor.value?.shoot?.zones?.mode) {
       case 'infrastructure-config-zoned':
-        return get(manifest.value, ['spec', 'provider', 'infrastructureConfig', 'zoned'], false)
+        return isNewCluster.value || get(manifest.value, ['spec', 'provider', 'infrastructureConfig', 'zoned'], false)
       case 'never':
         return false
       case 'always':

--- a/frontend/src/data/vendors/infra/alicloud.js
+++ b/frontend/src/data/vendors/infra/alicloud.js
@@ -47,6 +47,32 @@ export default {
   displayName: 'Alibaba Cloud',
   weight: 500,
   icon: 'alicloud.svg',
+  shoot: {
+    templates: {
+      provider: {
+        type: 'alicloud',
+        infrastructureConfig: {
+          apiVersion: 'alicloud.provider.extensions.gardener.cloud/v1alpha1',
+          kind: 'InfrastructureConfig',
+          networks: {
+            vpc: {
+              cidr: '__DEFAULT_WORKER_CIDR__',
+            },
+          },
+        },
+        controlPlaneConfig: {
+          apiVersion: 'alicloud.provider.extensions.gardener.cloud/v1alpha1',
+          kind: 'ControlPlaneConfig',
+        },
+      },
+      networking: {
+        nodes: '__DEFAULT_WORKER_CIDR__',
+      },
+    },
+    zoneNetworking: {
+      strategy: 'split-workers',
+    },
+  },
   secret: {
     details: [
       accessKeyIdDetail,

--- a/frontend/src/data/vendors/infra/aws.js
+++ b/frontend/src/data/vendors/infra/aws.js
@@ -53,6 +53,32 @@ export default {
   displayName: 'AWS',
   weight: 100,
   icon: 'aws.svg',
+  shoot: {
+    templates: {
+      provider: {
+        type: 'aws',
+        infrastructureConfig: {
+          apiVersion: 'aws.provider.extensions.gardener.cloud/v1alpha1',
+          kind: 'InfrastructureConfig',
+          networks: {
+            vpc: {
+              cidr: '__DEFAULT_WORKER_CIDR__',
+            },
+          },
+        },
+        controlPlaneConfig: {
+          apiVersion: 'aws.provider.extensions.gardener.cloud/v1alpha1',
+          kind: 'ControlPlaneConfig',
+        },
+      },
+      networking: {
+        nodes: '__DEFAULT_WORKER_CIDR__',
+      },
+    },
+    zoneNetworking: {
+      strategy: 'split-workers-public-internal',
+    },
+  },
   secret: {
     details: [
       accessKeyIdDetail,

--- a/frontend/src/data/vendors/infra/aws.js
+++ b/frontend/src/data/vendors/infra/aws.js
@@ -78,6 +78,17 @@ export default {
     zoneNetworking: {
       strategy: 'split-workers-public-internal',
     },
+    workerVolume: {
+      iops: {
+        min: 100,
+        hiddenForVolumeTypes: ['gp2'],
+        requiredForVolumeTypes: ['io1', 'io2'],
+      },
+    },
+    workerProviderConfig: {
+      apiVersion: 'aws.provider.extensions.gardener.cloud/v1alpha1',
+      kind: 'WorkerConfig',
+    },
   },
   secret: {
     details: [

--- a/frontend/src/data/vendors/infra/azure.js
+++ b/frontend/src/data/vendors/infra/azure.js
@@ -67,6 +67,34 @@ export default {
   displayName: 'Azure',
   weight: 200,
   icon: 'azure.svg',
+  shoot: {
+    templates: {
+      provider: {
+        type: 'azure',
+        infrastructureConfig: {
+          apiVersion: 'azure.provider.extensions.gardener.cloud/v1alpha1',
+          kind: 'InfrastructureConfig',
+          networks: {
+            vnet: {
+              cidr: '__DEFAULT_WORKER_CIDR__',
+            },
+            workers: '__DEFAULT_WORKER_CIDR__',
+          },
+          zoned: true,
+        },
+        controlPlaneConfig: {
+          apiVersion: 'azure.provider.extensions.gardener.cloud/v1alpha1',
+          kind: 'ControlPlaneConfig',
+        },
+      },
+      networking: {
+        nodes: '__DEFAULT_WORKER_CIDR__',
+      },
+    },
+    zones: {
+      mode: 'infrastructure-config-zoned',
+    },
+  },
   secret: {
     details: [
       subscriptionIdDetail,

--- a/frontend/src/data/vendors/infra/gcp.js
+++ b/frontend/src/data/vendors/infra/gcp.js
@@ -38,6 +38,30 @@ export default {
   displayName: 'Google Cloud',
   weight: 300,
   icon: 'gcp.svg',
+  shoot: {
+    templates: {
+      provider: {
+        type: 'gcp',
+        infrastructureConfig: {
+          apiVersion: 'gcp.provider.extensions.gardener.cloud/v1alpha1',
+          kind: 'InfrastructureConfig',
+          networks: {
+            workers: '__DEFAULT_WORKER_CIDR__',
+          },
+        },
+        controlPlaneConfig: {
+          apiVersion: 'gcp.provider.extensions.gardener.cloud/v1alpha1',
+          kind: 'ControlPlaneConfig',
+        },
+      },
+      networking: {
+        nodes: '__DEFAULT_WORKER_CIDR__',
+      },
+    },
+    controlPlane: {
+      zoneStrategy: 'worker-zones',
+    },
+  },
   secret: {
     details: [
       projectDetail,

--- a/frontend/src/data/vendors/infra/hcloud.js
+++ b/frontend/src/data/vendors/infra/hcloud.js
@@ -3,6 +3,30 @@ export default {
   displayName: 'Hetzner Cloud',
   weight: 800,
   icon: 'hcloud.svg',
+  shoot: {
+    templates: {
+      provider: {
+        type: 'hcloud',
+        infrastructureConfig: {
+          apiVersion: 'hcloud.provider.extensions.gardener.cloud/v1alpha1',
+          kind: 'InfrastructureConfig',
+          networks: {
+            workers: '__DEFAULT_WORKER_CIDR__',
+          },
+        },
+        controlPlaneConfig: {
+          apiVersion: 'hcloud.provider.extensions.gardener.cloud/v1alpha1',
+          kind: 'ControlPlaneConfig',
+        },
+      },
+      networking: {
+        nodes: '__DEFAULT_WORKER_CIDR__',
+      },
+    },
+    controlPlane: {
+      zoneStrategy: 'worker-zones',
+    },
+  },
   secret: {
     details: [
       {

--- a/frontend/src/data/vendors/infra/local.js
+++ b/frontend/src/data/vendors/infra/local.js
@@ -2,4 +2,9 @@ export default {
   name: 'local',
   displayName: 'Local',
   weight: 10100,
+  shoot: {
+    zones: {
+      mode: 'never',
+    },
+  },
 }

--- a/frontend/src/data/vendors/infra/metal.js
+++ b/frontend/src/data/vendors/infra/metal.js
@@ -3,6 +3,50 @@ export default {
   displayName: 'metal-stack',
   weight: 600,
   icon: 'metal.svg',
+  shoot: {
+    templates: {
+      provider: {
+        type: 'metal',
+        infrastructureConfig: {
+          apiVersion: 'metal.provider.extensions.gardener.cloud/v1alpha1',
+          kind: 'InfrastructureConfig',
+        },
+        controlPlaneConfig: {
+          apiVersion: 'metal.provider.extensions.gardener.cloud/v1alpha1',
+          kind: 'ControlPlaneConfig',
+        },
+      },
+      networking: {
+        type: 'calico',
+        pods: '10.244.128.0/18',
+        services: '10.244.192.0/18',
+        providerConfig: {
+          apiVersion: 'calico.networking.extensions.gardener.cloud/v1alpha1',
+          kind: 'NetworkConfig',
+          backend: 'vxlan',
+          ipv4: {
+            autoDetectionMethod: 'interface=lo',
+            mode: 'Always',
+            pool: 'vxlan',
+          },
+          typha: {
+            enabled: true,
+          },
+        },
+      },
+      kubernetes: {
+        kubeControllerManager: {
+          nodeCIDRMaskSize: 23,
+        },
+        kubelet: {
+          maxPods: 510,
+        },
+      },
+    },
+    zones: {
+      mode: 'never',
+    },
+  },
   secret: {
     details: [
       {

--- a/frontend/src/data/vendors/infra/openstack.js
+++ b/frontend/src/data/vendors/infra/openstack.js
@@ -121,4 +121,25 @@ export default {
       passwordField,
     ],
   },
+  shoot: {
+    templates: {
+      provider: {
+        type: 'openstack',
+        infrastructureConfig: {
+          apiVersion: 'openstack.provider.extensions.gardener.cloud/v1alpha1',
+          kind: 'InfrastructureConfig',
+          networks: {
+            workers: '__DEFAULT_WORKER_CIDR__',
+          },
+        },
+        controlPlaneConfig: {
+          apiVersion: 'openstack.provider.extensions.gardener.cloud/v1alpha1',
+          kind: 'ControlPlaneConfig',
+        },
+      },
+      networking: {
+        nodes: '__DEFAULT_WORKER_CIDR__',
+      },
+    },
+  },
 }

--- a/frontend/src/data/vendors/infra/stackit.js
+++ b/frontend/src/data/vendors/infra/stackit.js
@@ -64,4 +64,25 @@ export default {
       </p>
     `,
   },
+  shoot: {
+    templates: {
+      provider: {
+        type: 'stackit',
+        infrastructureConfig: {
+          apiVersion: 'stackit.provider.extensions.gardener.cloud/v1alpha1',
+          kind: 'InfrastructureConfig',
+          networks: {
+            workers: '__DEFAULT_WORKER_CIDR__',
+          },
+        },
+        controlPlaneConfig: {
+          apiVersion: 'stackit.provider.extensions.gardener.cloud/v1alpha1',
+          kind: 'ControlPlaneConfig',
+        },
+      },
+      networking: {
+        nodes: '__DEFAULT_WORKER_CIDR__',
+      },
+    },
+  },
 }

--- a/frontend/src/data/vendors/infra/vsphere.js
+++ b/frontend/src/data/vendors/infra/vsphere.js
@@ -3,6 +3,20 @@ export default {
   displayName: 'vSphere',
   weight: 700,
   icon: 'vsphere.svg',
+  shoot: {
+    templates: {
+      provider: {
+        type: 'vsphere',
+        controlPlaneConfig: {
+          apiVersion: 'vsphere.provider.extensions.gardener.cloud/v1alpha1',
+          kind: 'ControlPlaneConfig',
+        },
+      },
+      networking: {
+        nodes: '__DEFAULT_WORKER_CIDR__',
+      },
+    },
+  },
   secret: {
     details: [
       {

--- a/frontend/src/utils/shoot.js
+++ b/frontend/src/utils/shoot.js
@@ -17,201 +17,63 @@ import filter from 'lodash/filter'
 import range from 'lodash/range'
 import isEmpty from 'lodash/isEmpty'
 import compact from 'lodash/compact'
+import cloneDeep from 'lodash/cloneDeep'
 
-export function getSpecTemplate (providerType, defaultWorkerCIDR) {
-  const spec = {
-    provider: getProviderTemplate(providerType, defaultWorkerCIDR),
-    networking: getNetworkingTemplate(providerType, defaultWorkerCIDR),
+const DEFAULT_WORKER_CIDR_PLACEHOLDER = '__DEFAULT_WORKER_CIDR__'
+
+function replacePlaceholderInTemplate (value, defaultWorkerCIDR) {
+  if (typeof value === 'string') {
+    return value === DEFAULT_WORKER_CIDR_PLACEHOLDER ? defaultWorkerCIDR : value
   }
-  const kubernetes = getKubernetesTemplate(providerType)
+  if (Array.isArray(value)) {
+    return map(value, item => replacePlaceholderInTemplate(item, defaultWorkerCIDR))
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nestedValue]) => {
+        return [key, replacePlaceholderInTemplate(nestedValue, defaultWorkerCIDR)]
+      }),
+    )
+  }
+  return value
+}
+
+export function getSpecTemplate (providerType, defaultWorkerCIDR, shootVendor) {
+  const spec = {
+    provider: getProviderTemplate(providerType, defaultWorkerCIDR, shootVendor),
+    networking: getNetworkingTemplate(providerType, defaultWorkerCIDR, shootVendor),
+  }
+  const kubernetes = getKubernetesTemplate(shootVendor)
   if (!isEmpty(kubernetes)) {
     spec.kubernetes = kubernetes
   }
   return spec
 }
 
-export function getProviderTemplate (providerType, defaultWorkerCIDR) {
-  switch (providerType) {
-    case 'aws':
-      return {
-        type: 'aws',
-        infrastructureConfig: {
-          apiVersion: 'aws.provider.extensions.gardener.cloud/v1alpha1',
-          kind: 'InfrastructureConfig',
-          networks: {
-            vpc: {
-              cidr: defaultWorkerCIDR,
-            },
-          },
-        },
-        controlPlaneConfig: {
-          apiVersion: 'aws.provider.extensions.gardener.cloud/v1alpha1',
-          kind: 'ControlPlaneConfig',
-        },
-      }
-    case 'azure':
-      return {
-        type: 'azure',
-        infrastructureConfig: {
-          apiVersion: 'azure.provider.extensions.gardener.cloud/v1alpha1',
-          kind: 'InfrastructureConfig',
-          networks: {
-            vnet: {
-              cidr: defaultWorkerCIDR,
-            },
-            workers: defaultWorkerCIDR,
-          },
-          zoned: true,
-        },
-        controlPlaneConfig: {
-          apiVersion: 'azure.provider.extensions.gardener.cloud/v1alpha1',
-          kind: 'ControlPlaneConfig',
-        },
-      }
-    case 'gcp':
-      return {
-        type: 'gcp',
-        infrastructureConfig: {
-          apiVersion: 'gcp.provider.extensions.gardener.cloud/v1alpha1',
-          kind: 'InfrastructureConfig',
-          networks: {
-            workers: defaultWorkerCIDR,
-          },
-        },
-        controlPlaneConfig: {
-          apiVersion: 'gcp.provider.extensions.gardener.cloud/v1alpha1',
-          kind: 'ControlPlaneConfig',
-        },
-      }
-    case 'openstack':
-      return {
-        type: 'openstack',
-        infrastructureConfig: {
-          apiVersion: 'openstack.provider.extensions.gardener.cloud/v1alpha1',
-          kind: 'InfrastructureConfig',
-          networks: {
-            workers: defaultWorkerCIDR,
-          },
-        },
-        controlPlaneConfig: {
-          apiVersion: 'openstack.provider.extensions.gardener.cloud/v1alpha1',
-          kind: 'ControlPlaneConfig',
-        },
-      }
-    case 'stackit':
-      return {
-        type: 'stackit',
-        infrastructureConfig: {
-          apiVersion: 'stackit.provider.extensions.gardener.cloud/v1alpha1',
-          kind: 'InfrastructureConfig',
-          networks: {
-            workers: defaultWorkerCIDR,
-          },
-        },
-        controlPlaneConfig: {
-          apiVersion: 'stackit.provider.extensions.gardener.cloud/v1alpha1',
-          kind: 'ControlPlaneConfig',
-        },
-      }
-    case 'alicloud':
-      return {
-        type: 'alicloud',
-        infrastructureConfig: {
-          apiVersion: 'alicloud.provider.extensions.gardener.cloud/v1alpha1',
-          kind: 'InfrastructureConfig',
-          networks: {
-            vpc: {
-              cidr: defaultWorkerCIDR,
-            },
-          },
-        },
-        controlPlaneConfig: {
-          apiVersion: 'alicloud.provider.extensions.gardener.cloud/v1alpha1',
-          kind: 'ControlPlaneConfig',
-        },
-      }
-    case 'metal':
-      return {
-        type: 'metal',
-        infrastructureConfig: {
-          apiVersion: 'metal.provider.extensions.gardener.cloud/v1alpha1',
-          kind: 'InfrastructureConfig',
-        },
-        controlPlaneConfig: {
-          apiVersion: 'metal.provider.extensions.gardener.cloud/v1alpha1',
-          kind: 'ControlPlaneConfig',
-        },
-      }
-    case 'vsphere':
-      return {
-        type: 'vsphere',
-        controlPlaneConfig: {
-          apiVersion: 'vsphere.provider.extensions.gardener.cloud/v1alpha1',
-          kind: 'ControlPlaneConfig',
-        },
-      }
-    case 'hcloud':
-      return {
-        type: 'hcloud',
-        infrastructureConfig: {
-          apiVersion: 'hcloud.provider.extensions.gardener.cloud/v1alpha1',
-          kind: 'InfrastructureConfig',
-          networks: {
-            workers: defaultWorkerCIDR,
-          },
-        },
-        controlPlaneConfig: {
-          apiVersion: 'hcloud.provider.extensions.gardener.cloud/v1alpha1',
-          kind: 'ControlPlaneConfig',
-        },
-      }
-    default:
-      return {
-        type: providerType,
-      }
+export function getProviderTemplate (providerType, defaultWorkerCIDR, shootVendor) {
+  const template = shootVendor?.shoot?.templates?.provider
+  if (!template) {
+    return {
+      type: providerType,
+    }
   }
+
+  return replacePlaceholderInTemplate(template, defaultWorkerCIDR)
 }
 
-export function getNetworkingTemplate (providerType, defaultWorkerCIDR) {
-  switch (providerType) {
-    case 'metal':
-      return {
-        type: 'calico',
-        pods: '10.244.128.0/18',
-        services: '10.244.192.0/18',
-        providerConfig: {
-          apiVersion: 'calico.networking.extensions.gardener.cloud/v1alpha1',
-          kind: 'NetworkConfig',
-          backend: 'vxlan',
-          ipv4: {
-            autoDetectionMethod: 'interface=lo',
-            mode: 'Always',
-            pool: 'vxlan',
-          },
-          typha: {
-            enabled: true,
-          },
-        },
-      }
-    default:
-      return {
-        nodes: defaultWorkerCIDR,
-      }
+export function getNetworkingTemplate (providerType, defaultWorkerCIDR, shootVendor) {
+  const template = shootVendor?.shoot?.templates?.networking
+  if (!template) {
+    return {
+      nodes: defaultWorkerCIDR,
+    }
   }
+
+  return replacePlaceholderInTemplate(template, defaultWorkerCIDR)
 }
 
-export function getKubernetesTemplate (providerType) {
-  switch (providerType) {
-    case 'metal':
-      return {
-        kubeControllerManager: {
-          nodeCIDRMaskSize: 23,
-        },
-        kubelet: {
-          maxPods: 510,
-        },
-      }
-  }
+export function getKubernetesTemplate (shootVendor) {
+  return cloneDeep(shootVendor?.shoot?.templates?.kubernetes)
 }
 
 export function splitCIDR (cidrToSplitStr, numberOfNetworks) {
@@ -232,12 +94,12 @@ export function splitCIDR (cidrToSplitStr, numberOfNetworks) {
   return cidrArray
 }
 
-export function getDefaultNetworkConfigurationForAllZones (numberOfZones, providerType, workerCIDR) {
-  switch (providerType) {
-    case 'aws': {
-      const zoneNetworksAws = splitCIDR(workerCIDR, numberOfZones)
+export function getDefaultNetworkConfigurationForAllZones (numberOfZones, workerCIDR, shootVendor) {
+  switch (shootVendor?.shoot?.zoneNetworking?.strategy) {
+    case 'split-workers-public-internal': {
+      const zoneNetworks = splitCIDR(workerCIDR, numberOfZones)
       return map(range(numberOfZones), index => {
-        const zoneNetwork = zoneNetworksAws[index] // eslint-disable-line security/detect-object-injection
+        const zoneNetwork = zoneNetworks[index] // eslint-disable-line security/detect-object-injection
         const bigNetWorks = splitCIDR(zoneNetwork, 2)
         const workerNetwork = bigNetWorks[0]
         const smallNetworks = splitCIDR(bigNetWorks[1], 2)
@@ -250,10 +112,10 @@ export function getDefaultNetworkConfigurationForAllZones (numberOfZones, provid
         }
       })
     }
-    case 'alicloud': {
-      const zoneNetworksAli = splitCIDR(workerCIDR, numberOfZones)
+    case 'split-workers': {
+      const zoneNetworks = splitCIDR(workerCIDR, numberOfZones)
       return map(range(numberOfZones), index => {
-        const zoneNetwork = zoneNetworksAli[index] // eslint-disable-line security/detect-object-injection
+        const zoneNetwork = zoneNetworks[index] // eslint-disable-line security/detect-object-injection
         return {
           workers: zoneNetwork,
         }
@@ -262,8 +124,8 @@ export function getDefaultNetworkConfigurationForAllZones (numberOfZones, provid
   }
 }
 
-export function getDefaultZonesNetworkConfiguration (zones, providerType, maxNumberOfZones, workerCIDR) {
-  const zoneConfigurations = getDefaultNetworkConfigurationForAllZones(maxNumberOfZones, providerType, workerCIDR)
+export function getDefaultZonesNetworkConfiguration (zones, maxNumberOfZones, workerCIDR, shootVendor) {
+  const zoneConfigurations = getDefaultNetworkConfigurationForAllZones(maxNumberOfZones, workerCIDR, shootVendor)
   if (!zoneConfigurations) {
     return undefined
   }
@@ -276,12 +138,12 @@ export function getDefaultZonesNetworkConfiguration (zones, providerType, maxNum
   })
 }
 
-export function findFreeNetworks (existingZonesNetworkConfiguration, workerCIDR, providerType, maxNumberOfZones) {
+export function findFreeNetworks (existingZonesNetworkConfiguration, workerCIDR, maxNumberOfZones, shootVendor) {
   if (!existingZonesNetworkConfiguration) {
-    return getDefaultNetworkConfigurationForAllZones(maxNumberOfZones, providerType, workerCIDR)
+    return getDefaultNetworkConfigurationForAllZones(maxNumberOfZones, workerCIDR, shootVendor)
   }
   for (let numberOfZones = maxNumberOfZones; numberOfZones >= existingZonesNetworkConfiguration.length; numberOfZones--) {
-    const newZonesNetworkConfiguration = getDefaultNetworkConfigurationForAllZones(numberOfZones, providerType, workerCIDR)
+    const newZonesNetworkConfiguration = getDefaultNetworkConfigurationForAllZones(numberOfZones, workerCIDR, shootVendor)
     const freeZoneNetworks = filter(newZonesNetworkConfiguration, networkConfiguration => {
       return !some(existingZonesNetworkConfiguration, networkConfiguration)
     })
@@ -293,15 +155,15 @@ export function findFreeNetworks (existingZonesNetworkConfiguration, workerCIDR,
   return []
 }
 
-export function getZonesNetworkConfiguration (oldZonesNetworkConfiguration, workers, providerType, maxNumberOfZones, existingShootWorkerCIDR, newShootWorkerCIDR) {
-  if (isEmpty(workers) || !providerType || !maxNumberOfZones) {
+export function getZonesNetworkConfiguration (oldZonesNetworkConfiguration, workers, maxNumberOfZones, existingShootWorkerCIDR, newShootWorkerCIDR, shootVendor) {
+  if (isEmpty(workers) || !maxNumberOfZones) {
     return
   }
 
   const usedZones = uniq(flatMap(workers, 'zones'))
 
   const workerCIDR = existingShootWorkerCIDR || newShootWorkerCIDR
-  const defaultZonesNetworkConfiguration = getDefaultZonesNetworkConfiguration(usedZones, providerType, maxNumberOfZones, workerCIDR)
+  const defaultZonesNetworkConfiguration = getDefaultZonesNetworkConfiguration(usedZones, maxNumberOfZones, workerCIDR, shootVendor)
   if (!defaultZonesNetworkConfiguration) {
     return
   }
@@ -309,7 +171,7 @@ export function getZonesNetworkConfiguration (oldZonesNetworkConfiguration, work
   const existingZonesNetworkConfiguration = filter(oldZonesNetworkConfiguration, ({ name }) => includes(usedZones, name))
 
   if (existingShootWorkerCIDR) {
-    const freeZoneNetworks = findFreeNetworks(existingZonesNetworkConfiguration, existingShootWorkerCIDR, providerType, maxNumberOfZones)
+    const freeZoneNetworks = findFreeNetworks(existingZonesNetworkConfiguration, existingShootWorkerCIDR, maxNumberOfZones, shootVendor)
     const availableNetworksLength = existingZonesNetworkConfiguration.length + freeZoneNetworks.length
     if (availableNetworksLength < usedZones.length) {
       return
@@ -341,11 +203,10 @@ export function getZonesNetworkConfiguration (oldZonesNetworkConfiguration, work
     : existingZonesNetworkConfiguration
 }
 
-export function getControlPlaneZone (workers, providerType, oldControlPlaneZone) {
+export function getControlPlaneZone (workers, shootVendor, oldControlPlaneZone) {
   const workerZones = uniq(flatMap(workers, 'zones'))
-  switch (providerType) {
-    case 'gcp':
-    case 'hcloud':
+  switch (shootVendor?.shoot?.controlPlane?.zoneStrategy) {
+    case 'worker-zones':
       if (includes(workerZones, oldControlPlaneZone)) {
         return oldControlPlaneZone
       }

--- a/frontend/src/utils/shoot.js
+++ b/frontend/src/utils/shoot.js
@@ -216,13 +216,6 @@ export function getControlPlaneZone (workers, shootVendor, oldControlPlaneZone) 
   }
 }
 
-export function getWorkerProviderConfig (providerType) {
-  switch (providerType) {
-    case 'aws': {
-      return {
-        apiVersion: 'aws.provider.extensions.gardener.cloud/v1alpha1',
-        kind: 'WorkerConfig',
-      }
-    }
-  }
+export function getWorkerProviderConfig (shootVendor) {
+  return cloneDeep(shootVendor?.shoot?.workerProviderConfig)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Moves shoot-specific defaults from branching logic in `utils/shoot.js` into the infrastructure vendor configurations.

This includes:

- Provider, networking, and Kubernetes templates
- Zone-networking strategies
- Control-plane zone strategies
- Provider-specific zone behavior
- AWS worker volume and worker provider configuration

`useShootContext` now resolves these settings through the configured infrastructure vendor. The AWS IOPS behavior introduced by [#2951](https://github.com/gardener/dashboard/pull/2951) is preserved:

- The provider type is read from `cloudProfile.spec.type`
- IOPS is hidden for `gp2`
- IOPS is required for `io1` and `io2`

The PR also adds default shoot manifest coverage for all configured infrastructure providers and focused regression coverage for the AWS volume behavior.

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

This is intended to be a behavior-preserving refactoring that makes shoot defaults extensible through vendor configuration.
This is the last slice of #2824

**Release note**:

```other developer
Infrastructure-provider shoot defaults and templates now live in the provider's `shoot` configuration under `frontend/src/data/vendors/infra` instead of provider-specific branching in `utils/shoot.js`
```