### PR TITLE
add eslint rule for tonal color tokens

### DIFF
--- a/frontend/__tests__/eslint-rules/require-tonal-color-token.spec.js
+++ b/frontend/__tests__/eslint-rules/require-tonal-color-token.spec.js
@@ -1,0 +1,145 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import { RuleTester } from 'eslint'
+import vueParser from 'vue-eslint-parser'
+
+import requireTonalColorToken from '../../eslint-rules/require-tonal-color-token.cjs'
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: vueParser,
+    ecmaVersion: 2025,
+    sourceType: 'module',
+  },
+})
+
+ruleTester.run('require-tonal-color-token', requireTonalColorToken, {
+  valid: [
+    {
+      name: 'accepts a tonal alert with a tonal color token',
+      filename: 'test.vue',
+      code: '<template><v-alert variant="tonal" color="tonal-primary" /></template>',
+    },
+    {
+      name: 'accepts a chip with its default tonal variant and a tonal color token',
+      filename: 'test.vue',
+      code: '<template><v-chip color="tonal-warning" /></template>',
+    },
+    {
+      name: 'accepts a non-tonal alert with a semantic color',
+      filename: 'test.vue',
+      code: '<template><v-alert variant="outlined" color="error" /></template>',
+    },
+    {
+      name: 'accepts a non-tonal chip with a semantic color',
+      filename: 'test.vue',
+      code: '<template><v-chip variant="outlined" color="success" /></template>',
+    },
+    {
+      name: 'ignores values that are determined at runtime',
+      filename: 'test.vue',
+      code: '<template><v-alert :variant="variant" :color="color" /></template>',
+    },
+    {
+      name: 'does not assume a chip with a dynamic variant is tonal',
+      filename: 'test.vue',
+      code: '<template><v-chip :variant="variant" color="primary" /></template>',
+    },
+    {
+      name: 'ignores components other than alerts and chips',
+      filename: 'test.vue',
+      code: '<template><v-btn variant="tonal" color="primary" /></template>',
+    },
+  ],
+  invalid: [
+    {
+      name: 'reports every semantic color on tonal alerts',
+      filename: 'test.vue',
+      code: `
+        <template>
+          <v-alert variant="tonal" color="primary" />
+          <v-alert variant="tonal" color="warning" />
+          <v-alert variant="tonal" color="error" />
+          <v-alert variant="tonal" color="info" />
+          <v-alert variant="tonal" color="success" />
+        </template>
+      `,
+      errors: [
+        {
+          messageId: 'useTonalColor',
+          data: {
+            actual: 'primary',
+            expected: 'tonal-primary',
+            component: 'v-alert',
+          },
+        },
+        {
+          messageId: 'useTonalColor',
+          data: {
+            actual: 'warning',
+            expected: 'tonal-warning',
+            component: 'v-alert',
+          },
+        },
+        {
+          messageId: 'useTonalColor',
+          data: {
+            actual: 'error',
+            expected: 'tonal-error',
+            component: 'v-alert',
+          },
+        },
+        {
+          messageId: 'useTonalColor',
+          data: {
+            actual: 'info',
+            expected: 'tonal-info',
+            component: 'v-alert',
+          },
+        },
+        {
+          messageId: 'useTonalColor',
+          data: {
+            actual: 'success',
+            expected: 'tonal-success',
+            component: 'v-alert',
+          },
+        },
+      ],
+    },
+    {
+      name: 'reports a semantic color on a chip with its default tonal variant',
+      filename: 'test.vue',
+      code: '<template><v-chip color="warning" /></template>',
+      errors: [
+        {
+          messageId: 'useTonalColor',
+          data: {
+            actual: 'warning',
+            expected: 'tonal-warning',
+            component: 'v-chip',
+          },
+        },
+      ],
+    },
+    {
+      name: 'reports semantic colors passed as bound string literals',
+      filename: 'test.vue',
+      code: '<template><v-chip :variant="\'tonal\'" v-bind:color="\'info\'" /></template>',
+      errors: [
+        {
+          messageId: 'useTonalColor',
+          data: {
+            actual: 'info',
+            expected: 'tonal-info',
+            component: 'v-chip',
+          },
+        },
+      ],
+    },
+  ],
+})

--- a/frontend/__tests__/eslint-rules/require-tonal-color-token.spec.js
+++ b/frontend/__tests__/eslint-rules/require-tonal-color-token.spec.js
@@ -55,6 +55,11 @@ ruleTester.run('require-tonal-color-token', requireTonalColorToken, {
       code: '<template><v-chip :variant="variant" color="primary" /></template>',
     },
     {
+      name: 'does not assume a chip with an unqualified v-bind is tonal (chipProps.variant may be outlined)',
+      filename: 'test.vue',
+      code: '<template><v-chip v-bind="chipProps" color="primary" /></template>',
+    },
+    {
       name: 'ignores correlated variant and color conditions',
       filename: 'test.vue',
       code: `

--- a/frontend/__tests__/eslint-rules/require-tonal-color-token.spec.js
+++ b/frontend/__tests__/eslint-rules/require-tonal-color-token.spec.js
@@ -30,6 +30,11 @@ ruleTester.run('require-tonal-color-token', requireTonalColorToken, {
       code: '<template><v-chip color="tonal-warning" /></template>',
     },
     {
+      name: 'ignores a hard-coded hex color on a tonal component',
+      filename: 'test.vue',
+      code: '<template><v-alert variant="tonal" color="#ff0000" /></template>',
+    },
+    {
       name: 'accepts a non-tonal alert with a semantic color',
       filename: 'test.vue',
       code: '<template><v-alert variant="outlined" color="error" /></template>',
@@ -48,6 +53,35 @@ ruleTester.run('require-tonal-color-token', requireTonalColorToken, {
       name: 'does not assume a chip with a dynamic variant is tonal',
       filename: 'test.vue',
       code: '<template><v-chip :variant="variant" color="primary" /></template>',
+    },
+    {
+      name: 'ignores correlated variant and color conditions',
+      filename: 'test.vue',
+      code: `
+        <template>
+          <v-chip
+            :variant="isCritical ? 'flat' : 'tonal'"
+            :color="isCritical ? 'flat-primary' : 'tonal-primary'"
+          />
+        </template>
+      `,
+    },
+    {
+      name: 'ignores correlated conditions that call color helpers',
+      filename: 'test.vue',
+      code: `
+        <template>
+          <v-chip
+            :variant="isHovering ? 'flat' : 'tonal'"
+            :color="isHovering ? getFlatColorName(chipColor) : getTonalColorName(chipColor)"
+          />
+        </template>
+      `,
+    },
+    {
+      name: 'ignores a dynamic color on an explicitly tonal component',
+      filename: 'test.vue',
+      code: '<template><v-alert variant="tonal" :color="color" /></template>',
     },
     {
       name: 'ignores components other than alerts and chips',

--- a/frontend/__tests__/eslint-rules/require-tonal-color-token.spec.js
+++ b/frontend/__tests__/eslint-rules/require-tonal-color-token.spec.js
@@ -93,6 +93,16 @@ ruleTester.run('require-tonal-color-token', requireTonalColorToken, {
       filename: 'test.vue',
       code: '<template><v-btn variant="tonal" color="primary" /></template>',
     },
+    {
+      name: 'does not report PascalCase chip with a tonal color token',
+      filename: 'test.vue',
+      code: '<template><VChip color="tonal-primary" /></template>',
+    },
+    {
+      name: 'does not report PascalCase alert with a tonal color token',
+      filename: 'test.vue',
+      code: '<template><VAlert variant="tonal" color="tonal-error" /></template>',
+    },
   ],
   invalid: [
     {
@@ -176,6 +186,51 @@ ruleTester.run('require-tonal-color-token', requireTonalColorToken, {
             actual: 'info',
             expected: 'tonal-info',
             component: 'v-chip',
+          },
+        },
+      ],
+    },
+    {
+      name: 'reports secondary on a tonal chip (previously uncovered by hardcoded map)',
+      filename: 'test.vue',
+      code: '<template><v-chip color="secondary" /></template>',
+      errors: [
+        {
+          messageId: 'useTonalColor',
+          data: {
+            actual: 'secondary',
+            expected: 'tonal-secondary',
+            component: 'v-chip',
+          },
+        },
+      ],
+    },
+    {
+      name: 'reports PascalCase VChip with default tonal variant',
+      filename: 'test.vue',
+      code: '<template><VChip color="warning" /></template>',
+      errors: [
+        {
+          messageId: 'useTonalColor',
+          data: {
+            actual: 'warning',
+            expected: 'tonal-warning',
+            component: 'v-chip',
+          },
+        },
+      ],
+    },
+    {
+      name: 'reports PascalCase VAlert with tonal variant',
+      filename: 'test.vue',
+      code: '<template><VAlert variant="tonal" color="error" /></template>',
+      errors: [
+        {
+          messageId: 'useTonalColor',
+          data: {
+            actual: 'error',
+            expected: 'tonal-error',
+            component: 'v-alert',
           },
         },
       ],

--- a/frontend/eslint-rules/require-tonal-color-token.cjs
+++ b/frontend/eslint-rules/require-tonal-color-token.cjs
@@ -64,11 +64,14 @@ module.exports = {
           return
         }
 
+        const hasUnqualifiedBind = node.startTag.attributes.some(a =>
+          a.directive && a.key.name.name === 'bind' && !a.key.argument,
+        )
         const variantAttribute = findAttribute(node, 'variant')
         const variant = getStaticAttributeValue(node, 'variant')
         const isTonal =
           variant === 'tonal' ||
-          (component === 'v-chip' && !variantAttribute)
+          (component === 'v-chip' && !variantAttribute && !hasUnqualifiedBind)
 
         if (!isTonal) {
           return

--- a/frontend/eslint-rules/require-tonal-color-token.cjs
+++ b/frontend/eslint-rules/require-tonal-color-token.cjs
@@ -1,0 +1,96 @@
+//
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+const tonalColors = new Map([
+  ['primary', 'tonal-primary'],
+  ['warning', 'tonal-warning'],
+  ['error', 'tonal-error'],
+  ['info', 'tonal-info'],
+  ['success', 'tonal-success'],
+])
+
+function findAttribute (node, name) {
+  return node.startTag.attributes.find(attribute => {
+    if (!attribute.directive) {
+      return attribute.key.name === name
+    }
+
+    return attribute.key.name.name === 'bind' &&
+      attribute.key.argument?.name === name
+  })
+}
+
+function getStaticAttributeValue (node, name) {
+  const attribute = findAttribute(node, name)
+
+  if (!attribute?.value) {
+    return undefined
+  }
+
+  if (!attribute.directive) {
+    return attribute.value.value
+  }
+
+  const expression = attribute.value.expression
+
+  if (expression?.type === 'Literal') {
+    return expression.value
+  }
+
+  return undefined
+}
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'require semantic tonal color tokens on tonal alerts and chips',
+    },
+    schema: [],
+    messages: {
+      useTonalColor: 'Use "{{expected}}" instead of "{{actual}}" for tonal {{component}}.',
+    },
+  },
+
+  create (context) {
+    return context.sourceCode.parserServices.defineTemplateBodyVisitor({
+      VElement (node) {
+        const component = node.rawName
+
+        if (component !== 'v-alert' && component !== 'v-chip') {
+          return
+        }
+
+        const variantAttribute = findAttribute(node, 'variant')
+        const variant = getStaticAttributeValue(node, 'variant')
+        const isTonal =
+          variant === 'tonal' ||
+          (component === 'v-chip' && !variantAttribute)
+
+        if (!isTonal) {
+          return
+        }
+
+        const color = getStaticAttributeValue(node, 'color')
+        const expected = tonalColors.get(color)
+
+        if (!expected) {
+          return
+        }
+
+        context.report({
+          node,
+          messageId: 'useTonalColor',
+          data: {
+            actual: color,
+            expected,
+            component,
+          },
+        })
+      },
+    })
+  },
+}

--- a/frontend/eslint-rules/require-tonal-color-token.cjs
+++ b/frontend/eslint-rules/require-tonal-color-token.cjs
@@ -4,27 +4,25 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-const tonalColors = new Map([
-  ['primary', 'tonal-primary'],
-  ['warning', 'tonal-warning'],
-  ['error', 'tonal-error'],
-  ['info', 'tonal-info'],
-  ['success', 'tonal-success'],
-])
+const { SEMANTIC_COLOR_NAMES, getTonalColorName } = require('../src/utils/themeColors.js')
 
-function findAttribute (node, name) {
-  return node.startTag.attributes.find(attribute => {
-    if (!attribute.directive) {
-      return attribute.key.name === name
-    }
+const semanticColorNames = new Set(SEMANTIC_COLOR_NAMES)
 
-    return attribute.key.name.name === 'bind' &&
-      attribute.key.argument?.name === name
-  })
+const TONAL_COMPONENTS = new Set(['v-alert', 'v-chip'])
+const CHIP_COMPONENTS = new Set(['v-chip'])
+
+function normalizeComponentName (name) {
+  return name.replace(/([A-Z])/g, (_, char, index) => (index ? '-' : '') + char.toLowerCase())
 }
 
 function getStaticAttributeValue (node, name) {
-  const attribute = findAttribute(node, name)
+  const attribute = node.startTag.attributes.find(attr => {
+    if (!attr.directive) {
+      return attr.key.name === name
+    }
+
+    return attr.key.name.name === 'bind' && attr.key.argument?.name === name
+  })
 
   if (!attribute?.value) {
     return undefined
@@ -36,11 +34,25 @@ function getStaticAttributeValue (node, name) {
 
   const expression = attribute.value.expression
 
-  if (expression?.type === 'Literal') {
-    return expression.value
-  }
+  return expression?.type === 'Literal' ? expression.value : undefined
+}
 
-  return undefined
+function resolveProps (node) {
+  const attributes = node.startTag.attributes
+  const hasUnqualifiedBind = attributes.some(
+    attr => attr.directive && attr.key.name.name === 'bind' && !attr.key.argument,
+  )
+  const hasVariantAttr = hasUnqualifiedBind || attributes.some(attr => {
+    if (!attr.directive) {
+      return attr.key.name === 'variant'
+    }
+
+    return attr.key.name.name === 'bind' && attr.key.argument?.name === 'variant'
+  })
+  const variant = hasUnqualifiedBind ? undefined : getStaticAttributeValue(node, 'variant')
+  const color = getStaticAttributeValue(node, 'color')
+
+  return { variant, hasVariantAttr, color }
 }
 
 module.exports = {
@@ -58,29 +70,16 @@ module.exports = {
   create (context) {
     return context.sourceCode.parserServices.defineTemplateBodyVisitor({
       VElement (node) {
-        const component = node.rawName
+        const component = normalizeComponentName(node.rawName)
 
-        if (component !== 'v-alert' && component !== 'v-chip') {
+        if (!TONAL_COMPONENTS.has(component)) {
           return
         }
 
-        const hasUnqualifiedBind = node.startTag.attributes.some(a =>
-          a.directive && a.key.name.name === 'bind' && !a.key.argument,
-        )
-        const variantAttribute = findAttribute(node, 'variant')
-        const variant = getStaticAttributeValue(node, 'variant')
-        const isTonal =
-          variant === 'tonal' ||
-          (component === 'v-chip' && !variantAttribute && !hasUnqualifiedBind)
+        const { variant, hasVariantAttr, color } = resolveProps(node)
+        const isTonal = variant === 'tonal' || (CHIP_COMPONENTS.has(component) && !hasVariantAttr)
 
-        if (!isTonal) {
-          return
-        }
-
-        const color = getStaticAttributeValue(node, 'color')
-        const expected = tonalColors.get(color)
-
-        if (!expected) {
+        if (!isTonal || !semanticColorNames.has(color)) {
           return
         }
 
@@ -89,7 +88,7 @@ module.exports = {
           messageId: 'useTonalColor',
           data: {
             actual: color,
-            expected,
+            expected: getTonalColorName(color),
             component,
           },
         })

--- a/frontend/eslint.config.cjs
+++ b/frontend/eslint.config.cjs
@@ -14,7 +14,26 @@ const pluginImport = require('eslint-plugin-import')
 const pluginVitest = require('@vitest/eslint-plugin')
 const importNewlines = require('eslint-plugin-import-newlines')
 
+const requireTonalColorToken = require('./eslint-rules/require-tonal-color-token.cjs')
+
 const securityConfig = pluginSecurity.configs.recommended
+
+const gardenerConfig = {
+  files: ['**/*.vue'],
+  plugins: {
+    gardener: {
+      meta: {
+        name: '@gardener-dashboard/eslint-plugin',
+      },
+      rules: {
+        'require-tonal-color-token': requireTonalColorToken,
+      },
+    },
+  },
+  rules: {
+    'gardener/require-tonal-color-token': 'error',
+  },
+}
 
 const lodashConfig = {
   plugins: {
@@ -211,6 +230,7 @@ module.exports = [
       'vue/order-in-components': 'error',
     },
   },
+  gardenerConfig,
   importConfig,
   importNewlinesConfig,
   vitestConfig,


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->
**How to categorize this PR?**
/area quality
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Adds an ESLint rule requiring semantic tonal color tokens such as `tonal-primary` when a vuetify component uses the tonal variant. Works with kebab-case and PascalCase components.

This is related to PR #3092 which adds the color tokens for tonal variants

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
`v-chip` uses the tonal variant by default. The rule therefore also checks `v-chip`s without an explicit variant.
Dynamic bindings, conditional expressions, helper calls, hexadecimal colors, and non-semantic colors are intentionally ignored.

**Release note**:
```other developer
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added linting guidance for tonal `v-alert` and `v-chip` colors.
  * Flags non-tonal semantic colors and suggests the appropriate tonal color token.
  * Supports explicit tonal variants and common component usage patterns while avoiding unrelated components and bindings.

* **Tests**
  * Added coverage for valid tonal usage, dynamic values, non-tonal components, and invalid color tokens.
  * Verifies suggested replacements and diagnostic messages for unsupported semantic colors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->