### PR TITLE
Fix/improve unhealty shoot sorting

### DIFF
--- a/frontend/__tests__/composables/useSeedTableSorting.spec.js
+++ b/frontend/__tests__/composables/useSeedTableSorting.spec.js
@@ -131,11 +131,30 @@ describe('composables', () => {
     })
 
     it('should sort unhealthy shoots numerically', () => {
+      const a = {
+        healthy: 2,
+        unhealthy: 4,
+        otherUnhealthy: 3
+      }
+      const b = {
+        healthy: 20,
+        unhealthy: 3,
+        otherUnhealthy: 3
+      }
+      const c = {
+        healthy: 2,
+        unhealthy: 3,
+        otherUnhealthy: 4
+      }
       const { customKeySort } = useSeedTableSorting()
 
-      expect(customKeySort.unhealthyShoots(0, 1)).toBeLessThan(0)
-      expect(customKeySort.unhealthyShoots(3, 1)).toBeGreaterThan(0)
-      expect(customKeySort.unhealthyShoots(1, 1)).toBe(0)
+      expect(customKeySort.unhealthyShoots(b, a)).toBeLessThan(0)
+      expect(customKeySort.unhealthyShoots(a, b)).toBeGreaterThan(0)
+      expect(customKeySort.unhealthyShoots(c, a)).toBeLessThan(0)
+      expect(customKeySort.unhealthyShoots(a, c)).toBeGreaterThan(0)
+      expect(customKeySort.unhealthyShoots(b, c)).toBeLessThan(0)
+      expect(customKeySort.unhealthyShoots(c, b)).toBeGreaterThan(0)
+      expect(customKeySort.unhealthyShoots(a, a)).toBe(0)
     })
   })
 })

--- a/frontend/__tests__/composables/useSeedTableSorting.spec.js
+++ b/frontend/__tests__/composables/useSeedTableSorting.spec.js
@@ -134,17 +134,17 @@ describe('composables', () => {
       const a = {
         healthy: 2,
         unhealthy: 4,
-        otherUnhealthy: 3
+        otherUnhealthy: 3,
       }
       const b = {
         healthy: 20,
         unhealthy: 3,
-        otherUnhealthy: 3
+        otherUnhealthy: 3,
       }
       const c = {
         healthy: 2,
         unhealthy: 3,
-        otherUnhealthy: 4
+        otherUnhealthy: 4,
       }
       const { customKeySort } = useSeedTableSorting()
 

--- a/frontend/src/composables/useSeedTableSorting.js
+++ b/frontend/src/composables/useSeedTableSorting.js
@@ -56,9 +56,15 @@ function compareLastOperation (a, b, compareValues) {
 }
 
 function compareUnhealthyShoots (a, b, compareValues) {
-  if (a == null && b == null) {return 0}
-  if (a == null) {return -1}
-  if (b == null) {return 1}
+  if (a == null && b == null) {
+    return 0
+  }
+  if (a == null) {
+    return -1
+  }
+  if (b == null) {
+    return 1
+  }
 
   return compareValues(a.unhealthy, b.unhealthy) ||
     compareValues(a.otherUnhealthy, b.otherUnhealthy) ||

--- a/frontend/src/composables/useSeedTableSorting.js
+++ b/frontend/src/composables/useSeedTableSorting.js
@@ -56,13 +56,13 @@ function compareLastOperation (a, b, compareValues) {
 }
 
 function compareUnhealthyShoots (a, b, compareValues) {
-  if (a == null && b == null) return 0
-  if (a == null) return -1
-  if (b == null) return 1
+  if (a == null && b == null) {return 0}
+  if (a == null) {return -1}
+  if (b == null) {return 1}
 
-  return  compareValues(a.unhealthy, b.unhealthy)
-    || compareValues(a.otherUnhealthy, b.otherUnhealthy)
-    || compareValues(a.healthy, b.healthy)
+  return compareValues(a.unhealthy, b.unhealthy) ||
+    compareValues(a.otherUnhealthy, b.otherUnhealthy) ||
+    compareValues(a.healthy, b.healthy)
 }
 
 export function useSeedTableSorting () {

--- a/frontend/src/composables/useSeedTableSorting.js
+++ b/frontend/src/composables/useSeedTableSorting.js
@@ -55,6 +55,16 @@ function compareLastOperation (a, b, compareValues) {
   return compareValues(getSeedLastOperationSortVal(a), getSeedLastOperationSortVal(b))
 }
 
+function compareUnhealthyShoots (a, b, compareValues) {
+  if (a == null && b == null) return 0
+  if (a == null) return -1
+  if (b == null) return 1
+
+  return  compareValues(a.unhealthy, b.unhealthy)
+    || compareValues(a.otherUnhealthy, b.otherUnhealthy)
+    || compareValues(a.healthy, b.healthy)
+}
+
 export function useSeedTableSorting () {
   const configStore = useConfigStore()
 
@@ -67,7 +77,7 @@ export function useSeedTableSorting () {
     name: compareValues,
     infrastructure: compareValues,
     shootCount: compareValues,
-    unhealthyShoots: compareValues,
+    unhealthyShoots: (a, b) => compareUnhealthyShoots(a, b, compareValues),
     lastOperation: (a, b) => compareLastOperation(a, b, compareValues),
     kubernetesVersion: compareSemanticVersions,
     gardenerVersion: compareSemanticVersions,

--- a/frontend/src/views/GSeedList.vue
+++ b/frontend/src/views/GSeedList.vue
@@ -331,7 +331,7 @@ function isHeaderSelected (key) {
   return header?.selected ?? false
 }
 
-function getUnhealthyShootInformation(item) {
+function getUnhealthyShootInformation (item) {
   const name = get(item, ['metadata', 'name'])
   const shootCount = seedStatStore.shootCountForSeed(name) ?? 0
   if (shootCount === 0) {
@@ -341,7 +341,7 @@ function getUnhealthyShootInformation(item) {
   const total = seedStatStore.statByName(name)?.counts?.unhealthyShoots?.total ?? 0
   const otherUnhealthy = total - unhealthy
   const healthy = shootCount - total
-  return { unhealthy, otherUnhealthy, healthy, total}
+  return { unhealthy, otherUnhealthy, healthy, total }
 }
 
 const seedStatsSubscriptionOptions = computed(() => {

--- a/frontend/src/views/GSeedList.vue
+++ b/frontend/src/views/GSeedList.vue
@@ -198,7 +198,7 @@ const allHeaders = computed(() => [
     align: 'center',
     defaultSelected: true,
     hidden: false,
-    value: item => seedStatStore.unhealthyShootsForSeed(get(item, ['metadata', 'name'])) ?? 0,
+    value: item => getUnhealthyShootInformation(item),
   },
   {
     title: 'ACCESS RESTRICTIONS',
@@ -329,6 +329,19 @@ function getItemKey (item, fallback) {
 function isHeaderSelected (key) {
   const header = find(headers.value, ['key', key])
   return header?.selected ?? false
+}
+
+function getUnhealthyShootInformation(item) {
+  const name = get(item, ['metadata', 'name'])
+  const shootCount = seedStatStore.shootCountForSeed(name) ?? 0
+  if (shootCount === 0) {
+    return null
+  }
+  const unhealthy = seedStatStore.unhealthyShootsForSeed(name) ?? 0
+  const total = seedStatStore.statByName(name)?.counts?.unhealthyShoots?.total ?? 0
+  const otherUnhealthy = total - unhealthy
+  const healthy = shootCount - total
+  return { unhealthy, otherUnhealthy, healthy, total}
 }
 
 const seedStatsSubscriptionOptions = computed(() => {


### PR DESCRIPTION
**How to categorize this PR?**
  /area usability
  /kind enhancement

**What this PR does / why we need it**:
It improved the sorting behavior of the "UNHEALTHY SHOOTS" column in the Seed overview. Now there is a multistep sorting with the following priority: `Unhealthy > Other Unhealty > Healthy`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sorting for the unhealthy shoots column by prioritizing unhealthy, other unhealthy, and healthy shoot counts.
  * Seeds without shoots are now handled consistently during sorting.
  * The column now displays and compares comprehensive shoot health information rather than only a single count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->