### PR TITLE
fix: strip query params from mailto links

### DIFF
--- a/backend/__tests__/markdown.spec.js
+++ b/backend/__tests__/markdown.spec.js
@@ -105,7 +105,21 @@ describe('createConverter().makeSanitizedHtml', () => {
   test('mailto: query params stripped case-insensitively', async () => {
     const result = await render('<a href="MAILTO:test@example.com?subject=injected">mail</a>')
     expect(result).not.toContain('subject=')
-    expect(result).toContain('test@example.com')
+    expect(result).toContain('href="mailto:test@example.com"')
+  })
+
+  test('mailto: leading whitespace cannot bypass query-param stripping', async () => {
+    for (const prefix of ['\t', ' ']) {
+      const result = await render(`<a href="${prefix}mailto:test@example.com?subject=injected">mail</a>`)
+      expect(result).not.toContain('subject=')
+      expect(result).toContain('href="mailto:test@example.com"')
+    }
+  })
+
+  test('mailto: embedded control characters cannot bypass query-param stripping', async () => {
+    const result = await render('<a href="mail\x01to:test@example.com?subject=injected">mail</a>')
+    expect(result).not.toContain('subject=')
+    expect(result).toContain('href="mailto:test@example.com"')
   })
 
   test('Images: allow src/alt/title/width/height, strip event handlers', async () => {

--- a/backend/__tests__/markdown.spec.js
+++ b/backend/__tests__/markdown.spec.js
@@ -95,6 +95,13 @@ describe('createConverter().makeSanitizedHtml', () => {
     expect(await render(md)).toMatchSnapshot()
   })
 
+  test('mailto: query params stripped', async () => {
+    const result = await render('[mail](mailto:test@example.com?subject=injected&body=phishing)')
+    expect(result).toContain('href="mailto:test@example.com"')
+    expect(result).not.toContain('subject=')
+    expect(result).not.toContain('body=')
+  })
+
   test('Images: allow src/alt/title/width/height, strip event handlers', async () => {
     const md = [
     // Allowed attributes

--- a/backend/__tests__/markdown.spec.js
+++ b/backend/__tests__/markdown.spec.js
@@ -102,6 +102,12 @@ describe('createConverter().makeSanitizedHtml', () => {
     expect(result).not.toContain('body=')
   })
 
+  test('mailto: query params stripped case-insensitively', async () => {
+    const result = await render('<a href="MAILTO:test@example.com?subject=injected">mail</a>')
+    expect(result).not.toContain('subject=')
+    expect(result).toContain('test@example.com')
+  })
+
   test('Images: allow src/alt/title/width/height, strip event handlers', async () => {
     const md = [
     // Allowed attributes

--- a/backend/lib/markdown.js
+++ b/backend/lib/markdown.js
@@ -17,6 +17,15 @@ import sanitizeHtml from 'sanitize-html'
 
 const SANITIZE = {
   allowedTags: [...sanitizeHtml.defaults.allowedTags, 'img', 'details', 'summary'],
+  transformTags: {
+    a (tagName, attribs) {
+      if (attribs.href?.startsWith('mailto:')) {
+        const url = new URL(attribs.href)
+        attribs.href = `mailto:${url.pathname}`
+      }
+      return { tagName, attribs }
+    },
+  },
 }
 
 const processor = unified()

--- a/backend/lib/markdown.js
+++ b/backend/lib/markdown.js
@@ -19,7 +19,7 @@ const SANITIZE = {
   allowedTags: [...sanitizeHtml.defaults.allowedTags, 'img', 'details', 'summary'],
   transformTags: {
     a (tagName, attribs) {
-      if (attribs.href?.startsWith('mailto:')) {
+      if (attribs.href?.toLowerCase().startsWith('mailto:')) {
         const url = new URL(attribs.href)
         attribs.href = `mailto:${url.pathname}`
       }

--- a/backend/lib/markdown.js
+++ b/backend/lib/markdown.js
@@ -19,8 +19,10 @@ const SANITIZE = {
   allowedTags: [...sanitizeHtml.defaults.allowedTags, 'img', 'details', 'summary'],
   transformTags: {
     a (tagName, attribs) {
-      if (attribs.href?.toLowerCase().startsWith('mailto:')) {
-        const url = new URL(attribs.href)
+      // eslint-disable-next-line no-control-regex -- intentional: strip control chars and whitespace before scheme check
+      const href = attribs.href?.replace(/[\u0000-\u0020\u007f]/g, '')
+      if (href?.toLowerCase().startsWith('mailto:')) {
+        const url = new URL(href)
         attribs.href = `mailto:${url.pathname}`
       }
       return { tagName, attribs }

--- a/frontend/__tests__/composables/useSanatizeUrl.spec.js
+++ b/frontend/__tests__/composables/useSanatizeUrl.spec.js
@@ -33,8 +33,12 @@ describe('composables', () => {
       expect(sanitizeUrl('https://example.com:4567/path/to/something')).toBe('https://example.com:4567/path/to/something')
     })
 
-    it('does not alter mailto urls', () => {
-      expect(sanitizeUrl('mailto:test@example.com?subject=hello+world')).toBe('mailto:test@example.com?subject=hello+world')
+    it('strips query params from mailto urls', () => {
+      expect(sanitizeUrl('mailto:test@example.com')).toBe('mailto:test@example.com')
+      expect(sanitizeUrl('mailto:test@example.com?subject=hello+world')).toBe('mailto:test@example.com')
+      expect(sanitizeUrl('mailto:test@example.com?body=injected&subject=x')).toBe('mailto:test@example.com')
+      expect(sanitizeUrl('mailto:test@example.com?subject=javascript:alert(1)')).toBe('mailto:test@example.com')
+      expect(sanitizeUrl('mailto:test@example.com?body=javascript:alert(document.domain)')).toBe('mailto:test@example.com')
     })
 
     it('does not alter http(s) URLs with encoded search params', () => {

--- a/frontend/src/composables/useSanitizeUrl.js
+++ b/frontend/src/composables/useSanitizeUrl.js
@@ -20,6 +20,9 @@ export const useSanitizeUrl = (options = {}) => {
     try {
       const url = new URL(unref(value))
       if (allowedProtocolRegex.test(url.protocol)) {
+        if (url.protocol === 'mailto:') {
+          return `mailto:${url.pathname}`
+        }
         return url.toString()
       }
     } catch (err) {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area security
/kind bug

**What this PR does / why we need it**:
`mailto:` links with query params (`?subject=`, `?body=`) can pre-fill email content when clicked, enabling phishing. Two fixes:
- strip query params from `mailto:` hrefs for any external URL passed through the sanitizer, as well as for markdown parsed in the ticket bodies. This means subject and body will not be parsed into the link.

**Which issue(s) this PR fixes**:
related to #2612 

**Special notes for your reviewer**:
I couldn't reproduce that this was actually an issue for the standard mailto links generated by the dashboard. If you put something like `email@example.com?subject=foo&body=bar` as a user email, the query params are not rendered as a link on the dashboard. The only place the issue really seems to exist is in mailto links in the github issue comments (which do not get sanitized when viewing directly on github, by the way)

So I am unsure whether we should really be this defensive in this change.

**Release note**:
```bugfix user
Strip query params from mailto: links to prevent phishing via pre-filled subject/body injection.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Email links now retain only the email address, with query parameters removed during sanitization.
* Potentially unsafe content in email link subjects and bodies is no longer preserved.
* Email links are handled consistently across content processing.
* Email addresses remain intact while query parameters are removed despite capitalization, whitespace, or embedded control characters in the URL scheme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->