### PR TITLE
chore(hack): add gardenerless kubectl wrapper scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,10 @@ scripts/bin
 .DS_Store
 node_modules/
 bin/
+!hack/local-dashboard/bin/
+hack/local-dashboard/bin/*
+!hack/local-dashboard/bin/kubectl-gardenerless
+!hack/local-dashboard/bin/kubectl_complete-gardenerless
 dist/
 ssl/
 tmp/

--- a/docs/development/local-setup.md
+++ b/docs/development/local-setup.md
@@ -51,7 +51,19 @@ cd dashboard
 yarn
 ```
 
-### 3. Configuration
+### 3. Run it locally
+
+There are two local development setups:
+
+- **Local Gardener Dashboard (gardenerless)** — a lightweight, fixture-based environment for UI development and visual verification. The Garden API is backed by KCP with static fixture data; no Gardener controllers are running, so resources are not reconciled. Fast to start, with deterministic scenarios.
+- **Against a Garden cluster** — for testing against a fully reconciled Gardener environment with controllers.
+
+#### Local Gardener Dashboard (gardenerless)
+
+See [`hack/local-dashboard/README.md`](../../hack/local-dashboard/README.md) for setup, commands, scenarios, and login.
+
+#### Against a Garden cluster
+
 Place the Gardener Dashboard configuration under `${HOME}/.gardener/config.yaml` or alternatively set the path to the configuration file using the `GARDENER_CONFIG` environment variable.
 
 A local configuration example could look like follows:
@@ -80,12 +92,7 @@ frontend:
 
 The `websocketAllowedOrigins` list restricts which origins may establish socket.io connections. This setting is required; use `"*"` to allow all origins (not recommended for production).
 
-### 4. Run it locally
-The Gardener Dashboard [`backend`](../../backend) server requires a kubeconfig for the Garden cluster. You can set it e.g. by using the `KUBECONFIG` environment variable.
-
-If you want to run the Garden cluster locally, follow the [getting started locally](https://github.com/gardener/gardener/blob/master/docs/development/getting_started_locally.md) documentation.
-Gardener Dashboard supports the `local` infrastructure provider that comes with the local Gardener cluster setup.
-See [5. Login to the dashboard](#5-login-to-the-dashboard) for more information on how to use the Dashboard with a local gardener or any other Gardener landscape.
+The Gardener Dashboard [`backend`](../../backend) server requires a kubeconfig for the Garden cluster. You can set it e.g. by using the `KUBECONFIG` environment variable. To run a Garden cluster locally, follow the [getting started locally](https://github.com/gardener/gardener/blob/master/docs/development/getting_started_locally.md) documentation. Gardener Dashboard supports the `local` infrastructure provider that comes with the local Gardener cluster setup.
 
 Start the `backend` server (`http://localhost:3030`).
 
@@ -113,26 +120,8 @@ yarn serve
 
 You can now access the UI on https://localhost:8443/
 
-### Local Gardener Dashboard
+To log in, use OIDC if configured on the Garden cluster, or create a service account token for development use:
 
-For an isolated local environment useful for development and deterministic
-browser verification, use the Local Gardener Dashboard workflow described in
-[`hack/local-dashboard/README.md`](../../hack/local-dashboard/README.md).
-The initial implementation starts the complete Garden API (via gardenerless/KCP),
-backend, and frontend stack with managed defaults, deterministic scenarios, safe
-process ownership, and exact `setup`, `up`, `token`, `status`, and `down`
-commands. `up` never clones automatically; agents must ask before invoking the
-explicit `setup` command.
-
-The regular workflow above against a real landscape or local Gardener remains
-supported.
-
-### 5. Login to the dashboard
-For the Local Gardener Dashboard workflow, use the guarded `token` entry point
-described above. For a local Gardener or another landscape, you can either
-configure `oidc` or log in using a token:
-
-To login using a token, first create a service account.
 ```bash
 kubectl -n garden create serviceaccount dashboard-user
 ```

--- a/hack/local-dashboard/README.md
+++ b/hack/local-dashboard/README.md
@@ -1,17 +1,12 @@
 # Local Gardener Dashboard
 
-`node hack/local-dashboard.mjs` manages an isolated local Gardener Dashboard
-environment for development and deterministic browser verification. The initial
-implementation starts the complete Garden API, backend, and frontend stack
-without using ambient kubeconfig or Dashboard configuration.
+`node hack/local-dashboard.mjs` manages an isolated local Gardener Dashboard environment for development and deterministic browser verification. The initial implementation starts the complete Garden API, backend, and frontend stack without using ambient kubeconfig or Dashboard configuration.
 
-The local Garden API is implemented with gardenerless/KCP. It is not a complete
-Garden cluster.
+The local Garden API is implemented with gardenerless/KCP. It is not a complete Garden cluster.
 
 ## Prerequisites
 
-Install the repository dependencies and create the trusted frontend
-development certificate:
+Install the repository dependencies and create the trusted frontend development certificate:
 
 ```sh
 yarn
@@ -25,15 +20,11 @@ node hack/local-dashboard.mjs setup
 node hack/local-dashboard.mjs up
 ```
 
-Open `https://127.0.0.1:8444`. Run `node hack/local-dashboard.mjs token` when a
-login token is needed, and stop the stack with
-`node hack/local-dashboard.mjs down`.
+Open `https://127.0.0.1:8444`. Run `node hack/local-dashboard.mjs token` when a login token is needed, and stop the stack with `node hack/local-dashboard.mjs down`.
 
 ## Setup
 
-`setup` idempotently prepares the pinned gardenerless checkout and local Garden
-API runtime under `.local-dashboard`. Detailed output is written to
-`.local-dashboard/setup.log`.
+`setup` idempotently prepares the pinned gardenerless checkout and local Garden API runtime under `.local-dashboard`. Detailed output is written to `.local-dashboard/setup.log`.
 
 To reset the managed checkout and runtime:
 
@@ -65,8 +56,7 @@ Reports stack health and managed prerequisite versions.
 node hack/local-dashboard.mjs token
 ```
 
-Prints a login token for the operator service account
-`garden/dashboard-user` by default.
+Prints a login token for the operator service account `garden/dashboard-user` by default.
 
 ```sh
 node hack/local-dashboard.mjs token | pbcopy
@@ -84,6 +74,23 @@ node hack/local-dashboard.mjs down
 
 Stops the stack.
 
+## Accessing the local Garden API
+
+The bundled kubectl wrapper automatically targets the managed local Garden API, so no manual kubeconfig configuration is required:
+
+```sh
+./hack/local-dashboard/bin/kubectl-gardenerless get shoots -A
+./hack/local-dashboard/bin/kubectl-gardenerless get projects
+```
+
+No `PATH` change is required for direct invocation. To use the wrapper as `kubectl gardenerless` with shell completion, add the wrapper directory to `PATH`:
+
+```sh
+export PATH="$PWD/hack/local-dashboard/bin:$PATH"
+kubectl gardenerless get shoots -A
+kubectl gardenerless get projects
+```
+
 ## Managed resources
 
 The workflow uses these managed paths and fixed loopback endpoints:
@@ -95,15 +102,3 @@ The workflow uses these managed paths and fixed loopback endpoints:
 - garden: `https://127.0.0.1:6443`
 
 Managed components are presented as `garden`, `backend`, and `frontend`.
-
-## Tests
-
-The command contract is covered by
-`hack/local-dashboard/test/local-dashboard.spec.js`:
-
-```sh
-yarn test:hack
-```
-
-Run `yarn test:hack:cov` to write its dedicated coverage report to
-`coverage/local-dashboard`.

--- a/hack/local-dashboard/bin/kubectl-gardenerless
+++ b/hack/local-dashboard/bin/kubectl-gardenerless
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)" || exit 1
+REPOSITORY_ROOT="$(cd -- "${SCRIPT_DIR}/../../.." && pwd -P)" || exit 1
+MANAGED_ROOT="${REPOSITORY_ROOT}/.local-dashboard"
+GARDENERLESS_DIR="${MANAGED_ROOT}/gardenerless"
+GARDENERLESS_RUNTIME="${MANAGED_ROOT}/runtime"
+GARDENERLESS_KUBECTL="${GARDENERLESS_DIR}/bin/kubectl-gardenerless"
+
+if [[ ! -d "$MANAGED_ROOT" || -L "$MANAGED_ROOT" ||
+      ! -d "$GARDENERLESS_DIR" || -L "$GARDENERLESS_DIR" ||
+      ! -d "$GARDENERLESS_RUNTIME" || -L "$GARDENERLESS_RUNTIME" ||
+      ! -f "$GARDENERLESS_KUBECTL" || -L "$GARDENERLESS_KUBECTL" ||
+      ! -x "$GARDENERLESS_KUBECTL" ]]; then
+  printf '%s\n' \
+    "Error: local Dashboard Gardenerless runtime is unavailable. Run 'node hack/local-dashboard.mjs setup'." \
+    >&2
+  exit 1
+fi
+
+export GARDENERLESS_KCP_DIR="$GARDENERLESS_RUNTIME"
+exec "$GARDENERLESS_KUBECTL" "$@"

--- a/hack/local-dashboard/bin/kubectl_complete-gardenerless
+++ b/hack/local-dashboard/bin/kubectl_complete-gardenerless
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)" || exit 1
+exec "${SCRIPT_DIR}/kubectl-gardenerless" __complete "$@"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
- Adds a `kubectl-gardenerless` wrapper and shell completion for the local Dashboard, so you can run kubectl against the gardenerless Garden API without manual kubeconfig setup.
- Docs now clearly separate the two local setup paths (gardenerless vs. against a Garden cluster).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```other developer
Add `kubectl-gardenerless` wrapper for the local Dashboard gardenerless environment.
```