### PR TITLE
fix(frontend): keep project selector consistent during navigation

### DIFF
--- a/frontend/__tests__/components/GMainNavigation.spec.js
+++ b/frontend/__tests__/components/GMainNavigation.spec.js
@@ -73,6 +73,7 @@ function createTestRouter () {
         component: {},
         meta: {
           namespaced: true,
+          projectScope: false,
           menu: {
             icon: 'mdi-view-dashboard',
             title: 'Clusters',
@@ -88,63 +89,79 @@ function createTestRouter () {
   })
 }
 
+async function setup () {
+  const pinia = createPinia()
+  const authzStore = useAuthzStore(pinia)
+  const projectStore = useProjectStore(pinia)
+  projectStore.list = [
+    createProject('source'),
+    createProject('target'),
+  ]
+  const sourceProject = projectStore.list[0]
+  const targetProject = projectStore.list[1]
+
+  const router = createTestRouter()
+  router.afterEach((to, from, failure) => {
+    if (!failure) {
+      authzStore._setNamespace(to.params.namespace)
+    }
+  })
+  await router.push({
+    name: 'ShootItem',
+    params: {
+      namespace: sourceProject.spec.namespace,
+      name: 'source-shoot',
+    },
+  })
+
+  const wrapper = shallowMount(GMainNavigation, {
+    global: {
+      plugins: [
+        createVuetifyPlugin(),
+        pinia,
+        router,
+      ],
+      stubs: {
+        GMainProjectSelection: GMainProjectSelectionStub,
+        GProjectDialog: true,
+        GTeaser: SlotStub,
+        VList: SlotStub,
+        VListItem: VListItemStub,
+        VNavigationDrawer: SlotStub,
+      },
+    },
+  })
+
+  return {
+    authzStore,
+    projectStore,
+    router,
+    sourceProject,
+    targetProject,
+    wrapper,
+  }
+}
+
+function projectSelection (wrapper) {
+  return wrapper.findComponent(GMainProjectSelectionStub)
+}
+
+function sidebarTargets (wrapper) {
+  return wrapper
+    .findAllComponents(VListItemStub)
+    .map(item => item.props('to'))
+}
+
 describe('components', () => {
   describe('g-main-navigation', () => {
-    it('keeps project selection and sidebar targets on the committed namespace', async () => {
-      const pinia = createPinia()
-      const authzStore = useAuthzStore(pinia)
-      const projectStore = useProjectStore(pinia)
-      projectStore.list = [
-        createProject('source'),
-        createProject('target'),
-      ]
-      const sourceProject = projectStore.list[0]
-      const targetProject = projectStore.list[1]
-
-      const router = createTestRouter()
+    it('keeps project selection and sidebar targets on the committed namespace after cancelled navigation', async () => {
+      const {
+        router,
+        sourceProject,
+        targetProject,
+        wrapper,
+      } = await setup()
       const pushSpy = vi.spyOn(router, 'push')
-      router.afterEach((to, from, failure) => {
-        if (!failure) {
-          authzStore._setNamespace(to.params.namespace)
-        }
-      })
-      await router.push({
-        name: 'ShootItem',
-        params: {
-          namespace: sourceProject.spec.namespace,
-          name: 'source-shoot',
-        },
-      })
-
-      const wrapper = shallowMount(GMainNavigation, {
-        global: {
-          plugins: [
-            createVuetifyPlugin(),
-            pinia,
-            router,
-          ],
-          stubs: {
-            GMainProjectSelection: GMainProjectSelectionStub,
-            GProjectDialog: true,
-            GTeaser: SlotStub,
-            VList: SlotStub,
-            VListItem: VListItemStub,
-            VNavigationDrawer: SlotStub,
-          },
-        },
-      })
-      const projectSelection = () => wrapper.findComponent(GMainProjectSelectionStub)
-      const sidebarTargets = () => wrapper
-        .findAllComponents(VListItemStub)
-        .map(item => item.props('to'))
-
-      expect(projectSelection().props('selectedProject')).toBe(sourceProject)
-      expect(sidebarTargets()).toContainEqual({
-        name: 'ShootList',
-        params: {
-          namespace: sourceProject.spec.namespace,
-        },
-      })
 
       let continueTargetNavigation
       const removeGuard = router.beforeEach(to => {
@@ -154,10 +171,9 @@ describe('components', () => {
           })
         }
       })
-      const previousPushCount = pushSpy.mock.calls.length
-      projectSelection().vm.$emit('projectSelect', targetProject)
+      projectSelection(wrapper).vm.$emit('projectSelect', targetProject)
       await flushPromises()
-      const targetNavigation = pushSpy.mock.results[previousPushCount].value
+      const targetNavigation = pushSpy.mock.results[0].value
 
       const sourceNavigation = router.push({
         name: 'ShootList',
@@ -168,41 +184,85 @@ describe('components', () => {
       continueTargetNavigation()
       await sourceNavigation
       const failure = await targetNavigation
+      removeGuard()
 
       expect(isNavigationFailure(failure, NavigationFailureType.cancelled)).toBe(true)
       expect(router.currentRoute.value.params.namespace).toBe(sourceProject.spec.namespace)
-      expect(projectSelection().props('selectedProject')).toBe(sourceProject)
-      expect(sidebarTargets()).toContainEqual({
+      expect(projectSelection(wrapper).props('selectedProject')).toBe(sourceProject)
+      expect(sidebarTargets(wrapper)).toContainEqual({
         name: 'ShootList',
         params: {
           namespace: sourceProject.spec.namespace,
         },
       })
+    })
 
-      removeGuard()
-      projectSelection().vm.$emit('projectSelect', targetProject)
+    it('updates project selection and sidebar targets after successful navigation', async () => {
+      const {
+        router,
+        targetProject,
+        wrapper,
+      } = await setup()
+
+      projectSelection(wrapper).vm.$emit('projectSelect', targetProject)
       await flushPromises()
 
       expect(router.currentRoute.value.params.namespace).toBe(targetProject.spec.namespace)
-      expect(projectSelection().props('selectedProject')).toBe(targetProject)
-      expect(sidebarTargets()).toContainEqual({
+      expect(projectSelection(wrapper).props('selectedProject')).toBe(targetProject)
+      expect(sidebarTargets(wrapper)).toContainEqual({
         name: 'ShootList',
         params: {
           namespace: targetProject.spec.namespace,
         },
       })
+    })
 
-      const updatedTargetProject = {
-        ...targetProject,
+    it('propagates a replaced project object to the project selection', async () => {
+      const {
+        projectStore,
+        sourceProject,
+        wrapper,
+      } = await setup()
+
+      const updatedSourceProject = {
+        ...sourceProject,
         spec: {
-          ...targetProject.spec,
+          ...sourceProject.spec,
           description: 'Updated description',
         },
       }
-      projectStore.list.splice(1, 1, updatedTargetProject)
+      projectStore.list.splice(0, 1, updatedSourceProject)
       await nextTick()
 
-      expect(projectSelection().props('selectedProject')).toBe(projectStore.list[1])
+      expect(projectSelection(wrapper).props('selectedProject')).toBe(projectStore.list[0])
+    })
+
+    it('selects all projects and updates sidebar targets for the _all namespace', async () => {
+      const {
+        authzStore,
+        wrapper,
+      } = await setup()
+
+      authzStore._setNamespace('_all')
+      await nextTick()
+
+      expect(projectSelection(wrapper).props('selectedProject')).toEqual({
+        metadata: {
+          name: 'All Projects',
+        },
+        spec: {
+          namespace: '_all',
+        },
+        status: {
+          phase: 'Ready',
+        },
+      })
+      expect(sidebarTargets(wrapper)).toEqual([{
+        name: 'ShootList',
+        params: {
+          namespace: '_all',
+        },
+      }])
     })
   })
 })

--- a/frontend/__tests__/components/GMainNavigation.spec.js
+++ b/frontend/__tests__/components/GMainNavigation.spec.js
@@ -1,0 +1,208 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import { nextTick } from 'vue'
+import {
+  flushPromises,
+  shallowMount,
+} from '@vue/test-utils'
+import {
+  createMemoryHistory,
+  createRouter,
+  isNavigationFailure,
+  NavigationFailureType,
+} from 'vue-router'
+import { createPinia } from 'pinia'
+
+import { useAuthzStore } from '@/store/authz'
+import { useProjectStore } from '@/store/project'
+
+import GMainNavigation from '@/components/GMainNavigation.vue'
+
+const { createVuetifyPlugin } = global.fixtures.helper
+
+const SlotStub = {
+  template: '<div><slot /></div>',
+}
+
+const GMainProjectSelectionStub = {
+  name: 'GMainProjectSelection',
+  props: {
+    selectedProject: Object,
+  },
+  emits: [
+    'projectSelect',
+    'openProjectDialog',
+  ],
+  template: '<div />',
+}
+
+const VListItemStub = {
+  name: 'VListItem',
+  props: {
+    to: Object,
+  },
+  template: '<div />',
+}
+
+function createProject (name) {
+  return {
+    metadata: {
+      name,
+      uid: `${name}-uid`,
+    },
+    spec: {
+      namespace: `garden-${name}`,
+    },
+    status: {
+      phase: 'Ready',
+    },
+  }
+}
+
+function createTestRouter () {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      {
+        name: 'ShootList',
+        path: '/namespace/:namespace/shoots',
+        component: {},
+        meta: {
+          namespaced: true,
+          menu: {
+            icon: 'mdi-view-dashboard',
+            title: 'Clusters',
+          },
+        },
+      },
+      {
+        name: 'ShootItem',
+        path: '/namespace/:namespace/shoots/:name',
+        component: {},
+      },
+    ],
+  })
+}
+
+describe('components', () => {
+  describe('g-main-navigation', () => {
+    it('keeps project selection and sidebar targets on the committed namespace', async () => {
+      const pinia = createPinia()
+      const authzStore = useAuthzStore(pinia)
+      const projectStore = useProjectStore(pinia)
+      projectStore.list = [
+        createProject('source'),
+        createProject('target'),
+      ]
+      const sourceProject = projectStore.list[0]
+      const targetProject = projectStore.list[1]
+
+      const router = createTestRouter()
+      const pushSpy = vi.spyOn(router, 'push')
+      router.afterEach((to, from, failure) => {
+        if (!failure) {
+          authzStore._setNamespace(to.params.namespace)
+        }
+      })
+      await router.push({
+        name: 'ShootItem',
+        params: {
+          namespace: sourceProject.spec.namespace,
+          name: 'source-shoot',
+        },
+      })
+
+      const wrapper = shallowMount(GMainNavigation, {
+        global: {
+          plugins: [
+            createVuetifyPlugin(),
+            pinia,
+            router,
+          ],
+          stubs: {
+            GMainProjectSelection: GMainProjectSelectionStub,
+            GProjectDialog: true,
+            GTeaser: SlotStub,
+            VList: SlotStub,
+            VListItem: VListItemStub,
+            VNavigationDrawer: SlotStub,
+          },
+        },
+      })
+      const projectSelection = () => wrapper.findComponent(GMainProjectSelectionStub)
+      const sidebarTargets = () => wrapper
+        .findAllComponents(VListItemStub)
+        .map(item => item.props('to'))
+
+      expect(projectSelection().props('selectedProject')).toBe(sourceProject)
+      expect(sidebarTargets()).toContainEqual({
+        name: 'ShootList',
+        params: {
+          namespace: sourceProject.spec.namespace,
+        },
+      })
+
+      let continueTargetNavigation
+      const removeGuard = router.beforeEach(to => {
+        if (to.params.namespace === targetProject.spec.namespace) {
+          return new Promise(resolve => {
+            continueTargetNavigation = resolve
+          })
+        }
+      })
+      const previousPushCount = pushSpy.mock.calls.length
+      projectSelection().vm.$emit('projectSelect', targetProject)
+      await flushPromises()
+      const targetNavigation = pushSpy.mock.results[previousPushCount].value
+
+      const sourceNavigation = router.push({
+        name: 'ShootList',
+        params: {
+          namespace: sourceProject.spec.namespace,
+        },
+      })
+      continueTargetNavigation()
+      await sourceNavigation
+      const failure = await targetNavigation
+
+      expect(isNavigationFailure(failure, NavigationFailureType.cancelled)).toBe(true)
+      expect(router.currentRoute.value.params.namespace).toBe(sourceProject.spec.namespace)
+      expect(projectSelection().props('selectedProject')).toBe(sourceProject)
+      expect(sidebarTargets()).toContainEqual({
+        name: 'ShootList',
+        params: {
+          namespace: sourceProject.spec.namespace,
+        },
+      })
+
+      removeGuard()
+      projectSelection().vm.$emit('projectSelect', targetProject)
+      await flushPromises()
+
+      expect(router.currentRoute.value.params.namespace).toBe(targetProject.spec.namespace)
+      expect(projectSelection().props('selectedProject')).toBe(targetProject)
+      expect(sidebarTargets()).toContainEqual({
+        name: 'ShootList',
+        params: {
+          namespace: targetProject.spec.namespace,
+        },
+      })
+
+      const updatedTargetProject = {
+        ...targetProject,
+        spec: {
+          ...targetProject.spec,
+          description: 'Updated description',
+        },
+      }
+      projectStore.list.splice(1, 1, updatedTargetProject)
+      await nextTick()
+
+      expect(projectSelection().props('selectedProject')).toBe(projectStore.list[1])
+    })
+  })
+})

--- a/frontend/__tests__/components/GMainProjectSelection.spec.js
+++ b/frontend/__tests__/components/GMainProjectSelection.spec.js
@@ -4,12 +4,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { nextTick } from 'vue'
 import { shallowMount } from '@vue/test-utils'
 import { createPinia } from 'pinia'
-
-import { useAuthzStore } from '@/store/authz'
-import { useProjectStore } from '@/store/project'
 
 import GMainProjectSelection from '@/components/GMainProjectSelection.vue'
 
@@ -17,30 +13,36 @@ const { createVuetifyPlugin } = global.fixtures.helper
 
 describe('components', () => {
   describe('g-main-project-selection', () => {
-    it('should update the selected project when its store entry is replaced', async () => {
+    it('emits a selection request without changing the selected project', () => {
       const pinia = createPinia()
-      const projectStore = useProjectStore(pinia)
-      const authzStore = useAuthzStore(pinia)
-
-      const project = {
+      const sourceProject = {
         metadata: {
-          name: 'foo',
-          uid: 'foo-uid',
+          name: 'source',
+          uid: 'source-uid',
         },
         spec: {
-          namespace: 'garden-foo',
-          description: 'Old description',
+          namespace: 'garden-source',
         },
         status: {
           phase: 'Ready',
         },
       }
-      projectStore.list = [project]
-      authzStore._setNamespace(project.spec.namespace)
+      const targetProject = {
+        metadata: {
+          name: 'target',
+          uid: 'target-uid',
+        },
+        spec: {
+          namespace: 'garden-target',
+        },
+        status: {
+          phase: 'Ready',
+        },
+      }
 
       const wrapper = shallowMount(GMainProjectSelection, {
         props: {
-          modelValue: project,
+          selectedProject: sourceProject,
         },
         global: {
           plugins: [
@@ -50,18 +52,12 @@ describe('components', () => {
         },
       })
 
-      const updatedProject = {
-        ...project,
-        spec: {
-          ...project.spec,
-          description: 'New description',
-        },
-      }
-      projectStore.list.splice(0, 1, updatedProject)
-      await nextTick()
+      wrapper.vm.projectMenu = true
+      wrapper.vm.selectProject(targetProject)
 
-      const updates = wrapper.emitted('update:modelValue')
-      expect(updates.at(-1)).toEqual([projectStore.list[0]])
+      expect(wrapper.emitted('projectSelect')).toEqual([[targetProject]])
+      expect(wrapper.vm.selectedProjectName).toBe('source')
+      expect(wrapper.vm.projectMenu).toBe(false)
     })
   })
 })

--- a/frontend/__tests__/components/GMainProjectSelection.spec.js
+++ b/frontend/__tests__/components/GMainProjectSelection.spec.js
@@ -52,6 +52,9 @@ describe('components', () => {
         },
       })
 
+      wrapper.vm.selectProject(sourceProject)
+      expect(wrapper.emitted('projectSelect')).toBeUndefined()
+
       wrapper.vm.projectMenu = true
       wrapper.vm.selectProject(targetProject)
 

--- a/frontend/src/components/GMainNavigation.vue
+++ b/frontend/src/components/GMainNavigation.vue
@@ -135,7 +135,6 @@ import {
 } from '@/utils'
 
 import get from 'lodash/get'
-import find from 'lodash/find'
 import has from 'lodash/has'
 
 const allProjectsItem = {
@@ -166,10 +165,7 @@ const selectedProject = computed(() => {
   if (namespace.value === allProjectsItem.spec.namespace) {
     return allProjectsItem
   }
-  return find(projectList.value, [
-    'spec.namespace',
-    namespace.value,
-  ])
+  return projectStore.project
 })
 
 const visibleRoutes = computed(() => {

--- a/frontend/src/components/GMainNavigation.vue
+++ b/frontend/src/components/GMainNavigation.vue
@@ -23,7 +23,7 @@ SPDX-License-Identifier: Apache-2.0
     </g-teaser>
     <template v-if="projectList.length">
       <g-main-project-selection
-        v-model="selectedProject"
+        :selected-project="selectedProject"
         @project-select="onSelectProject"
         @open-project-dialog="projectDialog = true"
       />
@@ -135,6 +135,7 @@ import {
 } from '@/utils'
 
 import get from 'lodash/get'
+import find from 'lodash/find'
 import has from 'lodash/has'
 
 const allProjectsItem = {
@@ -161,7 +162,15 @@ const namespace = toRef(projectStore, 'namespace')
 const projectList = toRef(projectStore, 'projectList')
 const sidebar = toRef(appStore, 'sidebar')
 
-const selectedProject = ref()
+const selectedProject = computed(() => {
+  if (namespace.value === allProjectsItem.spec.namespace) {
+    return allProjectsItem
+  }
+  return find(projectList.value, [
+    'spec.namespace',
+    namespace.value,
+  ])
+})
 
 const visibleRoutes = computed(() => {
   if (!selectedProject.value) {

--- a/frontend/src/components/GMainProjectSelection.vue
+++ b/frontend/src/components/GMainProjectSelection.vue
@@ -219,6 +219,12 @@ const emit = defineEmits([
   'projectSelect',
   'openProjectDialog',
 ])
+const componentProps = defineProps({
+  selectedProject: {
+    type: Object,
+    default: undefined,
+  },
+})
 
 const allProjectsItem = {
   metadata: {
@@ -242,21 +248,10 @@ const highlightedProjectName = ref()
 const refProjectFilter = useTemplateRef('refProjectFilter')
 const refProjectVirtualScroll = useTemplateRef('refProjectVirtualScroll')
 
-const namespace = toRef(projectStore, 'namespace')
 const projectList = toRef(projectStore, 'projectList')
 const canCreateProject = toRef(authzStore, 'canCreateProject')
 
-const selectedProject = defineModel({ type: Object })
-
-const currentProject = computed(() => {
-  if (isAllProjectsNamespace(namespace.value)) {
-    return allProjectsItem
-  }
-  return find(projectList.value, [
-    'spec.namespace',
-    namespace.value,
-  ])
-})
+const selectedProject = toRef(componentProps, 'selectedProject')
 
 const projectMenuIcon = computed(() => {
   return projectMenu.value ? 'mdi-chevron-up' : 'mdi-chevron-down'
@@ -359,7 +354,6 @@ function selectProject (project) {
   projectMenu.value = false
 
   if (project?.spec.namespace !== selectedProject.value?.spec.namespace) {
-    selectedProject.value = project
     emit('projectSelect', project)
   }
 }
@@ -427,14 +421,6 @@ watch(projectMenu, value => {
     highlightedProjectName.value = undefined
   }
 })
-
-watch(
-  currentProject,
-  project => {
-    selectedProject.value = project
-  },
-  { immediate: true },
-)
 
 async function scrollToActiveProject () {
   const activeProjectName = highlightedProjectName.value ?? selectedProject.value?.metadata.name


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area usability
/kind bug

**What this PR does / why we need it**:

Derives the displayed project from the committed authorization namespace instead of optimistically updating it when project navigation starts.

This prevents canceled or otherwise failed navigation from leaving the project selector inconsistent with the URL, cluster list, and sidebar targets. The delayed namespace activation remains unchanged.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```bugfix user
Fixed the project selector showing a different project than the URL and cluster list after an interrupted project switch.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project selection consistency across the main navigation and project selector.
  * Cancelled navigation no longer changes the displayed project selection.
  * Successful project switches now update the project selector and sidebar routes together.
  * The selected project remains synchronized when project information changes, including the all-projects view.
  * Selecting a project closes the menu while preserving the displayed selection until navigation completes.

* **Tests**
  * Added coverage for project switching, cancelled navigation, route updates, changing project data, and all-projects selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->