### PR TITLE
refactor(useCustomColors): await value if needed, then apply

### DIFF
--- a/frontend/src/composables/useCustomColors.js
+++ b/frontend/src/composables/useCustomColors.js
@@ -6,7 +6,6 @@
 
 import {
   watch,
-  nextTick,
   toValue,
 } from 'vue'
 import { useTheme } from 'vuetify'
@@ -126,23 +125,27 @@ function patchThemes (themes, customThemes) {
   }
 }
 
-export const useCustomColors = (customThemes, theme = useTheme()) => {
-  return new Promise((resolve, reject) => {
-    const timeoutId = setTimeout(() => {
-      unwatch()
-      reject(new Error('Setting custom colors timed out'))
-    }, 3000)
-    const unwatch = watch(customThemes, value => {
-      if (!value) {
-        return
-      }
-      clearTimeout(timeoutId)
-      nextTick(() => unwatch())
-      const themes = toValue(theme.themes) ?? {}
-      patchThemes(themes, value)
-      resolve()
-    }, {
-      immediate: true,
+export const useCustomColors = async (customThemes, theme = useTheme()) => {
+  let value = toValue(customThemes)
+
+  // A nullish value means configuration is still loading; `{}` means loaded without overrides.
+  if (value == null) {
+    value = await new Promise((resolve, reject) => {
+      const timeoutId = setTimeout(() => {
+        unwatch()
+        reject(new Error('Setting custom colors timed out'))
+      }, 3000)
+      const unwatch = watch(customThemes, value => {
+        if (value == null) {
+          return
+        }
+        clearTimeout(timeoutId)
+        unwatch()
+        resolve(value)
+      })
     })
-  })
+  }
+
+  const themes = toValue(theme.themes) ?? {}
+  patchThemes(themes, value)
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area usability
/kind cleanup

**What this PR does / why we need it**:
Wait for the configuration to load if necessary, then apply it — instead of running the entire operation inside an immediate watcher.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```other developer
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved custom theme loading so immediately available settings are applied without unnecessary waiting.
  - Correctly handles empty theme configurations as loaded values.
  - Waits for configuration updates only when needed, with a three-second timeout.
  - Ensures theme values are applied after configuration loading completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->