### PR TITLE
fix(workers): prevent Safari runtime field shrinkage

### DIFF
--- a/frontend/src/components/ShootWorkers/GContainerRuntime.vue
+++ b/frontend/src/components/ShootWorkers/GContainerRuntime.vue
@@ -11,6 +11,7 @@ SPDX-License-Identifier: Apache-2.0
     <v-select
       v-model="criName"
       v-messages-color="{ color: 'warning' }"
+      :style="{ flex: criContainerRuntimeTypes.length ? '0 0 125px' : undefined }"
       color="primary"
       item-color="primary"
       :items="criItems"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area quality
  /area usability
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|cost|dev-productivity|documentation|high-availability|logging|monitoring|networking|open-source|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area usability
/kind bug

**What this PR does / why we need it**:
Prevents the container runtime field in the shoot workers configuration from shrinking in Safari.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed the container runtime selector from shrinking in Safari when configuring shoot workers
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the CRI selection layout to use space more effectively when additional OCI runtime options are available.
  * Preserved the default layout when no additional runtime options exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->