### PR TITLE
fix(frontend): remove local router.push ignore handlers

### DIFF
--- a/frontend/src/layouts/GLogin.vue
+++ b/frontend/src/layouts/GLogin.vue
@@ -323,11 +323,7 @@ export default {
         const token = this.token
         this.token = undefined
         await this.api.createTokenReview({ token })
-        try {
-          await this.$router.push(this.redirectPath)
-        } catch (err) {
-          /* Catch and ignore navigation aborted errors. Redirection happens in navigation guards */
-        }
+        await this.$router.push(this.redirectPath)
       } catch (err) {
         this.setError({
           title: `${this.getLoginTypeTitle('token')} Login Error`,

--- a/frontend/src/views/GNotFound.vue
+++ b/frontend/src/views/GNotFound.vue
@@ -55,7 +55,7 @@ const fallbackRoute = computed(() => {
 
 function onClick (from) {
   if (from?.name) {
-    router.push(fallbackRoute.value).catch(() => { /* ignore error */ })
+    return router.push(fallbackRoute.value)
   } else {
     router.back()
   }

--- a/frontend/src/views/GProjectError.vue
+++ b/frontend/src/views/GProjectError.vue
@@ -51,10 +51,6 @@ const props = defineProps({
 const { code, text, message, buttonText } = toRefs(props)
 
 async function onClick () {
-  try {
-    await router.push(props.fallbackRoute)
-  } catch (err) {
-    /* Catch and ignore navigation aborted errors. Redirection happens in navigation guards (see https://router.vuejs.org/guide/essentials/navigation.html#router-push-location-oncomplete-onabort). */
-  }
+  await router.push(props.fallbackRoute)
 }
 </script>

--- a/frontend/src/views/GShootItemError.vue
+++ b/frontend/src/views/GShootItemError.vue
@@ -66,11 +66,7 @@ export default {
   },
   methods: {
     async onClick () {
-      try {
-        await this.$router.push(this.fallbackRoute)
-      } catch (err) {
-        /* Catch and ignore navigation aborted errors. Redirection happens in navigation guards (see https://router.vuejs.org/guide/essentials/navigation.html#router-push-location-oncomplete-onabort). */
-      }
+      await this.$router.push(this.fallbackRoute)
     },
   },
 }


### PR DESCRIPTION
/area quality
/kind cleanup

**What this PR does / why we need it**:

Removes local `router.push` catch-and-ignore handlers so unexpected navigation errors reach the router’s central error handling instead of being silently suppressed. Expected aborted, cancelled, and duplicated navigations remain handled by the existing `afterEach` hook.

**Which issue(s) this PR fixes**:

Fixes #2825

**Special notes for your reviewer**:

Follows the same cleanup merged in #2820 (`937fe1f`).

Validation on Node 24.19.0:

- `make lint`
- `yarn workspace @gardener-dashboard/frontend build`
- isolated kube-client test suite (108/108)
- isolated backend server test suite (6/6)

The full frontend suite has one locale-format assertion failure reproduced on clean `origin/master`. The documented gardenless stack could not start because the remote host’s live RKE2 API server owns its fixed port 6443, so I did not disturb that service.

Follow-up validation after the review fix: frontend lint and the production build pass on Node 24.19.0. The full frontend test run has 984 passing tests and the same pre-existing locale-format failure in __tests__/utils/moment.spec.js.

**Release note**:

```other developer
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Navigation errors during login redirects and fallback actions on error pages are no longer silently ignored.
  * Failed or interrupted route changes now propagate correctly, improving error visibility and handling consistency across affected screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
