### PR TITLE
refactor(frontend): redesign worker group form with section cards

### DIFF
--- a/frontend/__tests__/composables/useShootContext.spec.js
+++ b/frontend/__tests__/composables/useShootContext.spec.js
@@ -469,4 +469,36 @@ describe('composables', () => {
       }])
     })
   })
+
+  describe('providerWorkers', () => {
+    beforeEach(() => {
+      shootContextStore.createShootManifest({ providerType: 'aws', workerless: false })
+    })
+
+    it('adds a worker', () => {
+      expect(shootContextStore.providerWorkers).toHaveLength(1)
+      shootContextStore.addProviderWorker()
+      expect(shootContextStore.providerWorkers).toHaveLength(2)
+    })
+
+    it('removes a worker by index', () => {
+      shootContextStore.addProviderWorker()
+      const nameToKeep = shootContextStore.providerWorkers[0].name
+      shootContextStore.removeProviderWorker(1)
+      expect(shootContextStore.providerWorkers).toHaveLength(1)
+      expect(shootContextStore.providerWorkers[0].name).toBe(nameToKeep)
+    })
+
+    it('duplicates a worker and inserts it after the source', () => {
+      const original = shootContextStore.providerWorkers[0]
+      original.name = 'worker-original'
+      original.machine = { type: 'z1.2xlarge', architecture: 'arm64' }
+      shootContextStore.duplicateProviderWorker(0)
+      expect(shootContextStore.providerWorkers).toHaveLength(2)
+      const clone = shootContextStore.providerWorkers[1]
+      expect(clone.name).not.toBe('worker-original')
+      expect(clone._uid).not.toBe(original._uid)
+      expect(clone.machine).toEqual({ type: 'z1.2xlarge', architecture: 'arm64' })
+    })
+  })
 })

--- a/frontend/__tests__/composables/useShootContext.spec.js
+++ b/frontend/__tests__/composables/useShootContext.spec.js
@@ -493,12 +493,15 @@ describe('composables', () => {
       const original = shootContextStore.providerWorkers[0]
       original.name = 'worker-original'
       original.machine = { type: 'z1.2xlarge', architecture: 'arm64' }
+      shootContextStore.addProviderWorker()
+      const third = shootContextStore.providerWorkers[1]
       shootContextStore.duplicateProviderWorker(0)
-      expect(shootContextStore.providerWorkers).toHaveLength(2)
+      expect(shootContextStore.providerWorkers).toHaveLength(3)
       const clone = shootContextStore.providerWorkers[1]
       expect(clone.name).not.toBe('worker-original')
       expect(clone._uid).not.toBe(original._uid)
       expect(clone.machine).toEqual({ type: 'z1.2xlarge', architecture: 'arm64' })
+      expect(shootContextStore.providerWorkers[2]._uid).toBe(third._uid)
     })
   })
 })

--- a/frontend/eslint.config.cjs
+++ b/frontend/eslint.config.cjs
@@ -171,6 +171,7 @@ module.exports = [
       MouseEvent: 'readonly',
       FileReader: 'readonly',
       Range: 'readonly',
+      ResizeObserver: 'readonly',
       fixtures: 'readonly',
       requestAnimationFrame: 'readonly',
     },

--- a/frontend/eslint.config.cjs
+++ b/frontend/eslint.config.cjs
@@ -171,7 +171,6 @@ module.exports = [
       MouseEvent: 'readonly',
       FileReader: 'readonly',
       Range: 'readonly',
-      ResizeObserver: 'readonly',
       fixtures: 'readonly',
       requestAnimationFrame: 'readonly',
     },

--- a/frontend/src/components/GActionButton.vue
+++ b/frontend/src/components/GActionButton.vue
@@ -21,6 +21,7 @@ SPDX-License-Identifier: Apache-2.0
       :loading="loading"
       :width="isTextBtn ? '100%' : undefined"
       :class="{ 'text-none font-weight-regular justify-start': isTextBtn }"
+      :aria-label="tooltip"
       @click.stop.prevent="emit('click', $event)"
     />
     <v-tooltip

--- a/frontend/src/components/NewShoot/GNewShootSelectInfrastructure.vue
+++ b/frontend/src/components/NewShoot/GNewShootSelectInfrastructure.vue
@@ -23,11 +23,24 @@ import { useShootContext } from '@/composables/useShootContext'
 
 import GNewShootInfrastructureCard from './GNewShootInfrastructureCard.vue'
 
+const props = defineProps({
+  scrollContainer: {
+    type: HTMLElement,
+    default: null,
+  },
+})
+
 const cloudProfileStore = useCloudProfileStore()
 
 const { providerType } = useShootContext()
 
 function setProviderType (value) {
+  const scrollTop = props.scrollContainer?.scrollTop ?? null
   providerType.value = value
+  if (scrollTop !== null && props.scrollContainer) {
+    requestAnimationFrame(() => {
+      props.scrollContainer.scrollTop = scrollTop
+    })
+  }
 }
 </script>

--- a/frontend/src/components/ShootWorkers/GContainerRuntime.vue
+++ b/frontend/src/components/ShootWorkers/GContainerRuntime.vue
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 
 <template>
   <div
-    class="d-flex flex-row regular-input"
+    class="d-flex flex-row"
     :class="{ 'has-oci-runtimes': criContainerRuntimeTypes.length }"
   >
     <v-select
@@ -28,11 +28,12 @@ SPDX-License-Identifier: Apache-2.0
       v-if="criContainerRuntimeTypes.length"
       v-model="selectedCriContainerRuntimeTypes"
       class="ml-1"
-      style="flex: 0 0 125px"
+      style="flex: 0 0 140px"
       color="primary"
       item-color="primary"
       :items="criContainerRuntimeTypes"
-      label="Add. OCI Runtimes"
+      label="Additional OCI Runtimes"
+      persistent-placeholder
       multiple
       chips
       closable-chips

--- a/frontend/src/components/ShootWorkers/GManageWorkers.vue
+++ b/frontend/src/components/ShootWorkers/GManageWorkers.vue
@@ -7,33 +7,40 @@ SPDX-License-Identifier: Apache-2.0
 <template>
   <div
     v-if="!workerless"
-    class="alternate-row-background d-flex flex-column ga-6"
+    class="d-flex flex-column ga-6"
   >
-    <v-expand-transition
-      group
-      :disabled="disableWorkerAnimation"
+    <template
+      v-for="(worker, index) in providerWorkers"
+      :key="index"
     >
-      <v-row
-        v-for="(worker, index) in providerWorkers"
-        :key="index"
-        class="list-item my-0"
+      <v-divider v-if="index > 0" />
+      <v-expand-transition
+        :disabled="disableWorkerAnimation"
+        @after-enter="el => el.scrollIntoView({ behavior: 'smooth', block: 'nearest' })"
       >
-        <g-worker-input-generic
-          :worker="worker"
+        <div
+          class="pa-2 rounded"
+          :class="index % 2 === 1 ? 'worker-group-even' : ''"
         >
-          <template #action>
-            <v-btn
-              v-show="providerWorkers.length > 1"
-              size="x-small"
-              variant="tonal"
-              icon="mdi-close"
-              color="grey"
-              @click.stop="removeProviderWorker(index)"
-            />
-          </template>
-        </g-worker-input-generic>
-      </v-row>
-    </v-expand-transition>
+          <g-worker-input-generic
+            :worker="worker"
+          >
+            <template #action>
+              <v-btn
+                v-show="providerWorkers.length > 1"
+                size="small"
+                variant="tonal"
+                color="error"
+                prepend-icon="mdi-delete-outline"
+                @click.stop="removeProviderWorker(index)"
+              >
+                Remove
+              </v-btn>
+            </template>
+          </g-worker-input-generic>
+        </div>
+      </v-expand-transition>
+    </template>
     <v-row
       key="addWorker"
       class="list-item my-0"
@@ -78,3 +85,9 @@ const {
   removeProviderWorker,
 } = useShootContext()
 </script>
+
+<style scoped>
+.worker-group-even {
+  background-color: rgba(0, 0, 0, 0.04);
+}
+</style>

--- a/frontend/src/components/ShootWorkers/GManageWorkers.vue
+++ b/frontend/src/components/ShootWorkers/GManageWorkers.vue
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 <template>
   <div
     v-if="!workerless"
-    ref="containerRef"
     class="d-flex flex-column"
   >
     <div
@@ -36,7 +35,7 @@ SPDX-License-Identifier: Apache-2.0
         <v-expansion-panels
           :model-value="openWorkers[worker._uid] ? [worker._uid] : []"
           multiple
-          @update:model-value="value => setOpen(worker._uid, value.length > 0)"
+          @update:model-value="openPanels => setExpanded(worker._uid, !!openPanels.length)"
         >
           <v-expansion-panel
             :value="worker._uid"
@@ -134,9 +133,6 @@ import {
   watch,
   toRefs,
   nextTick,
-  onMounted,
-  onUnmounted,
-  useTemplateRef,
 } from 'vue'
 
 import GWorkerInputGeneric from '@/components/ShootWorkers/GWorkerInputGeneric'
@@ -147,6 +143,10 @@ const props = defineProps({
   disableWorkerAnimation: {
     type: Boolean,
     default: false,
+  },
+  scrollContainer: {
+    type: HTMLElement,
+    default: null,
   },
 })
 const { disableWorkerAnimation } = toRefs(props)
@@ -199,21 +199,29 @@ function removeProviderWorker (index) {
     delete workerGroupRefs[uid] // eslint-disable-line security/detect-object-injection -- uid from internal worker list
     delete openWorkers.value[uid] // eslint-disable-line security/detect-object-injection -- uid from internal worker list
   }
-  lastInteracted = null
   removeProviderWorkerFromContext(index)
 }
 
 const openWorkers = ref({})
 const workerGroupRefs = {}
-const containerRef = useTemplateRef('containerRef')
-let lastInteracted = null
+let scrollOnEnter = false
+let savedScrollTop = null
 
 watch(providerWorkers, workers => {
+  savedScrollTop = props.scrollContainer?.scrollTop ?? null
   const firstUid = workers[0]?._uid
   if (workers.length === 1 && firstUid && !(firstUid in openWorkers.value)) {
     openWorkers.value = { ...openWorkers.value, [firstUid]: true }
   }
-}, { immediate: true })
+  if (savedScrollTop !== null) {
+    requestAnimationFrame(() => {
+      if (props.scrollContainer) {
+        props.scrollContainer.scrollTop = savedScrollTop
+      }
+      savedScrollTop = null
+    })
+  }
+}, { immediate: true, flush: 'sync' })
 
 const allCollapsed = computed(() =>
   providerWorkers.value.length > 0 &&
@@ -225,7 +233,10 @@ function scrollToWorker (uid) {
 }
 
 function scrollAddedWorkerGroup (element) {
-  element?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+  if (scrollOnEnter) {
+    element?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+    scrollOnEnter = false
+  }
 }
 
 function handleAddProviderWorker () {
@@ -235,7 +246,7 @@ function handleAddProviderWorker () {
     return
   }
   openWorkers.value = { ...openWorkers.value, [uid]: true }
-  lastInteracted = uid
+  scrollOnEnter = true
   nextTick(() => scrollToWorker(uid))
 }
 
@@ -246,14 +257,13 @@ function handleDuplicateProviderWorker (index) {
     return
   }
   openWorkers.value = { ...openWorkers.value, [uid]: true }
-  lastInteracted = uid
+  scrollOnEnter = true
   nextTick(() => scrollToWorker(uid))
 }
 
-function setOpen (uid, value) {
-  openWorkers.value = { ...openWorkers.value, [uid]: value }
-  lastInteracted = uid
-  if (!value) {
+function setExpanded (uid, isExpanded) {
+  openWorkers.value = { ...openWorkers.value, [uid]: isExpanded }
+  if (!isExpanded) {
     scrollToWorker(uid)
   }
 }
@@ -268,21 +278,4 @@ function toggleCollapseAll () {
   }
 }
 
-let resizeObserver = null
-
-onMounted(() => {
-  if (!containerRef.value) {
-    return
-  }
-  resizeObserver = new ResizeObserver(() => {
-    if (lastInteracted) {
-      scrollToWorker(lastInteracted)
-    }
-  })
-  resizeObserver.observe(containerRef.value)
-})
-
-onUnmounted(() => {
-  resizeObserver?.disconnect()
-})
 </script>

--- a/frontend/src/components/ShootWorkers/GManageWorkers.vue
+++ b/frontend/src/components/ShootWorkers/GManageWorkers.vue
@@ -79,6 +79,7 @@ SPDX-License-Identifier: Apache-2.0
                   color="secondary"
                   prepend-icon="mdi-content-copy"
                   class="mr-2"
+                  :disabled="!allMachineTypes.length"
                   @click.stop="handleDuplicateProviderWorker(index)"
                 >
                   Duplicate

--- a/frontend/src/components/ShootWorkers/GManageWorkers.vue
+++ b/frontend/src/components/ShootWorkers/GManageWorkers.vue
@@ -46,7 +46,7 @@ SPDX-License-Identifier: Apache-2.0
                 size="small"
                 class="mr-2 flex-grow-0 flex-shrink-0"
               >
-                {{ openWorkers[worker._uid] ? 'mdi-chevron-up' : 'mdi-chevron-down' }}
+                {{ openWorkers[worker._uid] ? 'mdi-chevron-down' : 'mdi-chevron-right' }}
               </v-icon>
               <span class="text-body-2 font-weight-medium">{{ worker.name }}</span>
               <template v-if="!openWorkers[worker._uid]">

--- a/frontend/src/components/ShootWorkers/GManageWorkers.vue
+++ b/frontend/src/components/ShootWorkers/GManageWorkers.vue
@@ -76,7 +76,7 @@ SPDX-License-Identifier: Apache-2.0
                 <v-btn
                   size="small"
                   variant="tonal"
-                  color="secondary"
+                  color="tonal-info"
                   prepend-icon="mdi-content-copy"
                   class="mr-2"
                   :disabled="!allMachineTypes.length"
@@ -88,7 +88,7 @@ SPDX-License-Identifier: Apache-2.0
                   v-show="providerWorkers.length > 1"
                   size="small"
                   variant="tonal"
-                  color="error"
+                  color="tonal-error"
                   prepend-icon="mdi-delete-outline"
                   class="mr-2"
                   @click.stop="removeProviderWorker(index)"

--- a/frontend/src/components/ShootWorkers/GManageWorkers.vue
+++ b/frontend/src/components/ShootWorkers/GManageWorkers.vue
@@ -178,13 +178,19 @@ function getCollapsedSummary (worker) {
 function getMachineImageText (worker) {
   const { name, version } = worker.machine?.image ?? {}
   const image = machineImages.value.find(i => i.name === name && i.version === version)
+  const imageName = image?.name ?? name
+  const imageVersion = image?.version ?? version
+  const baseText = [imageName, imageVersion].filter(Boolean).join(' ')
+  if (!baseText) {
+    return undefined
+  }
   if (image?.isDeprecated) {
-    return image.name + ' (deprecated)'
+    return baseText + ' (deprecated)'
   }
   if (image?.isExpirationWarning) {
-    return image.name + ' (expiring soon)'
+    return baseText + ' (expiring soon)'
   }
-  return image.name
+  return baseText
 }
 
 function removeProviderWorker (index) {

--- a/frontend/src/components/ShootWorkers/GManageWorkers.vue
+++ b/frontend/src/components/ShootWorkers/GManageWorkers.vue
@@ -10,7 +10,10 @@ SPDX-License-Identifier: Apache-2.0
     ref="containerRef"
     class="d-flex flex-column"
   >
-    <div class="d-flex justify-end mb-6">
+    <div
+      v-if="providerWorkers.length > 1"
+      class="d-flex justify-end mb-2"
+    >
       <v-btn
         variant="text"
         size="small"
@@ -22,57 +25,84 @@ SPDX-License-Identifier: Apache-2.0
     <v-expand-transition
       group
       :disabled="disableWorkerAnimation"
+      @after-enter="scrollAddedWorkerGroup"
     >
       <div
         v-for="(worker, index) in providerWorkers"
         :key="worker._uid"
         :ref="element => { if (element) workerGroupRefs[worker._uid] = element }"
-        class="worker-group-wrapper"
+        class="worker-group-wrapper mb-4"
       >
-        <div
-          class="worker-group-card rounded pa-3 mb-6"
-          :class="index % 2 === 1 ? 'worker-group-even' : ''"
+        <v-expansion-panels
+          :model-value="openWorkers[worker._uid] ? [worker._uid] : []"
+          multiple
+          @update:model-value="value => setOpen(worker._uid, value.length > 0)"
         >
-          <div
-            class="d-flex align-center py-1 cursor-pointer"
-            @click="setCollapsed(worker._uid, !collapsedWorkers[worker._uid])"
+          <v-expansion-panel
+            :value="worker._uid"
           >
-            <v-icon
-              :icon="collapsedWorkers[worker._uid] ? 'mdi-chevron-right' : 'mdi-chevron-down'"
-              size="small"
-              class="text-medium-emphasis mr-1"
-            />
-            <span class="text-body-2 font-weight-medium">{{ worker.name }}</span>
-            <span
-              v-if="collapsedWorkers[worker._uid]"
-              class="ml-3 text-body-2 text-medium-emphasis"
-            >{{ worker.machine.architecture }} / {{ worker.machine.type }}</span>
-            <v-spacer />
-            <v-btn
-              v-show="providerWorkers.length > 1"
-              size="small"
-              variant="tonal"
-              color="error"
-              prepend-icon="mdi-delete-outline"
-              @click.stop="removeProviderWorker(index)"
-            >
-              Remove
-            </v-btn>
-          </div>
-          <v-expand-transition
-            :disabled="disableWorkerAnimation"
-            @after-enter="() => scrollToWorker(worker._uid)"
-          >
-            <div
-              v-if="!collapsedWorkers[worker._uid]"
-              class="pt-3"
-            >
+            <v-expansion-panel-title>
+              <v-icon
+                size="small"
+                class="mr-2 flex-grow-0 flex-shrink-0"
+              >
+                {{ openWorkers[worker._uid] ? 'mdi-chevron-up' : 'mdi-chevron-down' }}
+              </v-icon>
+              <span class="text-body-2 font-weight-medium">{{ worker.name }}</span>
+              <template v-if="!openWorkers[worker._uid]">
+                <template v-if="getCollapsedSummary(worker)">
+                  <span class="mx-2 text-medium-emphasis">/</span>
+                  <span class="d-inline-flex align-center">
+                    <span class="text-body-2 text-medium-emphasis">{{ getCollapsedSummary(worker) }}</span>
+                  </span>
+                </template>
+                <template v-if="worker.zones?.length">
+                  <span class="mx-2 text-medium-emphasis">/</span>
+                  <v-chip
+                    v-for="zone in worker.zones.slice(0, 3)"
+                    :key="zone"
+                    size="x-small"
+                    class="mr-1"
+                  >
+                    {{ zone }}
+                  </v-chip>
+                  <span
+                    v-if="worker.zones.length > 3"
+                    class="text-body-2 text-medium-emphasis"
+                  >+{{ worker.zones.length - 3 }} more</span>
+                </template>
+              </template>
+              <template #actions>
+                <v-btn
+                  size="small"
+                  variant="tonal"
+                  color="secondary"
+                  prepend-icon="mdi-content-copy"
+                  class="mr-2"
+                  @click.stop="handleDuplicateProviderWorker(index)"
+                >
+                  Duplicate
+                </v-btn>
+                <v-btn
+                  v-show="providerWorkers.length > 1"
+                  size="small"
+                  variant="tonal"
+                  color="error"
+                  prepend-icon="mdi-delete-outline"
+                  class="mr-2"
+                  @click.stop="removeProviderWorker(index)"
+                >
+                  Remove
+                </v-btn>
+              </template>
+            </v-expansion-panel-title>
+            <v-expansion-panel-text>
               <g-worker-input-generic
                 :worker="worker"
               />
-            </div>
-          </v-expand-transition>
-        </div>
+            </v-expansion-panel-text>
+          </v-expansion-panel>
+        </v-expansion-panels>
       </div>
     </v-expand-transition>
     <v-row
@@ -84,7 +114,7 @@ SPDX-License-Identifier: Apache-2.0
           :disabled="!allMachineTypes.length"
           variant="text"
           color="primary"
-          @click="addProviderWorker"
+          @click="handleAddProviderWorker"
         >
           <v-icon class="text-primary">
             mdi-plus
@@ -100,6 +130,7 @@ SPDX-License-Identifier: Apache-2.0
 import {
   ref,
   computed,
+  watch,
   toRefs,
   nextTick,
   onMounted,
@@ -123,48 +154,110 @@ const {
   providerWorkers,
   workerless,
   allMachineTypes,
+  machineImages,
   addProviderWorker,
+  duplicateProviderWorker,
   removeProviderWorker: removeProviderWorkerFromContext,
 } = useShootContext()
 
+function getCollapsedSummary (worker) {
+  const parts = []
+  const machineLabel = [worker.machine?.architecture, worker.machine?.type].filter(Boolean).join(' / ')
+  if (machineLabel) {
+    parts.push(machineLabel)
+  }
+
+  const machineImageText = getMachineImageText(worker)
+  if (machineImageText) {
+    parts.push(machineImageText)
+  }
+  return parts.join(' / ')
+}
+
+function getMachineImageText (worker) {
+  const { name, version } = worker.machine?.image ?? {}
+  const image = machineImages.value.find(i => i.name === name && i.version === version)
+  if (image?.isDeprecated) {
+    return image.name + ' (deprecated)'
+  }
+  if (image?.isExpirationWarning) {
+    return image.name + ' (expiring soon)'
+  }
+  return image.name
+}
+
 function removeProviderWorker (index) {
-  const uid = providerWorkers.value.index?._uid
+  const uid = providerWorkers.value[index]?._uid // eslint-disable-line security/detect-object-injection -- index from internal click handler
   if (uid) {
-    delete workerGroupRefs.uid
+    delete workerGroupRefs[uid] // eslint-disable-line security/detect-object-injection -- uid from internal worker list
+    delete openWorkers.value[uid] // eslint-disable-line security/detect-object-injection -- uid from internal worker list
   }
   lastInteracted = null
   removeProviderWorkerFromContext(index)
 }
 
-const collapsedWorkers = ref({})
+const openWorkers = ref({})
 const workerGroupRefs = {}
 const containerRef = useTemplateRef('containerRef')
 let lastInteracted = null
 
+watch(providerWorkers, workers => {
+  const firstUid = workers[0]?._uid
+  if (workers.length === 1 && firstUid && !(firstUid in openWorkers.value)) {
+    openWorkers.value = { ...openWorkers.value, [firstUid]: true }
+  }
+}, { immediate: true })
+
 const allCollapsed = computed(() =>
   providerWorkers.value.length > 0 &&
-  providerWorkers.value.every(worker => collapsedWorkers.value[worker._uid]),
+  providerWorkers.value.every(worker => !openWorkers.value[worker._uid]),
 )
 
 function scrollToWorker (uid) {
-  nextTick(() => workerGroupRefs.uid?.scrollIntoView({ behavior: 'smooth', block: 'nearest' }))
+  nextTick(() => workerGroupRefs[uid]?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })) // eslint-disable-line security/detect-object-injection -- uid from internal worker list
 }
 
-function setCollapsed (uid, value) {
-  collapsedWorkers.value = { ...collapsedWorkers.value, [uid]: value }
+function scrollAddedWorkerGroup (element) {
+  element?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+}
+
+function handleAddProviderWorker () {
+  addProviderWorker()
+  const uid = providerWorkers.value.at(-1)?._uid
+  if (!uid) {
+    return
+  }
+  openWorkers.value = { ...openWorkers.value, [uid]: true }
   lastInteracted = uid
-  if (value) {
+  nextTick(() => scrollToWorker(uid))
+}
+
+function handleDuplicateProviderWorker (index) {
+  duplicateProviderWorker(index)
+  const uid = providerWorkers.value[index + 1]?._uid
+  if (!uid) {
+    return
+  }
+  openWorkers.value = { ...openWorkers.value, [uid]: true }
+  lastInteracted = uid
+  nextTick(() => scrollToWorker(uid))
+}
+
+function setOpen (uid, value) {
+  openWorkers.value = { ...openWorkers.value, [uid]: value }
+  lastInteracted = uid
+  if (!value) {
     scrollToWorker(uid)
   }
 }
 
 function toggleCollapseAll () {
   if (allCollapsed.value) {
-    collapsedWorkers.value = {}
-  } else {
-    collapsedWorkers.value = Object.fromEntries(
+    openWorkers.value = Object.fromEntries(
       providerWorkers.value.map(worker => [worker._uid, true]),
     )
+  } else {
+    openWorkers.value = {}
   }
 }
 
@@ -186,17 +279,3 @@ onUnmounted(() => {
   resizeObserver?.disconnect()
 })
 </script>
-
-<style scoped>
-.worker-group-even {
-  background-color: rgba(0, 0, 0, 0.04);
-}
-
-.worker-group-wrapper {
-  overflow: hidden;
-}
-
-.worker-group-card {
-  border: 1px solid rgba(var(--v-border-color), var(--v-border-opacity));
-}
-</style>

--- a/frontend/src/components/ShootWorkers/GManageWorkers.vue
+++ b/frontend/src/components/ShootWorkers/GManageWorkers.vue
@@ -7,40 +7,74 @@ SPDX-License-Identifier: Apache-2.0
 <template>
   <div
     v-if="!workerless"
-    class="d-flex flex-column ga-6"
+    ref="containerRef"
+    class="d-flex flex-column"
   >
-    <template
-      v-for="(worker, index) in providerWorkers"
-      :key="index"
+    <div class="d-flex justify-end mb-6">
+      <v-btn
+        variant="text"
+        size="small"
+        @click="toggleCollapseAll"
+      >
+        {{ allCollapsed ? 'Expand all' : 'Collapse all' }}
+      </v-btn>
+    </div>
+    <v-expand-transition
+      group
+      :disabled="disableWorkerAnimation"
     >
-      <v-divider v-if="index > 0" />
-      <v-expand-transition
-        :disabled="disableWorkerAnimation"
-        @after-enter="el => el.scrollIntoView({ behavior: 'smooth', block: 'nearest' })"
+      <div
+        v-for="(worker, index) in providerWorkers"
+        :key="worker._uid"
+        :ref="element => { if (element) workerGroupRefs[worker._uid] = element }"
+        class="worker-group-wrapper"
       >
         <div
-          class="pa-2 rounded"
+          class="worker-group-card rounded pa-3 mb-6"
           :class="index % 2 === 1 ? 'worker-group-even' : ''"
         >
-          <g-worker-input-generic
-            :worker="worker"
+          <div
+            class="d-flex align-center py-1 cursor-pointer"
+            @click="setCollapsed(worker._uid, !collapsedWorkers[worker._uid])"
           >
-            <template #action>
-              <v-btn
-                v-show="providerWorkers.length > 1"
-                size="small"
-                variant="tonal"
-                color="error"
-                prepend-icon="mdi-delete-outline"
-                @click.stop="removeProviderWorker(index)"
-              >
-                Remove
-              </v-btn>
-            </template>
-          </g-worker-input-generic>
+            <v-icon
+              :icon="collapsedWorkers[worker._uid] ? 'mdi-chevron-right' : 'mdi-chevron-down'"
+              size="small"
+              class="text-medium-emphasis mr-1"
+            />
+            <span class="text-body-2 font-weight-medium">{{ worker.name }}</span>
+            <span
+              v-if="collapsedWorkers[worker._uid]"
+              class="ml-3 text-body-2 text-medium-emphasis"
+            >{{ worker.machine.architecture }} / {{ worker.machine.type }}</span>
+            <v-spacer />
+            <v-btn
+              v-show="providerWorkers.length > 1"
+              size="small"
+              variant="tonal"
+              color="error"
+              prepend-icon="mdi-delete-outline"
+              @click.stop="removeProviderWorker(index)"
+            >
+              Remove
+            </v-btn>
+          </div>
+          <v-expand-transition
+            :disabled="disableWorkerAnimation"
+            @after-enter="() => scrollToWorker(worker._uid)"
+          >
+            <div
+              v-if="!collapsedWorkers[worker._uid]"
+              class="pt-3"
+            >
+              <g-worker-input-generic
+                :worker="worker"
+              />
+            </div>
+          </v-expand-transition>
         </div>
-      </v-expand-transition>
-    </template>
+      </div>
+    </v-expand-transition>
     <v-row
       key="addWorker"
       class="list-item my-0"
@@ -63,7 +97,15 @@ SPDX-License-Identifier: Apache-2.0
 </template>
 
 <script setup>
-import { toRefs } from 'vue'
+import {
+  ref,
+  computed,
+  toRefs,
+  nextTick,
+  onMounted,
+  onUnmounted,
+  useTemplateRef,
+} from 'vue'
 
 import GWorkerInputGeneric from '@/components/ShootWorkers/GWorkerInputGeneric'
 
@@ -82,12 +124,79 @@ const {
   workerless,
   allMachineTypes,
   addProviderWorker,
-  removeProviderWorker,
+  removeProviderWorker: removeProviderWorkerFromContext,
 } = useShootContext()
+
+function removeProviderWorker (index) {
+  const uid = providerWorkers.value.index?._uid
+  if (uid) {
+    delete workerGroupRefs.uid
+  }
+  lastInteracted = null
+  removeProviderWorkerFromContext(index)
+}
+
+const collapsedWorkers = ref({})
+const workerGroupRefs = {}
+const containerRef = useTemplateRef('containerRef')
+let lastInteracted = null
+
+const allCollapsed = computed(() =>
+  providerWorkers.value.length > 0 &&
+  providerWorkers.value.every(worker => collapsedWorkers.value[worker._uid]),
+)
+
+function scrollToWorker (uid) {
+  nextTick(() => workerGroupRefs.uid?.scrollIntoView({ behavior: 'smooth', block: 'nearest' }))
+}
+
+function setCollapsed (uid, value) {
+  collapsedWorkers.value = { ...collapsedWorkers.value, [uid]: value }
+  lastInteracted = uid
+  if (value) {
+    scrollToWorker(uid)
+  }
+}
+
+function toggleCollapseAll () {
+  if (allCollapsed.value) {
+    collapsedWorkers.value = {}
+  } else {
+    collapsedWorkers.value = Object.fromEntries(
+      providerWorkers.value.map(worker => [worker._uid, true]),
+    )
+  }
+}
+
+let resizeObserver = null
+
+onMounted(() => {
+  if (!containerRef.value) {
+    return
+  }
+  resizeObserver = new ResizeObserver(() => {
+    if (lastInteracted) {
+      scrollToWorker(lastInteracted)
+    }
+  })
+  resizeObserver.observe(containerRef.value)
+})
+
+onUnmounted(() => {
+  resizeObserver?.disconnect()
+})
 </script>
 
 <style scoped>
 .worker-group-even {
   background-color: rgba(0, 0, 0, 0.04);
+}
+
+.worker-group-wrapper {
+  overflow: hidden;
+}
+
+.worker-group-card {
+  border: 1px solid rgba(var(--v-border-color), var(--v-border-opacity));
 }
 </style>

--- a/frontend/src/components/ShootWorkers/GManageWorkers.vue
+++ b/frontend/src/components/ShootWorkers/GManageWorkers.vue
@@ -79,7 +79,7 @@ SPDX-License-Identifier: Apache-2.0
                   prepend-icon="mdi-content-copy"
                   class="mr-2"
                   :disabled="!allMachineTypes.length"
-                  @click.stop="handleDuplicateProviderWorker(index)"
+                  @click.stop="duplicateWorker(index)"
                 >
                   Duplicate
                 </v-btn>
@@ -114,7 +114,7 @@ SPDX-License-Identifier: Apache-2.0
           :disabled="!allMachineTypes.length"
           variant="text"
           color="primary"
-          @click="handleAddProviderWorker"
+          @click="addWorker"
         >
           <v-icon class="text-primary">
             mdi-plus
@@ -177,7 +177,7 @@ function getCollapsedSummary (worker) {
 
 function getMachineImageText (worker) {
   const { name, version } = worker.machine?.image ?? {}
-  const image = machineImages.value.find(i => i.name === name && i.version === version)
+  const image = machineImages.value.find(image => image.name === name && image.version === version)
   const imageName = image?.name ?? name
   const imageVersion = image?.version ?? version
   const baseText = [imageName, imageVersion].filter(Boolean).join(' ')
@@ -236,9 +236,7 @@ function scrollAddedWorkerGroup (element) {
   }
 }
 
-function handleAddProviderWorker () {
-  addProviderWorker()
-  const uid = providerWorkers.value.at(-1)?._uid
+function openAndScrollToWorker (uid) {
   if (!uid) {
     return
   }
@@ -247,15 +245,14 @@ function handleAddProviderWorker () {
   nextTick(() => scrollToWorker(uid))
 }
 
-function handleDuplicateProviderWorker (index) {
+function addWorker () {
+  addProviderWorker()
+  openAndScrollToWorker(providerWorkers.value.at(-1)?._uid)
+}
+
+function duplicateWorker (index) {
   duplicateProviderWorker(index)
-  const uid = providerWorkers.value[index + 1]?._uid
-  if (!uid) {
-    return
-  }
-  openWorkers.value = { ...openWorkers.value, [uid]: true }
-  scrollOnEnter = true
-  nextTick(() => scrollToWorker(uid))
+  openAndScrollToWorker(providerWorkers.value[index + 1]?._uid)
 }
 
 function setExpanded (uid, isExpanded) {

--- a/frontend/src/components/ShootWorkers/GManageWorkers.vue
+++ b/frontend/src/components/ShootWorkers/GManageWorkers.vue
@@ -24,7 +24,7 @@ SPDX-License-Identifier: Apache-2.0
     <v-expand-transition
       group
       :disabled="disableWorkerAnimation"
-      @after-enter="scrollAddedWorkerGroup"
+      @after-enter="scrollToAddedWorkerGroup"
     >
       <div
         v-for="(worker, index) in providerWorkers"
@@ -224,7 +224,7 @@ function scrollToWorker (uid) {
   nextTick(() => workerGroupRefs[uid]?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })) // eslint-disable-line security/detect-object-injection -- uid from internal worker list
 }
 
-function scrollAddedWorkerGroup (element) {
+function scrollToAddedWorkerGroup (element) {
   if (scrollOnEnter) {
     element?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
     scrollOnEnter = false

--- a/frontend/src/components/ShootWorkers/GManageWorkers.vue
+++ b/frontend/src/components/ShootWorkers/GManageWorkers.vue
@@ -178,9 +178,7 @@ function getCollapsedSummary (worker) {
 function getMachineImageText (worker) {
   const { name, version } = worker.machine?.image ?? {}
   const image = machineImages.value.find(image => image.name === name && image.version === version)
-  const imageName = image?.name ?? name
-  const imageVersion = image?.version ?? version
-  const baseText = [imageName, imageVersion].filter(Boolean).join(' ')
+  const baseText = [name, version].filter(Boolean).join(' ')
   if (!baseText) {
     return undefined
   }

--- a/frontend/src/components/ShootWorkers/GManageWorkers.vue
+++ b/frontend/src/components/ShootWorkers/GManageWorkers.vue
@@ -179,13 +179,10 @@ function getMachineImageText (worker) {
   const { name, version } = worker.machine?.image ?? {}
   const image = machineImages.value.find(image => image.name === name && image.version === version)
   const baseText = [name, version].filter(Boolean).join(' ')
-  if (!baseText) {
-    return undefined
-  }
   if (image?.isDeprecated) {
     return baseText + ' (deprecated)'
   }
-  return baseText
+  return baseText || undefined
 }
 
 function removeProviderWorker (index) {

--- a/frontend/src/components/ShootWorkers/GManageWorkers.vue
+++ b/frontend/src/components/ShootWorkers/GManageWorkers.vue
@@ -29,7 +29,7 @@ SPDX-License-Identifier: Apache-2.0
       <div
         v-for="(worker, index) in providerWorkers"
         :key="worker._uid"
-        :ref="element => { if (element) workerGroupRefs[worker._uid] = element }"
+        :ref="element => setWorkerGroupRef(worker._uid, element)"
         class="worker-group-wrapper mb-4"
       >
         <v-expansion-panels
@@ -185,10 +185,17 @@ function getMachineImageText (worker) {
   return baseText || undefined
 }
 
+function setWorkerGroupRef (uid, element) {
+  if (element) {
+    workerGroupRefs[uid] = element // eslint-disable-line security/detect-object-injection -- uid from internal worker list
+  } else {
+    delete workerGroupRefs[uid] // eslint-disable-line security/detect-object-injection -- uid from internal worker list
+  }
+}
+
 function removeWorker (index) {
   const uid = providerWorkers.value[index]?._uid // eslint-disable-line security/detect-object-injection -- index from internal click handler
   if (uid) {
-    delete workerGroupRefs[uid] // eslint-disable-line security/detect-object-injection -- uid from internal worker list
     delete openWorkers.value[uid] // eslint-disable-line security/detect-object-injection -- uid from internal worker list
   }
   removeProviderWorker(index)
@@ -201,6 +208,12 @@ let savedScrollTop = null
 
 watch(providerWorkers, workers => {
   savedScrollTop = props.scrollContainer?.scrollTop ?? null
+  const activeUids = new Set(workers.map(worker => worker._uid))
+  for (const uid of Object.keys(openWorkers.value)) {
+    if (!activeUids.has(uid)) {
+      delete openWorkers.value[uid] // eslint-disable-line security/detect-object-injection -- uid from internal worker list
+    }
+  }
   const firstUid = workers[0]?._uid
   if (workers.length === 1 && firstUid && !(firstUid in openWorkers.value)) {
     openWorkers.value = { ...openWorkers.value, [firstUid]: true }

--- a/frontend/src/components/ShootWorkers/GManageWorkers.vue
+++ b/frontend/src/components/ShootWorkers/GManageWorkers.vue
@@ -187,9 +187,6 @@ function getMachineImageText (worker) {
   if (image?.isDeprecated) {
     return baseText + ' (deprecated)'
   }
-  if (image?.isExpirationWarning) {
-    return baseText + ' (expiring soon)'
-  }
   return baseText
 }
 

--- a/frontend/src/components/ShootWorkers/GManageWorkers.vue
+++ b/frontend/src/components/ShootWorkers/GManageWorkers.vue
@@ -90,7 +90,7 @@ SPDX-License-Identifier: Apache-2.0
                   color="tonal-error"
                   prepend-icon="mdi-delete-outline"
                   class="mr-2"
-                  @click.stop="removeProviderWorker(index)"
+                  @click.stop="removeWorker(index)"
                 >
                   Remove
                 </v-btn>
@@ -158,7 +158,7 @@ const {
   machineImages,
   addProviderWorker,
   duplicateProviderWorker,
-  removeProviderWorker: removeProviderWorkerFromContext,
+  removeProviderWorker,
 } = useShootContext()
 
 function getCollapsedSummary (worker) {
@@ -185,13 +185,13 @@ function getMachineImageText (worker) {
   return baseText || undefined
 }
 
-function removeProviderWorker (index) {
+function removeWorker (index) {
   const uid = providerWorkers.value[index]?._uid // eslint-disable-line security/detect-object-injection -- index from internal click handler
   if (uid) {
     delete workerGroupRefs[uid] // eslint-disable-line security/detect-object-injection -- uid from internal worker list
     delete openWorkers.value[uid] // eslint-disable-line security/detect-object-injection -- uid from internal worker list
   }
-  removeProviderWorkerFromContext(index)
+  removeProviderWorker(index)
 }
 
 const openWorkers = ref({})

--- a/frontend/src/components/ShootWorkers/GVolumeSizeInput.vue
+++ b/frontend/src/components/ShootWorkers/GVolumeSizeInput.vue
@@ -11,6 +11,7 @@ SPDX-License-Identifier: Apache-2.0
       v-model="storageKind"
       :color="color"
       label="Volume"
+      persistent-placeholder
       variant="underlined"
       :items="storageKindItems"
       class="mr-1"
@@ -27,6 +28,7 @@ SPDX-License-Identifier: Apache-2.0
       label="Volume Size"
       type="number"
       :error-messages="errorMessages"
+      persistent-placeholder
       variant="underlined"
       style="maxWidth: 80px"
       @blur="emitBlur"

--- a/frontend/src/components/ShootWorkers/GVolumeType.vue
+++ b/frontend/src/components/ShootWorkers/GVolumeType.vue
@@ -18,6 +18,7 @@ SPDX-License-Identifier: Apache-2.0
       label="Volume Type"
       :hint="hint"
       persistent-hint
+      persistent-placeholder
       variant="underlined"
       @update:model-value="onInputVolumeType"
       @blur="v$.worker.volume.type.$touch()"
@@ -33,12 +34,15 @@ SPDX-License-Identifier: Apache-2.0
     <v-text-field
       v-if="isAWS && worker.volume.type !== 'gp2'"
       v-model.number="workerIops"
-      class="ml-1"
+      class="ml-4"
+      style="width: 80px;"
       color="primary"
       :error-messages="getErrorMessages(v$.workerIops)"
       type="number"
       min="100"
       label="IOPS"
+      hint="I/O operations per second"
+      persistent-placeholder
       variant="underlined"
       @update:model-value="onInputIops"
       @blur="v$.workerIops.$touch()"

--- a/frontend/src/components/ShootWorkers/GWorkerInputGeneric.vue
+++ b/frontend/src/components/ShootWorkers/GWorkerInputGeneric.vue
@@ -5,145 +5,288 @@ SPDX-License-Identifier: Apache-2.0
 -->
 
 <template>
-  <div class="d-flex flex-nowrap align-center ga-4">
-    <div class="d-flex flex-wrap">
-      <div class="regular-input">
-        <v-text-field
-          v-model="worker.name"
-          color="primary"
-          :error-messages="getErrorMessages(v$.worker.name)"
-          counter="15"
-          label="Group Name"
-          variant="underlined"
-          @input="v$.worker.name.$touch()"
-          @blur="v$.worker.name.$touch()"
-        />
-      </div>
-      <div class="small-input">
-        <v-select
-          v-model="machineArchitecture"
-          color="primary"
-          item-color="primary"
-          :items="machineArchitectures"
-          :error-messages="getErrorMessages(v$.machineArchitecture)"
-          label="Architecture"
-          variant="underlined"
-          @blur="v$.machineArchitecture.$touch()"
-        />
-      </div>
-      <div class="regular-input">
-        <g-machine-type
-          v-model="machineTypeValue"
-          :machine-types="machineTypes"
-          :field-name="`${workerGroupName} Machine Type`"
-        />
-      </div>
-      <div class="regular-input">
-        <g-machine-image
-          :machine-images="filteredMachineImages"
-          :worker="worker"
-          :machine-type="selectedMachineType"
-          :auto-update="maintenanceAutoUpdateMachineImageVersion"
-          :field-name="`${workerGroupName} Machine Image`"
-        />
-      </div>
-      <g-container-runtime
-        :machine-image-cri="machineImageCri"
-        :worker="worker"
-        :kubernetes-version="kubernetesVersion"
-        :field-name="`${workerGroupName} Container Runtime`"
-      />
-      <div
-        v-if="volumeInCloudProfile"
-        class="regular-input"
-      >
-        <g-volume-type
-          :volume-types="volumeTypes"
-          :worker="worker"
-          :cloud-profile-ref="cloudProfileRef"
-          :field-name="`${workerGroupName} Volume Type`"
-        />
-      </div>
-      <div :class="volumeInCloudProfile ? 'small-input' : 'regular-input'">
-        <g-volume-size-input
-          v-model="volumeSize"
-          v-model:has-custom-storage-size="hasCustomStorageSize"
-          :min="minVolumeSizeGi"
-          :default-storage-size="defaultStorageSize"
-          :has-volume-types="volumeInCloudProfile"
-          color="primary"
-          :error-messages="getErrorMessages(v$.volumeSize)"
-          @update:custom-storage="onInputVolumeSize"
-          @update:model-value="onInputVolumeSize"
-          @blur="v$.volumeSize.$touch()"
-        />
-      </div>
-      <div class="small-input">
-        <v-text-field
-          v-model="innerMin"
-          min="0"
-          color="primary"
-          :error-messages="getErrorMessages(v$.worker.minimum)"
-          type="number"
-          label="Autoscaler Min."
-          variant="underlined"
-          @input="v$.worker.minimum.$touch()"
-          @blur="ensureValidAutoscalerMin()"
-        />
-      </div>
-      <div class="small-input">
-        <v-text-field
-          v-model="innerMax"
-          min="0"
-          color="primary"
-          type="number"
-          label="Autoscaler Max."
-          variant="underlined"
-          :error-messages="getErrorMessages(v$.worker.maximum)"
-          @input="v$.worker.maximum.$touch()"
-          @blur="ensureValidAutoscalerMax()"
-        />
-      </div>
-      <div class="small-input">
-        <v-text-field
-          v-model="maxSurge"
-          min="0"
-          color="primary"
-          :error-messages="getErrorMessages(v$.worker.maxSurge)"
-          label="Max. Surge"
-          variant="underlined"
-          @input="v$.worker.maxSurge.$touch()"
-          @blur="v$.worker.maxSurge.$touch()"
-        />
-      </div>
-
-      <div
-        v-if="isZonedCluster"
-        class="regular-input"
-      >
-        <v-select
-          v-model="selectedZones"
-          color="primary"
-          item-color="primary"
-          label="Zones"
-          :items="zoneItems"
-          :error-messages="getErrorMessages(v$.selectedZones)"
-          multiple
-          chips
-          closable-chips
-          :hint="zoneHint"
-          persistent-hint
-          item-title="text"
-          variant="underlined"
-          @update:model-value="onInputZones"
-          @blur="v$.selectedZones.$touch()"
-        />
-      </div>
+  <v-container
+    fluid
+    class="pa-0"
+  >
+    <div class="worker-cards">
+      <v-card class="border">
+        <v-toolbar
+          height="28"
+          class="text-medium-emphasis"
+        >
+          <div class="d-flex align-center ga-2 px-3">
+            <v-icon
+              icon="mdi-label-outline"
+              size="x-small"
+            />
+            <span class="text-body-medium">Worker Group</span>
+          </div>
+        </v-toolbar>
+        <v-card-text class="pa-3">
+          <v-row density="compact">
+            <v-col
+              cols="12"
+              class="py-0"
+            >
+              <v-text-field
+                v-model="worker.name"
+                color="primary"
+                :error-messages="getErrorMessages(v$.worker.name)"
+                counter="15"
+                label="Group Name"
+                variant="underlined"
+                @input="v$.worker.name.$touch()"
+                @blur="v$.worker.name.$touch()"
+              />
+            </v-col>
+            <v-col
+              v-if="isZonedCluster"
+              cols="12"
+              class="py-0"
+            >
+              <v-select
+                v-model="selectedZones"
+                color="primary"
+                item-color="primary"
+                label="Zones"
+                :items="zoneItems"
+                :error-messages="getErrorMessages(v$.selectedZones)"
+                multiple
+                chips
+                closable-chips
+                :hint="zoneHint"
+                persistent-hint
+                item-title="text"
+                variant="underlined"
+                @update:model-value="onInputZones"
+                @blur="v$.selectedZones.$touch()"
+              />
+            </v-col>
+          </v-row>
+        </v-card-text>
+      </v-card>
+      <v-card class="border">
+        <v-toolbar
+          height="28"
+          class="text-medium-emphasis"
+        >
+          <div class="d-flex align-center ga-2 px-3">
+            <v-icon
+              icon="mdi-server"
+              size="x-small"
+            />
+            <span class="text-body-medium">Machine</span>
+          </div>
+        </v-toolbar>
+        <v-card-text class="pa-3">
+          <v-row density="compact">
+            <v-col
+              cols="6"
+              class="py-0"
+            >
+              <v-select
+                v-model="machineArchitecture"
+                color="primary"
+                item-color="primary"
+                :items="machineArchitectures"
+                :error-messages="getErrorMessages(v$.machineArchitecture)"
+                label="Architecture"
+                variant="underlined"
+                @blur="v$.machineArchitecture.$touch()"
+              />
+            </v-col>
+            <v-col
+              cols="12"
+              class="py-0"
+            >
+              <g-machine-type
+                v-model="machineTypeValue"
+                :machine-types="machineTypes"
+                :field-name="`${workerGroupName} Machine Type`"
+              />
+            </v-col>
+          </v-row>
+        </v-card-text>
+      </v-card>
+      <v-card class="border">
+        <v-toolbar
+          height="28"
+          class="text-medium-emphasis"
+        >
+          <div class="d-flex align-center ga-2 px-3">
+            <v-icon
+              icon="mdi-disc"
+              size="x-small"
+            />
+            <span class="text-body-medium">Image</span>
+          </div>
+        </v-toolbar>
+        <v-card-text class="pa-3">
+          <v-row density="compact">
+            <v-col
+              cols="12"
+              class="py-0"
+            >
+              <g-machine-image
+                :machine-images="filteredMachineImages"
+                :worker="worker"
+                :machine-type="selectedMachineType"
+                :auto-update="maintenanceAutoUpdateMachineImageVersion"
+                :field-name="`${workerGroupName} Machine Image`"
+              />
+            </v-col>
+          </v-row>
+        </v-card-text>
+      </v-card>
+      <v-card class="border">
+        <v-toolbar
+          height="28"
+          class="text-medium-emphasis"
+        >
+          <div class="d-flex align-center ga-2 px-3">
+            <v-icon
+              icon="mdi-oci"
+              size="x-small"
+            />
+            <span class="text-body-medium">Container Runtime</span>
+          </div>
+        </v-toolbar>
+        <v-card-text class="pa-3">
+          <v-row density="compact">
+            <v-col
+              cols="12"
+              class="py-0"
+            >
+              <g-container-runtime
+                :machine-image-cri="machineImageCri"
+                :worker="worker"
+                :kubernetes-version="kubernetesVersion"
+                :field-name="`${workerGroupName} Container Runtime`"
+              />
+            </v-col>
+          </v-row>
+        </v-card-text>
+      </v-card>
+      <v-card class="border">
+        <v-toolbar
+          height="28"
+          class="text-medium-emphasis"
+        >
+          <div class="d-flex align-center ga-2 px-3">
+            <v-icon
+              icon="mdi-chart-line-variant"
+              size="x-small"
+            />
+            <span class="text-body-medium">Autoscaler</span>
+          </div>
+        </v-toolbar>
+        <v-card-text class="pa-3">
+          <v-row density="compact">
+            <v-col
+              cols="6"
+              class="py-0"
+            >
+              <v-text-field
+                v-model="innerMin"
+                min="0"
+                color="primary"
+                :error-messages="getErrorMessages(v$.worker.minimum)"
+                type="number"
+                label="Autoscaler Min."
+                hint="Minimum nodes kept running at all times"
+                variant="underlined"
+                @blur="ensureValidAutoscalerMin()"
+              />
+            </v-col>
+            <v-col
+              cols="6"
+              class="py-0"
+            >
+              <v-text-field
+                v-model="innerMax"
+                min="0"
+                color="primary"
+                type="number"
+                label="Autoscaler Max."
+                hint="Maximum nodes the autoscaler can scale up to"
+                variant="underlined"
+                :error-messages="getErrorMessages(v$.worker.maximum)"
+                @input="v$.worker.maximum.$touch()"
+                @blur="ensureValidAutoscalerMax()"
+              />
+            </v-col>
+            <v-col
+              cols="6"
+              class="py-0"
+            >
+              <v-text-field
+                v-model="maxSurge"
+                min="0"
+                color="primary"
+                :error-messages="getErrorMessages(v$.worker.maxSurge)"
+                label="Max. Surge"
+                hint="Number of extra nodes allowed during a rolling update"
+                variant="underlined"
+                @input="v$.worker.maxSurge.$touch()"
+                @blur="v$.worker.maxSurge.$touch()"
+              />
+            </v-col>
+          </v-row>
+        </v-card-text>
+      </v-card>
+      <v-card class="border">
+        <v-toolbar
+          height="28"
+          class="text-medium-emphasis"
+        >
+          <div class="d-flex align-center ga-2 px-3">
+            <v-icon
+              icon="mdi-harddisk"
+              size="x-small"
+            />
+            <span class="text-body-medium">Volume</span>
+          </div>
+        </v-toolbar>
+        <v-card-text class="pa-3">
+          <v-row density="compact">
+            <v-col
+              v-if="volumeInCloudProfile"
+              cols="12"
+              class="py-0"
+            >
+              <g-volume-type
+                :volume-types="volumeTypes"
+                :worker="worker"
+                :cloud-profile-ref="cloudProfileRef"
+                :field-name="`${workerGroupName} Volume Type`"
+              />
+            </v-col>
+            <v-col
+              cols="12"
+              class="py-0"
+            >
+              <g-volume-size-input
+                v-model="volumeSize"
+                v-model:has-custom-storage-size="hasCustomStorageSize"
+                :min="minVolumeSizeGi"
+                :default-storage-size="defaultStorageSize"
+                :has-volume-types="volumeInCloudProfile"
+                color="primary"
+                :error-messages="getErrorMessages(v$.volumeSize)"
+                @update:custom-storage="onInputVolumeSize"
+                @update:model-value="onInputVolumeSize"
+                @blur="v$.volumeSize.$touch()"
+              />
+            </v-col>
+          </v-row>
+        </v-card-text>
+      </v-card>
     </div>
-    <div>
+    <div class="mt-2">
       <slot name="action" />
     </div>
-  </div>
+  </v-container>
 </template>
 
 <script>
@@ -537,8 +680,19 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
-  :deep(.v-chip--disabled) {
-    opacity: 1;
-  }
+<style scoped>
+.worker-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 300px));
+  gap: 8px;
+  align-items: start;
+}
+
+:deep(.v-chip--disabled) {
+  opacity: 1;
+}
+
+.border {
+  border-color: rgba(var(--v-border-color), var(--v-border-opacity)) !important;
+}
 </style>

--- a/frontend/src/components/ShootWorkers/GWorkerInputGeneric.vue
+++ b/frontend/src/components/ShootWorkers/GWorkerInputGeneric.vue
@@ -10,7 +10,7 @@ SPDX-License-Identifier: Apache-2.0
     class="pa-0"
   >
     <div class="worker-cards">
-      <v-card class="border">
+      <v-card class="worker-section-card">
         <v-toolbar
           height="28"
           class="text-medium-emphasis"
@@ -66,7 +66,7 @@ SPDX-License-Identifier: Apache-2.0
           </v-row>
         </v-card-text>
       </v-card>
-      <v-card class="border">
+      <v-card class="worker-section-card">
         <v-toolbar
           height="28"
           class="text-medium-emphasis"
@@ -109,7 +109,7 @@ SPDX-License-Identifier: Apache-2.0
           </v-row>
         </v-card-text>
       </v-card>
-      <v-card class="border">
+      <v-card class="worker-section-card">
         <v-toolbar
           height="28"
           class="text-medium-emphasis"
@@ -139,7 +139,7 @@ SPDX-License-Identifier: Apache-2.0
           </v-row>
         </v-card-text>
       </v-card>
-      <v-card class="border">
+      <v-card class="worker-section-card">
         <v-toolbar
           height="28"
           class="text-medium-emphasis"
@@ -168,7 +168,7 @@ SPDX-License-Identifier: Apache-2.0
           </v-row>
         </v-card-text>
       </v-card>
-      <v-card class="border">
+      <v-card class="worker-section-card">
         <v-toolbar
           height="28"
           class="text-medium-emphasis"
@@ -235,7 +235,7 @@ SPDX-License-Identifier: Apache-2.0
           </v-row>
         </v-card-text>
       </v-card>
-      <v-card class="border">
+      <v-card class="worker-section-card">
         <v-toolbar
           height="28"
           class="text-medium-emphasis"
@@ -692,7 +692,8 @@ export default {
   opacity: 1;
 }
 
-.border {
+.worker-section-card {
   border-color: rgba(var(--v-border-color), var(--v-border-opacity)) !important;
+  min-height: 200px;
 }
 </style>

--- a/frontend/src/components/ShootWorkers/GWorkerInputGeneric.vue
+++ b/frontend/src/components/ShootWorkers/GWorkerInputGeneric.vue
@@ -196,6 +196,7 @@ SPDX-License-Identifier: Apache-2.0
                 label="Autoscaler Min."
                 hint="Minimum nodes kept running at all times"
                 variant="underlined"
+                @input="v$.worker.minimum.$touch()"
                 @blur="ensureValidAutoscalerMin()"
               />
             </v-col>

--- a/frontend/src/composables/useShootContext.js
+++ b/frontend/src/composables/useShootContext.js
@@ -579,7 +579,13 @@ export function createShootContextComposable (options = {}) {
 
   const providerWorkers = computed({
     get () {
-      return get(manifest.value, ['spec', 'provider', 'workers'], [])
+      const workers = get(manifest.value, ['spec', 'provider', 'workers'], [])
+      for (const worker of workers) {
+        if (!Object.prototype.hasOwnProperty.call(worker, '_uid')) {
+          Object.defineProperty(worker, '_uid', { value: uuidv4() })
+        }
+      }
+      return workers
     },
     set (value = []) {
       set(manifest.value, ['spec', 'provider', 'workers'], value)
@@ -611,6 +617,7 @@ export function createShootContextComposable (options = {}) {
         : availableZones.value,
     )
     Object.defineProperty(worker, 'isNew', { value: isNew })
+    Object.defineProperty(worker, '_uid', { value: id })
     return worker
   }
 

--- a/frontend/src/composables/useShootContext.js
+++ b/frontend/src/composables/useShootContext.js
@@ -610,6 +610,19 @@ export function createShootContextComposable (options = {}) {
     providerWorkers.value = filter(providerWorkers.value, (_, i) => i !== index)
   }
 
+  function duplicateProviderWorker (index) {
+    const source = providerWorkers.value[index] // eslint-disable-line security/detect-object-injection -- index from internal click handler
+    const clone = JSON.parse(JSON.stringify(source)) // get rid of uid and isNew (not serializable)
+    clone.name = `worker-${shortRandomString(5)}`
+    Object.defineProperty(clone, 'isNew', { value: true })
+    Object.defineProperty(clone, '_uid', { value: uuidv4() })
+    providerWorkers.value = [
+      ...providerWorkers.value.slice(0, index + 1),
+      clone,
+      ...providerWorkers.value.slice(index + 1),
+    ]
+  }
+
   function generateProviderWorker (zones) {
     const { id, isNew, ...worker } = generateWorker(
       !isEmpty(zones)
@@ -1118,6 +1131,7 @@ export function createShootContextComposable (options = {}) {
     providerWorkers,
     addProviderWorker,
     removeProviderWorker,
+    duplicateProviderWorker,
     workerless,
     usedZones,
     unusedZones,

--- a/frontend/src/composables/useShootContext.js
+++ b/frontend/src/composables/useShootContext.js
@@ -612,7 +612,7 @@ export function createShootContextComposable (options = {}) {
 
   function duplicateProviderWorker (index) {
     const source = providerWorkers.value[index] // eslint-disable-line security/detect-object-injection -- index from internal click handler
-    const clone = structuredClone(source) // get rid of uid and isNew (not serializable)
+    const clone = JSON.parse(JSON.stringify(source))
     clone.name = `worker-${shortRandomString(5)}`
     Object.defineProperty(clone, 'isNew', { value: true })
     Object.defineProperty(clone, '_uid', { value: uuidv4() })

--- a/frontend/src/composables/useShootContext.js
+++ b/frontend/src/composables/useShootContext.js
@@ -612,7 +612,7 @@ export function createShootContextComposable (options = {}) {
 
   function duplicateProviderWorker (index) {
     const source = providerWorkers.value[index] // eslint-disable-line security/detect-object-injection -- index from internal click handler
-    const clone = JSON.parse(JSON.stringify(source)) // get rid of uid and isNew (not serializable)
+    const clone = structuredClone(source) // get rid of uid and isNew (not serializable)
     clone.name = `worker-${shortRandomString(5)}`
     Object.defineProperty(clone, 'isNew', { value: true })
     Object.defineProperty(clone, '_uid', { value: uuidv4() })

--- a/frontend/src/views/GNewShoot.vue
+++ b/frontend/src/views/GNewShoot.vue
@@ -10,13 +10,14 @@ SPDX-License-Identifier: Apache-2.0
     class="d-flex flex-column justify-space-between fill-height"
   >
     <v-container
+      ref="scrollContainer"
       class="overflow-auto"
       fluid
     >
       <v-card>
         <g-toolbar title="Infrastructure" />
         <v-card-text>
-          <g-new-shoot-select-infrastructure />
+          <g-new-shoot-select-infrastructure :scroll-container="$refs.scrollContainer?.$el" />
         </v-card-text>
       </v-card>
       <v-card
@@ -62,7 +63,7 @@ SPDX-License-Identifier: Apache-2.0
           title="Worker"
         />
         <v-card-text>
-          <g-manage-workers />
+          <g-manage-workers :scroll-container="$refs.scrollContainer?.$el" />
         </v-card-text>
       </v-card>
       <v-card

--- a/frontend/src/views/GNewShoot.vue
+++ b/frontend/src/views/GNewShoot.vue
@@ -128,7 +128,10 @@ SPDX-License-Identifier: Apache-2.0
 </template>
 
 <script>
-import { defineAsyncComponent, ref } from 'vue'
+import {
+  defineAsyncComponent,
+  ref,
+} from 'vue'
 import { useVuelidate } from '@vuelidate/core'
 import {
   mapActions,

--- a/frontend/src/views/GNewShoot.vue
+++ b/frontend/src/views/GNewShoot.vue
@@ -17,7 +17,7 @@ SPDX-License-Identifier: Apache-2.0
       <v-card>
         <g-toolbar title="Infrastructure" />
         <v-card-text>
-          <g-new-shoot-select-infrastructure :scroll-container="$refs.scrollContainer?.$el" />
+          <g-new-shoot-select-infrastructure :scroll-container="scrollContainer?.$el" />
         </v-card-text>
       </v-card>
       <v-card
@@ -63,7 +63,7 @@ SPDX-License-Identifier: Apache-2.0
           title="Worker"
         />
         <v-card-text>
-          <g-manage-workers :scroll-container="$refs.scrollContainer?.$el" />
+          <g-manage-workers :scroll-container="scrollContainer?.$el" />
         </v-card-text>
       </v-card>
       <v-card
@@ -128,7 +128,7 @@ SPDX-License-Identifier: Apache-2.0
 </template>
 
 <script>
-import { defineAsyncComponent } from 'vue'
+import { defineAsyncComponent, ref } from 'vue'
 import { useVuelidate } from '@vuelidate/core'
 import {
   mapActions,
@@ -199,6 +199,8 @@ export default {
     return true
   },
   setup () {
+    const scrollContainer = ref(null)
+
     const {
       shootNamespace,
       shootName,
@@ -211,6 +213,7 @@ export default {
 
     return {
       v$: useVuelidate(),
+      scrollContainer,
       shootNamespace,
       shootName,
       shootManifest,


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area usability
/kind enhancement

**What this PR does / why we need it**:

Restructures the form from a flat flex-row of inputs into a CSS grid
of labeled section cards for each worker group, aligned with the existing
readonly view.

Additional improvements:
- Worker groups are collapsible with animated expand/collapse;
  collapsed state shows a summary
- Collapse all / Expand all toggle above the worker group list
- Remove button pinned to the group header row (always visible)
- adding a worker group scrolls it into focus
- added the possibility to pick a worker group and duplicate it

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```feature user
Redesigned add/edit worker group form to improve usability
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Worker groups now appear as collapsible cards with summaries, expand/collapse controls, and Duplicate/Remove actions.
  - Added worker duplication with automatic naming and placement next to the original.
  - Preserved page scroll position when changing infrastructure settings and managing workers.

- **UI Improvements**
  - Improved worker configuration layout and grouping.
  - Added clearer labels, hints, persistent placeholders, and field sizing.
  - Improved accessibility for action-button tooltips.
  - Removed load balancer class configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->