### PR TITLE
fix: sanitize GitHub label color in GTicketLabel

### DIFF
--- a/frontend/src/components/ShootTickets/GTicketLabel.vue
+++ b/frontend/src/components/ShootTickets/GTicketLabel.vue
@@ -9,32 +9,29 @@ SPDX-License-Identifier: Apache-2.0
     label
     size="x-small"
     class="mr-1"
-    :style="labelStyle(label)"
+    :style="labelStyle"
   >
     {{ label.name }}
   </v-chip>
 </template>
 
-<script>
+<script setup>
+import { computed } from 'vue'
+
 import { pickAccessibleTextColor } from '@/utils/accessibleColors'
 
 import get from 'lodash/get'
 
-export default {
-  props: {
-    label: {
-      type: Object,
-      required: true,
-    },
+const props = defineProps({
+  label: {
+    type: Object,
+    required: true,
   },
-  computed: {
-    labelStyle () {
-      return label => {
-        const background = `#${get(label, ['color'])}`
-        const textColor = pickAccessibleTextColor(background)
-        return `background-color: ${background}; color: ${textColor};`
-      }
-    },
-  },
-}
+})
+
+const labelStyle = computed(() => {
+  const background = `#${get(props.label, ['color'])}`
+  const textColor = pickAccessibleTextColor(background)
+  return `background-color: ${background}; color: ${textColor};`
+})
 </script>

--- a/frontend/src/components/ShootTickets/GTicketLabel.vue
+++ b/frontend/src/components/ShootTickets/GTicketLabel.vue
@@ -20,18 +20,27 @@ import { computed } from 'vue'
 
 import { pickAccessibleTextColor } from '@/utils/accessibleColors'
 
-import get from 'lodash/get'
-
 const props = defineProps({
   label: {
     type: Object,
     required: true,
   },
 })
+const HEX_COLOR_REGEX = /^[0-9a-fA-F]{6}$/
 
 const labelStyle = computed(() => {
-  const background = `#${get(props.label, ['color'])}`
-  const textColor = pickAccessibleTextColor(background)
-  return `background-color: ${background}; color: ${textColor};`
+  if (!HEX_COLOR_REGEX.test(props.label.color)) {
+    return {
+      backgroundColor: 'rgb(var(--v-theme-surface-variant))',
+      color: 'rgb(var(--v-theme-on-surface-variant))',
+    }
+  }
+
+  const background = `#${props.label.color}`
+  return {
+    backgroundColor: background,
+    color: pickAccessibleTextColor(background),
+  }
 })
+
 </script>


### PR DESCRIPTION
**How to categorize this PR?**
/area security
/kind bug

**What this PR does / why we need it**:
- Sanitizes label colors from GitHub API before using in `:style` binding
- adds a fallback to surface color combo if the given label color is malformed
- Converts the component to `<script setup>` (see https://github.com/gardener/dashboard/issues/2877)

**Which issue(s) this PR fixes**:
Related to #2612

**Special notes for your reviewer**:

**Release note**:
```bugfix user
NONE
```