### PR TITLE
fix(auth): stringify authorization redirect

### DIFF
--- a/backend/__tests__/acceptance/auth.spec.js
+++ b/backend/__tests__/acceptance/auth.spec.js
@@ -177,7 +177,7 @@ describe('auth', function () {
       searchParams.append('state', params.state)
       searchParams.append('scope', params.scope)
       searchParams.append('response_type', head(oidc.response_types))
-      return url.toString()
+      return url
     })
 
     randomState.mockReturnValueOnce('state')

--- a/backend/lib/auth.js
+++ b/backend/lib/auth.js
@@ -25,7 +25,7 @@ router.use(bodyParser.json())
 router.route('/')
   .get(async (req, res, next) => {
     try {
-      res.redirect(await authorizationUrl(req, res))
+      res.redirect((await authorizationUrl(req, res)).toString())
     } catch (err) {
       logger.error('failed to redirect to authorization url: %s', err)
       res.redirect(`/login#error=${encodeURIComponent(err.message)}`)


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area quality
  /area usability
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|cost|dev-productivity|documentation|high-availability|logging|monitoring|networking|open-source|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind bug

**What this PR does / why we need it**:

Converts the OpenID Connect authorization URL to a string before passing it to Express.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

Raw dashboard log:

```text
express deprecated Url must be a string backend/lib/auth.js:28:11
```

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authorization redirects by ensuring authorization URLs are handled consistently.
  * Updated authentication behavior to support URL objects correctly during sign-in flows.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->