### PR TITLE
fix(frontend): Improve main project selection on small viewports

### DIFF
--- a/frontend/src/components/GMainProjectSelection.vue
+++ b/frontend/src/components/GMainProjectSelection.vue
@@ -500,6 +500,7 @@ async function scrollToActiveProject () {
     }
 
     .project-list {
+      min-height: 62px;
       max-height: calc(100vh - 420px);
       max-width: 255px;
 


### PR DESCRIPTION
**How to categorize this PR?**
  /area quality
  /area usability
 
**What this PR does / why we need it**:
On small viewports it was not possible to select a main project as the dynamic height of the selection lists was decreasing to 0px. Hence setting a min-height to display at least one project. 

**Which issue(s) this PR fixes**:
Fixes #2922

**Special notes for your reviewer**:

**Release note**:
```bugfix user
Improved main project selection on small viewports.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved project list layout stability by ensuring the list maintains a minimum height, including when using virtual scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->