### PR TITLE
fix(frontend): guard against null projectFilter in GMainProjectSelection

### DIFF
--- a/frontend/__tests__/components/GMainProjectSelection.spec.js
+++ b/frontend/__tests__/components/GMainProjectSelection.spec.js
@@ -62,5 +62,20 @@ describe('components', () => {
       expect(wrapper.vm.selectedProjectName).toBe('source')
       expect(wrapper.vm.projectMenu).toBe(false)
     })
+
+    it('handles a cleared project filter', () => {
+      const wrapper = shallowMount(GMainProjectSelection, {
+        global: {
+          plugins: [
+            createVuetifyPlugin(),
+            createPinia(),
+          ],
+        },
+      })
+
+      wrapper.vm.projectFilter = null
+
+      expect(wrapper.vm.sortedAndFilteredProjectItems).toHaveLength(1)
+    })
   })
 })

--- a/frontend/src/components/GMainProjectSelection.vue
+++ b/frontend/src/components/GMainProjectSelection.vue
@@ -283,7 +283,7 @@ const sortedAndFilteredProjectItems = computed(() => {
     }
   })
 
-  const normalizedFilter = toLower(projectFilter.value.trimStart())
+  const normalizedFilter = toLower(projectFilter.value?.trim())
 
   const predicate = item => {
     if (!projectFilter.value) {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area usability
/kind bug

**What this PR does / why we need it**:
Fixes a crash when `projectFilter` is `null` — `trimStart()` on a null value throws a TypeError.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```bugfix user
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved project filtering by ignoring extra spaces at the beginning or end of the search text.
  - Ensured clearing the project filter continues to display available projects.

- **Tests**
  - Added coverage for project selection after the filter is cleared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->