### PR TITLE
fix(workers): prevent runtime input overlap

### DIFF
--- a/frontend/src/components/ShootWorkers/GContainerRuntime.vue
+++ b/frontend/src/components/ShootWorkers/GContainerRuntime.vue
@@ -6,7 +6,8 @@ SPDX-License-Identifier: Apache-2.0
 
 <template>
   <div
-    class="d-flex flex-row"
+    class="d-flex flex-row regular-input"
+    :class="{ 'has-oci-runtimes': criContainerRuntimeTypes.length }"
   >
     <v-select
       v-model="criName"
@@ -167,3 +168,9 @@ export default {
   },
 }
 </script>
+
+<style scoped>
+.has-oci-runtimes {
+  min-width: 278px;
+}
+</style>

--- a/frontend/src/components/ShootWorkers/GWorkerInputGeneric.vue
+++ b/frontend/src/components/ShootWorkers/GWorkerInputGeneric.vue
@@ -47,14 +47,12 @@ SPDX-License-Identifier: Apache-2.0
           :field-name="`${workerGroupName} Machine Image`"
         />
       </div>
-      <div class="regular-input">
-        <g-container-runtime
-          :machine-image-cri="machineImageCri"
-          :worker="worker"
-          :kubernetes-version="kubernetesVersion"
-          :field-name="`${workerGroupName} Container Runtime`"
-        />
-      </div>
+      <g-container-runtime
+        :machine-image-cri="machineImageCri"
+        :worker="worker"
+        :kubernetes-version="kubernetesVersion"
+        :field-name="`${workerGroupName} Container Runtime`"
+      />
       <div
         v-if="volumeInCloudProfile"
         class="regular-input"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area usability
/kind bug

**What this PR does / why we need it**:
Fixes overlapping input fields in the container runtime section of the worker configuration. Two components (`GContainerRuntime.vue` and `GWorkerInputGeneric.vue`) were adjusted to prevent UI elements from visually colliding.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```bugfix user
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the runtime selector’s layout and minimum width when OCI runtime options are available.
  * Adjusted input styling for more consistent alignment with other worker configuration fields.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->