### PR TITLE
fix(frontend): clarify automatic update notifications

### DIFF
--- a/frontend/__tests__/components/GK8sExpirationMessage.spec.js
+++ b/frontend/__tests__/components/GK8sExpirationMessage.spec.js
@@ -1,0 +1,55 @@
+//
+// SPDX-FileCopyrightText: Contributors to the Gardener project
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import { mount } from '@vue/test-utils'
+
+import GK8sExpirationMessage from '@/components/ShootMessages/GK8sExpirationMessage.vue'
+
+describe('components', () => {
+  describe('g-k8s-expiration-message', () => {
+    const defaultProps = {
+      expirationDate: '2027-07-07T14:58:37Z',
+      isValidTerminationDate: true,
+      isExpired: false,
+      version: '1.35.5',
+      regularUpdate: false,
+      forcedUpdate: false,
+      noUpdate: false,
+    }
+
+    function mountK8sExpirationMessage (props = {}) {
+      return mount(GK8sExpirationMessage, {
+        global: {
+          stubs: {
+            GTimeString: true,
+          },
+        },
+        props: {
+          ...defaultProps,
+          ...props,
+        },
+      })
+    }
+
+    it('explains automatic patch updates without implying that expiration caused them', () => {
+      const wrapper = mountK8sExpirationMessage({
+        regularUpdate: true,
+      })
+
+      expect(wrapper.text()).toContain('has a newer supported patch version available and will be updated automatically in the next maintenance window.')
+      expect(wrapper.text()).not.toContain('expires')
+    })
+
+    it('keeps the expiration reason for forced updates', () => {
+      const wrapper = mountK8sExpirationMessage({
+        forcedUpdate: true,
+      })
+
+      expect(wrapper.text()).toContain('expires')
+      expect(wrapper.text()).toContain('Version update will be enforced after that date')
+    })
+  })
+})

--- a/frontend/__tests__/components/GWorkerGroupExpirationMessage.spec.js
+++ b/frontend/__tests__/components/GWorkerGroupExpirationMessage.spec.js
@@ -1,0 +1,58 @@
+//
+// SPDX-FileCopyrightText: Contributors to the Gardener project
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import { mount } from '@vue/test-utils'
+
+import GWorkerGroupExpirationMessage from '@/components/ShootMessages/GWorkerGroupExpirationMessage.vue'
+
+describe('components', () => {
+  describe('g-worker-group-expiration-message', () => {
+    const defaultProps = {
+      expirationDate: '2027-07-07T14:58:37Z',
+      isValidTerminationDate: true,
+      isExpired: false,
+      version: '1.0.0',
+      name: 'gardenlinux',
+      workerName: 'worker-1',
+      regularUpdate: false,
+      forcedUpdate: false,
+      noUpdate: false,
+      supportedVersionAvailable: false,
+    }
+
+    function mountWorkerGroupExpirationMessage (props = {}) {
+      return mount(GWorkerGroupExpirationMessage, {
+        global: {
+          stubs: {
+            GTimeString: true,
+          },
+        },
+        props: {
+          ...defaultProps,
+          ...props,
+        },
+      })
+    }
+
+    it('explains automatic image updates without implying that expiration caused them', () => {
+      const wrapper = mountWorkerGroupExpirationMessage({
+        regularUpdate: true,
+      })
+
+      expect(wrapper.text()).toContain('has a newer supported version available and will be updated automatically in the next maintenance window.')
+      expect(wrapper.text()).not.toContain('expires')
+    })
+
+    it('keeps the expiration reason for forced image updates', () => {
+      const wrapper = mountWorkerGroupExpirationMessage({
+        forcedUpdate: true,
+      })
+
+      expect(wrapper.text()).toContain('expires')
+      expect(wrapper.text()).toContain('Machine Image update will be enforced after that date')
+    })
+  })
+})

--- a/frontend/src/components/ShootMessages/GK8sExpirationMessage.vue
+++ b/frontend/src/components/ShootMessages/GK8sExpirationMessage.vue
@@ -7,19 +7,23 @@ SPDX-License-Identifier: Apache-2.0
 <template>
   <div>
     Kubernetes <span class="font-weight-bold">version {{ version }}</span> of this cluster
-    <span v-if="isValidTerminationDate">
-      expires
-      <g-time-string
-        :date-time="expirationDate"
-        mode="future"
-        date-tooltip
-        content-class="font-weight-bold"
-      />
-      <span>. </span>
+    <template v-if="!regularUpdate">
+      <span v-if="isValidTerminationDate">
+        expires
+        <g-time-string
+          :date-time="expirationDate"
+          mode="future"
+          date-tooltip
+          content-class="font-weight-bold"
+        />
+        <span>. </span>
+      </span>
+      <span v-else-if="isExpired">is expired. </span>
+      <span v-else>will expire soon. </span>
+    </template>
+    <span v-if="regularUpdate">
+      has a newer supported patch version available and will be updated automatically in the next maintenance window.
     </span>
-    <span v-else-if="isExpired">is expired. </span>
-    <span v-else>will expire soon. </span>
-    <span v-if="regularUpdate">Version will be updated in the next maintenance window</span>
     <template v-else-if="forcedUpdate">
       <span v-if="isValidTerminationDate">Version update will be enforced after that date</span>
       <span v-else>Version update will be enforced soon</span>

--- a/frontend/src/components/ShootMessages/GWorkerGroupExpirationMessage.vue
+++ b/frontend/src/components/ShootMessages/GWorkerGroupExpirationMessage.vue
@@ -7,19 +7,23 @@ SPDX-License-Identifier: Apache-2.0
 <template>
   <div>
     Machine image <span class="font-weight-bold">{{ name }} | version {{ version }}</span> of worker group <span class="font-weight-bold">{{ workerName }}</span>
-    <span v-if="isValidTerminationDate">
-      expires
-      <g-time-string
-        :date-time="expirationDate"
-        mode="future"
-        date-tooltip
-        content-class="font-weight-bold"
-      />
-      <span>. </span>
+    <template v-if="!regularUpdate">
+      <span v-if="isValidTerminationDate">
+        expires
+        <g-time-string
+          :date-time="expirationDate"
+          mode="future"
+          date-tooltip
+          content-class="font-weight-bold"
+        />
+        <span>. </span>
+      </span>
+      <span v-else-if="isExpired"> is expired. </span>
+      <span v-else>will expire soon. </span>
+    </template>
+    <span v-if="regularUpdate">
+      has a newer supported version available and will be updated automatically in the next maintenance window.
     </span>
-    <span v-else-if="isExpired"> is expired. </span>
-    <span v-else>will expire soon. </span>
-    <span v-if="regularUpdate">Version will be updated in the next maintenance window</span>
     <template v-else-if="forcedUpdate">
       <span v-if="isValidTerminationDate">Machine Image update will be enforced after that date</span>
       <span v-else>Machine Image update will be enforced soon</span>


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area usability
/kind bug

**What this PR does / why we need it**:

Clarifies automatic Kubernetes and machine-image update notifications. When a newer supported version will be installed during the next maintenance window, the message now explains that reason instead of implying that a distant expiration date triggered the update.

**Which issue(s) this PR fixes**:
Fixes #3156

**Special notes for your reviewer**:

- The existing `regularUpdate` state already identifies the automatic-update path, so forced-update and no-supported-version messages retain their expiration guidance.
- Validation: immutable dependency install, focused component tests (4/4), full frontend lint, and production frontend build all pass. The full frontend suite has one unrelated locale-format assertion failure in `moment.spec.js`; it reproduces on the base branch (`03:51 PM` expected, `3:51 PM` rendered).
- I did not start the local dashboard stack because its fixed `127.0.0.1:6443` listener conflicts with the remote host's active RKE2 API server.

**Release note**:
```bugfix user
Clarified automatic Kubernetes and machine-image update notifications so they explain why the maintenance-window update is planned.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Regular patch updates now display a message explaining that a newer supported version will be applied automatically during the next maintenance window.
  * Expiration and enforcement messages remain visible for forced updates.
* **Tests**
  * Added coverage to verify the correct messaging for regular and forced updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->