### PR TITLE
fix(frontend): reduce infrastructure selector spacing

### DIFF
--- a/frontend/src/components/NewShoot/GNewShootInfrastructureCard.vue
+++ b/frontend/src/components/NewShoot/GNewShootInfrastructureCard.vue
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Apache-2.0
   <v-hover v-slot="{ isHovering, props }">
     <v-card
       v-bind="props"
-      class="cursor-pointer pa-2 ma-3"
+      class="cursor-pointer pa-2"
       min-width="120"
       hover
       elevation="3"

--- a/frontend/src/components/NewShoot/GNewShootSelectInfrastructure.vue
+++ b/frontend/src/components/NewShoot/GNewShootSelectInfrastructure.vue
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 -->
 
 <template>
-  <v-row class="my-0">
+  <v-row class="my-3">
     <g-new-shoot-infrastructure-card
       v-for="value in cloudProfileStore.sortedInfraProviderTypeList"
       :key="value"


### PR DESCRIPTION
/area usability
/kind bug

**What this PR does / why we need it**:
Reduces excess spacing in the infrastructure selector of the new shoot creation flow.

**Which issue(s) this PR fixes**:
Fixes #

**Release note**:
```bugfix user
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted spacing around infrastructure cards and provider rows for a cleaner, more consistent layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->