### PR TITLE
fix(tickets): link GitHub issue references in ticket comments to configured GitHub repo

### DIFF
--- a/backend/__tests__/acceptance/__snapshots__/api.tickets.spec.js.snap
+++ b/backend/__tests__/acceptance/__snapshots__/api.tickets.spec.js.snap
@@ -70,7 +70,7 @@ exports[`api > tickets > should fetch open issues and comments for shoot cluster
   "comments": [
     {
       "data": {
-        "body": "<p>This is comment 1 for issue <a href="https://github.com/gardener/dashboard/issues/2" target="_blank">#2</a></p>",
+        "body": "<p>This is comment 1 for issue <a href="https://github.com/gardener/ticket-dev/issues/2" target="_blank">#2</a></p>",
         "html_url": "https://github.com/gardener/ticket-dev/issues/2#issuecomment-1",
         "user": {
           "avatar_url": "https://avatars1.githubusercontent.com/u/21031061?v=4",

--- a/backend/__tests__/markdown.spec.js
+++ b/backend/__tests__/markdown.spec.js
@@ -10,6 +10,7 @@ import {
   expect,
 } from 'vitest'
 import { createConverter } from '../lib/markdown.js'
+import { defaultBuildUrl } from 'remark-github'
 
 async function render (md, sanitizeOptions) {
   const { makeSanitizedHtml } = createConverter()
@@ -165,5 +166,15 @@ describe('createConverter().makeSanitizedHtml', () => {
   test('Non-string input does not throw (treated as empty)', async () => {
   // Your converter already coalesces null/undefined to empty, but we ensure it never throws.
     expect(await render({})).toMatchSnapshot()
+  })
+
+  test('issue reference in a comment should link to configured repo, not the default GitHub', async () => {
+    const { makeSanitizedHtml } = createConverter({
+      repository: 'ticket-org/ticket-repo',
+      buildUrl: values => defaultBuildUrl(values).replace('https://github.com', 'https://enterprise.github.example.com'),
+    })
+    const html = await makeSanitizedHtml('See #123 for details.')
+    expect(html).toContain('https://enterprise.github.example.com/ticket-org/ticket-repo/issues/123')
+    expect(html).not.toContain('https://github.com')
   })
 })

--- a/backend/__tests__/markdown.spec.js
+++ b/backend/__tests__/markdown.spec.js
@@ -10,7 +10,7 @@ import {
   expect,
 } from 'vitest'
 import { createConverter } from '../lib/markdown.js'
-import { defaultBuildUrl } from 'remark-github'
+import { buildConverterOptions } from '../lib/services/tickets.js'
 
 async function render (md, sanitizeOptions) {
   const { makeSanitizedHtml } = createConverter()
@@ -169,27 +169,22 @@ describe('createConverter().makeSanitizedHtml', () => {
   })
 
   test('issue reference in a comment should link to configured repo, not the default GitHub', async () => {
-    const { makeSanitizedHtml } = createConverter({
-      github: {
-        repository: 'ticket-org/ticket-repo',
-        buildUrl: values => defaultBuildUrl(values).replace('https://github.com', 'https://enterprise.github.example.com'),
-      },
-    })
+    const { makeSanitizedHtml } = createConverter(buildConverterOptions({
+      apiUrl: 'https://enterprise.github.example.com/api/v3',
+      org: 'ticket-org',
+      repository: 'ticket-repo',
+    }))
     const html = await makeSanitizedHtml('See #123 for details.')
     expect(html).toContain('https://enterprise.github.example.com/ticket-org/ticket-repo/issues/123')
     expect(html).not.toContain('https://github.com')
   })
 
   test('issue reference links also work with api.subdomain url from config', async () => {
-    const apiUrl = 'https://api.github.example.com'
-    const { protocol, hostname } = new URL(apiUrl)
-    const webOrigin = `${protocol}//${hostname.replace(/^api\./, '')}`
-    const { makeSanitizedHtml } = createConverter({
-      github: {
-        repository: 'ticket-org/ticket-repo',
-        buildUrl: values => defaultBuildUrl(values).replace('https://github.com', webOrigin),
-      },
-    })
+    const { makeSanitizedHtml } = createConverter(buildConverterOptions({
+      apiUrl: 'https://api.github.example.com',
+      org: 'ticket-org',
+      repository: 'ticket-repo',
+    }))
     const html = await makeSanitizedHtml('See #456 for details.')
     expect(html).toContain('https://github.example.com/ticket-org/ticket-repo/issues/456')
     expect(html).not.toContain('https://api.github.example.com')

--- a/backend/__tests__/markdown.spec.js
+++ b/backend/__tests__/markdown.spec.js
@@ -177,4 +177,17 @@ describe('createConverter().makeSanitizedHtml', () => {
     expect(html).toContain('https://enterprise.github.example.com/ticket-org/ticket-repo/issues/123')
     expect(html).not.toContain('https://github.com')
   })
+
+  test('issue reference links also work with api.subdomain url from config', async () => {
+    const apiUrl = 'https://api.github.example.com'
+    const { protocol, hostname } = new URL(apiUrl)
+    const webOrigin = `${protocol}//${hostname.replace(/^api\./, '')}`
+    const { makeSanitizedHtml } = createConverter({
+      repository: 'ticket-org/ticket-repo',
+      buildUrl: values => defaultBuildUrl(values).replace('https://github.com', webOrigin),
+    })
+    const html = await makeSanitizedHtml('See #456 for details.')
+    expect(html).toContain('https://github.example.com/ticket-org/ticket-repo/issues/456')
+    expect(html).not.toContain('https://api.github.example.com')
+  })
 })

--- a/backend/__tests__/markdown.spec.js
+++ b/backend/__tests__/markdown.spec.js
@@ -189,4 +189,14 @@ describe('createConverter().makeSanitizedHtml', () => {
     expect(html).toContain('https://github.example.com/ticket-org/ticket-repo/issues/456')
     expect(html).not.toContain('https://api.github.example.com')
   })
+
+  test('issue reference links preserve non-default port from api.subdomain url', async () => {
+    const { makeSanitizedHtml } = createConverter(buildConverterOptions({
+      apiUrl: 'https://api.github.example.com:8443/api/v3',
+      org: 'ticket-org',
+      repository: 'ticket-repo',
+    }))
+    const html = await makeSanitizedHtml('See #789 for details.')
+    expect(html).toContain('https://github.example.com:8443/ticket-org/ticket-repo/issues/789')
+  })
 })

--- a/backend/__tests__/markdown.spec.js
+++ b/backend/__tests__/markdown.spec.js
@@ -170,8 +170,10 @@ describe('createConverter().makeSanitizedHtml', () => {
 
   test('issue reference in a comment should link to configured repo, not the default GitHub', async () => {
     const { makeSanitizedHtml } = createConverter({
-      repository: 'ticket-org/ticket-repo',
-      buildUrl: values => defaultBuildUrl(values).replace('https://github.com', 'https://enterprise.github.example.com'),
+      github: {
+        repository: 'ticket-org/ticket-repo',
+        buildUrl: values => defaultBuildUrl(values).replace('https://github.com', 'https://enterprise.github.example.com'),
+      },
     })
     const html = await makeSanitizedHtml('See #123 for details.')
     expect(html).toContain('https://enterprise.github.example.com/ticket-org/ticket-repo/issues/123')
@@ -183,8 +185,10 @@ describe('createConverter().makeSanitizedHtml', () => {
     const { protocol, hostname } = new URL(apiUrl)
     const webOrigin = `${protocol}//${hostname.replace(/^api\./, '')}`
     const { makeSanitizedHtml } = createConverter({
-      repository: 'ticket-org/ticket-repo',
-      buildUrl: values => defaultBuildUrl(values).replace('https://github.com', webOrigin),
+      github: {
+        repository: 'ticket-org/ticket-repo',
+        buildUrl: values => defaultBuildUrl(values).replace('https://github.com', webOrigin),
+      },
     })
     const html = await makeSanitizedHtml('See #456 for details.')
     expect(html).toContain('https://github.example.com/ticket-org/ticket-repo/issues/456')

--- a/backend/lib/markdown.js
+++ b/backend/lib/markdown.js
@@ -14,33 +14,31 @@ import remarkRehype from 'remark-rehype'
 import rehypeExternalLinks from 'rehype-external-links'
 import rehypeStringify from 'rehype-stringify'
 import sanitizeHtml from 'sanitize-html'
-
 const SANITIZE = {
   allowedTags: [...sanitizeHtml.defaults.allowedTags, 'img', 'details', 'summary'],
 }
 
-const processor = unified()
-  .use(remarkParse)
-  .use(remarkGfm)
-  .use(remarkGithub)
-  .use(remarkBreaks)
-  .use(remarkEmoji, { emoticon: false })
-
+function buildProcessor (githubOptions = {}) {
+  return unified()
+    .use(remarkParse)
+    .use(remarkGfm)
+    .use(remarkGithub, githubOptions)
+    .use(remarkBreaks)
+    .use(remarkEmoji, { emoticon: false })
   // Keep raw HTML as raw nodes, required too keep some tags like details/summary
   // Unsafe HTML will be sanitized later
-  .use(remarkRehype, { allowDangerousHtml: true })
-
-  .use(rehypeExternalLinks, { target: '_blank', rel: ['noopener', 'noreferrer'] })
-
+    .use(remarkRehype, { allowDangerousHtml: true })
+    .use(rehypeExternalLinks, { target: '_blank', rel: ['noopener', 'noreferrer'] })
   // emit raw nodes as HTML (unsafe until sanitized)
-  .use(rehypeStringify, { allowDangerousHtml: true })
+    .use(rehypeStringify, { allowDangerousHtml: true })
+}
 
-export function createConverter () {
+export function createConverter (githubOptions = {}) {
+  const processor = buildProcessor(githubOptions)
   return {
     async makeSanitizedHtml (text) {
       const file = await processor.process(text)
       const rawHtml = String(file)
-      // Sanitize the generated HTML
       return sanitizeHtml(rawHtml, SANITIZE).trim()
     },
   }

--- a/backend/lib/markdown.js
+++ b/backend/lib/markdown.js
@@ -18,11 +18,11 @@ const SANITIZE = {
   allowedTags: [...sanitizeHtml.defaults.allowedTags, 'img', 'details', 'summary'],
 }
 
-function buildProcessor (githubOptions = {}) {
+function buildProcessor ({ github } = {}) {
   return unified()
     .use(remarkParse)
     .use(remarkGfm)
-    .use(remarkGithub, githubOptions)
+    .use(remarkGithub, github ?? {})
     .use(remarkBreaks)
     .use(remarkEmoji, { emoticon: false })
   // Keep raw HTML as raw nodes, required too keep some tags like details/summary
@@ -33,8 +33,8 @@ function buildProcessor (githubOptions = {}) {
     .use(rehypeStringify, { allowDangerousHtml: true })
 }
 
-export function createConverter (githubOptions = {}) {
-  const processor = buildProcessor(githubOptions)
+export function createConverter (options = {}) {
+  const processor = buildProcessor(options)
   return {
     async makeSanitizedHtml (text) {
       const file = await processor.process(text)

--- a/backend/lib/services/tickets.js
+++ b/backend/lib/services/tickets.js
@@ -28,8 +28,9 @@ export function buildConverterOptions ({ apiUrl, org, repository } = {}) {
     options.github.repository = `${org}/${repository}`
   }
   if (apiUrl) {
-    const { protocol, hostname } = new URL(apiUrl)
-    const webOrigin = `${protocol}//${hostname.replace(/^api\./, '')}`
+    const parsedUrl = new URL(apiUrl)
+    parsedUrl.hostname = parsedUrl.hostname.replace(/^api\./, '')
+    const webOrigin = parsedUrl.origin
     options.github.ghMentions = true
     options.github.ghMentionsLink = `${webOrigin}/{u}`
     options.github.buildUrl = values => defaultBuildUrl(values).replace('https://github.com', webOrigin)

--- a/backend/lib/services/tickets.js
+++ b/backend/lib/services/tickets.js
@@ -22,22 +22,22 @@ function fromLabel (item) {
   ])
 }
 
-const { apiUrl, org, repository } = config.gitHub ?? {}
-const options = { github: {} }
-
-if (org && repository) {
-  options.github.repository = `${org}/${repository}`
+export function buildConverterOptions ({ apiUrl, org, repository } = {}) {
+  const options = { github: {} }
+  if (org && repository) {
+    options.github.repository = `${org}/${repository}`
+  }
+  if (apiUrl) {
+    const { protocol, hostname } = new URL(apiUrl)
+    const webOrigin = `${protocol}//${hostname.replace(/^api\./, '')}`
+    options.github.ghMentions = true
+    options.github.ghMentionsLink = `${webOrigin}/{u}`
+    options.github.buildUrl = values => defaultBuildUrl(values).replace('https://github.com', webOrigin)
+  }
+  return options
 }
 
-if (apiUrl) {
-  const { protocol, hostname } = new URL(apiUrl)
-  const webOrigin = `${protocol}//${hostname.replace(/^api\./, '')}`
-  options.github.ghMentions = true
-  options.github.ghMentionsLink = `${webOrigin}/{u}`
-  options.github.buildUrl = values => defaultBuildUrl(values).replace('https://github.com', webOrigin)
-}
-
-export const converter = createConverter(options)
+export const converter = createConverter(buildConverterOptions(config.gitHub ?? {}))
 
 export async function fromIssue (issue) {
   const labels = _.map(issue.labels, fromLabel)

--- a/backend/lib/services/tickets.js
+++ b/backend/lib/services/tickets.js
@@ -23,21 +23,21 @@ function fromLabel (item) {
 }
 
 const { apiUrl, org, repository } = config.gitHub ?? {}
-const githubOptions = {}
+const options = { github: {} }
 
 if (org && repository) {
-  githubOptions.repository = `${org}/${repository}`
+  options.github.repository = `${org}/${repository}`
 }
 
 if (apiUrl) {
   const { protocol, hostname } = new URL(apiUrl)
   const webOrigin = `${protocol}//${hostname.replace(/^api\./, '')}`
-  githubOptions.ghMentions = true
-  githubOptions.ghMentionsLink = `${webOrigin}/{u}`
-  githubOptions.buildUrl = values => defaultBuildUrl(values).replace('https://github.com', webOrigin)
+  options.github.ghMentions = true
+  options.github.ghMentionsLink = `${webOrigin}/{u}`
+  options.github.buildUrl = values => defaultBuildUrl(values).replace('https://github.com', webOrigin)
 }
 
-export const converter = createConverter(githubOptions)
+export const converter = createConverter(options)
 
 export async function fromIssue (issue) {
   const labels = _.map(issue.labels, fromLabel)

--- a/backend/lib/services/tickets.js
+++ b/backend/lib/services/tickets.js
@@ -11,6 +11,7 @@ import {
   getComments,
 } from '../github/index.js'
 import { createConverter } from '../markdown.js'
+import { defaultBuildUrl } from 'remark-github'
 import cache from '../cache/index.js'
 
 function fromLabel (item) {
@@ -21,15 +22,22 @@ function fromLabel (item) {
   ])
 }
 
-const apiUrl = _.get(config, ['gitHub', 'apiUrl'])
-const options = {}
+const { apiUrl, org, repository } = config.gitHub ?? {}
+const githubOptions = {}
 
-if (apiUrl) {
-  options.ghMentions = true
-  options.ghMentionsLink = new URL(apiUrl).origin + '/{u}'
+if (org && repository) {
+  githubOptions.repository = `${org}/${repository}`
 }
 
-export const converter = createConverter(options)
+if (apiUrl) {
+  const { protocol, hostname } = new URL(apiUrl)
+  const webOrigin = `${protocol}//${hostname.replace(/^api\./, '')}`
+  githubOptions.ghMentions = true
+  githubOptions.ghMentionsLink = `${webOrigin}/{u}`
+  githubOptions.buildUrl = values => defaultBuildUrl(values).replace('https://github.com', webOrigin)
+}
+
+export const converter = createConverter(githubOptions)
 
 export async function fromIssue (issue) {
   const labels = _.map(issue.labels, fromLabel)


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area quality
/kind bug

**What this PR does / why we need it**:
When a ticket comment contains a `#123`-style issue reference, the markdown parsing lib would render it as a link to the dashboard repo's issues instead of the configured ticket repository. This PR fixes that behavior so that issue links correctly point to the configured repo (by parsing the backend `gitHub` config).

Both URL styles are handled:
- Path-based API URL (e.g. `enterprise.github.example.com/api/v3`)
- Subdomain-based API URL (e.g. `api.enterprise.github.example.com`)
- Also custom ports are handled: (e.g. `api.enterprise.github.example.com:1234/api/v3`)

**Which issue(s) this PR fixes**:
Fixes #2806

**Special notes for your reviewer**:

**Release note**:
```bugfix user
Fix issue reference links in ticket comments to resolve against the configured GitHub instance and repository
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Markdown issue references in ticket comments now link to the configured repository instead of the default GitHub destination.
  - Issue and user mention links now use the appropriate repository and web address across supported deployments.
  - Links correctly support custom repository settings and GitHub-compatible web origins derived from configured API URLs.
  - Ticket comment links now remain accurate when installations use customized GitHub-compatible service addresses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->