### PR TITLE
refactor(frontend): redesign worker group form with labeled sections

### DIFF
--- a/frontend/src/components/ShootWorkers/GContainerRuntime.vue
+++ b/frontend/src/components/ShootWorkers/GContainerRuntime.vue
@@ -6,12 +6,13 @@ SPDX-License-Identifier: Apache-2.0
 
 <template>
   <div
-    class="d-flex flex-row regular-input"
+    class="d-flex flex-row"
     :class="{ 'has-oci-runtimes': criContainerRuntimeTypes.length }"
   >
     <v-select
       v-model="criName"
       v-messages-color="{ color: 'warning' }"
+      class="regular-input"
       :style="{ flex: criContainerRuntimeTypes.length ? '0 0 125px' : undefined }"
       color="primary"
       item-color="primary"
@@ -27,7 +28,7 @@ SPDX-License-Identifier: Apache-2.0
     <v-select
       v-if="criContainerRuntimeTypes.length"
       v-model="selectedCriContainerRuntimeTypes"
-      class="ml-1"
+      class="regular-input ml-1"
       style="flex: 0 0 140px"
       color="primary"
       item-color="primary"

--- a/frontend/src/components/ShootWorkers/GContainerRuntime.vue
+++ b/frontend/src/components/ShootWorkers/GContainerRuntime.vue
@@ -19,7 +19,7 @@ SPDX-License-Identifier: Apache-2.0
       :error-messages="getErrorMessages(v$.criName)"
       label="Container Runtime"
       :hint="hint"
-      persistent-hint
+      persistent-placeholder
       variant="underlined"
       @update:model-value="onInputCriName"
       @blur="v$.criName.$touch()"
@@ -28,11 +28,12 @@ SPDX-License-Identifier: Apache-2.0
       v-if="criContainerRuntimeTypes.length"
       v-model="selectedCriContainerRuntimeTypes"
       class="ml-1"
-      style="flex: 0 0 125px"
+      style="flex: 0 0 140px"
       color="primary"
       item-color="primary"
       :items="criContainerRuntimeTypes"
-      label="Add. OCI Runtimes"
+      label="Additional OCI Runtimes"
+      persistent-placeholder
       multiple
       chips
       closable-chips

--- a/frontend/src/components/ShootWorkers/GManageWorkers.vue
+++ b/frontend/src/components/ShootWorkers/GManageWorkers.vue
@@ -11,6 +11,7 @@ SPDX-License-Identifier: Apache-2.0
     <v-expand-transition
       group
       :disabled="disableWorkerAnimation"
+      @after-enter="onAfterEnter"
     >
       <div
         v-for="(worker, index) in providerWorkers"
@@ -52,7 +53,7 @@ SPDX-License-Identifier: Apache-2.0
 </template>
 
 <script setup>
-import { toRefs, inject, nextTick } from 'vue'
+import { toRefs, inject } from 'vue'
 
 import GWorkerInputGeneric from '@/components/ShootWorkers/GWorkerInputGeneric'
 
@@ -78,10 +79,9 @@ const scrollContainer = inject('dialogScrollContainer', null)
 
 function addProviderWorker () {
   _addProviderWorker()
-  nextTick(() => {
-    if (scrollContainer?.value) {
-      scrollContainer.value.scrollTo({ top: scrollContainer.value.scrollHeight, behavior: 'smooth' })
-    }
-  })
+}
+
+function onAfterEnter () {
+  scrollContainer.value?.scrollTo({ top: scrollContainer.value.scrollHeight, behavior: 'smooth' })
 }
 </script>

--- a/frontend/src/components/ShootWorkers/GManageWorkers.vue
+++ b/frontend/src/components/ShootWorkers/GManageWorkers.vue
@@ -7,51 +7,47 @@ SPDX-License-Identifier: Apache-2.0
 <template>
   <div
     v-if="!workerless"
-    class="alternate-row-background d-flex flex-column ga-6"
   >
     <v-expand-transition
       group
       :disabled="disableWorkerAnimation"
     >
-      <v-row
+      <div
         v-for="(worker, index) in providerWorkers"
         :key="index"
-        class="list-item my-0"
       >
         <g-worker-input-generic
           :worker="worker"
+          :worker-index="index"
         >
           <template #action>
             <v-btn
               v-show="providerWorkers.length > 1"
-              size="x-small"
-              variant="tonal"
-              icon="mdi-close"
-              color="grey"
+              variant="text"
+              prepend-icon="mdi-delete-outline"
+              color="error"
               @click.stop="removeProviderWorker(index)"
-            />
+            >
+              Remove
+            </v-btn>
           </template>
         </g-worker-input-generic>
-      </v-row>
+      </div>
     </v-expand-transition>
-    <v-row
+    <div
       key="addWorker"
-      class="list-item my-0"
+      class="mt-2"
     >
-      <v-col>
-        <v-btn
-          :disabled="!allMachineTypes.length"
-          variant="text"
-          color="primary"
-          @click="addProviderWorker"
-        >
-          <v-icon class="text-primary">
-            mdi-plus
-          </v-icon>
-          Add Worker Group
-        </v-btn>
-      </v-col>
-    </v-row>
+      <v-btn
+        :disabled="!allMachineTypes.length"
+        variant="text"
+        prepend-icon="mdi-plus"
+        color="primary"
+        @click="addProviderWorker"
+      >
+        Add Worker Group
+      </v-btn>
+    </div>
   </div>
 </template>
 

--- a/frontend/src/components/ShootWorkers/GManageWorkers.vue
+++ b/frontend/src/components/ShootWorkers/GManageWorkers.vue
@@ -53,7 +53,7 @@ SPDX-License-Identifier: Apache-2.0
 </template>
 
 <script setup>
-import { toRefs, inject } from 'vue'
+import { toRefs } from 'vue'
 
 import GWorkerInputGeneric from '@/components/ShootWorkers/GWorkerInputGeneric'
 
@@ -71,17 +71,11 @@ const {
   providerWorkers,
   workerless,
   allMachineTypes,
-  addProviderWorker: _addProviderWorker,
+  addProviderWorker,
   removeProviderWorker,
 } = useShootContext()
 
-const scrollContainer = inject('dialogScrollContainer', null)
-
-function addProviderWorker () {
-  _addProviderWorker()
-}
-
-function onAfterEnter () {
-  scrollContainer.value?.scrollTo({ top: scrollContainer.value.scrollHeight, behavior: 'smooth' })
+function onAfterEnter (element) {
+  element.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
 }
 </script>

--- a/frontend/src/components/ShootWorkers/GManageWorkers.vue
+++ b/frontend/src/components/ShootWorkers/GManageWorkers.vue
@@ -15,6 +15,7 @@ SPDX-License-Identifier: Apache-2.0
       <div
         v-for="(worker, index) in providerWorkers"
         :key="index"
+        class="mb-4"
       >
         <g-worker-input-generic
           :worker="worker"

--- a/frontend/src/components/ShootWorkers/GManageWorkers.vue
+++ b/frontend/src/components/ShootWorkers/GManageWorkers.vue
@@ -25,6 +25,7 @@ SPDX-License-Identifier: Apache-2.0
           <template #action>
             <v-btn
               v-show="providerWorkers.length > 1"
+              class="mr-2"
               variant="text"
               prepend-icon="mdi-delete-outline"
               color="error"

--- a/frontend/src/components/ShootWorkers/GManageWorkers.vue
+++ b/frontend/src/components/ShootWorkers/GManageWorkers.vue
@@ -36,7 +36,6 @@ SPDX-License-Identifier: Apache-2.0
       </div>
     </v-expand-transition>
     <div
-      key="addWorker"
       class="mt-2"
     >
       <v-btn
@@ -53,7 +52,7 @@ SPDX-License-Identifier: Apache-2.0
 </template>
 
 <script setup>
-import { toRefs } from 'vue'
+import { toRefs, inject, nextTick } from 'vue'
 
 import GWorkerInputGeneric from '@/components/ShootWorkers/GWorkerInputGeneric'
 
@@ -71,7 +70,18 @@ const {
   providerWorkers,
   workerless,
   allMachineTypes,
-  addProviderWorker,
+  addProviderWorker: _addProviderWorker,
   removeProviderWorker,
 } = useShootContext()
+
+const scrollContainer = inject('dialogScrollContainer', null)
+
+function addProviderWorker () {
+  _addProviderWorker()
+  nextTick(() => {
+    if (scrollContainer?.value) {
+      scrollContainer.value.scrollTo({ top: scrollContainer.value.scrollHeight, behavior: 'smooth' })
+    }
+  })
+}
 </script>

--- a/frontend/src/components/ShootWorkers/GVolumeSizeInput.vue
+++ b/frontend/src/components/ShootWorkers/GVolumeSizeInput.vue
@@ -11,6 +11,7 @@ SPDX-License-Identifier: Apache-2.0
       v-model="storageKind"
       :color="color"
       label="Volume"
+      persistent-placeholder
       variant="underlined"
       :items="storageKindItems"
       class="mr-1"
@@ -27,6 +28,7 @@ SPDX-License-Identifier: Apache-2.0
       label="Volume Size"
       type="number"
       :error-messages="errorMessages"
+      persistent-placeholder
       variant="underlined"
       style="maxWidth: 80px"
       @blur="emitBlur"

--- a/frontend/src/components/ShootWorkers/GVolumeType.vue
+++ b/frontend/src/components/ShootWorkers/GVolumeType.vue
@@ -18,6 +18,7 @@ SPDX-License-Identifier: Apache-2.0
       :error-messages="getErrorMessages(v$.worker.volume.type)"
       label="Volume Type"
       :hint="hint"
+      persistent-hint
       persistent-placeholder
       variant="underlined"
       @update:model-value="onInputVolumeType"

--- a/frontend/src/components/ShootWorkers/GVolumeType.vue
+++ b/frontend/src/components/ShootWorkers/GVolumeType.vue
@@ -35,7 +35,8 @@ SPDX-License-Identifier: Apache-2.0
     <v-text-field
       v-if="isAWS && worker.volume.type !== 'gp2'"
       v-model.number="workerIops"
-      class="ml-4 small-input"
+      class="ml-4"
+      style="width: 80px;"
       color="primary"
       :error-messages="getErrorMessages(v$.workerIops)"
       type="number"

--- a/frontend/src/components/ShootWorkers/GVolumeType.vue
+++ b/frontend/src/components/ShootWorkers/GVolumeType.vue
@@ -35,8 +35,7 @@ SPDX-License-Identifier: Apache-2.0
     <v-text-field
       v-if="isAWS && worker.volume.type !== 'gp2'"
       v-model.number="workerIops"
-      class="ml-4 flex-0-0"
-      style="width: 120px"
+      class="ml-4 small-input"
       color="primary"
       :error-messages="getErrorMessages(v$.workerIops)"
       type="number"

--- a/frontend/src/components/ShootWorkers/GVolumeType.vue
+++ b/frontend/src/components/ShootWorkers/GVolumeType.vue
@@ -5,10 +5,11 @@ SPDX-License-Identifier: Apache-2.0
 -->
 
 <template>
-  <div class="d-flex flex-row">
+  <div class="d-flex flex-row align-start">
     <v-select
       v-model="worker.volume.type"
       v-messages-color="{ color: 'warning' }"
+      class="flex-grow-1"
       color="primary"
       item-color="primary"
       :items="volumeTypeItems"
@@ -17,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
       :error-messages="getErrorMessages(v$.worker.volume.type)"
       label="Volume Type"
       :hint="hint"
-      persistent-hint
+      persistent-placeholder
       variant="underlined"
       @update:model-value="onInputVolumeType"
       @blur="v$.worker.volume.type.$touch()"
@@ -33,12 +34,15 @@ SPDX-License-Identifier: Apache-2.0
     <v-text-field
       v-if="isAWS && worker.volume.type !== 'gp2'"
       v-model.number="workerIops"
-      class="ml-1"
+      class="ml-4 flex-0-0"
+      style="width: 120px"
       color="primary"
       :error-messages="getErrorMessages(v$.workerIops)"
       type="number"
       min="100"
       label="IOPS"
+      hint="I/O operations per second"
+      persistent-placeholder
       variant="underlined"
       @update:model-value="onInputIops"
       @blur="v$.workerIops.$touch()"

--- a/frontend/src/components/ShootWorkers/GWorkerConfiguration.vue
+++ b/frontend/src/components/ShootWorkers/GWorkerConfiguration.vue
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Apache-2.0
   <g-action-button-dialog
     :key="componentKey"
     ref="actionDialog"
-    width="1250"
+    width="900"
     confirm-required
     caption="Configure Workers"
     :tooltip="dialogTooltip"

--- a/frontend/src/components/ShootWorkers/GWorkerInputGeneric.vue
+++ b/frontend/src/components/ShootWorkers/GWorkerInputGeneric.vue
@@ -11,191 +11,192 @@ SPDX-License-Identifier: Apache-2.0
     style="border-color: rgba(var(--v-border-color), 0.15)"
   >
     <v-card-text class="pa-0 pb-4">
-      <div class="px-3 pt-2 pb-1 text-caption text-medium-emphasis font-weight-bold text-uppercase">
+      <div class="section-head px-3 pt-2 pb-1">
         Worker Group
       </div>
-      <div class="d-flex align-center flex-wrap">
-        <div class="regular-input">
-          <v-text-field
-            v-model="worker.name"
-            color="primary"
-            :error-messages="getErrorMessages(v$.worker.name)"
-            counter="15"
-            label="Group Name"
-            variant="underlined"
-            density="compact"
-            @input="v$.worker.name.$touch()"
-            @blur="v$.worker.name.$touch()"
-          />
+      <div class="pl-4">
+        <div class="d-flex align-center flex-wrap">
+          <div class="regular-input">
+            <v-text-field
+              v-model="worker.name"
+              color="primary"
+              :error-messages="getErrorMessages(v$.worker.name)"
+              counter="15"
+              label="Group Name"
+              variant="underlined"
+              density="compact"
+              @input="v$.worker.name.$touch()"
+              @blur="v$.worker.name.$touch()"
+            />
+          </div>
+          <div
+            v-if="isZonedCluster"
+            class="regular-input"
+          >
+            <v-select
+              v-model="selectedZones"
+              color="primary"
+              item-color="primary"
+              label="Zones"
+              :items="zoneItems"
+              :error-messages="getErrorMessages(v$.selectedZones)"
+              multiple
+              chips
+              closable-chips
+              :hint="zoneHint"
+              persistent-hint
+              item-title="text"
+              variant="underlined"
+              density="compact"
+              @update:model-value="onInputZones"
+              @blur="v$.selectedZones.$touch()"
+            />
+          </div>
+          <v-spacer />
+          <slot name="action" />
         </div>
-        <div
-          v-if="isZonedCluster"
-          class="regular-input"
-        >
-          <v-select
-            v-model="selectedZones"
-            color="primary"
-            item-color="primary"
-            label="Zones"
-            :items="zoneItems"
-            :error-messages="getErrorMessages(v$.selectedZones)"
-            multiple
-            chips
-            closable-chips
-            :hint="zoneHint"
-            persistent-hint
-            item-title="text"
-            variant="underlined"
-            density="compact"
-            @update:model-value="onInputZones"
-            @blur="v$.selectedZones.$touch()"
-          />
-        </div>
-        <v-spacer />
-        <slot name="action" />
       </div>
     </v-card-text>
 
-    <v-divider />
-
     <v-card-text class="pa-0 pb-4">
-      <div class="px-3 pt-2 pb-1 text-caption text-medium-emphasis font-weight-bold text-uppercase">
+      <div class="section-head px-3 pt-2 pb-1">
         Machine
       </div>
-      <div class="d-flex flex-wrap align-start">
-        <div
-          v-if="machineArchitectures.length > 1"
-          class="small-input"
-        >
-          <v-select
-            v-model="machineArchitecture"
-            color="primary"
-            item-color="primary"
-            :items="machineArchitectures"
-            :error-messages="getErrorMessages(v$.machineArchitecture)"
-            label="Architecture"
-            persistent-placeholder
-            variant="underlined"
-            @blur="v$.machineArchitecture.$touch()"
-          />
+      <div class="pl-4">
+        <div class="d-flex flex-wrap align-start">
+          <div
+            v-if="machineArchitectures.length > 1"
+            class="small-input"
+          >
+            <v-select
+              v-model="machineArchitecture"
+              color="primary"
+              item-color="primary"
+              :items="machineArchitectures"
+              :error-messages="getErrorMessages(v$.machineArchitecture)"
+              label="Architecture"
+              persistent-placeholder
+              variant="underlined"
+              @blur="v$.machineArchitecture.$touch()"
+            />
+          </div>
+          <div class="regular-input flex-grow-1">
+            <g-machine-type
+              v-model="machineTypeValue"
+              :machine-types="machineTypes"
+              :field-name="`${workerGroupName} Machine Type`"
+            />
+          </div>
+          <div class="regular-input flex-grow-1">
+            <g-machine-image
+              :machine-images="filteredMachineImages"
+              :worker="worker"
+              :machine-type="selectedMachineType"
+              :auto-update="maintenanceAutoUpdateMachineImageVersion"
+              :field-name="`${workerGroupName} Machine Image`"
+            />
+          </div>
         </div>
-        <div class="regular-input flex-grow-1">
-          <g-machine-type
-            v-model="machineTypeValue"
-            :machine-types="machineTypes"
-            :field-name="`${workerGroupName} Machine Type`"
-          />
-        </div>
-        <div class="regular-input flex-grow-1">
-          <g-machine-image
-            :machine-images="filteredMachineImages"
+        <div class="d-flex flex-wrap align-start">
+          <g-container-runtime
+            :machine-image-cri="machineImageCri"
             :worker="worker"
-            :machine-type="selectedMachineType"
-            :auto-update="maintenanceAutoUpdateMachineImageVersion"
-            :field-name="`${workerGroupName} Machine Image`"
+            :kubernetes-version="kubernetesVersion"
+            :field-name="`${workerGroupName} Container Runtime`"
           />
         </div>
-      </div>
-      <div class="d-flex flex-wrap align-start">
-        <g-container-runtime
-          :machine-image-cri="machineImageCri"
-          :worker="worker"
-          :kubernetes-version="kubernetesVersion"
-          :field-name="`${workerGroupName} Container Runtime`"
-        />
       </div>
     </v-card-text>
-
-    <v-divider />
 
     <v-card-text class="pa-0 pb-4">
-      <div class="px-3 pt-2 pb-1 text-caption text-medium-emphasis font-weight-bold text-uppercase">
+      <div class="section-head px-3 pt-2 pb-1">
         Volume
       </div>
-      <div class="d-flex flex-wrap align-start">
-        <div
-          v-if="volumeInCloudProfile"
-          class="regular-input"
-        >
-          <g-volume-type
-            :volume-types="volumeTypes"
-            :worker="worker"
-            :cloud-profile-ref="cloudProfileRef"
-            :field-name="`${workerGroupName} Volume Type`"
-          />
-        </div>
-        <div class="small-input">
-          <g-volume-size-input
-            v-model="volumeSize"
-            v-model:has-custom-storage-size="hasCustomStorageSize"
-            :min="minVolumeSizeGi"
-            :default-storage-size="defaultStorageSize"
-            :has-volume-types="volumeInCloudProfile"
-            color="primary"
-            :error-messages="getErrorMessages(v$.volumeSize)"
-            @update:custom-storage="onInputVolumeSize"
-            @update:model-value="onInputVolumeSize"
-            @blur="v$.volumeSize.$touch()"
-          />
+      <div class="pl-4">
+        <div class="d-flex flex-wrap align-start">
+          <div
+            v-if="volumeInCloudProfile"
+            class="regular-input"
+          >
+            <g-volume-type
+              :volume-types="volumeTypes"
+              :worker="worker"
+              :cloud-profile-ref="cloudProfileRef"
+              :field-name="`${workerGroupName} Volume Type`"
+            />
+          </div>
+          <div class="small-input">
+            <g-volume-size-input
+              v-model="volumeSize"
+              v-model:has-custom-storage-size="hasCustomStorageSize"
+              :min="minVolumeSizeGi"
+              :default-storage-size="defaultStorageSize"
+              :has-volume-types="volumeInCloudProfile"
+              color="primary"
+              :error-messages="getErrorMessages(v$.volumeSize)"
+              @update:custom-storage="onInputVolumeSize"
+              @update:model-value="onInputVolumeSize"
+              @blur="v$.volumeSize.$touch()"
+            />
+          </div>
         </div>
       </div>
     </v-card-text>
 
-    <v-divider />
-
-    <div class="d-flex flex-wrap gap-4 pb-4">
+    <div class="pb-4">
       <div
-        class="px-3 pt-2 pb-1 text-caption text-medium-emphasis font-weight-bold text-uppercase"
-        style="width: 100%"
+        class="section-head px-3 pt-2 pb-1"
       >
         Scaling &amp; Rollout
       </div>
-      <div class="d-flex">
-        <div class="small-input">
-          <v-text-field
-            v-model="innerMin"
-            min="0"
-            color="primary"
-            :error-messages="getErrorMessages(v$.worker.minimum)"
-            type="number"
-            label="Autoscaler Min."
-            hint="Minimum nodes kept running at all times"
-            persistent-hint
-            variant="underlined"
-            @input="v$.worker.minimum.$touch()"
-            @blur="ensureValidAutoscalerMin()"
-          />
-        </div>
-        <div class="small-input">
-          <v-text-field
-            v-model="innerMax"
-            min="0"
-            color="primary"
-            type="number"
-            label="Autoscaler Max."
-            hint="Maximum nodes the autoscaler can scale up to"
-            persistent-hint
-            variant="underlined"
-            :error-messages="getErrorMessages(v$.worker.maximum)"
-            @input="v$.worker.maximum.$touch()"
-            @blur="ensureValidAutoscalerMax()"
-          />
-        </div>
-      </div>
-      <div>
-        <div class="regular-input">
-          <v-text-field
-            v-model="maxSurge"
-            min="0"
-            color="primary"
-            :error-messages="getErrorMessages(v$.worker.maxSurge)"
-            label="Max. Surge"
-            hint="Number of extra nodes allowed during a rolling update"
-            persistent-hint
-            variant="underlined"
-            @input="v$.worker.maxSurge.$touch()"
-            @blur="v$.worker.maxSurge.$touch()"
-          />
+      <div class="pl-4">
+        <div class="d-flex flex-wrap gap-4">
+          <div class="d-flex">
+            <div class="small-input">
+              <v-text-field
+                v-model="innerMin"
+                min="0"
+                color="primary"
+                :error-messages="getErrorMessages(v$.worker.minimum)"
+                type="number"
+                label="Autoscaler Min."
+                hint="Minimum nodes kept running at all times"
+                persistent-hint
+                variant="underlined"
+                @input="v$.worker.minimum.$touch()"
+                @blur="ensureValidAutoscalerMin()"
+              />
+            </div>
+            <div class="small-input">
+              <v-text-field
+                v-model="innerMax"
+                min="0"
+                color="primary"
+                type="number"
+                label="Autoscaler Max."
+                hint="Maximum nodes the autoscaler can scale up to"
+                persistent-hint
+                variant="underlined"
+                :error-messages="getErrorMessages(v$.worker.maximum)"
+                @input="v$.worker.maximum.$touch()"
+                @blur="ensureValidAutoscalerMax()"
+              />
+            </div>
+          </div>
+          <div class="regular-input">
+            <v-text-field
+              v-model="maxSurge"
+              min="0"
+              color="primary"
+              :error-messages="getErrorMessages(v$.worker.maxSurge)"
+              label="Max. Surge"
+              hint="Number of extra nodes allowed during a rolling update"
+              persistent-hint
+              variant="underlined"
+              @input="v$.worker.maxSurge.$touch()"
+              @blur="v$.worker.maxSurge.$touch()"
+            />
+          </div>
         </div>
       </div>
     </div>
@@ -600,6 +601,23 @@ export default {
 <style lang="scss" scoped>
   :deep(.v-chip--disabled) {
     opacity: 1;
+  }
+
+  .section-head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 14px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: rgba(var(--v-theme-on-surface), var(--v-medium-emphasis-opacity));
+  }
+
+  .section-head::after {
+    content: '';
+    flex: 1;
+    border-top: 1px solid rgba(var(--v-border-color), var(--v-border-opacity));
   }
 
   .worker-tinted {

--- a/frontend/src/components/ShootWorkers/GWorkerInputGeneric.vue
+++ b/frontend/src/components/ShootWorkers/GWorkerInputGeneric.vue
@@ -97,7 +97,7 @@ SPDX-License-Identifier: Apache-2.0
             />
           </div>
         </div>
-        <div class="d-flex flex-wrap align-start">
+        <div class="d-flex flex-wrap align-end">
           <g-container-runtime
             :machine-image-cri="machineImageCri"
             :worker="worker"
@@ -125,7 +125,7 @@ SPDX-License-Identifier: Apache-2.0
               :field-name="`${workerGroupName} Volume Type`"
             />
           </div>
-          <div class="small-input">
+          <div class="regular-input">
             <g-volume-size-input
               v-model="volumeSize"
               v-model:has-custom-storage-size="hasCustomStorageSize"
@@ -150,38 +150,36 @@ SPDX-License-Identifier: Apache-2.0
         Scaling &amp; Rollout
       </div>
       <div class="pl-4">
-        <div class="d-flex flex-wrap gap-4">
-          <div class="d-flex">
-            <div class="small-input">
-              <v-text-field
-                v-model="innerMin"
-                min="0"
-                color="primary"
-                :error-messages="getErrorMessages(v$.worker.minimum)"
-                type="number"
-                label="Autoscaler Min."
-                hint="Minimum nodes kept running at all times"
-                persistent-hint
-                variant="underlined"
-                @input="v$.worker.minimum.$touch()"
-                @blur="ensureValidAutoscalerMin()"
-              />
-            </div>
-            <div class="small-input">
-              <v-text-field
-                v-model="innerMax"
-                min="0"
-                color="primary"
-                type="number"
-                label="Autoscaler Max."
-                hint="Maximum nodes the autoscaler can scale up to"
-                persistent-hint
-                variant="underlined"
-                :error-messages="getErrorMessages(v$.worker.maximum)"
-                @input="v$.worker.maximum.$touch()"
-                @blur="ensureValidAutoscalerMax()"
-              />
-            </div>
+        <div class="d-flex flex-wrap">
+          <div class="small-input">
+            <v-text-field
+              v-model="innerMin"
+              min="0"
+              color="primary"
+              :error-messages="getErrorMessages(v$.worker.minimum)"
+              type="number"
+              label="Autoscaler Min."
+              hint="Minimum nodes kept running at all times"
+              persistent-hint
+              variant="underlined"
+              @input="v$.worker.minimum.$touch()"
+              @blur="ensureValidAutoscalerMin()"
+            />
+          </div>
+          <div class="small-input">
+            <v-text-field
+              v-model="innerMax"
+              min="0"
+              color="primary"
+              type="number"
+              label="Autoscaler Max."
+              hint="Maximum nodes the autoscaler can scale up to"
+              persistent-hint
+              variant="underlined"
+              :error-messages="getErrorMessages(v$.worker.maximum)"
+              @input="v$.worker.maximum.$touch()"
+              @blur="ensureValidAutoscalerMax()"
+            />
           </div>
           <div class="regular-input">
             <v-text-field

--- a/frontend/src/components/ShootWorkers/GWorkerInputGeneric.vue
+++ b/frontend/src/components/ShootWorkers/GWorkerInputGeneric.vue
@@ -605,7 +605,7 @@ export default {
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.5px;
-    font-size: 16px;
+    font-size: 14px;
   }
 
   .worker-tinted {

--- a/frontend/src/components/ShootWorkers/GWorkerInputGeneric.vue
+++ b/frontend/src/components/ShootWorkers/GWorkerInputGeneric.vue
@@ -599,11 +599,6 @@ export default {
     opacity: 1;
   }
 
-  .field-group {
-    border-left: 2px solid rgba(var(--v-border-color), var(--v-border-opacity));
-    padding-left: 4px;
-  }
-
   .worker-tinted {
     background-color: rgba(var(--v-border-color), 0.04);
   }

--- a/frontend/src/components/ShootWorkers/GWorkerInputGeneric.vue
+++ b/frontend/src/components/ShootWorkers/GWorkerInputGeneric.vue
@@ -11,7 +11,7 @@ SPDX-License-Identifier: Apache-2.0
     style="border-color: rgba(var(--v-border-color), 0.15)"
   >
     <v-card-text class="pa-0 pb-4">
-      <div class="section-head text-medium-emphasis px-3 pt-2 pb-1">
+      <div class="text-medium-emphasis section-heading px-3 pt-2 pb-1">
         Worker Group
       </div>
       <div class="pl-4">
@@ -59,7 +59,7 @@ SPDX-License-Identifier: Apache-2.0
     </v-card-text>
 
     <v-card-text class="pa-0 pb-4">
-      <div class="section-head text-medium-emphasis px-3 pt-2 pb-1">
+      <div class="text-medium-emphasis section-heading px-3 pt-2 pb-1">
         Machine
       </div>
       <div class="pl-4">
@@ -97,7 +97,7 @@ SPDX-License-Identifier: Apache-2.0
             />
           </div>
         </div>
-        <div class="d-flex flex-wrap align-end">
+        <div class="d-flex mt-n6 flex-wrap align-end">
           <g-container-runtime
             :machine-image-cri="machineImageCri"
             :worker="worker"
@@ -109,7 +109,7 @@ SPDX-License-Identifier: Apache-2.0
     </v-card-text>
 
     <v-card-text class="pa-0 pb-4">
-      <div class="section-head text-medium-emphasis px-3 pt-2 pb-1">
+      <div class="text-medium-emphasis section-heading px-3 pt-2 pb-1">
         Volume
       </div>
       <div class="pl-4">
@@ -145,7 +145,7 @@ SPDX-License-Identifier: Apache-2.0
 
     <div class="pb-4">
       <div
-        class="section-head text-medium-emphasis px-3 pt-2 pb-1"
+        class="text-medium-emphasis section-heading px-3 pt-2 pb-1"
       >
         Scaling &amp; Rollout
       </div>
@@ -601,20 +601,11 @@ export default {
     opacity: 1;
   }
 
-  .section-head {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-size: 14px;
+  .section-heading {
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.5px;
-  }
-
-  .section-head::after {
-    content: '';
-    flex: 1;
-    border-top: 1px solid rgba(var(--v-border-color), var(--v-border-opacity));
+    font-size: 16px;
   }
 
   .worker-tinted {

--- a/frontend/src/components/ShootWorkers/GWorkerInputGeneric.vue
+++ b/frontend/src/components/ShootWorkers/GWorkerInputGeneric.vue
@@ -11,7 +11,7 @@ SPDX-License-Identifier: Apache-2.0
     style="border-color: rgba(var(--v-border-color), 0.15)"
   >
     <v-card-text class="pa-0 pb-4">
-      <div class="section-head px-3 pt-2 pb-1">
+      <div class="section-head text-medium-emphasis px-3 pt-2 pb-1">
         Worker Group
       </div>
       <div class="pl-4">
@@ -59,7 +59,7 @@ SPDX-License-Identifier: Apache-2.0
     </v-card-text>
 
     <v-card-text class="pa-0 pb-4">
-      <div class="section-head px-3 pt-2 pb-1">
+      <div class="section-head text-medium-emphasis px-3 pt-2 pb-1">
         Machine
       </div>
       <div class="pl-4">
@@ -109,7 +109,7 @@ SPDX-License-Identifier: Apache-2.0
     </v-card-text>
 
     <v-card-text class="pa-0 pb-4">
-      <div class="section-head px-3 pt-2 pb-1">
+      <div class="section-head text-medium-emphasis px-3 pt-2 pb-1">
         Volume
       </div>
       <div class="pl-4">
@@ -145,7 +145,7 @@ SPDX-License-Identifier: Apache-2.0
 
     <div class="pb-4">
       <div
-        class="section-head px-3 pt-2 pb-1"
+        class="section-head text-medium-emphasis px-3 pt-2 pb-1"
       >
         Scaling &amp; Rollout
       </div>
@@ -609,7 +609,6 @@ export default {
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.5px;
-    color: rgba(var(--v-theme-on-surface), var(--v-medium-emphasis-opacity));
   }
 
   .section-head::after {

--- a/frontend/src/components/ShootWorkers/GWorkerInputGeneric.vue
+++ b/frontend/src/components/ShootWorkers/GWorkerInputGeneric.vue
@@ -160,7 +160,6 @@ SPDX-License-Identifier: Apache-2.0
               type="number"
               label="Autoscaler Min."
               hint="Minimum nodes kept running at all times"
-              persistent-hint
               variant="underlined"
               @input="v$.worker.minimum.$touch()"
               @blur="ensureValidAutoscalerMin()"
@@ -174,7 +173,6 @@ SPDX-License-Identifier: Apache-2.0
               type="number"
               label="Autoscaler Max."
               hint="Maximum nodes the autoscaler can scale up to"
-              persistent-hint
               variant="underlined"
               :error-messages="getErrorMessages(v$.worker.maximum)"
               @input="v$.worker.maximum.$touch()"
@@ -189,7 +187,6 @@ SPDX-License-Identifier: Apache-2.0
               :error-messages="getErrorMessages(v$.worker.maxSurge)"
               label="Max. Surge"
               hint="Number of extra nodes allowed during a rolling update"
-              persistent-hint
               variant="underlined"
               @input="v$.worker.maxSurge.$touch()"
               @blur="v$.worker.maxSurge.$touch()"

--- a/frontend/src/components/ShootWorkers/GWorkerInputGeneric.vue
+++ b/frontend/src/components/ShootWorkers/GWorkerInputGeneric.vue
@@ -5,145 +5,194 @@ SPDX-License-Identifier: Apache-2.0
 -->
 
 <template>
-  <div class="d-flex flex-nowrap align-center ga-4">
-    <div class="d-flex flex-wrap">
-      <div class="regular-input">
-        <v-text-field
-          v-model="worker.name"
-          color="primary"
-          :error-messages="getErrorMessages(v$.worker.name)"
-          counter="15"
-          label="Group Name"
-          variant="underlined"
-          @input="v$.worker.name.$touch()"
-          @blur="v$.worker.name.$touch()"
-        />
+  <v-card variant="outlined">
+    <v-card-text class="pa-0 pb-4">
+      <div class="px-3 pt-2 pb-1 text-caption text-high-emphasis font-weight-bold text-uppercase">
+        Worker Group
       </div>
-      <div class="small-input">
-        <v-select
-          v-model="machineArchitecture"
-          color="primary"
-          item-color="primary"
-          :items="machineArchitectures"
-          :error-messages="getErrorMessages(v$.machineArchitecture)"
-          label="Architecture"
-          variant="underlined"
-          @blur="v$.machineArchitecture.$touch()"
-        />
+      <div class="d-flex align-center flex-wrap">
+        <div class="regular-input">
+          <v-text-field
+            v-model="worker.name"
+            color="primary"
+            :error-messages="getErrorMessages(v$.worker.name)"
+            counter="15"
+            label="Group Name"
+            variant="underlined"
+            density="compact"
+            @input="v$.worker.name.$touch()"
+            @blur="v$.worker.name.$touch()"
+          />
+        </div>
+        <div
+          v-if="isZonedCluster"
+          class="regular-input"
+        >
+          <v-select
+            v-model="selectedZones"
+            color="primary"
+            item-color="primary"
+            label="Zones"
+            :items="zoneItems"
+            :error-messages="getErrorMessages(v$.selectedZones)"
+            multiple
+            chips
+            closable-chips
+            :hint="zoneHint"
+            persistent-hint
+            item-title="text"
+            variant="underlined"
+            density="compact"
+            @update:model-value="onInputZones"
+            @blur="v$.selectedZones.$touch()"
+          />
+        </div>
+        <v-spacer />
+        <slot name="action" />
       </div>
-      <div class="regular-input">
-        <g-machine-type
-          v-model="machineTypeValue"
-          :machine-types="machineTypes"
-          :field-name="`${workerGroupName} Machine Type`"
-        />
-      </div>
-      <div class="regular-input">
-        <g-machine-image
-          :machine-images="filteredMachineImages"
-          :worker="worker"
-          :machine-type="selectedMachineType"
-          :auto-update="maintenanceAutoUpdateMachineImageVersion"
-          :field-name="`${workerGroupName} Machine Image`"
-        />
-      </div>
-      <g-container-runtime
-        :machine-image-cri="machineImageCri"
-        :worker="worker"
-        :kubernetes-version="kubernetesVersion"
-        :field-name="`${workerGroupName} Container Runtime`"
-      />
-      <div
-        v-if="volumeInCloudProfile"
-        class="regular-input"
-      >
-        <g-volume-type
-          :volume-types="volumeTypes"
-          :worker="worker"
-          :cloud-profile-ref="cloudProfileRef"
-          :field-name="`${workerGroupName} Volume Type`"
-        />
-      </div>
-      <div :class="volumeInCloudProfile ? 'small-input' : 'regular-input'">
-        <g-volume-size-input
-          v-model="volumeSize"
-          v-model:has-custom-storage-size="hasCustomStorageSize"
-          :min="minVolumeSizeGi"
-          :default-storage-size="defaultStorageSize"
-          :has-volume-types="volumeInCloudProfile"
-          color="primary"
-          :error-messages="getErrorMessages(v$.volumeSize)"
-          @update:custom-storage="onInputVolumeSize"
-          @update:model-value="onInputVolumeSize"
-          @blur="v$.volumeSize.$touch()"
-        />
-      </div>
-      <div class="small-input">
-        <v-text-field
-          v-model="innerMin"
-          min="0"
-          color="primary"
-          :error-messages="getErrorMessages(v$.worker.minimum)"
-          type="number"
-          label="Autoscaler Min."
-          variant="underlined"
-          @input="v$.worker.minimum.$touch()"
-          @blur="ensureValidAutoscalerMin()"
-        />
-      </div>
-      <div class="small-input">
-        <v-text-field
-          v-model="innerMax"
-          min="0"
-          color="primary"
-          type="number"
-          label="Autoscaler Max."
-          variant="underlined"
-          :error-messages="getErrorMessages(v$.worker.maximum)"
-          @input="v$.worker.maximum.$touch()"
-          @blur="ensureValidAutoscalerMax()"
-        />
-      </div>
-      <div class="small-input">
-        <v-text-field
-          v-model="maxSurge"
-          min="0"
-          color="primary"
-          :error-messages="getErrorMessages(v$.worker.maxSurge)"
-          label="Max. Surge"
-          variant="underlined"
-          @input="v$.worker.maxSurge.$touch()"
-          @blur="v$.worker.maxSurge.$touch()"
-        />
-      </div>
+    </v-card-text>
 
-      <div
-        v-if="isZonedCluster"
-        class="regular-input"
-      >
-        <v-select
-          v-model="selectedZones"
-          color="primary"
-          item-color="primary"
-          label="Zones"
-          :items="zoneItems"
-          :error-messages="getErrorMessages(v$.selectedZones)"
-          multiple
-          chips
-          closable-chips
-          :hint="zoneHint"
-          persistent-hint
-          item-title="text"
-          variant="underlined"
-          @update:model-value="onInputZones"
-          @blur="v$.selectedZones.$touch()"
+    <v-divider />
+
+    <v-card-text class="pa-0 pb-4">
+      <div class="px-3 pt-2 pb-1 text-caption text-high-emphasis font-weight-bold text-uppercase">
+        Machine
+      </div>
+      <div class="d-flex flex-wrap align-start">
+        <div
+          v-if="machineArchitectures.length > 1"
+          class="small-input"
+        >
+          <v-select
+            v-model="machineArchitecture"
+            color="primary"
+            item-color="primary"
+            :items="machineArchitectures"
+            :error-messages="getErrorMessages(v$.machineArchitecture)"
+            label="Architecture"
+            persistent-placeholder
+            variant="underlined"
+            @blur="v$.machineArchitecture.$touch()"
+          />
+        </div>
+        <div class="regular-input flex-grow-1">
+          <g-machine-type
+            v-model="machineTypeValue"
+            :machine-types="machineTypes"
+            :field-name="`${workerGroupName} Machine Type`"
+          />
+        </div>
+        <div class="regular-input flex-grow-1">
+          <g-machine-image
+            :machine-images="filteredMachineImages"
+            :worker="worker"
+            :machine-type="selectedMachineType"
+            :auto-update="maintenanceAutoUpdateMachineImageVersion"
+            :field-name="`${workerGroupName} Machine Image`"
+          />
+        </div>
+      </div>
+      <div class="d-flex flex-wrap align-start">
+        <g-container-runtime
+          :machine-image-cri="machineImageCri"
+          :worker="worker"
+          :kubernetes-version="kubernetesVersion"
+          :field-name="`${workerGroupName} Container Runtime`"
         />
       </div>
+    </v-card-text>
+
+    <v-divider />
+
+    <v-card-text class="pa-0 pb-4">
+      <div class="px-3 pt-2 pb-1 text-caption text-high-emphasis font-weight-bold text-uppercase">
+        Volume
+      </div>
+      <div class="d-flex flex-wrap align-start">
+        <div
+          v-if="volumeInCloudProfile"
+          class="regular-input"
+        >
+          <g-volume-type
+            :volume-types="volumeTypes"
+            :worker="worker"
+            :cloud-profile-ref="cloudProfileRef"
+            :field-name="`${workerGroupName} Volume Type`"
+          />
+        </div>
+        <div class="small-input">
+          <g-volume-size-input
+            v-model="volumeSize"
+            v-model:has-custom-storage-size="hasCustomStorageSize"
+            :min="minVolumeSizeGi"
+            :default-storage-size="defaultStorageSize"
+            :has-volume-types="volumeInCloudProfile"
+            color="primary"
+            :error-messages="getErrorMessages(v$.volumeSize)"
+            @update:custom-storage="onInputVolumeSize"
+            @update:model-value="onInputVolumeSize"
+            @blur="v$.volumeSize.$touch()"
+          />
+        </div>
+      </div>
+    </v-card-text>
+
+    <v-divider />
+
+    <div class="d-flex flex-wrap gap-4 pb-4">
+      <div class="px-3 pt-2 pb-1 text-caption text-high-emphasis font-weight-bold text-uppercase" style="width: 100%">
+        Scaling &amp; Rollout
+      </div>
+      <div class="d-flex">
+        <div class="small-input">
+          <v-text-field
+            v-model="innerMin"
+            min="0"
+            color="primary"
+            :error-messages="getErrorMessages(v$.worker.minimum)"
+            type="number"
+            label="Autoscaler Min."
+            hint="Minimum nodes kept running at all times"
+            persistent-hint
+            variant="underlined"
+            @input="v$.worker.minimum.$touch()"
+            @blur="ensureValidAutoscalerMin()"
+          />
+        </div>
+        <div class="small-input">
+          <v-text-field
+            v-model="innerMax"
+            min="0"
+            color="primary"
+            type="number"
+            label="Autoscaler Max."
+            hint="Maximum nodes the autoscaler can scale up to"
+            persistent-hint
+            variant="underlined"
+            :error-messages="getErrorMessages(v$.worker.maximum)"
+            @input="v$.worker.maximum.$touch()"
+            @blur="ensureValidAutoscalerMax()"
+          />
+        </div>
+      </div>
+      <div>
+        <div class="regular-input">
+          <v-text-field
+            v-model="maxSurge"
+            min="0"
+            color="primary"
+            :error-messages="getErrorMessages(v$.worker.maxSurge)"
+            label="Max. Surge"
+            hint="Number of extra nodes allowed during a rolling update"
+            persistent-hint
+            variant="underlined"
+            @input="v$.worker.maxSurge.$touch()"
+            @blur="v$.worker.maxSurge.$touch()"
+          />
+        </div>
+      </div>
     </div>
-    <div>
-      <slot name="action" />
-    </div>
-  </div>
+  </v-card>
 </template>
 
 <script>
@@ -540,5 +589,10 @@ export default {
 <style lang="scss" scoped>
   :deep(.v-chip--disabled) {
     opacity: 1;
+  }
+
+  .field-group {
+    border-left: 2px solid rgba(var(--v-border-color), var(--v-border-opacity));
+    padding-left: 4px;
   }
 </style>

--- a/frontend/src/components/ShootWorkers/GWorkerInputGeneric.vue
+++ b/frontend/src/components/ShootWorkers/GWorkerInputGeneric.vue
@@ -144,7 +144,10 @@ SPDX-License-Identifier: Apache-2.0
     <v-divider />
 
     <div class="d-flex flex-wrap gap-4 pb-4">
-      <div class="px-3 pt-2 pb-1 text-caption text-medium-emphasis font-weight-bold text-uppercase" style="width: 100%">
+      <div
+        class="px-3 pt-2 pb-1 text-caption text-medium-emphasis font-weight-bold text-uppercase"
+        style="width: 100%"
+      >
         Scaling &amp; Rollout
       </div>
       <div class="d-flex">

--- a/frontend/src/components/ShootWorkers/GWorkerInputGeneric.vue
+++ b/frontend/src/components/ShootWorkers/GWorkerInputGeneric.vue
@@ -5,9 +5,13 @@ SPDX-License-Identifier: Apache-2.0
 -->
 
 <template>
-  <v-card variant="outlined">
+  <v-card
+    variant="outlined"
+    :class="{ 'worker-tinted': workerIndex % 2 === 1 }"
+    style="border-color: rgba(var(--v-border-color), 0.15)"
+  >
     <v-card-text class="pa-0 pb-4">
-      <div class="px-3 pt-2 pb-1 text-caption text-high-emphasis font-weight-bold text-uppercase">
+      <div class="px-3 pt-2 pb-1 text-caption text-medium-emphasis font-weight-bold text-uppercase">
         Worker Group
       </div>
       <div class="d-flex align-center flex-wrap">
@@ -55,7 +59,7 @@ SPDX-License-Identifier: Apache-2.0
     <v-divider />
 
     <v-card-text class="pa-0 pb-4">
-      <div class="px-3 pt-2 pb-1 text-caption text-high-emphasis font-weight-bold text-uppercase">
+      <div class="px-3 pt-2 pb-1 text-caption text-medium-emphasis font-weight-bold text-uppercase">
         Machine
       </div>
       <div class="d-flex flex-wrap align-start">
@@ -105,7 +109,7 @@ SPDX-License-Identifier: Apache-2.0
     <v-divider />
 
     <v-card-text class="pa-0 pb-4">
-      <div class="px-3 pt-2 pb-1 text-caption text-high-emphasis font-weight-bold text-uppercase">
+      <div class="px-3 pt-2 pb-1 text-caption text-medium-emphasis font-weight-bold text-uppercase">
         Volume
       </div>
       <div class="d-flex flex-wrap align-start">
@@ -140,7 +144,7 @@ SPDX-License-Identifier: Apache-2.0
     <v-divider />
 
     <div class="d-flex flex-wrap gap-4 pb-4">
-      <div class="px-3 pt-2 pb-1 text-caption text-high-emphasis font-weight-bold text-uppercase" style="width: 100%">
+      <div class="px-3 pt-2 pb-1 text-caption text-medium-emphasis font-weight-bold text-uppercase" style="width: 100%">
         Scaling &amp; Rollout
       </div>
       <div class="d-flex">
@@ -257,6 +261,10 @@ export default {
     worker: {
       type: Object,
       required: true,
+    },
+    workerIndex: {
+      type: Number,
+      default: 0,
     },
   },
   setup (props) {
@@ -594,5 +602,9 @@ export default {
   .field-group {
     border-left: 2px solid rgba(var(--v-border-color), var(--v-border-opacity));
     padding-left: 4px;
+  }
+
+  .worker-tinted {
+    background-color: rgba(var(--v-border-color), 0.04);
   }
 </style>

--- a/frontend/src/components/dialogs/GDialog.vue
+++ b/frontend/src/components/dialogs/GDialog.vue
@@ -44,6 +44,7 @@ SPDX-License-Identifier: Apache-2.0
       <div
         ref="cardContentRef"
         class="card-content"
+        :style="maxHeight ? { maxHeight } : undefined"
       >
         <slot name="content" />
       </div>
@@ -107,7 +108,7 @@ SPDX-License-Identifier: Apache-2.0
 </template>
 
 <script>
-import { ref } from 'vue'
+import { ref, provide } from 'vue'
 import { useVuelidate } from '@vuelidate/core'
 
 import GMessage from '@/components/GMessage.vue'
@@ -176,6 +177,7 @@ export default {
   setup () {
     const cardContentRef = ref(null)
     useScrollBar(cardContentRef)
+    provide('dialogScrollContainer', cardContentRef)
 
     return {
       v$: useVuelidate(),

--- a/frontend/src/components/dialogs/GDialog.vue
+++ b/frontend/src/components/dialogs/GDialog.vue
@@ -108,7 +108,7 @@ SPDX-License-Identifier: Apache-2.0
 </template>
 
 <script>
-import { ref, provide } from 'vue'
+import { ref } from 'vue'
 import { useVuelidate } from '@vuelidate/core'
 
 import GMessage from '@/components/GMessage.vue'
@@ -177,7 +177,6 @@ export default {
   setup () {
     const cardContentRef = ref(null)
     useScrollBar(cardContentRef)
-    provide('dialogScrollContainer', cardContentRef)
 
     return {
       v$: useVuelidate(),


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area usability
/kind enhancement

**What this PR does / why we need it**:

Restructures the shoot worker group form from a flat flex-row of inputs into an outlined card per worker group with four clearly labeled sections.

Additional improvements:
- Remove button changed to text button with icon for clarity
- Worker configuration dialog width reduced from 1250 to 900px so it fits to the size of the changed contents
- New worker group scrolls into view after the expand animation completes (both dialog and create-cluster page)
- Field alignment fixed across sub-components using `persistent-placeholder` and `align-start`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

No logic, validation, or binding changes — purely structural/visual.

**Release note**:
```feature user
Worker group configuration form redesigned with labeled sections for improved readability
```