### PR TITLE
fix(backend): handle missing credential and terminal resources correctly

### DIFF
--- a/backend/__tests__/acceptance/api.cloudProviderCredentials.spec.js
+++ b/backend/__tests__/acceptance/api.cloudProviderCredentials.spec.js
@@ -285,6 +285,21 @@ describe('api', function () {
       expect(res.body).toMatchSnapshot()
     })
 
+    it('should not re-create an infra credential when the update fails with a non-404 error', async function () {
+      const secret = find(fixtures.secrets.list(namespace), { metadata: { name: 'secret1', namespace } })
+      secret.metadata.resourceVersion = '42'
+
+      mockRequest.mockImplementationOnce(fixtures.secrets.mocks.patch())
+
+      await agent
+        .post('/api/cloudprovidercredentials')
+        .set('cookie', await user.cookie)
+        .send({ method: 'patchInfra', params: { secret } })
+        .expect(409)
+
+      expect(mockRequest).toHaveBeenCalledTimes(1)
+    })
+
     it('should delete an own cloudProvider credential (secretbinding)', async function () {
       const params = {
         bindingKind: 'SecretBinding',

--- a/backend/__tests__/acceptance/api.terminals.spec.js
+++ b/backend/__tests__/acceptance/api.terminals.spec.js
@@ -14,6 +14,7 @@ import {
   beforeEach,
 } from 'vitest'
 import { padStart } from 'lodash-es'
+import createError from 'http-errors'
 import request from '@gardener-dashboard/request'
 import { seedProjectNamespaceIndex } from '../helpers/cache.js'
 import { converter } from '../../lib/services/terminals/index.js'
@@ -134,6 +135,26 @@ describe('api', function () {
         expect(mockRequest.mock.calls).toMatchSnapshot()
 
         expect(res.body).toMatchSnapshot()
+      })
+
+      it('should propagate errors when listing terminal shortcuts fails', async function () {
+        mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+        mockRequest.mockRejectedValueOnce(createError(500))
+
+        await agent
+          .post('/api/terminals')
+          .set('cookie', await admin.cookie)
+          .send({
+            method: 'listProjectTerminalShortcuts',
+            params: {
+              coordinate: {
+                namespace,
+              },
+            },
+          })
+          .expect(500)
+
+        expect(mockRequest).toHaveBeenCalledTimes(2)
       })
     })
 
@@ -348,6 +369,26 @@ describe('api', function () {
         expect(mockRequest.mock.calls).toMatchSnapshot()
 
         expect(res.body).toMatchSnapshot()
+      })
+
+      it('should propagate errors when deleting a terminal resource fails', async function () {
+        mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+        mockRequest.mockImplementationOnce(fixtures.terminals.mocks.get())
+        mockRequest.mockRejectedValueOnce(createError(500))
+
+        await agent
+          .post('/api/terminals')
+          .set('cookie', await admin.cookie)
+          .send({
+            method: 'remove',
+            params: {
+              name,
+              namespace,
+            },
+          })
+          .expect(500)
+
+        expect(mockRequest).toHaveBeenCalledTimes(3)
       })
     })
 

--- a/backend/lib/services/cloudProviderCredentials.js
+++ b/backend/lib/services/cloudProviderCredentials.js
@@ -5,9 +5,11 @@
 //
 
 import _ from 'lodash-es'
-import createError, { isHttpError } from 'http-errors'
+import createError from 'http-errors'
+import requestModule from '@gardener-dashboard/request'
 import cache from '../cache/index.js'
 import logger from '../logger/index.js'
+const { isHttpError } = requestModule
 const { getQuotas } = cache
 
 export async function list ({ user, params }) {

--- a/backend/lib/services/terminals/index.js
+++ b/backend/lib/services/terminals/index.js
@@ -11,6 +11,7 @@ import { load as yamlLoad } from 'js-yaml'
 import gardenerConfig from '../../config/index.js'
 import { getClusterCaData } from '../shoots.js'
 import kubeClientModule from '@gardener-dashboard/kube-client'
+import requestModule from '@gardener-dashboard/request'
 import {
   decodeBase64,
   getConfigValue,
@@ -31,7 +32,8 @@ import cache from '../../cache/index.js'
 import logger from '../../logger/index.js'
 import { createConverter } from '../../markdown.js'
 const { Resources } = kubeClientModule
-const { Forbidden, UnprocessableEntity, InternalServerError, isHttpError } = httpErrors
+const { isHttpError } = requestModule
+const { Forbidden, UnprocessableEntity, InternalServerError } = httpErrors
 const { getSeed, findProjectByNamespace } = cache
 
 const TERMINAL_CONTAINER_NAME = 'terminal'


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area robustness
/kind regression

**What this PR does / why we need it**:

The backend ESM migration replaced the status-aware `isHttpError` helper from `@gardener-dashboard/request` with the similarly named helper from `http-errors`. The latter ignores the expected status argument, causing every HTTP error to be handled as if it were a `404 Not Found`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

The regression was introduced by the backend ESM migration in #2494 and first released with Dashboard 1.82.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented failed infrastructure credential updates from triggering duplicate credential recreation requests.
  - Improved error handling for terminal operations so upstream server errors are returned accurately when listing shortcuts or deleting terminals.
  - Ensured affected operations make only the expected number of requests when failures occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->