### PR TITLE
feat(auth): resolve user groups on-demand via TokenReview

### DIFF
--- a/backend/__tests__/acceptance/api.shoots.spec.js
+++ b/backend/__tests__/acceptance/api.shoots.spec.js
@@ -105,6 +105,7 @@ describe('api', function () {
 
     it('should return all shoots for a non-admin user', async () => {
       mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess({ allowed: false }))
+      mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewToken())
       mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
       mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess({ allowed: false }))
 
@@ -114,11 +115,39 @@ describe('api', function () {
         .expect('content-type', /json/)
         .expect(200)
 
-      expect(mockRequest).toHaveBeenCalledTimes(3)
-      expect(mockRequest.mock.calls).toMatchSnapshot()
+      expect(mockRequest).toHaveBeenCalledTimes(4)
+      expect(mockRequest.mock.calls[1][0][':path']).toBe('/apis/authentication.k8s.io/v1/tokenreviews')
+      const accessReviews = mockRequest.mock.calls.filter(([headers]) =>
+        headers[':path'] === '/apis/authorization.k8s.io/v1/selfsubjectaccessreviews',
+      )
+      expect(accessReviews).toMatchSnapshot()
 
       expect(res.body.items.map(item => item.metadata.uid)).toEqual([1, 2, 3])
       expect(res.body).toMatchSnapshot()
+    })
+
+    it('should use group membership for the _all shoot fallback', async () => {
+      const groupUser = fixtures.auth.createUser({
+        id: 'group-user@example.org',
+        groups: ['group1'],
+      })
+      mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess({ allowed: false }))
+      mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewToken())
+      mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+
+      const res = await agent
+        .get('/api/namespaces/_all/shoots')
+        .set('cookie', await groupUser.cookie)
+        .expect('content-type', /json/)
+        .expect(200)
+
+      expect(mockRequest).toHaveBeenCalledTimes(3)
+      expect(mockRequest.mock.calls[1][0][':path']).toBe('/apis/authentication.k8s.io/v1/tokenreviews')
+      const reviewedNamespaces = mockRequest.mock.calls
+        .filter(([headers]) => headers[':path'] === '/apis/authorization.k8s.io/v1/selfsubjectaccessreviews')
+        .map(([, json]) => json.spec.resourceAttributes.namespace)
+      expect(reviewedNamespaces).toEqual([undefined, 'garden-GroupMember1'])
+      expect(res.body.items).toEqual([])
     })
 
     it('should return all unhealthy shoots', async () => {

--- a/backend/__tests__/acceptance/api.tickets.spec.js
+++ b/backend/__tests__/acceptance/api.tickets.spec.js
@@ -22,6 +22,9 @@ import { seedProjectNamespaceIndex } from '../helpers/cache.js'
 import cache from '../../lib/cache/index.js'
 import * as authorization from '../../lib/services/authorization.js'
 import * as tickets from '../../lib/services/tickets.js'
+import request from '@gardener-dashboard/request'
+
+const { mockRequest } = request
 
 describe('api', function () {
   let agent
@@ -37,6 +40,7 @@ describe('api', function () {
   })
 
   beforeEach(async () => {
+    mockRequest.mockReset()
     mockListIssues.mockReturnValue([
       fixtures.github.createIssue(1, 'foo'),
       fixtures.github.createIssue(2, 'bar', { comments: 1 }),
@@ -78,6 +82,7 @@ describe('api', function () {
     it('should fetch only member project issues for all namespaces when user cannot list projects', async () => {
       const namespace = '_all'
       vi.spyOn(authorization, 'canListProjects').mockResolvedValueOnce(false)
+      mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewToken())
 
       const res = await agent
         .get(`/api/namespaces/${namespace}/tickets`)
@@ -108,6 +113,7 @@ describe('api', function () {
     it('should return 403 for namespace the user is not a member of', async () => {
       const namespace = 'garden-GroupMember1'
       vi.spyOn(authorization, 'canListProjects').mockResolvedValueOnce(false)
+      mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewToken())
 
       const result = await agent
         .get(`/api/namespaces/${namespace}/tickets`)
@@ -118,11 +124,33 @@ describe('api', function () {
     it('should return 403 for a namespace that does not exist', async () => {
       const namespace = 'garden-nonexistent'
       vi.spyOn(authorization, 'canListProjects').mockResolvedValueOnce(false)
+      mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewToken())
 
       const result = await agent
         .get(`/api/namespaces/${namespace}/tickets`)
         .set('cookie', await user.cookie)
       expect(result.status).toEqual(403)
+    })
+
+    it('should fetch tickets for a group-only project with a group-free dashboard JWT', async () => {
+      const groupUser = fixtures.auth.createUser({
+        id: 'group-user@example.org',
+        groups: ['group1'],
+      })
+      vi.spyOn(authorization, 'canListProjects').mockResolvedValueOnce(false)
+      mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewToken())
+
+      const res = await agent
+        .get('/api/namespaces/garden-GroupMember1/tickets')
+        .set('cookie', await groupUser.cookie)
+        .expect('content-type', /json/)
+        .expect(200)
+
+      expect(mockRequest).toHaveBeenCalledTimes(1)
+      expect(mockRequest.mock.calls[0][0][':path']).toBe('/apis/authentication.k8s.io/v1/tokenreviews')
+      expect(res.body).toEqual({
+        issues: [],
+      })
     })
 
     it('should fetch open issues and comments for shoot cluster test in namespace bar', async () => {
@@ -143,6 +171,7 @@ describe('api', function () {
       const namespace = 'garden-GroupMember1'
       const name = 'test'
       vi.spyOn(authorization, 'canListProjects').mockResolvedValueOnce(false)
+      mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewToken())
 
       const result = await agent
         .get(`/api/namespaces/${namespace}/tickets/${name}`)

--- a/backend/__tests__/acceptance/api.user.spec.js
+++ b/backend/__tests__/acceptance/api.user.spec.js
@@ -62,5 +62,65 @@ describe('api', function () {
 
       expect(res.body).toMatchSnapshot()
     })
+
+    it('should return the current user groups', async function () {
+      const groups = ['group-a', 'group-b']
+      const groupUser = fixtures.auth.createUser({
+        id: 'bar@example.org',
+        groups,
+      })
+      mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewToken())
+
+      const res = await agent
+        .get('/api/user/groups')
+        .set('cookie', await groupUser.cookie)
+        .expect('content-type', /json/)
+        .expect(200)
+
+      expect(mockRequest).toHaveBeenCalledTimes(1)
+      expect(mockRequest.mock.calls[0][0][':path']).toBe('/apis/authentication.k8s.io/v1/tokenreviews')
+      expect(res.body).toEqual(groups)
+    })
+
+    it('should return an empty list when TokenReview omits groups', async function () {
+      mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewToken())
+
+      const res = await agent
+        .get('/api/user/groups')
+        .set('cookie', await user.cookie)
+        .expect('content-type', /json/)
+        .expect(200)
+
+      expect(res.body).toEqual([])
+    })
+
+    it('should reject a TokenReview username that does not match the session user', async function () {
+      const mismatchedUser = fixtures.auth.createUser({
+        id: 'bar@example.org',
+        bearerId: 'other@example.org',
+      })
+      mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewToken())
+
+      const res = await agent
+        .get('/api/user/groups')
+        .set('cookie', await mismatchedUser.cookie)
+        .expect('content-type', /json/)
+        .expect(401)
+
+      expect(res.body).toEqual(expect.objectContaining({
+        code: 401,
+        reason: 'Unauthorized',
+        message: 'Bearer token user does not match dashboard session user',
+      }))
+    })
+
+    it('should reject unauthenticated requests for user groups', async function () {
+      const res = await agent
+        .get('/api/user/groups')
+        .expect('content-type', /json/)
+        .expect(401)
+
+      expect(res.status).toBe(401)
+    })
   })
 })

--- a/backend/__tests__/acceptance/auth.spec.js
+++ b/backend/__tests__/acceptance/auth.spec.js
@@ -393,8 +393,34 @@ describe('auth', function () {
       exp: expect.toBeWithinRange(expiresAt, expiresAt + 3),
       jti: expect.stringMatching(/[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}/i),
     }))
+    expect(Object.hasOwn(payload, 'groups')).toBe(false)
 
     expect(res.body.id).toBe(id)
+  })
+
+  it('should omit groups from the dashboard JWT after token login', async function () {
+    const groups = ['group-a', 'group-b']
+    const groupUser = fixtures.user.create({ id, groups })
+    const bearer = await groupUser.bearer
+
+    mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewToken())
+    mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+    mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+
+    const res = await agent
+      .post('/auth')
+      .send({ token: bearer })
+      .expect('content-type', /json/)
+      .expect(200)
+
+    const [accessToken, idToken] = await parseCookies(res)
+    expect(idToken).toEqual(bearer)
+    expect(decode(idToken).groups).toEqual(groups)
+
+    const payload = await security.verify(accessToken)
+    expect(payload.id).toBe(id)
+    expect(Object.hasOwn(payload, 'groups')).toBe(false)
+    expect(Object.hasOwn(res.body, 'groups')).toBe(false)
   })
 
   it('should logout', async function () {
@@ -443,6 +469,7 @@ describe('auth', function () {
       iat: iat + 60,
       sub: id,
       exp: iat + 61 * 60,
+      groups: ['group-a', 'group-b'],
     }
     const tokenSet = {
       id_token: await sign(idTokenPayload),
@@ -545,5 +572,6 @@ describe('auth', function () {
       refresh_at: refreshTokenPayload.exp,
       rti: expect.stringMatching(/^[a-z0-9]{7}$/),
     })
+    expect(Object.hasOwn(payload, 'groups')).toBe(false)
   })
 })

--- a/backend/__tests__/acceptance/io.cors.spec.js
+++ b/backend/__tests__/acceptance/io.cors.spec.js
@@ -17,6 +17,17 @@ import config from '../../lib/config/index.js'
 
 const { mockRequest } = request
 
+function mockSocketAuthentication () {
+  mockRequest.mockReset()
+  mockRequest
+    .mockImplementationOnce(fixtures.auth.mocks.reviewToken())
+    .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+    .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+    .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+    .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+    .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+}
+
 describe('cors', () => {
   let agent
   let socket
@@ -33,6 +44,7 @@ describe('cors', () => {
   afterEach(async () => {
     await socket?.destroy()
     await agent?.close()
+    mockRequest.mockReset()
     vi.clearAllMocks()
   })
 
@@ -80,12 +92,7 @@ describe('cors', () => {
 
   it('should allow connections from allowed origins', async () => {
     Object.defineProperty(config, 'websocketAllowedOrigins', { value: ['https://allowed.example.org'] })
-    mockRequest
-      .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
-      .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
-      .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
-      .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
-      .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+    mockSocketAuthentication()
     agent = await createAgent('io', cache)
     const cookie = await user.cookie
     socket = await agent.connect({ cookie, originHeader: 'https://allowed.example.org' })
@@ -94,12 +101,7 @@ describe('cors', () => {
 
   it('should allow connections when "*" is configured', async () => {
     Object.defineProperty(config, 'websocketAllowedOrigins', { value: ['*'] })
-    mockRequest
-      .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
-      .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
-      .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
-      .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
-      .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+    mockSocketAuthentication()
     agent = await createAgent('io', cache)
     const cookie = await user.cookie
     socket = await agent.connect({ cookie, originHeader: 'https://any.example.org' })

--- a/backend/__tests__/acceptance/io.spec.js
+++ b/backend/__tests__/acceptance/io.spec.js
@@ -117,6 +117,14 @@ function notFoundStatus ({ group, kind, uid }) {
   }
 }
 
+function mockSocketAuthentication (accessReviews = [{}, {}, {}, {}, {}]) {
+  mockRequest.mockReset()
+  mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewToken())
+  for (const options of accessReviews) {
+    mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess(options))
+  }
+}
+
 describe('api', function () {
   let agent
   let socket
@@ -190,6 +198,7 @@ describe('api', function () {
 
   afterEach(function () {
     socket?.destroy()
+    mockRequest.mockReset()
     vi.clearAllMocks()
   })
 
@@ -205,12 +214,7 @@ describe('api', function () {
       beforeEach(async () => {
         // authorization check for `canListProjects`, `canListSeeds`, `canListShoots`,
         // `canListManagedSeedsInGardenNamespace`, and `canListShootsInGardenNamespace`
-        mockRequest
-          .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
-          .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
-          .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
-          .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
-          .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+        mockSocketAuthentication()
         socket = await agent.connect({
           cookie: await user.cookie,
         })
@@ -221,7 +225,7 @@ describe('api', function () {
           'managedseeds;garden',
           'managedseed-shoots;garden',
         ]
-        expect(mockRequest).toHaveBeenCalledTimes(5)
+        expect(mockRequest).toHaveBeenCalledTimes(6)
         mockRequest.mockClear()
       })
 
@@ -396,12 +400,13 @@ describe('api', function () {
       })
 
       it('should fail to synchronize managed seeds without garden access', async function () {
-        mockRequest
-          .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
-          .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
-          .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
-          .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess({ allowed: false }))
-          .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess({ allowed: false }))
+        mockSocketAuthentication([
+          {},
+          {},
+          {},
+          { allowed: false },
+          { allowed: false },
+        ])
 
         const limitedSocket = await agent.connect({
           cookie: await user.cookie,
@@ -422,12 +427,13 @@ describe('api', function () {
       })
 
       it('should fail to synchronize managed seed shoots without garden access', async function () {
-        mockRequest
-          .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
-          .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
-          .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
-          .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess({ allowed: false }))
-          .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess({ allowed: false }))
+        mockSocketAuthentication([
+          {},
+          {},
+          {},
+          { allowed: false },
+          { allowed: false },
+        ])
 
         const limitedSocket = await agent.connect({
           cookie: await user.cookie,
@@ -458,12 +464,7 @@ describe('api', function () {
       beforeEach(async () => {
         // authorization check for `canListProjects`, `canListSeeds`, `canListShoots`,
         // `canListManagedSeedsInGardenNamespace`, and `canListShootsInGardenNamespace`
-        mockRequest
-          .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
-          .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
-          .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
-          .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
-          .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+        mockSocketAuthentication()
         socket = await agent.connect({
           cookie: await user.cookie,
         })
@@ -474,7 +475,7 @@ describe('api', function () {
           'managedseeds;garden',
           'managedseed-shoots;garden',
         ]
-        expect(mockRequest).toHaveBeenCalledTimes(5)
+        expect(mockRequest).toHaveBeenCalledTimes(6)
         mockRequest.mockClear()
       })
 
@@ -629,15 +630,47 @@ describe('api', function () {
     })
   })
 
+  describe('when user belongs to a project only through a group', () => {
+    const username = 'group-user@example.org'
+    const user = fixtures.auth.createUser({
+      id: username,
+      groups: ['group1'],
+    })
+
+    beforeEach(async () => {
+      mockSocketAuthentication()
+      socket = await agent.connect({
+        cookie: await user.cookie,
+      })
+      expect(mockRequest.mock.calls[0][0][':path']).toBe('/apis/authentication.k8s.io/v1/tokenreviews')
+      mockRequest.mockClear()
+    })
+
+    it('should synchronize a group-only project from a group-free dashboard JWT', async function () {
+      const items = await synchronize(socket, 'projects', [3])
+      expect(items).toEqual([
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            name: 'GroupMember1',
+            uid: 3,
+          }),
+        }),
+      ])
+    })
+
+    it('should subscribe tickets for the group-only project', async function () {
+      mockRequest.mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+
+      await subscribe(socket, 'issues', { namespace: 'garden-GroupMember1' })
+
+      expect(getRooms(socket, nsp).has('issues;garden-GroupMember1')).toBe(true)
+    })
+  })
+
   describe('when user authentication fails', () => {
     let timestamp
 
     beforeEach(() => {
-      mockRequest
-        .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
-        .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
-        .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
-        .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
       timestamp = Math.floor(Date.now() / 1000)
     })
 
@@ -666,6 +699,7 @@ describe('api', function () {
         rti,
         refresh_at: refreshAt,
       })
+      mockSocketAuthentication()
       const cookie = await user.cookie
       await expect(agent.connect({ cookie })).rejects.toEqual(expect.objectContaining({
         name: 'Error',
@@ -703,16 +737,11 @@ describe('api', function () {
       const user = fixtures.auth.createUser(options)
       // authorization check for `canListProjects`, `canListSeeds`, `canListShoots`,
       // `canListManagedSeedsInGardenNamespace`, and `canListShootsInGardenNamespace`
-      mockRequest
-        .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
-        .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
-        .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
-        .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
-        .mockImplementationOnce(fixtures.auth.mocks.reviewSelfSubjectAccess())
+      mockSocketAuthentication()
       socket = await agent.connect({
         cookie: await user.cookie,
       })
-      expect(mockRequest).toHaveBeenCalledTimes(5)
+      expect(mockRequest).toHaveBeenCalledTimes(6)
       expect(mockSetDisconnectTimeout).toHaveBeenCalledTimes(1)
       expect(mockSetDisconnectTimeout.mock.calls[0]).toEqual([
         expect.objectContaining({

--- a/backend/__tests__/fixtures/auth.js
+++ b/backend/__tests__/fixtures/auth.js
@@ -28,10 +28,10 @@ const iat = 1577836800
 const expiresIn = '50y'
 const jwtid = 'jti'
 
-async function getCookieValue (token) {
-  const bearer = await token
+async function getCookieValue (accessToken, idToken = accessToken) {
+  const [bearer, encryptedBearer] = await Promise.all([accessToken, idToken])
   const [header, payload, signature] = split(bearer, '.')
-  const encrypted = await encrypt(bearer)
+  const encrypted = await encrypt(encryptedBearer)
   const cookies = {
     [COOKIE_HEADER_PAYLOAD]: join([header, payload], '.'),
     [COOKIE_SIGNATURE]: signature,
@@ -47,7 +47,7 @@ async function getCookieValue (token) {
 }
 
 const auth = {
-  createUser ({ id, aud = ['gardener'], ...rest }, invalid) {
+  createUser ({ id, aud = ['gardener'], groups, bearerId, ...rest }, invalid) {
     const secret = invalid === true
       ? 'invalid-secret'
       : undefined
@@ -59,16 +59,28 @@ const auth = {
     if (!rest.jti) {
       options.jwtid = jwtid
     }
-    const bearer = sign({ id, iat, aud, ...rest }, secret, options)
+    const accessToken = sign({ id, iat, aud, ...rest }, secret, options)
+    const idTokenPayload = {
+      id: bearerId ?? id,
+      iat,
+      aud,
+      ...rest,
+    }
+    if (groups !== undefined) {
+      idTokenPayload.groups = groups
+    }
+    const idToken = (groups !== undefined || bearerId !== undefined)
+      ? sign(idTokenPayload, secret, options)
+      : accessToken
     return {
       isAdmin () {
         return /^admin/.test(id)
       },
       get cookie () {
-        return getCookieValue(bearer)
+        return getCookieValue(accessToken, idToken)
       },
       get bearer () {
-        return bearer
+        return idToken
       },
     }
   },

--- a/backend/__tests__/io.tickets.spec.js
+++ b/backend/__tests__/io.tickets.spec.js
@@ -38,7 +38,7 @@ describe('io/tickets', () => {
   }
 
   // foo@example.org is a member of projects 'foo' and 'bar' in fixtures
-  const user = { id: 'foo@example.org' }
+  const user = { id: 'foo@example.org', groups: [] }
 
   it('should join all non-pending project rooms when user can list projects', async () => {
     vi.spyOn(authorization, 'canListProjects').mockResolvedValue(true)
@@ -74,6 +74,16 @@ describe('io/tickets', () => {
       message: 'Forbidden to subscribe to tickets in namespace garden-GroupMember1',
     })
     expect(socket.join).not.toHaveBeenCalled()
+  })
+
+  it('should join a group-only project room when the socket user has groups', async () => {
+    vi.spyOn(authorization, 'canListProjects').mockResolvedValue(false)
+    const socket = createSocket({
+      id: 'group-user@example.org',
+      groups: ['group1'],
+    })
+    await subscribe(socket, { namespace: 'garden-GroupMember1' })
+    expect(socket.join).toHaveBeenCalledExactlyOnceWith('issues;garden-GroupMember1')
   })
 
   it('should throw when the requested namespace does not exist', async () => {

--- a/backend/__tests__/security.spec.js
+++ b/backend/__tests__/security.spec.js
@@ -378,7 +378,7 @@ describe('security', function () {
         })
         const { refreshToken } = security
 
-        authentication.isAuthenticated.mockResolvedValue({ username: sub, groups: [] })
+        authentication.isAuthenticated.mockResolvedValue({ username: sub, groups: ['group-a', 'group-b'] })
         authorization.isAdmin.mockResolvedValue(false)
         authorization.canListShoots.mockResolvedValue(true)
 
@@ -476,12 +476,12 @@ describe('security', function () {
         expect(user).toEqual(
           expect.objectContaining({
             id: sub,
-            groups: [],
             aud: ['gardener'],
             isAdmin: false,
             canListShootsAllNamespaces: true,
           }),
         )
+        expect(Object.hasOwn(user, 'groups')).toBe(false)
       })
     })
 

--- a/backend/__tests__/services.projects.spec.js
+++ b/backend/__tests__/services.projects.spec.js
@@ -32,6 +32,10 @@ vi.mock('../lib/cache/index.js', async () => {
             name: 'robot-sa',
             namespace: 'garden-foo',
           },
+          {
+            kind: 'Group',
+            name: 'team-a',
+          },
         ],
       },
       status: {
@@ -89,6 +93,12 @@ vi.mock('../lib/cache/index.js', async () => {
 })
 vi.mock('../lib/services/shoots.js')
 vi.mock('../lib/services/authorization.js')
+vi.mock('../lib/services/authentication.js', () => ({
+  ensureUserGroups: vi.fn(async user => {
+    user.groups ??= []
+    return user.groups
+  }),
+}))
 vi.mock('@gardener-dashboard/kube-client', () => {
   const mockKubeClient = {
     dashboardClient: {
@@ -170,6 +180,16 @@ describe('services/projects', () => {
 
       const result = await projects.list({ user })
       expect(result).toHaveLength(0)
+    })
+
+    it('should return project for group member with a group-free dashboard user', async () => {
+      authorization.canListProjects.mockResolvedValue(false)
+      const user = createUser('group-user@bar.com')
+      user.groups = ['team-a']
+
+      const result = await projects.list({ user })
+      expect(result).toHaveLength(1)
+      expect(result[0].metadata.name).toBe('foo')
     })
   })
 

--- a/backend/__tests__/utils.spec.js
+++ b/backend/__tests__/utils.spec.js
@@ -17,6 +17,8 @@ import {
 import {
   encodeBase64,
   decodeBase64,
+  guardUserGroups,
+  isMemberOf,
   getConfigValue,
   isTruthyValue,
   shootHasIssue,
@@ -43,6 +45,18 @@ describe('utils', function () {
       expect(decodeBase64()).toBeUndefined()
       expect(decodeBase64('')).toBeUndefined()
       expect(decodeBase64('Zm9v')).toBe('foo')
+    })
+
+    it('should guard access to user groups until they have been ensured', function () {
+      const user = { groups: ['legacy-group'] }
+      guardUserGroups(user)
+
+      expect(() => user.groups).toThrow('User groups have not been ensured')
+      expect(Object.keys(user)).not.toContain('groups')
+      expect(() => isMemberOf({ spec: { members: [{ kind: 'Group' }] } }, user)).toThrow('User groups have not been ensured')
+
+      user.groups = []
+      expect(user.groups).toEqual([])
     })
 
     it('should return some config values with defaults', function () {

--- a/backend/__tests__/watches.spec.js
+++ b/backend/__tests__/watches.spec.js
@@ -74,6 +74,7 @@ const sockets = [
     data: {
       user: {
         id: 'admin@example.org',
+        groups: [],
         profiles: {
           canListProjects: true,
           canListSeeds: true,
@@ -86,6 +87,7 @@ const sockets = [
     data: {
       user: {
         id: 'foo@example.org',
+        groups: [],
         profiles: {
           canListProjects: false,
           canListSeeds: false,
@@ -98,6 +100,7 @@ const sockets = [
     data: {
       user: {
         id: 'bar@example.org',
+        groups: [],
         profiles: {
           canListProjects: false,
           canListSeeds: true,
@@ -526,6 +529,46 @@ describe('watches', function () {
       expect(fooRoom.emit.mock.calls).toEqual([
         ['projects', { type: 'ADDED', uid }],
         ['projects', { type: 'DELETED', uid }],
+      ])
+    })
+
+    it('should notify users who belong to a project only through a group', async function () {
+      const groupUserId = 'group-user@example.org'
+      io.fetchSockets.mockResolvedValueOnce([{
+        id: 4,
+        data: {
+          user: {
+            id: groupUserId,
+            groups: ['group1'],
+            profiles: {
+              canListProjects: false,
+              canListSeeds: false,
+            },
+          },
+        },
+      }])
+      watches.projects(io, informer)
+
+      const uid = 8
+      const project = {
+        metadata: {
+          name: 'GroupMember1',
+          uid,
+        },
+        spec: {
+          members: [{
+            kind: 'Group',
+            name: 'group1',
+          }],
+        },
+      }
+
+      informer.emit('add', project)
+      await flushPromises()
+
+      const roomId = sha256(groupUserId)
+      expect(rooms.get(roomId).emit.mock.calls).toEqual([
+        ['projects', { type: 'ADDED', uid }],
       ])
     })
   })

--- a/backend/lib/io/helper.js
+++ b/backend/lib/io/helper.js
@@ -12,6 +12,7 @@ import kubeClientModule from '@gardener-dashboard/kube-client'
 import { cloneDeep } from 'lodash-es'
 import cache from '../cache/index.js'
 import logger from '../logger/index.js'
+import * as authentication from '../services/authentication.js'
 import * as authorization from '../services/authorization.js'
 import { authenticate } from '../security/index.js'
 import { simplifyObjectMetadata } from '../utils/index.js'
@@ -65,12 +66,15 @@ function expiresIn (socket) {
 async function userProfiles (req, res, next) {
   try {
     const [
+      ,
       canListProjects,
       canListSeeds,
       canListShoots,
       canListManagedSeedsInGardenNamespace,
       canListShootsInGardenNamespace,
     ] = await Promise.all([
+      // Hydrate the shared socket user once for authorization in later events.
+      authentication.ensureUserGroups(req.user),
       authorization.canListProjects(req.user),
       authorization.canListSeeds(req.user),
       authorization.canListShoots(req.user),

--- a/backend/lib/routes/tickets.js
+++ b/backend/lib/routes/tickets.js
@@ -11,6 +11,7 @@ import cache from '../cache/index.js'
 import * as tickets from '../services/tickets.js'
 import { metricsRoute } from '../middleware.js'
 import * as authorization from '../services/authorization.js'
+import * as authentication from '../services/authentication.js'
 import { projectFilter } from '../utils/index.js'
 
 const router = express.Router({
@@ -22,6 +23,10 @@ const metricsMiddleware = metricsRoute('tickets')
 
 async function getIssues (namespace, user) {
   const canListProjects = await authorization.canListProjects(user)
+  if (!canListProjects) {
+    // Without cluster-wide project access, projectFilter evaluates user and group membership.
+    await authentication.ensureUserGroups(user)
+  }
   let allowedProjects = cache.getProjects()
     .filter(projectFilter(user, canListProjects))
 

--- a/backend/lib/routes/user.js
+++ b/backend/lib/routes/user.js
@@ -9,13 +9,24 @@ import services from '../services/index.js'
 import { metricsRoute } from '../middleware.js'
 import config from '../config/index.js'
 import { encodeBase64 } from '../utils/index.js'
-const { authorization } = services
+const { authentication, authorization } = services
 
 const router = express.Router({
   mergeParams: true,
 })
 
 const metricsMiddleware = metricsRoute('user')
+router.route('/groups')
+  .all(metricsMiddleware)
+  .get(async (req, res, next) => {
+    try {
+      const groups = await authentication.ensureUserGroups(req.user)
+      res.send(groups)
+    } catch (err) {
+      next(err)
+    }
+  })
+
 router.route('/subjectrules')
   .all(metricsMiddleware)
   .post(async (req, res, next) => {

--- a/backend/lib/security/index.js
+++ b/backend/lib/security/index.js
@@ -21,6 +21,7 @@ import {
 } from 'lodash-es'
 import pRetry from 'p-retry'
 import { pTimeout } from '../utils/p-timeout.js'
+import { guardUserGroups } from '../utils/index.js'
 import services from '../services/index.js'
 import createError from 'http-errors'
 import logger from '../logger/index.js'
@@ -290,13 +291,12 @@ async function createAccessToken (payload, idToken) {
     }
   }
   const [
-    { value: { username, groups } },
+    { value: { username } },
     { value: isAdmin },
     { value: canListShootsAllNamespaces },
   ] = results
   Object.assign(payload, {
     id: username,
-    groups,
     aud: [GARDENER_AUDIENCE],
     isAdmin,
     canListShootsAllNamespaces,
@@ -569,6 +569,7 @@ function authenticate (options = {}) {
       csrfProtection(req, res)
       const tokenSet = await getTokenSet(req.cookies)
       const user = await verifyAccessToken(tokenSet.access_token)
+      guardUserGroups(user)
       const auth = Object.freeze({
         bearer: tokenSet.id_token,
       })

--- a/backend/lib/services/authentication.js
+++ b/backend/lib/services/authentication.js
@@ -39,3 +39,14 @@ export async function isAuthenticated ({ token } = {}) {
     throw new Unauthorized(err.message)
   }
 }
+
+export async function ensureUserGroups (user) {
+  const { username, groups } = await isAuthenticated({
+    token: user.auth.bearer,
+  })
+  if (username !== user.id) {
+    throw new Unauthorized('Bearer token user does not match dashboard session user')
+  }
+  user.groups = groups ?? []
+  return user.groups
+}

--- a/backend/lib/services/projects.js
+++ b/backend/lib/services/projects.js
@@ -14,6 +14,7 @@ import {
   simplifyProject,
 } from '../utils/index.js'
 import cache from '../cache/index.js'
+import * as authentication from './authentication.js'
 const { dashboardClient } = kubeClientModule
 const { PreconditionFailed, InternalServerError } = httpErrors
 
@@ -32,6 +33,10 @@ async function validateDeletePreconditions ({ user, name }) {
 
 export async function list ({ user }) {
   const canListProjects = await authorization.canListProjects(user)
+  if (!canListProjects) {
+    // Without cluster-wide project access, projectFilter evaluates user and group membership.
+    await authentication.ensureUserGroups(user)
+  }
   return _
     .chain(cache.getProjects())
     .filter(projectFilter(user, canListProjects))

--- a/backend/lib/services/shoots.js
+++ b/backend/lib/services/shoots.js
@@ -11,6 +11,7 @@ import createError from 'http-errors'
 import * as utils from '../utils/index.js'
 import cache from '../cache/index.js'
 import * as authorization from './authorization.js'
+import * as authentication from './authentication.js'
 import logger from '../logger/index.js'
 import _ from 'lodash-es'
 import semver from 'semver'
@@ -39,7 +40,9 @@ export async function list ({ user, namespace, labelSelector }) {
         items: cache.getShoots(namespace, query),
       }
     } else {
-      // user is permitted to list shoots only in namespaces associated with their projects
+      // Without cluster-wide shoot access, fall back to namespaces of projects the user belongs to.
+      // Project membership can be granted through a group, so hydrate groups before filtering.
+      await authentication.ensureUserGroups(user)
       const namespaces = _
         .chain(cache.getProjects())
         .filter(projectFilter(user, false))

--- a/backend/lib/utils/index.js
+++ b/backend/lib/utils/index.js
@@ -29,6 +29,22 @@ function encodeBase64 (value) {
   return Buffer.from(value, 'utf8').toString('base64')
 }
 
+function guardUserGroups (user) {
+  let groups
+  Object.defineProperty(user, 'groups', {
+    configurable: false,
+    enumerable: false,
+    get () {
+      assert.ok(groups, 'User groups have not been ensured')
+      return groups
+    },
+    set (value) {
+      assert.ok(Array.isArray(value), 'User groups must be an array')
+      groups = value
+    },
+  })
+}
+
 function isMemberOf (project, user) {
   return _
     .chain(project)
@@ -56,6 +72,7 @@ function isMemberOf (project, user) {
     .value()
 }
 
+// user.groups must be hydrated when canListProjects is false.
 function projectFilter (user, canListProjects = false) {
   const isPending = project => {
     return _.get(project, ['status', 'phase'], 'Pending') === 'Pending'
@@ -282,6 +299,7 @@ export {
   constants,
   decodeBase64,
   encodeBase64,
+  guardUserGroups,
   isMemberOf,
   projectFilter,
   parseRooms,

--- a/frontend/__tests__/composables/useApi.spec.js
+++ b/frontend/__tests__/composables/useApi.spec.js
@@ -51,6 +51,26 @@ describe('composables', () => {
         })
       })
 
+      describe('#getUserGroups', () => {
+        it('should fetch the current user groups', async () => {
+          const groups = ['group-a', 'group-b']
+          fetch.mockResponseOnce(JSON.stringify(groups), {
+            headers: {
+              'content-type': 'application/json; charset=UTF-8',
+            },
+          })
+
+          const res = await api.getUserGroups()
+
+          expect(res.status).toBe(200)
+          expect(res.data).toEqual(groups)
+          expect(fetch).toBeCalledTimes(1)
+          const [req] = fetch.mock.calls[0]
+          expect(req.method).toBe('GET')
+          expect(req.url).toBe('http://localhost:3000/api/user/groups')
+        })
+      })
+
       describe('#getConfiguration', () => {
         it('should fetch the configuration', async () => {
           const { getConfiguration } = api

--- a/frontend/__tests__/views/GAccount.spec.js
+++ b/frontend/__tests__/views/GAccount.spec.js
@@ -1,0 +1,141 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import { nextTick } from 'vue'
+import {
+  flushPromises,
+  shallowMount,
+} from '@vue/test-utils'
+import {
+  createPinia,
+  setActivePinia,
+} from 'pinia'
+
+import { useAppStore } from '@/store/app'
+import { useAuthnStore } from '@/store/authn'
+import { useConfigStore } from '@/store/config'
+
+import GAccount from '@/views/GAccount.vue'
+
+import { notify as notifyPlugin } from '@/plugins'
+
+const { createVuetifyPlugin } = global.fixtures.helper
+
+const SlotStub = {
+  template: '<div><slot /><slot name="prepend" /><slot name="append" /></div>',
+}
+
+describe('views', () => {
+  describe('g-account', () => {
+    let api
+    let appStore
+    let authnStore
+    let pinia
+    let wrapper
+
+    const groups = ['group-a', 'group-b']
+
+    function mountComponent () {
+      wrapper = shallowMount(GAccount, {
+        global: {
+          plugins: [
+            createVuetifyPlugin(),
+            notifyPlugin,
+            pinia,
+          ],
+          provide: {
+            api,
+            logger: {
+              debug: vi.fn(),
+              error: vi.fn(),
+              info: vi.fn(),
+              warn: vi.fn(),
+            },
+          },
+          stubs: {
+            GAccountAvatar: true,
+            GList: SlotStub,
+            GListItem: SlotStub,
+            GTimeString: true,
+            GToolbar: true,
+            VCard: SlotStub,
+            VChip: {
+              template: '<span class="v-chip"><slot /></span>',
+            },
+            VCol: SlotStub,
+            VContainer: SlotStub,
+            VRow: SlotStub,
+          },
+        },
+      })
+    }
+
+    beforeEach(() => {
+      api = {
+        getUserGroups: vi.fn(),
+      }
+      pinia = createPinia()
+      setActivePinia(pinia)
+      useConfigStore().setConfiguration({})
+      authnStore = useAuthnStore()
+      authnStore.user = {
+        id: 'foo@example.org',
+        email: 'foo@example.org',
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      }
+      appStore = useAppStore()
+      vi.spyOn(appStore, 'setError')
+    })
+
+    afterEach(() => {
+      wrapper?.unmount()
+    })
+
+    it('should keep account identity independent of cookie groups', () => {
+      expect(Object.hasOwn(authnStore.user, 'groups')).toBe(false)
+    })
+
+    it('should show a loading indicator until groups resolve', async () => {
+      let resolveGroups
+      api.getUserGroups.mockReturnValue(new Promise(resolve => {
+        resolveGroups = resolve
+      }))
+
+      mountComponent()
+      await nextTick()
+
+      expect(api.getUserGroups).toHaveBeenCalledTimes(1)
+      expect(wrapper.find('[data-test="groups-loading"]').exists()).toBe(true)
+      expect(wrapper.findAll('.v-chip')).toHaveLength(0)
+
+      resolveGroups({ data: groups })
+      await flushPromises()
+
+      expect(wrapper.find('[data-test="groups-loading"]').exists()).toBe(false)
+      expect(wrapper.findAll('.v-chip')).toHaveLength(2)
+      expect(wrapper.findAll('.v-chip').map(chip => chip.text())).toEqual(groups)
+    })
+
+    it('should render no chips and report the error when the request fails', async () => {
+      const error = Object.assign(new Error('Request failed with status code 500'), {
+        response: {
+          status: 500,
+          data: { message: 'TokenReview failed' },
+        },
+      })
+      api.getUserGroups.mockRejectedValue(error)
+
+      mountComponent()
+      await flushPromises()
+
+      expect(api.getUserGroups).toHaveBeenCalledTimes(1)
+      expect(wrapper.find('[data-test="groups-loading"]').exists()).toBe(false)
+      expect(wrapper.findAll('.v-chip')).toHaveLength(0)
+      expect(appStore.setError).toHaveBeenCalledTimes(1)
+      expect(appStore.setError).toHaveBeenCalledWith(error)
+    })
+  })
+})

--- a/frontend/src/composables/useApi/api.js
+++ b/frontend/src/composables/useApi/api.js
@@ -359,6 +359,10 @@ export function getKubeconfigData () {
   return getResource('/api/user/kubeconfig')
 }
 
+export function getUserGroups () {
+  return getResource('/api/user/groups')
+}
+
 /* Info */
 export function getInfo () {
   return getResource('/api/info')
@@ -497,6 +501,7 @@ export default {
   createTokenReview,
   getSubjectRules,
   getKubeconfigData,
+  getUserGroups,
   getInfo,
   createTerminal,
   fetchTerminalSession,

--- a/frontend/src/views/GAccount.vue
+++ b/frontend/src/views/GAccount.vue
@@ -48,15 +48,24 @@ SPDX-License-Identifier: Apache-2.0
                 Groups
               </div>
               <div class="content py-1">
-                <v-chip
-                  v-for="(group, index) in groups"
-                  :key="index"
-                  label
-                  size="small"
-                  class="mr-2"
+                <span
+                  v-if="groups === null"
+                  role="status"
+                  data-test="groups-loading"
                 >
-                  {{ group }}
-                </v-chip>
+                  Loading groups…
+                </span>
+                <template v-else>
+                  <v-chip
+                    v-for="(group, index) in groups"
+                    :key="index"
+                    label
+                    size="small"
+                    class="mr-2"
+                  >
+                    {{ group }}
+                  </v-chip>
+                </template>
               </div>
             </g-list-item>
           </g-list>
@@ -231,11 +240,13 @@ import {
 } from 'vue'
 import download from 'downloadjs'
 import {
+  mapActions,
   mapState,
   storeToRefs,
 } from 'pinia'
 import { dump as yamlDump } from 'js-yaml'
 
+import { useAppStore } from '@/store/app'
 import { useAuthnStore } from '@/store/authn'
 import { useAuthzStore } from '@/store/authz'
 import { useConfigStore } from '@/store/config'
@@ -259,7 +270,7 @@ export default {
     GAccountAvatar,
     GTimeString,
   },
-  inject: ['logger'],
+  inject: ['api', 'logger'],
   setup () {
     const projectStore = useProjectStore()
     const configStore = useConfigStore()
@@ -293,6 +304,7 @@ export default {
       skipOpenBrowser: false,
       showToken: false,
       showMessage: false,
+      groups: null,
     }
   },
   computed: {
@@ -321,9 +333,6 @@ export default {
     },
     id () {
       return this.user.id
-    },
-    groups () {
-      return this.user.groups
     },
     expiresAt () {
       return this.user.exp * 1000
@@ -425,7 +434,22 @@ export default {
       this.internalProjectName = value
     },
   },
+  mounted () {
+    this.fetchGroups()
+  },
   methods: {
+    ...mapActions(useAppStore, [
+      'setError',
+    ]),
+    async fetchGroups () {
+      try {
+        const { data } = await this.api.getUserGroups()
+        this.groups = data
+      } catch (err) {
+        this.groups = []
+        this.setError(err)
+      }
+    },
     async onDownload () {
       const kubeconfig = this.kubeconfigYaml
       const filename = this.kubeconfigFilename


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area quality
  /area usability
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|cost|dev-productivity|documentation|high-availability|logging|monitoring|networking|open-source|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area security
/area user-management
/kind enhancement

**What this PR does / why we need it**:

- Removes user groups from the signed dashboard JWT to reduce duplicated group data in browser cookie headers.
- Resolves groups through Kubernetes TokenReview at group-dependent authorization boundaries while verifying that the reviewed identity matches the authenticated user.
- Adds an authenticated groups endpoint and loads groups on demand only on the My Account page.

**Which issue(s) this PR fixes**:
Fixes #3038

**Special notes for your reviewer**:
During a rolling update, old pods may briefly fail group-only authorization when handling a new group-free session. This accepted inconsistency ends when all pods run the new version; no forced login or compatibility cookie is introduced.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
User group memberships are now resolved on demand instead of being stored in the readable dashboard session cookie, reducing HTTP request header size.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Account pages now display the groups associated with the authenticated user.
  * Added loading and error states when retrieving group information.
  * Group-based project access is supported across project, shoot, ticket, and real-time updates.
  * Added an endpoint for retrieving the current user’s groups.

* **Security**
  * Groups are refreshed securely from the authenticated session and excluded from dashboard tokens.

* **Bug Fixes**
  * Improved authorization for users accessing projects through group membership.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->