### PR TITLE
refactor(utils): replace js-base64 with native Base64 APIs

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -1065,7 +1065,6 @@ const RAW_RUNTIME_STATE =
           ["floating-vue", "virtual:8d919ffb8fd728f827df3f6a566e8e923223ffcec68f7450d83bbbc2dc25d6b8c987e111cbab484b209f253bdf2f2e00663b01a986262c44511128466462a76f#npm:5.2.2"],\
           ["get-contrast", "npm:3.0.0"],\
           ["highlight.js", "npm:11.12.0"],\
-          ["js-base64", "npm:3.9.2"],\
           ["js-yaml", "npm:5.3.0"],\
           ["jsdom", "virtual:f3f18773c1f2811e8d448670abfc3fed18cdffc11b444f7cbc3548ae5868e74f3c4ee449327c1fc9c24ce0732ee02505411a07539789bec8257188d17bbada1f#npm:26.1.0"],\
           ["jwt-decode", "npm:4.0.0"],\
@@ -8665,15 +8664,6 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/jose-npm-6.2.9-3ac85d642f-fc6d79b11f.zip/node_modules/jose/",\
         "packageDependencies": [\
           ["jose", "npm:6.2.9"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["js-base64", [\
-      ["npm:3.9.2", {\
-        "packageLocation": "./.yarn/cache/js-base64-npm-3.9.2-9e2bfa903e-59bfa7f059.zip/node_modules/js-base64/",\
-        "packageDependencies": [\
-          ["js-base64", "npm:3.9.2"]\
         ],\
         "linkType": "HARD"\
       }]\

--- a/frontend/__tests__/composables/credential.helper.spec.js
+++ b/frontend/__tests__/composables/credential.helper.spec.js
@@ -4,16 +4,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { Base64 } from 'js-base64'
-
 import { secretDetails } from '@/composables/credential/helper'
 
+import { encodeBase64 as encode } from '@/utils'
 import infraProviders from '@/data/vendors/infra'
 import dnsProviders from '@/data/vendors/dns'
-
-function encode (value) {
-  return Base64.encode(value)
-}
 
 function createSecretData () {
   return {

--- a/frontend/__tests__/utils/index.spec.js
+++ b/frontend/__tests__/utils/index.spec.js
@@ -22,12 +22,29 @@ import {
   convertToGi,
   convertToGibibyte,
   handleTextFieldDrop,
+  encodeBase64,
+  encodeBase64Url,
+  decodeBase64,
 } from '@/utils'
 
 import pick from 'lodash/pick'
 import find from 'lodash/find'
 
 describe('utils', () => {
+  describe('base64', () => {
+    it('encodes and decodes UTF-8 strings', () => {
+      const value = 'a Ā 𐀀 文 🦄'
+      const encoded = 'YSDEgCDwkICAIOaWhyDwn6aE'
+
+      expect(encodeBase64(value)).toBe(encoded)
+      expect(decodeBase64(encoded)).toBe(value)
+    })
+
+    it('encodes URL-safe strings without padding', () => {
+      expect(encodeBase64Url('hello??')).toBe('aGVsbG8_Pw')
+    })
+  })
+
   describe('#handleTextFieldDrop', () => {
     const originalFileReader = globalThis.FileReader
 

--- a/frontend/__tests__/utils/validators.spec.js
+++ b/frontend/__tests__/utils/validators.spec.js
@@ -4,7 +4,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { unique } from '@/utils/validators'
+import {
+  unique,
+  base64,
+} from '@/utils/validators'
 
 describe('utils', () => {
   describe('validators', () => {
@@ -17,6 +20,23 @@ describe('utils', () => {
       })
       it('should validate unique values', () => {
         expect(unique('keys').$validator.call(parentVm, 0)).toBe(true)
+      })
+    })
+    describe('#base64', () => {
+      it.each([
+        'YWJjZA==',
+        'YWJj',
+        '',
+      ])('validates %j', value => {
+        expect(base64.$validator(value)).toBe(true)
+      })
+
+      it.each([
+        'a',
+        'YWJjZA=',
+        'invalid%',
+      ])('rejects %j', value => {
+        expect(base64.$validator(value)).toBe(false)
       })
     })
   })

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -60,7 +60,6 @@
     "floating-vue": "^5.2.2",
     "get-contrast": "^3.0.0",
     "highlight.js": "^11.9.0",
-    "js-base64": "^3.7.6",
     "js-yaml": "^5.0.0",
     "jwt-decode": "^4.0.0",
     "lodash": "^4.17.21",

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import { Base64 } from 'js-base64'
 import semver from 'semver'
 import {
   unref,
@@ -508,19 +507,18 @@ export function parseServiceAccountUsername (username) {
 }
 
 export function encodeBase64 (input) {
-  return Base64.encode(input)
+  return new TextEncoder().encode(input).toBase64()
 }
 
 export function encodeBase64Url (input) {
-  let output = encodeBase64(input)
-  output = output.replace(/=/g, '')
-  output = output.replace(/\+/g, '-')
-  output = output.replace(/\//g, '_')
-  return output
+  return new TextEncoder().encode(input).toBase64({
+    alphabet: 'base64url',
+    omitPadding: true,
+  })
 }
 
 export function decodeBase64 (input) {
-  return Base64.decode(input)
+  return new TextDecoder().decode(Uint8Array.fromBase64(input))
 }
 
 export function shortRandomString (length) {

--- a/frontend/src/utils/validators.js
+++ b/frontend/src/utils/validators.js
@@ -5,7 +5,6 @@
 //
 
 import { helpers } from '@vuelidate/validators'
-import { Base64 } from 'js-base64'
 
 import get from 'lodash/get'
 import set from 'lodash/set'
@@ -22,7 +21,15 @@ const guidPattern = /^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4
 export const timezonePattern = /^([+-])(\d{2}):(\d{2})$/
 
 const base64 = withMessage('Must be a valid base64 string', value => {
-  return Base64.isValid(value)
+  if (typeof value !== 'string') {
+    return false
+  }
+  try {
+    Uint8Array.fromBase64(value, { lastChunkHandling: 'strict' })
+    return true
+  } catch {
+    return false
+  }
 })
 const alphaNumUnderscore = withMessage('Must contain only alphanumeric characters and underscore', regex(alphaNumUnderscorePattern))
 const lowerCaseAlphaNumHyphen = withMessage('Must contain only lowercase alphanumeric characters or hyphen', regex(lowerCaseAlphaNumHyphenPattern))

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -78,7 +78,6 @@ export default defineConfig(({ command, mode }) => {
       'socket.io-client',
       'dayjs',
       'semver',
-      'js-base64',
       'downloadjs',
       'md5',
       'uuid',

--- a/frontend/vitest.setup.js
+++ b/frontend/vitest.setup.js
@@ -45,7 +45,7 @@ if (!Uint8Array.fromBase64) {
         if (alphabet === 'base64url') {
           encoded = encoded.replace(/\+/g, '-').replace(/\//g, '_')
         }
-        if (encoded !== input.replace(/\s/g, '')) {
+        if (encoded !== input.replace(/[\t\n\f\r ]/g, '')) {
           throw new SyntaxError('Invalid base64 string')
         }
       }

--- a/frontend/vitest.setup.js
+++ b/frontend/vitest.setup.js
@@ -15,6 +15,44 @@ import * as fixtures from './__fixtures__'
 const globalConsole = global.console
 const globalDocument = global.document
 const globalWindow = global.window
+const NodeBuffer = global.Buffer
+
+// TODO: Remove these Base64 shims after the test runtime is upgraded beyond Node.js 24
+const encodedBytesPrototype = Object.getPrototypeOf(new TextEncoder().encode())
+
+for (const prototype of new Set([Uint8Array.prototype, encodedBytesPrototype])) {
+  if (!prototype.toBase64) {
+    Object.defineProperty(prototype, 'toBase64', {
+      configurable: true,
+      value ({ alphabet = 'base64', omitPadding = false } = {}) {
+        let output = NodeBuffer.from(this).toString('base64')
+        if (alphabet === 'base64url') {
+          output = output.replace(/\+/g, '-').replace(/\//g, '_')
+        }
+        return omitPadding ? output.replace(/=+$/, '') : output
+      },
+    })
+  }
+}
+
+if (!Uint8Array.fromBase64) {
+  Object.defineProperty(Uint8Array, 'fromBase64', {
+    configurable: true,
+    value (input, { alphabet = 'base64', lastChunkHandling = 'loose' } = {}) {
+      const bytes = NodeBuffer.from(input, alphabet)
+      if (lastChunkHandling === 'strict') {
+        let encoded = bytes.toString('base64')
+        if (alphabet === 'base64url') {
+          encoded = encoded.replace(/\+/g, '-').replace(/\//g, '_')
+        }
+        if (encoded !== input.replace(/\s/g, '')) {
+          throw new SyntaxError('Invalid base64 string')
+        }
+      }
+      return new Uint8Array(bytes)
+    },
+  })
+}
 
 const fetchMock = createFetchMock(vi)
 fetchMock.enableMocks()

--- a/yarn.lock
+++ b/yarn.lock
@@ -794,7 +794,6 @@ __metadata:
     floating-vue: "npm:^5.2.2"
     get-contrast: "npm:^3.0.0"
     highlight.js: "npm:^11.9.0"
-    js-base64: "npm:^3.7.6"
     js-yaml: "npm:^5.0.0"
     jsdom: "npm:^26.0.0"
     jwt-decode: "npm:^4.0.0"
@@ -6250,13 +6249,6 @@ __metadata:
   version: 6.2.9
   resolution: "jose@npm:6.2.9"
   checksum: 10c0/fc6d79b11fdd5cc1393bccd644533b3e2445fd8eb2468066eb23c01ed7f6b41deca710e8aabe9379a382cca7920740900c7f610bdf0be4ff5e7ee44412730d4c
-  languageName: node
-  linkType: hard
-
-"js-base64@npm:^3.7.6":
-  version: 3.9.2
-  resolution: "js-base64@npm:3.9.2"
-  checksum: 10c0/59bfa7f05953aa3e630812d3fcf96ea56597100b4baf367fdaacb696712e5b774cbb95f90185f88cf0ccbb864fcf62b1f75e8eed283214076d6bec8952f621dc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
/area dependency
/kind cleanup

**What this PR does / why we need it**:
Removes the `js-base64` third-party dependency in favour of the TC39 native `Uint8Array.toBase64`/`fromBase64` APIs available in modern browsers.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
A vitest setup shim is added to cover test environments running on Node.js <24 where the native API is not yet available.

**Release note**:
```bugfix dependency
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Base64 encoding and decoding for UTF-8 content.
  - Added support for URL-safe Base64 values, including unpadded formats.
  - Base64 validation now consistently rejects invalid, malformed, or non-string values.
  - Improved compatibility across supported environments.

- **Tests**
  - Expanded coverage for UTF-8 round trips, URL-safe encoding, and valid and invalid Base64 input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->